### PR TITLE
fix(server): add spacing above the test failure card divider

### DIFF
--- a/server/assets/app/css/pages/test_run.css
+++ b/server/assets/app/css/pages/test_run.css
@@ -936,6 +936,7 @@
     & > [data-part="content"] {
       display: flex;
       flex-direction: column;
+      margin-top: var(--noora-spacing-5);
       border-top: 1px solid var(--noora-surface-border-primary);
       padding: var(--noora-spacing-5);
 


### PR DESCRIPTION
Expanded test failure cards on the test run page rendered their divider flush against the header text, with no breathing room between the module and suite subtitle and the line separating it from the failure body.

### What changed

Added `margin-top: var(--noora-spacing-5)` to the collapsible content pane of `.test-failure-card` in `server/assets/app/css/pages/test_run.css`.

### Root cause

The content pane already carried `border-top` plus `padding: var(--noora-spacing-5)`. Padding sits inside the border, so it only spaced the failure body away from the divider. Nothing spaced the divider away from the trigger header above it, leaving the line 0px below the subtitle while the body below it was inset by 12px. The asymmetry read as missing padding under the header.

### Why this solution

Adding a top margin to the content pane is the smallest change that balances the divider, and it applies only when the card is expanded since the closed state is `display: none`. Adding `padding-bottom` to the trigger instead would have needed an extra `[data-state="open"]` guard to avoid padding the collapsed header, and moving the border onto the trigger would have split a single visual seam across two rules.

### Impact

The same rule backs both the failures overview card and the failures tab of the test run page, so both get the corrected spacing. No markup or behavior changes.

### How to test locally

Open any test run with failures, for example a run under `/tuist/tuist/tests/test-runs/`, and expand a failure card. The divider under the test name and suite subtitle now sits 12px below the header text and 12px above the first failure row, instead of hugging the subtitle.

Validated by rendering the card markup against the real rule block and the Noora tokens, then measuring both gaps in the browser. Before: 0px above the divider, 13px below. After: 12px above, 13px below.

Prettier confirms the changed file still matches the project CSS property order.