### PR TITLE
fix(cli): support selective testing with xctestrun artifacts

### DIFF
--- a/cli/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/cli/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -113,6 +113,7 @@ public struct XcodeBuildController: XcodeBuildControlling {
     ) async throws {
         let extraArguments = arguments.flatMap(\.arguments)
         var arguments: [String] = []
+        let usesXCTestRun = action == .testWithoutBuilding && passthroughXcodeBuildArguments.contains("-xctestrun")
 
         // Action
         if clean {
@@ -128,11 +129,13 @@ public struct XcodeBuildController: XcodeBuildControlling {
             arguments.append("test-without-building")
         }
 
-        // Scheme
-        arguments.append(contentsOf: ["-scheme", scheme])
+        if !usesXCTestRun {
+            // Scheme
+            arguments.append(contentsOf: ["-scheme", scheme])
 
-        // Target
-        arguments.append(contentsOf: target.xcodebuildArguments)
+            // Target
+            arguments.append(contentsOf: target.xcodebuildArguments)
+        }
 
         // Arguments
         arguments.append(contentsOf: extraArguments)
@@ -179,7 +182,7 @@ public struct XcodeBuildController: XcodeBuildControlling {
             arguments.append(contentsOf: ["-skip-testing", test.description])
         }
 
-        if let testPlanConfiguration {
+        if let testPlanConfiguration, !usesXCTestRun {
             arguments.append(contentsOf: ["-testPlan", testPlanConfiguration.testPlan])
             for configuration in testPlanConfiguration.configurations {
                 arguments.append(contentsOf: ["-only-test-configuration", configuration])

--- a/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildCommand.swift
+++ b/cli/Sources/TuistKit/Commands/XcodeBuild/XcodeBuildCommand.swift
@@ -18,7 +18,7 @@ public struct XcodeBuildCommand: AsyncParsableCommand, TrackableParsableCommand 
         CommandConfiguration(
             commandName: "xcodebuild",
             abstract:
-            "tuist xcodebuild extends the xcodebuild CLI with server capabilities such as selective testing or analytics.",
+            "tuist xcodebuild extends the xcodebuild CLI with server capabilities such as insights and analytics.",
             subcommands: [
                 XcodeBuildTestCommand.self,
                 XcodeBuildTestWithoutBuildingCommand.self,

--- a/cli/Sources/TuistKit/Services/TestService.swift
+++ b/cli/Sources/TuistKit/Services/TestService.swift
@@ -1224,6 +1224,20 @@ public struct TestService { // swiftlint:disable:this type_body_length
         do {
             for testSchemeRun in testSchemeRuns {
                 let testScheme = testSchemeRun.scheme
+                let xctestrunTestTargets: [TestIdentifier]
+                if action == .testWithoutBuilding,
+                   passthroughXcodeBuildArguments.contains("-xctestrun"),
+                   testSchemeRun.testTargets.isEmpty
+                {
+                    xctestrunTestTargets = try testActionTargetReferences(
+                        scheme: testScheme,
+                        testPlanConfiguration: testPlanConfiguration,
+                        action: action
+                    )
+                    .map { try TestIdentifier(target: $0.name) }
+                } else {
+                    xctestrunTestTargets = testSchemeRun.testTargets
+                }
                 let testSchemeResultBundlePath = schemeResultBundlePath(
                     resultBundlePath,
                     schemeName: testScheme.name,
@@ -1247,7 +1261,7 @@ public struct TestService { // swiftlint:disable:this type_body_length
                         resultBundlePath: testSchemeResultBundlePath,
                         derivedDataPath: derivedDataPath,
                         retryCount: retryCount,
-                        testTargets: testSchemeRun.testTargets,
+                        testTargets: xctestrunTestTargets,
                         skipTestTargets: skipTestTargets,
                         testPlanConfiguration: testPlanConfiguration,
                         passthroughXcodeBuildArguments: passthroughXcodeBuildArguments,

--- a/cli/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
+++ b/cli/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
@@ -486,6 +486,46 @@ struct XcodeBuildControllerTests {
             passthroughXcodeBuildArguments: []
         )
     }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func without_building_with_xctestrun() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let xcworkspacePath = temporaryDirectory.appending(component: "Project.xcworkspace")
+        let xctestrunPath = temporaryDirectory.appending(component: "Project.xctestrun")
+        let target = XcodeBuildTarget.workspace(xcworkspacePath)
+
+        let command = [
+            "/usr/bin/xcrun",
+            "xcodebuild",
+            "test-without-building",
+            "-configuration",
+            "Debug",
+            "-xctestrun",
+            xctestrunPath.pathString,
+            "-only-testing",
+            "ProjectTests",
+        ]
+        commandRunner.succeedCommand(command, output: "output")
+
+        // When
+        try await subject.test(
+            target,
+            scheme: "Project",
+            clean: false,
+            destination: nil,
+            action: .testWithoutBuilding,
+            rosetta: false,
+            derivedDataPath: nil,
+            resultBundlePath: nil,
+            arguments: [.configuration("Debug")],
+            retryCount: 0,
+            testTargets: [try TestIdentifier(target: "ProjectTests")],
+            skipTestTargets: [],
+            testPlanConfiguration: nil,
+            passthroughXcodeBuildArguments: ["-xctestrun", xctestrunPath.pathString]
+        )
+    }
 }
 
 extension AsyncSequence {

--- a/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/TestServiceTests.swift
@@ -6631,6 +6631,34 @@ struct TestServiceSchemePlanningTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedDependencies())
+    func run_without_building_with_xctestrun_forwards_selected_test_targets() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let fixture = TestServiceSchemePlanningFixture(
+            scenario: SchemePlanningScenario(rootDirectory: temporaryDirectory)
+        )
+
+        try await fixture.run(
+            path: temporaryDirectory,
+            action: .testWithoutBuilding,
+            passthroughXcodeBuildArguments: ["-xctestrun", "/tmp/Sample.xctestrun"]
+        )
+
+        #expect(fixture.testRuns == [
+            CapturedTestRun(
+                scheme: "Sample-Workspace",
+                action: .testWithoutBuilding,
+                testTargets: [
+                    try TestIdentifier(target: "AppTests"),
+                    try TestIdentifier(target: "AppSnapshotTests"),
+                    try TestIdentifier(target: "FeatureTests"),
+                ],
+                resultBundlePath: nil,
+                derivedDataPath: nil
+            ),
+        ])
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedDependencies())
     func run_excludes_passthrough_skips_from_invocations_and_hashes() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let scenario = SchemePlanningScenario(rootDirectory: temporaryDirectory)

--- a/server/priv/docs/en/guides/features/selective-testing.md
+++ b/server/priv/docs/en/guides/features/selective-testing.md
@@ -15,6 +15,42 @@ To run tests selectively with your <.localized_link href="/guides/features/proje
 
 `tuist test` integrates directly with the <.localized_link href="/guides/features/cache/module-cache">module cache</.localized_link> to use as many binaries from your local or remote storage to improve the build time when running your test suite. The combination of selective testing with module caching can dramatically reduce the time it takes to run tests on your CI.
 
+## Separate build and test jobs {#separate-build-and-test-jobs}
+
+Selective testing supports separate build and test jobs. If the build job produces an `.xctestrun` file, restore it in the test job and forward it to `tuist test --without-building`:
+
+```sh
+tuist test MyScheme \
+  --without-building \
+  -- \
+  -destination 'platform=iOS Simulator,id=SIMULATOR_IDENTIFIER' \
+  -xctestrun artifacts/MyScheme.xctestrun
+```
+
+Tuist generates the project to determine which test targets changed, then forwards those targets through `-only-testing`. It does not pass a project, workspace, or scheme to `xcodebuild` when `-xctestrun` is present because those input modes are mutually exclusive.
+
+Alternatively, build with `tuist test --build-only` and persist the complete `.xctestproducts` bundle:
+
+```sh
+tuist test MyScheme \
+  --build-only \
+  -- \
+  -testProductsPath artifacts/MyScheme.xctestproducts \
+  -destination 'platform=iOS Simulator,id=SIMULATOR_IDENTIFIER'
+```
+
+In the test job, restore that complete bundle and pass the same path with `--without-building`:
+
+```sh
+tuist test MyScheme \
+  --without-building \
+  -- \
+  -testProductsPath artifacts/MyScheme.xctestproducts \
+  -destination 'platform=iOS Simulator,id=SIMULATOR_IDENTIFIER'
+```
+
+An `.xctestrun` file is the test-run configuration: it identifies the built test bundles and how to launch them. An `.xctestproducts` bundle also contains the built test products and their `.xctestrun` files. Tuist adds the selective-testing graph to that bundle during the build job, letting the test job execute the selected tests without regenerating the project.
+
 > [!WARNING]
 > **Module Vs File-level Granularity**
 >


### PR DESCRIPTION
Selective testing now supports a separate test job that supplies an `.xctestrun` file. Tuist previously combined that file with `-workspace` and `-scheme`, which is an invalid Xcode invocation. The command now treats the test-run file as the input mode, retains compatible configuration, and forwards the selected test targets through `-only-testing`.

The guide explicitly distinguishes an `.xctestrun` execution configuration from an `.xctestproducts` product bundle. It documents both the raw configuration workflow, which still generates the project to select test targets, and the portable bundle workflow, which also persists Tuist's selective-testing graph.

### How to test locally

- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace '-only-testing:TuistAutomationTests/XcodeBuildControllerTests/without_building_with_xctestrun()' '-only-testing:TuistKitTests/TestServiceSchemePlanningTests/run_without_building_with_xctestrun_forwards_selected_test_targets()' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''`
- `mise run cli:lint`
