### PR TITLE
fix(linux-runner-image): report real memory and disk in job metrics

### DIFF
--- a/.github/workflows/linux-runner-image.yml
+++ b/.github/workflows/linux-runner-image.yml
@@ -54,6 +54,18 @@ jobs:
           bash -n infra/linux-runner-image/dispatch-poll.sh
           bash -n infra/linux-runner-image/run-job.sh
           bash -n infra/linux-runner-image/vitals.sh
+          bash -n infra/linux-runner-image/metrics-sampler.sh
+
+      # Runs on the image's own base rather than the CI runner, because
+      # the assertions are about how Ubuntu's awk (mawk) formats byte
+      # counters. Under gawk or BWK awk they pass no matter what the
+      # sampler does. Keep the tag in step with the Dockerfile's final
+      # `FROM`.
+      - name: Test metrics sampler
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}/infra/linux-runner-image:/w" \
+            -w /w ubuntu:22.04 bash ./metrics-sampler_test.sh
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3

--- a/infra/linux-runner-image/AGENTS.md
+++ b/infra/linux-runner-image/AGENTS.md
@@ -52,7 +52,13 @@ macOS image). Same single-shot lifecycle, much simpler substrate.
   warm-standby Pods don't post — then samples VM-wide `/proc` plus the
   JIT volume's backing filesystem every `TUIST_RUNNER_METRICS_INTERVAL`
   (default 15s) and POSTs to `…/pods/<pod>/metrics`. Best-effort;
