### PR TITLE
fix(infra): trim the pentest cluster's metrics scraping

### DIFF
--- a/infra/helm/k8s-monitoring/values-pentest.yaml
+++ b/infra/helm/k8s-monitoring/values-pentest.yaml
@@ -1,4 +1,16 @@
 # Monitoring identity for the dedicated pentest workload cluster.
+#
+# This cluster is fixed-duration (see k8s/clusters/README.md) and nothing
+# dashboards it. Every overlay below therefore trims the default scrape set
+# down to the signals that answer "is the cluster broken, is the app broken,
+# is something being blocked" and drops inventory and per-object detail.
+# Logs, cluster events, traces, node_exporter host metrics and the Cilium /
+# Hubble drop counters are all left untouched: those are the ones that carry
+# the engagement's audit trail and network-policy enforcement signal.
+#
+# Helm replaces lists rather than merging them, so each `excludeMetrics`
+# below restates the base entries from values.yaml in full. Dropping one
+# here silently re-admits it.
 k8s-monitoring:
   cluster:
     name: tuist-pentest
@@ -17,3 +29,83 @@ k8s-monitoring:
             - action: insert
               key: deployment.environment
               value: pentest
+
+  clusterMetrics:
+    # kube-state-metrics is the cluster's single largest metrics source
+    # (~2k series of the ~4.7k it ships). The default allow-list is built
+    # for clusters people run dashboards against; here it is mostly
+    # object inventory (replicaset/*, init_container/*, configmap/*,
+    # secret/*, resource requests and limits, node capacity), none of which
+    # is read. Swap it for an explicit workload-health list.
+    kube-state-metrics:
+      metricsTuning:
+        useDefaultAllowList: false
+        includeMetrics:
+          # Pod and container health.
+          - kube_pod_status_phase
+          - kube_pod_status_unschedulable
+          - kube_pod_info
+          - kube_pod_container_status_restarts_total
+          - kube_pod_container_status_last_terminated_reason
+          # Zero series while every container is healthy, and the one that
+          # names CrashLoopBackOff / ImagePullBackOff when one is not.
+          - kube_pod_container_status_waiting_reason
+          # Workload readiness: desired vs actual, per controller kind.
+          - kube_deployment_spec_replicas
+          - kube_deployment_status_replicas_available
+          - kube_daemonset_status_desired_number_scheduled
+          - kube_daemonset_status_number_ready
+          - kube_statefulset_replicas
+          - kube_statefulset_status_replicas_ready
+          - kube_job_status_failed
+          # Node and storage health for the embedded data services.
+          - kube_node_info
+          - kube_node_status_condition
+          - kube_node_spec_unschedulable
+          - kube_persistentvolumeclaim_status_phase
+
+    cadvisor:
+      metricsTuning:
+        excludeMetrics:
+          # Base entries from values.yaml.
+          - container_memory_cache
+          - container_memory_rss
+          - container_memory_swap
+          - container_memory_usage_bytes
+          # Per-container disk and network counters, ~620 series across the
+          # five nodes. Host-level equivalents already arrive from
+          # node_exporter, and packet-level attack signal comes from the
+          # Hubble and Cilium drop counters, not from these byte totals.
+          # container_cpu_usage_seconds_total and
+          # container_memory_working_set_bytes stay: they are what shows a
+          # container being driven into resource exhaustion by a test.
+          - container_fs_.*
+          - container_network_.*
+
+  annotationAutodiscovery:
+    metricsTuning:
+      excludeMetrics:
+        # Base entries from values.yaml.
+        - cilium_event_ts
+        - cilium_bpf_map_capacity
+        - cilium_bpf_map_pressure
+        - cilium_bpf_map_ops_total
+        - cilium_agent_bootstrap_seconds
+        - cilium_api_limiter_.*
+        - cilium_k8s_client_.*
+        - cilium_triggers_.*
+        - cilium_controllers_.*
+        - cilium_datapath_.*
+        - cilium_policy_endpoint_enforcement_status
+        - go_.*
+        - tuist_prom_ex_phoenix_http_response_size_bytes_bucket
+        # Request-latency buckets fan out by route, method and status, and
+        # an assessment walks routes and status codes that production never
+        # sees, so this is ~600 series here against ~1.5k across all of
+        # production. Nobody does latency work on this cluster. The _count
+        # and _sum series stay, so request rate, error rate and mean
+        # latency all survive.
+        - tuist_prom_ex_phoenix_http_request_duration_milliseconds_bucket
+        # Cilium's Envoy listener histograms, ~140 series of proxy
+        # internals with no dashboard or alert behind them.
+        - envoy_listener_.*


