### PR TITLE
fix(cli): only suppress vendor module maps for direct links that survive generation

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -44,7 +44,8 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
         var sideEffects: [SideEffectDescriptor] = []
         let graphTraverser = GraphTraverser(graph: graph)
         let unconditionallyDirectlyLinkedXCFrameworkPaths = Self.unconditionallyDirectlyLinkedXCFrameworkPaths(
-            in: [graph, environment.initialGraphWithSources].compactMap { $0 }
+            in: graph,
+            initialGraphWithSources: environment.initialGraphWithSources
         )
 
         let graph = try await mapGraph(
@@ -250,18 +251,36 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
     /// visible to the target graph, so adding the same vendor module map from a dynamic route would define the module
     /// twice. A platform-qualified direct dependency cannot prove that it covers the dynamic route. The original graph
     /// is retained in the mapper environment before binary-cache replacement, which can otherwise remove the direct
-    /// dependency from the graph being generated.
-    private static func unconditionallyDirectlyLinkedXCFrameworkPaths(in graphs: [Graph]) -> Set<AbsolutePath> {
-        var paths = Set<AbsolutePath>()
-        for graph in graphs {
-            for (source, dependencies) in graph.dependencies {
-                guard case .target = source else { continue }
-                for dependency in dependencies {
-                    guard graph.dependencyConditions[(source, dependency)] == nil,
-                          case let .xcframework(xcframework) = dependency
-                    else { continue }
-                    paths.insert(xcframework.path)
+    /// dependency from the graph being generated. Only the targets that survive into the generated projects count
+    /// there: a target replaced by a cached binary, or dropped by tree shaking, no longer references the xcframework,
+    /// so Xcode never produces the copy that would define the module.
+    private static func unconditionallyDirectlyLinkedXCFrameworkPaths(
+        in graph: Graph,
+        initialGraphWithSources: Graph?
+    ) -> Set<AbsolutePath> {
+        var paths = unconditionallyDirectlyLinkedXCFrameworkPaths(in: graph)
+        if let initialGraphWithSources {
+            paths.formUnion(
+                unconditionallyDirectlyLinkedXCFrameworkPaths(in: initialGraphWithSources) { name, path in
+                    graph.projects[path]?.targets[name] != nil
                 }
+            )
+        }
+        return paths
+    }
+
+    private static func unconditionallyDirectlyLinkedXCFrameworkPaths(
+        in graph: Graph,
+        isGenerated: (String, AbsolutePath) -> Bool = { _, _ in true }
+    ) -> Set<AbsolutePath> {
+        var paths = Set<AbsolutePath>()
+        for (source, dependencies) in graph.dependencies {
+            guard case let .target(name, path, _) = source, isGenerated(name, path) else { continue }
+            for dependency in dependencies {
+                guard graph.dependencyConditions[(source, dependency)] == nil,
+                      case let .xcframework(xcframework) = dependency
+                else { continue }
+                paths.insert(xcframework.path)
             }
         }
         return paths

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -356,6 +356,162 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         XCTAssertBetterEqual([], gotSideEffects)
     }
 
+    func test_map_when_static_xcframework_library_was_linked_directly_by_a_binary_cache_replaced_target() async throws {
+        // Given
+        let projectPath = try temporaryPath()
+            .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
+        let googleMapsPath = projectPath
+            .parentDirectory
+            .appending(component: "GoogleMaps.xcframework")
+        let googleMapsHeadersPath = googleMapsPath.appending(components: "ios-arm64", "Headers")
+        try await fileSystem.makeDirectory(at: googleMapsHeadersPath)
+        try await fileSystem.writeText(
+            "modulemap",
+            at: googleMapsHeadersPath.appending(component: "module.modulemap")
+        )
+        try await fileSystem.writeText(
+            """
+            #import <GoogleMaps/GMSIndoorBuilding.h>
+            #import <GoogleMaps/GMSIndoorLevel.h>
+            """,
+            at: googleMapsHeadersPath.appending(component: "GoogleMaps.h")
+        )
+
+        let derivedDirectory = projectPath.appending(
+            components: [
+                Constants.tuistDirectoryName,
+                Constants.SwiftPackageManager.packageBuildDirectoryName,
+                Constants.DerivedDirectory.dependenciesDerivedDirectory,
+                Constants.DerivedDirectory.dependenciesXCFrameworkDirectory,
+            ]
+        )
+
+        let googleMaps: GraphDependency = .testXCFramework(
+            path: googleMapsPath,
+            infoPlist: .test(
+                libraries: [
+                    .test(
+                        path: try RelativePath(validating: "GoogleMaps.a")
+                    ),
+                ]
+            ),
+            linking: .static,
+            moduleMaps: [
+                googleMapsHeadersPath.appending(component: "module.modulemap"),
+            ]
+        )
+        let cachedLibrary: GraphDependency = .testXCFramework(
+            path: try temporaryPath()
+                .appending(component: "Library.xcframework")
+        )
+        let graphWithSources: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(name: "App"),
+                        .test(name: "Library"),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "App", path: projectPath): [
+                    .target(name: "Library", path: projectPath),
+                ],
+                .target(name: "Library", path: projectPath): [
+                    googleMaps,
+                ],
+            ]
+        )
+        let graphWithBinaryCache: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(name: "App"),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "App", path: projectPath): [
+                    cachedLibrary,
+                ],
+                cachedLibrary: [
+                    googleMaps,
+                ],
+            ]
+        )
+        var environment = MapperEnvironment()
+        environment.initialGraphWithSources = graphWithSources
+
+        var expectedGraph = graphWithBinaryCache
+        expectedGraph.projects = [
+            projectPath: .test(
+                path: projectPath,
+                targets: [
+                    .test(
+                        name: "App",
+                        settings: .test(
+                            base: [
+                                "OTHER_SWIFT_FLAGS": [
+                                    "-Xcc",
+                                    "-fmodule-map-file=\"$(SRCROOT)/Tuist/.build/tuist-derived/XCFrameworks/GoogleMaps/Headers/module.modulemap\"",
+                                ],
+                                "OTHER_C_FLAGS": [
+                                    "-fmodule-map-file=\"$(SRCROOT)/Tuist/.build/tuist-derived/XCFrameworks/GoogleMaps/Headers/module.modulemap\"",
+                                ],
+                                "HEADER_SEARCH_PATHS": [
+                                    "\"$(SRCROOT)/Tuist/.build/tuist-derived/XCFrameworks/GoogleMaps/Headers\"",
+                                ],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+        ]
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try await subject.map(
+            graph: graphWithBinaryCache,
+            environment: environment
+        )
+
+        // Then
+        XCTAssertBetterEqual(expectedGraph, gotGraph)
+        XCTAssertBetterEqual(
+            [
+                .directory(
+                    DirectoryDescriptor(path: derivedDirectory.appending(components: "GoogleMaps", "Headers"))
+                ),
+                .file(
+                    FileDescriptor(
+                        path: derivedDirectory.appending(components: "GoogleMaps", "Headers", "module.modulemap"),
+                        contents: "modulemap".data(using: .utf8)
+                    )
+                ),
+                .file(
+                    FileDescriptor(
+                        path: derivedDirectory.appending(components: "GoogleMaps", "Headers", "GoogleMaps.h"),
+                        contents: """
+                        #import <GMSIndoorBuilding.h>
+                        #import <GMSIndoorLevel.h>
+                        """.data(using: .utf8)
+                    )
+                ),
+            ],
+            gotSideEffects
+        )
+    }
+
     func test_map_when_static_xcframework_library_is_linked_directly_for_other_platforms() async throws {
         // Given
         let projectPath = try temporaryPath()


### PR DESCRIPTION
Unbreaks the `generated_macos_tool_with_cached_nested_header_xcframework` acceptance test, which has failed on every `main` run since #12745 landed (the shard it lands in moves between runs, so it shows up as `Acceptance Tests (0)` or `Acceptance Tests (1)`).

## What changed

`StaticXCFrameworkModuleMapGraphMapper` collects the xcframeworks that are unconditionally linked directly, and suppresses the vendor module map for them. #12745 widened that collection to also scan `environment.initialGraphWithSources` — the graph preserved before binary-cache replacement. This restricts the preserved graph's contribution to direct links made by targets that are still present in the generated projects.

## Why

The suppression exists because Xcode runs `ProcessXCFramework` for every unconditionally direct xcframework and copies its headers into `$(BUILT_PRODUCTS_DIR)/include`. Adding the vendor module map on top of that copy defines the module twice.

Counting every target in the preserved graph breaks that premise. A target replaced by its cached binary, or dropped by tree shaking, no longer references the xcframework in the generated project, so Xcode never produces the copy. The mapper suppressed the module map anyway, and nothing defined the module.

## Root cause

In the fixture the failure hits exactly that shape: `Library` directly links `NestedObjC.xcframework` and `NestedObjCKit.xcframework`, and `Library` is the target `tuist cache` replaces. `Tool` then reaches both only behind `Library.xcframework`. After #12745, `Library`'s direct links were read out of the preserved graph and the module maps were skipped, so building `Tool` failed with:

```
Tool/Sources/main.swift:1:8: error: missing required modules: 'NestedObjC', 'NestedObjCKit'
```

`ToolLinkingXCFrameworksDirectly` kept passing because it links the two xcframeworks itself and survives generation, so Xcode really does process them.

## Why this solution

The alternative was reverting #12745. That case is real: an app target that directly links a static xcframework and also reaches it behind a cached dynamic xcframework can have its direct edge moved by the cache mapper, and the preserved graph is the only place that link still shows. Requiring the linking target to survive into the generated projects separates the two cases precisely — #12745's target is still generated, this one is replaced — and keeps that fix working. The mapper runs after `TreeShakePrunedTargetsGraphMapper`, so `graph.projects[path]?.targets[name]` is an accurate answer to "will Xcode see this reference".

## Impact

Binary-cache generation restores module visibility for static Objective-C xcframeworks whose only remaining route is behind a cached dynamic xcframework. No change for graphs where the direct link survives.

## Validation

- Manual reproduction on the fixture with a locally built `tuist`: `missing required modules` before the change, `** BUILD SUCCEEDED **` after, for both the `Tool` and `ToolLinkingXCFrameworksDirectly` schemes.
- `xcodebuild test-without-building -workspace Tuist.xcworkspace -scheme TuistCacheEEAcceptanceTests -destination "platform=macOS" -skip-testing TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests` — 15 tests, all pass, including both nested-header tests.
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistKitTests/StaticXCFrameworkModuleMapGraphMapperTests` — 23 tests pass, including the one #12745 added and a new one covering this scenario. The new test was confirmed to fail against unmodified `main`.
- `mise x -- swiftformat ... --lint` clean; `swiftlint` reports only warnings that already existed on that file.

### How to test locally

```
tuist cache Library --path examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework
tuist generate --no-open --path examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework Tool
xcodebuild build -project examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/NestedHeaderXCFramework.xcodeproj -scheme Tool CODE_SIGNING_ALLOWED=NO
```

On `main` the last step fails with `missing required modules: 'NestedObjC', 'NestedObjCKit'`; with this change it builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