-  never affects the job.
+  never affects the job. Format byte counters with awk's `%.0f` and
+  compute counter deltas in bash: `awk` here is mawk, whose
+  `printf "%d"` saturates at INT_MAX and whose bare `print` renders
+  integers above 2^31 in `%.6g` scientific notation. Read `MemTotal`
+  and `MemAvailable` in the same pass — kata hot-plugs the sandbox up
+  to the shape's memory after boot, so a total cached at sidecar
+  start goes stale mid-job. `metrics-sampler_test.sh` covers both.
 - `/usr/local/bin/runner-shell-agent` — interactive shell bridge.
   Built from the Go source in `cmd/runner-shell-agent/`. The trusted
   `shell` native sidecar waits for the poller to stage a JIT (claimed
@@ -178,6 +184,11 @@ rebuilds for branch validation go through
 without pushing, `workflow_dispatch` pushes `:sha-<git-sha>` only
 (`:latest` and semver tags belong exclusively to the release
 flow).
+
+`pull_request` also syntax-checks every shell script and runs
+`metrics-sampler_test.sh` inside `ubuntu:22.04` — the image's own
+base, so the sampler's byte formatting is exercised against mawk
+rather than whichever awk the CI runner happens to ship.
 
 ## How it ends up serving traffic
 

--- a/infra/linux-runner-image/metrics-sampler.sh
+++ b/infra/linux-runner-image/metrics-sampler.sh
@@ -18,38 +18,55 @@
 # unclaimed Pod (warm standby, before a job is claimed) is a no-op
 # there. Fail-open: a bad sample or failed POST is skipped, never
 # affecting the job.
+#
+# ## Byte counters and awk
+#
+# Ubuntu's `awk` is mawk, whose `printf "%d"` saturates at INT_MAX
+# (2147483647) and whose bare `print` renders integers above 2^31 in
+# OFMT (`%.6g`) scientific notation. Neither can carry a byte count.
+# Every byte-valued field here is therefore formatted with `%.0f`,
+# which goes through the C double path and is exact to 2^53, and
+# counter deltas are computed in bash arithmetic (64-bit) rather than
+# in awk.
 
 set -uo pipefail
 
 TOKEN_PATH="${TUIST_RUNNER_TOKEN_PATH:-/var/run/secrets/tuist-runner/token}"
 DISK_PATH="${TUIST_RUNNER_DISK_PATH:-/var/lib/tuist-runner}"
+MEMINFO_PATH=/proc/meminfo
+STAT_PATH=/proc/stat
+NET_DEV_PATH=/proc/net/dev
 interval="${TUIST_RUNNER_METRICS_INTERVAL:-15}"
 
 log() { echo "$(date -u +%FT%TZ) metrics-sampler: $*"; }
 
-if [ -z "${TUIST_RUNNER_DISPATCH_URL:-}" ] || [ -z "${TUIST_RUNNER_POD_NAME:-}" ]; then
-  log "dispatch URL or pod name unset; not sampling"
-  exit 0
-fi
-
-metrics_url="${TUIST_RUNNER_DISPATCH_URL%/dispatch}/pods/${TUIST_RUNNER_POD_NAME}/metrics"
-mem_total_bytes=$(awk '/^MemTotal:/ { print $2 * 1024 }' /proc/meminfo 2>/dev/null || echo 0)
-
-# The sidecar starts at Pod boot, but a warm-standby Pod has no job
-# yet — sampling then would just no-op against the server and add load
-# for every idle Pod. The poller stages the JIT here the instant a job
-# is claimed, so wait for it: sampling then spans exactly the job, the
-# same window the macOS sampler covers.
-jit_path="${TUIST_RUNNER_JIT_PATH:-/var/lib/tuist-runner/jit}"
-log "waiting for a claimed job (JIT at ${jit_path}) before sampling"
-while [ ! -f "${jit_path}" ]; do sleep 1; done
-
-log "job claimed; sampling every ${interval}s -> ${metrics_url}"
-
 # read_cpu echoes "total idle_all iowait" jiffies from /proc/stat's
 # aggregate cpu line (idle_all = idle + iowait).
 read_cpu() {
-  awk '/^cpu / { total = 0; for (i = 2; i <= NF; i++) total += $i; print total, $5 + $6, $6; exit }' /proc/stat
+  awk '/^cpu / { total = 0; for (i = 2; i <= NF; i++) total += $i; print total, $5 + $6, $6; exit }' "${1:-${STAT_PATH}}"
+}
+
+# mem_totals echoes "used total" bytes for the guest.
+#
+# Both values come from one read of the file. kata boots the sandbox
+# at its default size and hot-plugs it up to the shape's configured
+# memory, so MemTotal grows during the Pod's life — pairing a MemTotal
+# read at sidecar start with a live MemAvailable reports the boot-time
+# size forever and drives `used` negative once the guest grows. Reading
+# the pair together is what keeps the two consistent, so keep them in
+# this single pass.
+mem_totals() {
+  awk '
+    /^MemTotal:/ { total = $2 }
+    /^MemAvailable:/ { avail = $2 }
+    END { printf "%.0f %.0f", (total - avail) * 1024, total * 1024 }' "${1:-${MEMINFO_PATH}}" 2>/dev/null
+}
+
+# disk_totals echoes "used total" bytes for the filesystem backing the
+# given path. `-P` keeps df to one line per filesystem, which NR == 2
+# relies on.
+disk_totals() {
+  df -k -P "${1:-${DISK_PATH}}" 2>/dev/null | awk 'NR == 2 { printf "%.0f %.0f", $3 * 1024, $2 * 1024 }'
 }
 
 # net_totals echoes cumulative "rx tx" bytes summed over every
@@ -65,68 +82,105 @@ net_totals() {
       split($2, v, " ")
       rx += v[1]; tx += v[9]
     }
-    END { printf "%d %d", rx + 0, tx + 0 }' /proc/net/dev 2>/dev/null
+    END { printf "%.0f %.0f", rx + 0, tx + 0 }' "${1:-${NET_DEV_PATH}}" 2>/dev/null
 }
 
 # delta cur prev -> max(0, cur-prev); a counter reset reports 0.
 delta() {
-  awk -v c="$1" -v p="$2" 'BEGIN { d = c - p; if (d < 0) d = 0; printf "%d", d }'
+  local d=$(( $1 - $2 ))
+  if [ "${d}" -lt 0 ]; then d=0; fi
+  printf '%d' "${d}"
 }
 