### PR DESCRIPTION
> Describe here the purpose of your PR.

The pentest cluster inherited the full default scrape set. [values-pentest.yaml](https://github.com/tuist/tuist/blob/main/infra/helm/k8s-monitoring/values-pentest.yaml) only overrode the cluster name and env labels, so a five-node, fixed-duration cluster that nothing dashboards was shipping production-grade observability.

That made it the largest single new source behind the Grafana Cloud "Anomaly: Metrics Usage" alert that fired on 2026-09-01: ~4.75k of the stack's ~118k active series, up from zero before the cluster came online on 2026-08-26. (The other two contributors to that anomaly are expected and not addressed here: the node count going 56 to 67 as the OVH bare-metal Linux fleet landed, and server-side metric additions in the `tuist` and `kura` namespaces.)

### What changed

Three sources trimmed, each sized by querying the live series it removes:

| Source | Before | After | Saved |
|---|---|---|---|
| kube-state-metrics | 1,999 | 558 | −1,441 |
| cAdvisor (`container_fs_*`, `container_network_*`) | — | — | −624 |
| Autodiscovery (Phoenix latency buckets, `envoy_listener_*`) | — | — | −852 |
| **Cluster total** | **4,754** | **~1,837** | **−61%** |

Stack-wide that is ~118k to ~115k active series.

- **kube-state-metrics** swaps the default allow-list for an explicit workload-health list. The default is built for clusters people run dashboards against; here it was mostly object inventory. Dropped: `kube_replicaset_*` (232 series, redundant with the deployment-level series), `kube_pod_init_container_*` (186), configmap and secret resource-version inventory (122), resource requests and limits, node capacity/allocatable.
- **cAdvisor** drops per-container disk and network counters. Host-level equivalents already arrive from node_exporter. `container_cpu_usage_seconds_total` and `container_memory_working_set_bytes` stay, since those are what show a container being driven into resource exhaustion by a test.
- **Autodiscovery** drops the Phoenix request-latency buckets and Cilium's Envoy listener histograms. The latency `_count` and `_sum` series stay, so request rate, error rate and mean latency all survive; only percentiles and heatmaps go.

### What is deliberately kept

Everything that says "broken" or "under attack": pod phase, container restarts, waiting and last-terminated reasons, deployment/daemonset/statefulset readiness, node conditions and cordon state, PVC phase, per-container CPU and memory working set.

Untouched entirely: cluster events, pod logs, node logs, traces, node_exporter host metrics, and the Hubble and Cilium drop counters. Those carry the engagement's audit trail, and network-policy enforcement is itself under test on this cluster (see `pentest-networkpolicy.yaml`).

An earlier revision of the allow-list kept 553 series but dropped `kube_pod_container_status_waiting_reason`. That one costs zero series while every container is healthy and is the metric that names CrashLoopBackOff or ImagePullBackOff when one is not, so it went back in along with `kube_node_spec_unschedulable`, for +5 series.

### Reviewer note

Helm replaces lists rather than merging them, so both `excludeMetrics` blocks restate the base entries from `values.yaml` in full. Deleting one of those repeated lines silently re-admits the metric rather than erroring, which is why the file calls it out at the top.

### How to test locally

```
cd infra/helm/k8s-monitoring
helm dependency build
helm template k8s-monitoring . -n observability -f values-pentest.yaml
```

Rendering the chart against the pre-change and post-change values produces configs that differ in exactly three relabel rules and nothing else:

- the autodiscovery drop regex gains `tuist_prom_ex_phoenix_http_request_duration_milliseconds_bucket|envoy_listener_.*`
- the cAdvisor drop regex gains `container_fs_.*|container_network_.*`
- the kube-state-metrics keep regex narrows to the explicit list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
