### PR TITLE
ci(infra): add a runner cache volume reset workflow

### DIFF
--- a/.github/workflows/runner-cache-reset.yml
+++ b/.github/workflows/runner-cache-reset.yml
@@ -1,0 +1,79 @@
+name: Runner Cache Volume Reset
+
+# Reclaims space on this account's runner cache volume.
+#
+# Runner jobs mount a per-account cache image cloned from the account's master.
+# Only the binary cache and the folded compilation cache are bounded by a byte
+# budget; the rest of the volume grows against a fixed reserve. Once that reserve
+# is gone the image reaches ENOSPC, and because the CLI writes to the volume on
+# the load path of every command, jobs then fail at their first command rather
+# than merely running cold. Nothing on the job path reclaims those bytes, and a
+# failing job never promotes a replacement master, so the account stays wedged
+# until an image with headroom is promoted from a job that passed.
+#
+# This job is that job. It touches the volume with plain shell and never through
+# the Tuist CLI, which would itself fail on a full volume, then exits 0 so
+# teardown measures the smaller image, promotes it as the account's new master
+# and publishes the HEAD the rest of the fleet converges to. Hosts converge in
+# the background after materializing, so expect one more failed job per host that
+# is still holding the old master.
+
+on:
+  workflow_dispatch:
+    inputs:
+      drop-binaries:
+        description: "Also drop the binary cache. Only needed when dropping everything else did not free enough; the next builds recompile from source."
+        type: boolean
+        default: false
+  # Bootstrap trigger, and the self-test for edits to this file: workflow_dispatch
+  # is only offered for workflows that already exist on the default branch.
+  pull_request:
+    paths:
+      - ".github/workflows/runner-cache-reset.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  reset:
+    name: Reset the cache volume
+    runs-on: tuist-macos
+    timeout-minutes: 15
+    steps:
+      - name: Reclaim space on the cache volume
+        env:
+          DROP_BINARIES: ${{ inputs.drop-binaries }}
+        run: |
+          set -euo pipefail
+          volume="$HOME/.tuist-cache-volume"
+          if [ ! -d "$volume" ]; then
+            echo "No cache volume is mounted at $volume; nothing to reset."
+            exit 0
+          fi
+
+          echo "::group::Before"
+          df -h "$volume"
+          du -sh "$volume"/* "$volume"/tuist/* 2>/dev/null | sort -h || true
+          echo "::endgroup::"
+
+          # The folded Xcode compilation cache is the largest reclaimable subtree,
+          # and its contents are republished from the remote cache on the next build.
+          rm -rf "$volume/CompilationCache.noindex"
+          # Result bundles are deleted once their analytics upload succeeds, so what
+          # is left here leaked from runs that failed or were cancelled.
+          rm -rf "$volume/tuist/Runs"
+          # Memoized manifests, compiled helpers and generated projects, all of which
+          # the next command recomputes.
+          rm -rf "$volume/tuist/Manifests" \
+                 "$volume/tuist/ProjectDescriptionHelpers" \
+                 "$volume/tuist/EditProjects" \
+                 "$volume/tuist/Projects" \
+                 "$volume/tuist/GenerationMetadata"
+
+          if [ "${DROP_BINARIES:-false}" = "true" ]; then
+            rm -rf "$volume/tuist/Binaries"
+          fi
+
+          echo "::group::After"
+          df -h "$volume"
+          echo "::endgroup::"


### PR DESCRIPTION
## Why

The `tuist` account's runner cache-volume master (`runner_volume_heads` generation 589, promoted 2026-09-02 07:35Z) is ~100% full. Every macOS job clones it and dies at its first cache write:

```
✖ Error
  Failed to create temp file in '/Users/runner/.tuist-cache-volume/tuist/Manifests': No space left on device (errno=28)
```

The account cannot recover on its own. A master is only replaced by a job that promotes one, promotion requires `rc == 0`, and every job fails — so the full image stays the master indefinitely. And there is no reset capability anywhere: the only functions that mutate `runner_volume_heads` are `establish_first_head/4`, `fast_forward_head/5` and `retire_unverifiable_head/5`, none of which clears or rewinds a HEAD, and the two prune workers explicitly refuse to delete the object the current HEAD points at.

The obvious manual fixes make it worse:

- `DELETE FROM runner_volume_heads` for the account permanently splits the fleet. A host still holding generation 589 materializes warm, reports base 589 against a `nil` HEAD, is rejected by the fast-forward pre-flight and can never publish; if a cold host meanwhile establishes generation 1, the 589 host skips convergence forever because its local generation is higher.
- Setting `casGib: 0` does strip the compilation cache at teardown, but that runs inside the VM's copy-on-write branch, which is discarded when the job failed. It is also fleet-wide, and in the meantime it raises `TUIST_CACHE_MAX_BYTES` from 7 GiB to 16 GiB while the stale CAS bytes are still in the image.
- Raising `masterCapGib` does nothing: promoted masters are cloned byte-for-byte, so an existing 20 GiB image stays 20 GiB.

## What this does

A job on `tuist-macos` that reclaims space on the mounted volume with plain shell and exits 0. It deliberately runs no Tuist command, since the CLI writes to the volume on the load path of every command and would fail before reaching the cleanup.

That satisfies every promote gate — `rc == 0`, changed inventory, clean detach, measurable settled image, fill under the ceiling — so teardown promotes the smaller image as the account's new master and publishes the HEAD the rest of the fleet converges to.

It drops the folded compilation cache (the largest reclaimable subtree, republished from the remote cache on the next build), leaked result bundles under `Runs`, and the memoized manifests, compiled helpers and generated projects. The binary cache is kept, since it is the expensive part and it is already bounded by its own byte budget; `drop-binaries` is there for the case where the rest is not enough.

## Expected behaviour after it runs

Hosts converge in the background *after* materializing, so a host still holding the old master will materialize it once more, fail that job, and only then converge. Expect one more failed job per stale host. Check `runner_volume_heads.generation` for the account rather than reading those failures as the reset not landing.

## The pull_request trigger

`workflow_dispatch` is only offered for workflows that already exist on the default branch, so the first run has to come from a PR. The trigger is scoped to this file's own path, so after merge it fires only when this workflow is edited, which doubles as its self-test. `workflow_dispatch` is the interface from then on.

Related: https://github.com/tuist/tuist/pull/12758 stops a full volume from failing commands, and stops a full image from becoming the master in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)