-prev_rx=""
-prev_tx=""
+# metrics_payload TS CPU IOWAIT NET_IN NET_OUT
+#
+# Reads memory and disk itself so every sample carries a view taken at
+# the same moment as the CPU window it is paired with.
+metrics_payload() {
+  local ts="$1" cpu="$2" iowait="$3" net_in="$4" net_out="$5"
+  local mem_used mem_total disk_used disk_total
 
-while true; do
-  ts="$(date +%s)"
+  read -r mem_used mem_total <<<"$(mem_totals)"
+  read -r disk_used disk_total <<<"$(disk_totals)"
 
-  # CPU over a short in-loop window so the first sample is real (not 0).
-  read -r t1 i1 w1 <<<"$(read_cpu)"
-  sleep 1
-  read -r t2 i2 w2 <<<"$(read_cpu)"
-  read -r cpu iowait <<<"$(awk -v t1="${t1:-0}" -v i1="${i1:-0}" -v w1="${w1:-0}" -v t2="${t2:-0}" -v i2="${i2:-0}" -v w2="${w2:-0}" '
-    BEGIN {
-      dt = t2 - t1
-      if (dt <= 0) { print "0 0"; exit }
-      busy = dt - (i2 - i1)
-      cpu = busy * 100 / dt
-      io = (w2 - w1) * 100 / dt
-      if (cpu < 0) cpu = 0; if (cpu > 100) cpu = 100
-      if (io < 0) io = 0; if (io > 100) io = 100
-      printf "%.1f %.1f", cpu, io
-    }')"
+  printf '{"samples":[{"timestamp":%s,"cpu_usage_percent":%s,"cpu_iowait_percent":%s,"memory_used_bytes":%s,"memory_total_bytes":%s,"network_bytes_in":%s,"network_bytes_out":%s,"disk_used_bytes":%s,"disk_total_bytes":%s}]}' \
+    "${ts}" "${cpu:-0}" "${iowait:-0}" "${mem_used:-0}" "${mem_total:-0}" \
+    "${net_in}" "${net_out}" "${disk_used:-0}" "${disk_total:-0}"
+}
 
-  mem_avail_bytes=$(awk '/^MemAvailable:/ { print $2 * 1024 }' /proc/meminfo 2>/dev/null || echo 0)
-  mem_used=$(awk -v t="${mem_total_bytes:-0}" -v a="${mem_avail_bytes:-0}" 'BEGIN { u = t - a; if (u < 0) u = 0; printf "%d", u }')
-
-  read -r rx tx <<<"$(net_totals)"
-  if [ -n "${prev_rx}" ]; then
-    net_in="$(delta "${rx:-0}" "${prev_rx}")"
-    net_out="$(delta "${tx:-0}" "${prev_tx}")"
-  else
-    net_in=0
-    net_out=0
+main() {
+  if [ -z "${TUIST_RUNNER_DISPATCH_URL:-}" ] || [ -z "${TUIST_RUNNER_POD_NAME:-}" ]; then
+    log "dispatch URL or pod name unset; not sampling"
+    exit 0
   fi
-  prev_rx="${rx:-0}"
-  prev_tx="${tx:-0}"
 
-  read -r disk_used disk_total <<<"$(df -k "${DISK_PATH}" 2>/dev/null | awk 'NR == 2 { printf "%d %d", $3 * 1024, $2 * 1024 }')"
+  local metrics_url="${TUIST_RUNNER_DISPATCH_URL%/dispatch}/pods/${TUIST_RUNNER_POD_NAME}/metrics"
 
-  token="$(cat "${TOKEN_PATH}" 2>/dev/null || true)"
-  if [ -z "${token}" ]; then
-    log "SA token unreadable at ${TOKEN_PATH}; skipping POST"
+  # The sidecar starts at Pod boot, but a warm-standby Pod has no job
+  # yet — sampling then would just no-op against the server and add load
+  # for every idle Pod. The poller stages the JIT here the instant a job
+  # is claimed, so wait for it: sampling then spans exactly the job, the
+  # same window the macOS sampler covers.
+  local jit_path="${TUIST_RUNNER_JIT_PATH:-/var/lib/tuist-runner/jit}"
+  log "waiting for a claimed job (JIT at ${jit_path}) before sampling"
+  while [ ! -f "${jit_path}" ]; do sleep 1; done
+
+  log "job claimed; sampling every ${interval}s -> ${metrics_url}"
+
+  local prev_rx="" prev_tx=""
+  local ts t1 i1 w1 t2 i2 w2 cpu iowait rx tx net_in net_out token payload
+
+  while true; do
+    ts="$(date +%s)"
+
+    # CPU over a short in-loop window so the first sample is real (not 0).
+    read -r t1 i1 w1 <<<"$(read_cpu)"
+    sleep 1
+    read -r t2 i2 w2 <<<"$(read_cpu)"
+    read -r cpu iowait <<<"$(awk -v t1="${t1:-0}" -v i1="${i1:-0}" -v w1="${w1:-0}" -v t2="${t2:-0}" -v i2="${i2:-0}" -v w2="${w2:-0}" '
+      BEGIN {
+        dt = t2 - t1
+        if (dt <= 0) { print "0 0"; exit }
+        busy = dt - (i2 - i1)
+        cpu = busy * 100 / dt
+        io = (w2 - w1) * 100 / dt
+        if (cpu < 0) cpu = 0; if (cpu > 100) cpu = 100
+        if (io < 0) io = 0; if (io > 100) io = 100
+        printf "%.1f %.1f", cpu, io
+      }')"
+
+    read -r rx tx <<<"$(net_totals)"
+    if [ -n "${prev_rx}" ]; then
+      net_in="$(delta "${rx:-0}" "${prev_rx}")"
+      net_out="$(delta "${tx:-0}" "${prev_tx}")"
+    else
+      net_in=0
+      net_out=0
+    fi
+    prev_rx="${rx:-0}"
+    prev_tx="${tx:-0}"
+
+    token="$(cat "${TOKEN_PATH}" 2>/dev/null || true)"
+    if [ -z "${token}" ]; then
+      log "SA token unreadable at ${TOKEN_PATH}; skipping POST"
+      sleep "${interval}"
+      continue
+    fi
+
+    payload="$(metrics_payload "${ts}" "${cpu:-0}" "${iowait:-0}" "${net_in}" "${net_out}")"
+
+    curl -sS -o /dev/null --max-time 10 \
+      --request POST \
+      --header "Authorization: Bearer ${token}" \
+      --header "Content-Type: application/json" \
+      --data "${payload}" \
+      "${metrics_url}" || true
+
     sleep "${interval}"
-    continue
-  fi
+  done
+}
 
-  payload="$(printf '{"samples":[{"timestamp":%s,"cpu_usage_percent":%s,"cpu_iowait_percent":%s,"memory_used_bytes":%s,"memory_total_bytes":%s,"network_bytes_in":%s,"network_bytes_out":%s,"disk_used_bytes":%s,"disk_total_bytes":%s}]}' \
-    "${ts}" "${cpu:-0}" "${iowait:-0}" "${mem_used:-0}" "${mem_total_bytes:-0}" "${net_in}" "${net_out}" "${disk_used:-0}" "${disk_total:-0}")"
-
-  curl -sS -o /dev/null --max-time 10 \
-    --request POST \
-    --header "Authorization: Bearer ${token}" \
-    --header "Content-Type: application/json" \
-    --data "${payload}" \
-    "${metrics_url}" || true
-
-  sleep "${interval}"
-done
+# Sourced by metrics-sampler_test.sh to exercise the samplers directly.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/infra/linux-runner-image/metrics-sampler_test.sh
+++ b/infra/linux-runner-image/metrics-sampler_test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Regression tests for metrics-sampler.sh's byte-valued metrics.
+#
+# Must run on the runner image's base (Ubuntu, so `awk` is mawk).
+# mawk saturates `printf "%d"` at INT_MAX and renders integers above
+# 2^31 through OFMT, so a byte counter formatted either way is wrong
+# above 2 GiB while still looking like a plausible number. Running
+# these under gawk or BWK awk would pass regardless and prove nothing.
+
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=metrics-sampler.sh
+source ./metrics-sampler.sh
+
+INT32_MAX=2147483647
+failures=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "${expected}" = "${actual}" ]; then
+    echo "  ok   ${label}"
+  else
+    echo "  FAIL ${label}: expected ${expected}, got ${actual}"
+    failures=$((failures + 1))
+  fi
+}
+
+assert_ne() {
+  local label="$1" unexpected="$2" actual="$3"
+  if [ "${unexpected}" != "${actual}" ]; then
+    echo "  ok   ${label}"
+  else
+    echo "  FAIL ${label}: expected anything but ${unexpected}"
+    failures=$((failures + 1))
+  fi
+}
+
+fixtures="$(mktemp -d)"
+trap 'rm -rf "${fixtures}"' EXIT
+
+meminfo_fixture() {
+  local name="$1" total_kb="$2" avail_kb="$3"
+  cat > "${fixtures}/${name}" <<MEM
+MemTotal:       ${total_kb} kB
+MemFree:        ${avail_kb} kB
+MemAvailable:   ${avail_kb} kB
+MEM
+  echo "${fixtures}/${name}"
+}
+
+echo "memory_total_bytes tracks the guest's configured memory"
+# One fixture per fleet shape. A total that is constant across these,
+# or quantized to OFMT's six significant digits, is the regression.
+boot=$(meminfo_fixture boot 1950752 1850000)       # kata sandbox default, pre-hotplug
+mem32=$(meminfo_fixture mem32 33554432 27262976)   # 32 GiB shape, 6 GiB in use
+mem64=$(meminfo_fixture mem64 67108864 58720256)   # 64 GiB shape, 8 GiB in use
+
+read -r used total <<<"$(mem_totals "${boot}")"
+assert_eq "2 GiB sandbox total" 1997570048 "${total}"
+
+read -r used total <<<"$(mem_totals "${mem32}")"
+assert_eq "32 GiB shape total" 34359738368 "${total}"
+assert_eq "32 GiB shape used" 6442450944 "${used}"
+
+read -r used total <<<"$(mem_totals "${mem64}")"
+assert_eq "64 GiB shape total" 68719476736 "${total}"
+assert_eq "64 GiB shape used" 8589934592 "${used}"
+
+echo
+echo "memory survives kata hot-plugging the sandbox mid-job"
+# The sidecar starts while the guest is still at its boot size and the
+# guest grows underneath it. Reporting the boot-time total against a
+# post-hotplug MemAvailable is what pinned memory_total_bytes at
+# 1997570048 and memory_used_bytes at 0.
+MEMINFO_PATH="${boot}"
+read -r used_before total_before <<<"$(mem_totals)"
+MEMINFO_PATH="${mem32}"
+read -r used_after total_after <<<"$(mem_totals)"
+assert_ne "total is re-read after hotplug" "${total_before}" "${total_after}"
+assert_eq "post-hotplug total" 34359738368 "${total_after}"
+assert_ne "post-hotplug used is not zeroed" 0 "${used_after}"
+assert_ne "pre-hotplug used is not zeroed" 0 "${used_before}"
+
+echo
+echo "disk_total_bytes is not clamped at Int32 max"
+disk_kb="$(df -k -P / | awk 'NR == 2 { print $2 }')"
+expected_disk=$(( disk_kb * 1024 ))
+if [ "${expected_disk}" -le "${INT32_MAX}" ]; then
+  echo "  FAIL / is ${expected_disk} bytes, too small to exercise the INT_MAX clamp"
+  failures=$((failures + 1))
+fi
+read -r disk_used disk_total <<<"$(disk_totals /)"
+assert_eq "total matches df" "${expected_disk}" "${disk_total}"
+assert_ne "total is not INT_MAX" "${INT32_MAX}" "${disk_total}"
+assert_ne "used is not INT_MAX" "${INT32_MAX}" "${disk_used}"
+
+echo
+echo "network counters are not clamped at Int32 max"
+cat > "${fixtures}/net_dev" <<'NET'
+Inter-|   Receive                                                |  Transmit
+ face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+    lo:     100       1    0    0    0     0          0         0      100       1    0    0    0     0       0          0
+  eth0: 9663676416 1000    0    0    0     0          0         0 5368709120 900    0    0    0     0       0          0
+NET
+read -r rx tx <<<"$(net_totals "${fixtures}/net_dev")"
+assert_eq "rx total" 9663676416 "${rx}"
+assert_eq "tx total" 5368709120 "${tx}"
+assert_eq "delta above 2 GiB" 4294967296 "$(delta 9663676416 5368709120)"
+assert_eq "counter reset floors at 0" 0 "$(delta 100 9663676416)"
+
+echo
+echo "metrics_payload carries the real byte values"
+# Guards the caller as well as the readers: a total hoisted out of the
+# sampling loop cannot reach the payload from here.
+MEMINFO_PATH="${mem64}"
+DISK_PATH=/
+payload="$(metrics_payload 1750684800 42.5 1.2 1024 2048)"
+echo "  ${payload}"
+for field in \
+  '"memory_total_bytes":68719476736' \
+  '"memory_used_bytes":8589934592' \
+  "\"disk_total_bytes\":${expected_disk}"; do
+  if [[ "${payload}" == *"${field}"* ]]; then
+    echo "  ok   payload has ${field}"
+  else
+    echo "  FAIL payload missing ${field}"
+    failures=$((failures + 1))
+  fi
+done
+if [[ "${payload}" == *"${INT32_MAX}"* ]]; then
+  echo "  FAIL payload contains INT_MAX ${INT32_MAX}"
+  failures=$((failures + 1))
+else
+  echo "  ok   payload contains no INT_MAX clamp"
+fi
+if [[ "${payload}" == *e+* ]]; then
+  echo "  FAIL payload contains scientific notation"
+  failures=$((failures + 1))
+else
+  echo "  ok   payload contains no scientific notation"
+fi
+
+echo
+if [ "${failures}" -ne 0 ]; then
+  echo "${failures} assertion(s) failed"
+  exit 1
+fi
+echo "all assertions passed"


### PR DESCRIPTION
## What changed

Linux runner jobs charted useless memory and disk graphs. Over a recent two day window roughly 72% of samples in `runner_job_machine_metrics` had `memory_used_bytes = 0`, `memory_total_bytes` was a constant 1997570048 regardless of the job's shape, and both disk fields were pinned at 2147483647. Only 3 distinct memory totals and 2 distinct disk totals existed across the entire fleet, which is implausible for a fleet running several machine shapes.

Two independent defects in `infra/linux-runner-image/metrics-sampler.sh`, both reproduced exactly before any code changed. The server ingest path (`RunnerJobMetricsController` to `Runners.JobMetrics` to `JobMachineMetric`) is `Int64` end to end and needed no change.

## Root cause 1: memory total captured once at sidecar boot

`mem_total_bytes` was read from `/proc/meminfo` a single time, before the wait-for-a-claimed-job loop, and reused for every subsequent sample.

The metrics sidecar starts at Pod boot. At that moment the kata sandbox is still at its default 2 GiB, whose `MemTotal` of 1950752 kB is exactly the 1997570048 bytes the fleet reported. kata then hot-plugs the guest up to the shape's configured memory, but the cached total never moved, so it stayed identical across every machine shape.

`MemAvailable` was read live inside the loop. Once the guest grew past the stale total, `used = total - avail` went negative and the `if (u < 0) u = 0` guard turned it into a permanent 0. The guard converted a visible bug into a silent one, which is why this shipped unnoticed.

This was not a wrong cgroup or namespace. The sidecar's `/proc` view is correct; only the timing of the read was wrong.

## Root cause 2: mawk saturates `printf "%d"` at INT_MAX

The image is Ubuntu 22.04, so `awk` is mawk 1.3.4. Verified against the base image:

```
printf "%d", 107374182400  ->  2147483647
print 67108864 * 1024      ->  6.87195e+10
```

mawk's `d_to_I` saturates any double at or above 2^31 before `%d` formatting, and its bare `print` renders integers above 2^31 through OFMT (`%.6g`) as scientific notation. Every byte-valued field went through one or the other.

That is the exact 2147483647 on both disk fields for any filesystem over 2 GiB. It also silently zeroed network throughput, which had not been reported: cumulative rx/tx both saturate, so every delta after the first 2 GiB read 0.

CPU was unaffected because it is a ratio formatted with `%.1f` and recomputed per sample, which matches the observed symptom of plausible CPU alongside constant memory and disk.

## The fix

`MemTotal` and `MemAvailable` now come from a single pass over `/proc/meminfo` taken per sample. That makes the stale pairing unrepresentable rather than merely corrected: the two values can no longer come from different points in time. The `u < 0` clamp is gone, since from one consistent read it cannot fire, and its only effect was masking.

Byte counters format with `%.0f`, which goes through the C double path and is exact to 2^53. Counter deltas moved to bash's 64-bit arithmetic instead of awk. `df` gains `-P` so the `NR == 2` row stays one line per filesystem.

Sampling logic moved behind functions with a sourced-guard so the test can drive it directly. This also aligns the Linux sampler's shape with the macOS one, which already had `disk_totals` / `metrics_payload` helpers.

## Why not other approaches

Switching the image to gawk would fix the formatting but not the stale total, adds a package to every runner image, and leaves the next `%d` someone writes broken. Keeping `%d` and clamping server side would discard real data. Reading memory from the cgroup instead of `/proc/meminfo` would change what the graph means (container limit rather than guest memory) without fixing the formatting.

## Scope: macOS is genuinely unaffected

`infra/runner-image/metrics-poll.sh` uses the same `printf "%d"` pattern but is correct: macOS ships BWK awk, which handles 64-bit values in both `printf "%d"` and `print`, and Tart VM memory is fixed at boot with no hot-plug, so its hoisted `sysctl -n hw.memsize` is fine. Left alone deliberately.

## Validation

- Reproduced all four production values exactly (`memory_used_bytes` 0, `memory_total_bytes` 1997570048, both disk fields 2147483647) against `ubuntu:22.04` before changing anything.
- New `infra/linux-runner-image/metrics-sampler_test.sh` asserts `memory_total_bytes` tracks the guest across three shape fixtures (2 GiB sandbox, 32 GiB, 64 GiB), that a hot-plugged guest reports its grown total with a non-zero used, and that disk and network counters are neither clamped at INT_MAX nor rendered in scientific notation.
- Run against a shim of the pre-fix logic, the test fails 19 assertions. Against the fix, all pass.
- End to end smoke test of the real script with a stubbed `curl`: memory total tracks actual VM RAM, used is non-zero and varies between samples, disk reports 58.4 GiB, network deltas are real.

## Reviewer notes

- The test runs in CI inside `ubuntu:22.04` rather than on the CI runner. Under gawk or BWK awk every assertion passes no matter what the sampler does, so running it anywhere else would prove nothing. The tag needs to stay in step with the Dockerfile's final `FROM`.
- `metrics-sampler.sh` was also missing from the workflow's `bash -n` list. Added.
- Merging this triggers `release-linux-runner-image`, which builds, pushes, and rewrites the image pins in the managed-env values files. That is intended, since the fix only reaches the fleet via a new image, but it makes this more than a docs-only change.
- Existing rows keep the bad values until the table's 90-day TTL ages them out. No production data was mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
