### PR TITLE
feat(cli): make Kura cache routing the default

### DIFF
--- a/cli/Sources/TuistKit/Mappers/Factories/ProjectMapperFactory.swift
+++ b/cli/Sources/TuistKit/Mappers/Factories/ProjectMapperFactory.swift
@@ -106,8 +106,8 @@ public struct ProjectMapperFactory: ProjectMapperFactorying {
         mappers.append(IDETemplateMacrosMapper())
 
         // Xcode cache settings. The `kura` client feature flag selects the CAS
-        // plugin + machine-wide proxy; without it, the legacy per-project daemon
-        // path (COMPILATION_CACHE_REMOTE_SERVICE_PATH) is used.
+        // plugin + machine-wide proxy; disabling it falls back to the legacy
+        // per-project daemon path (COMPILATION_CACHE_REMOTE_SERVICE_PATH).
         mappers.append(XcodeCacheSettingsProjectMapper(
             tuist: tuist,
             kuraEnabled: ClientFeatureFlags.contains("kura"),

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -307,8 +307,9 @@ struct SetupCacheCommandService {
         }
 
         // The `kura` client feature flag selects the machine-wide CAS proxy +
-        // plugin. Without it, accounts stay on the legacy per-project cache daemon
-        // they rely on today, until they are migrated to kura.
+        // plugin. It is on unless `TUIST_FEATURE_FLAG_KURA` is set to a falsey
+        // value, which puts the machine back on the legacy per-project cache
+        // daemon.
         let kuraEnabled = ClientFeatureFlags.contains("kura")
         if kuraEnabled {
             // Register BEFORE starting the proxy. The proxy

--- a/cli/Sources/TuistServer/ClientFeatureFlags.swift
+++ b/cli/Sources/TuistServer/ClientFeatureFlags.swift
@@ -9,6 +9,12 @@ public enum ClientFeatureFlags {
 
     private static let environmentPrefix = "TUIST_FEATURE_FLAG_"
 
+    /// Feature flags that are on unless a `TUIST_FEATURE_FLAG_<NAME>` variable
+    /// turns them off.
+    static let defaultEnabled: Set<String> = ["KURA"]
+
+    private static let disablingValues: Set<String> = ["", "0", "false", "no", "off"]
+
     public static func headerValue(environment: Environmenting = Environment.current) -> String? {
         let featureFlags = featureFlags(environment: environment)
         return featureFlags.isEmpty ? nil : featureFlags.joined(separator: ",")
@@ -24,26 +30,35 @@ public enum ClientFeatureFlags {
     }
 
     /// The raw `TUIST_FEATURE_FLAG_*` variables, for forwarding the client
-    /// feature flags to a process that does not inherit the environment.
+    /// feature flags to a process that does not inherit the environment. The
+    /// default-enabled flags do not travel here; the receiving process derives
+    /// them from `defaultEnabled` itself.
     public static func environmentVariables(environment: Environmenting = Environment.current) -> [String: String] {
         environment.variables.filter { $0.key.hasPrefix(environmentPrefix) }
     }
 
     static func featureFlags(environment: Environmenting = Environment.current) -> [String] {
-        Array(
-            Set(
-                environment.variables.compactMap { variable in
-                    featureName(from: variable.key)
+        environment.variables
+            .reduce(into: defaultEnabled) { featureFlags, variable in
+                guard let featureName = featureName(from: variable.key) else { return }
+
+                if isEnabling(variable.value) {
+                    featureFlags.insert(featureName)
+                } else {
+                    featureFlags.remove(featureName)
                 }
-            )
-        )
-        .sorted()
+            }
+            .sorted()
     }
 
     static func featureName(from variableName: String) -> String? {
         guard variableName.hasPrefix(environmentPrefix) else { return nil }
 
         let featureName = String(variableName.dropFirst(environmentPrefix.count))
-        return featureName.isEmpty ? nil : featureName
+        return featureName.isEmpty ? nil : featureName.uppercased()
+    }
+
+    private static func isEnabling(_ value: String) -> Bool {
+        !disablingValues.contains(value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
     }
 }

--- a/cli/Tests/TuistCASTests/CacheURLStoreTests.swift
+++ b/cli/Tests/TuistCASTests/CacheURLStoreTests.swift
@@ -331,9 +331,10 @@
         }
 
         @Test(.withMockedEnvironment())
-        func separates_cached_endpoints_when_kura_feature_flag_is_enabled() async throws {
+        func separates_cached_endpoints_by_kura_feature_flag() async throws {
             // Given
             let serverURL = URL(string: "https://tuist.dev")!
+            Environment.mocked?.variables["TUIST_FEATURE_FLAG_KURA"] = "0"
             let defaultEndpoint = "https://cache.example.com"
             let kuraEndpoint = "https://kura-cache.example.com"
             let kuraGetCacheEndpoints = MockGetCacheEndpointsServicing()

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -624,14 +624,16 @@ struct SetupCacheCommandServiceTests {
         .inTemporaryDirectory,
         .withMockedEnvironment(),
         .withMockedLogger()
-    ) func setupCache_withoutKuraFlag_installsLegacyDaemon() async throws {
-        // Given: no TUIST_FEATURE_FLAG_KURA, so setup takes the legacy per-project
-        // daemon path that every not-yet-migrated account still runs. The kura
-        // backwards-compat promise rests on this branch, so pin its behaviour.
+    ) func setupCache_withKuraDisabled_installsLegacyDaemon() async throws {
+        // Given: TUIST_FEATURE_FLAG_KURA turned off, so setup takes the legacy
+        // per-project daemon path that every not-yet-migrated account still runs.
+        // The kura backwards-compat promise rests on this branch, so pin its
+        // behaviour.
         let environment = try #require(Environment.mocked)
         environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
         let token = "test-auth-token-123"
         environment.variables[Constants.EnvironmentVariables.token] = token
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "0"
 
         let config = Tuist.test(
             fullHandle: "organization/project",
@@ -658,7 +660,10 @@ struct SetupCacheCommandServiceTests {
                     Constants.URLs.production.absoluteString,
                     "--no-upload",
                 ]),
-                environmentVariables: .value(["TUIST_TOKEN": token])
+                environmentVariables: .value([
+                    "TUIST_TOKEN": token,
+                    "TUIST_FEATURE_FLAG_KURA": "0",
+                ])
             )
             .called(1)
         verify(cacheSocketService)

--- a/cli/Tests/TuistServerTests/Client/ClientFeatureFlagsTests.swift
+++ b/cli/Tests/TuistServerTests/Client/ClientFeatureFlagsTests.swift
@@ -4,7 +4,7 @@ import TuistEnvironment
 @testable import TuistServer
 
 struct ClientFeatureFlagsTests {
-    @Test func header_value_is_nil_when_no_feature_flags_are_present() async {
+    @Test func header_value_carries_the_default_enabled_flags_when_no_variable_is_set() async {
         let environment = Environment(
             variables: [
                 "TUIST_TOKEN": "token",
@@ -17,7 +17,66 @@ struct ClientFeatureFlagsTests {
             ClientFeatureFlags.headerValue()
         }
 
+        #expect(headerValue == "KURA")
+    }
+
+    @Test func kura_is_enabled_when_no_variable_is_set() async {
+        let environment = Environment(variables: [:], arguments: [])
+
+        let containsKura = await Environment.$current.withValue(environment) {
+            ClientFeatureFlags.contains("kura")
+        }
+
+        #expect(containsKura)
+    }
+
+    @Test(arguments: ["0", "false", "FALSE", "no", "", " 0 "])
+    func a_falsey_value_disables_a_default_enabled_flag(value: String) async {
+        let environment = Environment(
+            variables: [
+                "TUIST_FEATURE_FLAG_KURA": value,
+            ],
+            arguments: []
+        )
+
+        let (containsKura, headerValue) = await Environment.$current.withValue(environment) {
+            (ClientFeatureFlags.contains("kura"), ClientFeatureFlags.headerValue())
+        }
+
+        #expect(containsKura == false)
         #expect(headerValue == nil)
+    }
+
+    @Test(arguments: ["1", "true", "yes", "enabled"])
+    func a_truthy_value_enables_a_flag(value: String) async {
+        let environment = Environment(
+            variables: [
+                "TUIST_FEATURE_FLAG_KURA": value,
+            ],
+            arguments: []
+        )
+
+        let (containsKura, headerValue) = await Environment.$current.withValue(environment) {
+            (ClientFeatureFlags.contains("kura"), ClientFeatureFlags.headerValue())
+        }
+
+        #expect(containsKura)
+        #expect(headerValue == "KURA")
+    }
+
+    @Test func a_falsey_value_disables_a_flag_declared_in_lowercase() async {
+        let environment = Environment(
+            variables: [
+                "TUIST_FEATURE_FLAG_kura": "0",
+            ],
+            arguments: []
+        )
+
+        let containsKura = await Environment.$current.withValue(environment) {
+            ClientFeatureFlags.contains("kura")
+        }
+
+        #expect(containsKura == false)
     }
 
     @Test func header_value_encodes_feature_flags_as_a_comma_separated_list() async {
@@ -34,18 +93,79 @@ struct ClientFeatureFlagsTests {
             ClientFeatureFlags.headerValue()
         }
 
-        #expect(headerValue == "A,B")
+        #expect(headerValue == "A,B,KURA")
+    }
+
+    @Test func a_falsey_value_disables_only_the_flag_it_names() async {
+        let environment = Environment(
+            variables: [
+                "TUIST_FEATURE_FLAG_KURA": "0",
+                "TUIST_FEATURE_FLAG_A": "1",
+            ],
+            arguments: []
+        )
+
+        let headerValue = await Environment.$current.withValue(environment) {
+            ClientFeatureFlags.headerValue()
+        }
+
+        #expect(headerValue == "A")
     }
 
     @Test func contains_matches_feature_flags_case_insensitively() async {
         let environment = Environment(
             variables: [
-                "TUIST_FEATURE_FLAG_KURA": "1",
+                "TUIST_FEATURE_FLAG_EXPERIMENT": "1",
             ],
             arguments: []
         )
 
-        let containsKura = await Environment.$current.withValue(environment) {
+        let containsExperiment = await Environment.$current.withValue(environment) {
+            ClientFeatureFlags.contains("experiment")
+        }
+
+        #expect(containsExperiment)
+    }
+
+    @Test func environment_variables_forward_an_opt_out_to_processes_that_do_not_inherit_the_environment() async {
+        let environment = Environment(
+            variables: [
+                "TUIST_FEATURE_FLAG_KURA": "0",
+                "TUIST_TOKEN": "token",
+            ],
+            arguments: []
+        )
+
+        let variables = await Environment.$current.withValue(environment) {
+            ClientFeatureFlags.environmentVariables()
+        }
+
+        #expect(variables == ["TUIST_FEATURE_FLAG_KURA": "0"])
+
+        let forwarded = Environment(variables: variables, arguments: [])
+        let containsKura = await Environment.$current.withValue(forwarded) {
+            ClientFeatureFlags.contains("kura")
+        }
+
+        #expect(containsKura == false)
+    }
+
+    @Test func a_process_that_inherits_no_variables_computes_the_same_defaults() async {
+        let environment = Environment(
+            variables: [
+                "TUIST_TOKEN": "token",
+            ],
+            arguments: []
+        )
+
+        let variables = await Environment.$current.withValue(environment) {
+            ClientFeatureFlags.environmentVariables()
+        }
+
+        #expect(variables.isEmpty)
+
+        let forwarded = Environment(variables: variables, arguments: [])
+        let containsKura = await Environment.$current.withValue(forwarded) {
             ClientFeatureFlags.contains("kura")
         }
 

--- a/cli/Tests/TuistServerTests/Client/ServerClientFeatureFlagsHeadersMiddlewareTests.swift
+++ b/cli/Tests/TuistServerTests/Client/ServerClientFeatureFlagsHeadersMiddlewareTests.swift
@@ -14,6 +14,48 @@ struct ServerClientFeatureFlagsHeadersMiddlewareTests {
             ],
             arguments: []
         )
+
+        let headerValue = try await headerValue(environment: environment)
+
+        #expect(headerValue == "A,KURA")
+    }
+
+    @Test func adds_the_default_enabled_feature_flags_when_no_variable_is_set() async throws {
+        let environment = Environment(variables: [:], arguments: [])
+
+        let headerValue = try await headerValue(environment: environment)
+
+        #expect(headerValue == "KURA")
+    }
+
+    @Test func omits_a_feature_flag_disabled_by_a_falsey_value() async throws {
+        let environment = Environment(
+            variables: [
+                "TUIST_FEATURE_FLAG_KURA": "0",
+                "TUIST_FEATURE_FLAG_A": "1",
+            ],
+            arguments: []
+        )
+
+        let headerValue = try await headerValue(environment: environment)
+
+        #expect(headerValue == "A")
+    }
+
+    @Test func omits_the_header_when_every_feature_flag_is_disabled() async throws {
+        let environment = Environment(
+            variables: [
+                "TUIST_FEATURE_FLAG_KURA": "false",
+            ],
+            arguments: []
+        )
+
+        let headerValue = try await headerValue(environment: environment)
+
+        #expect(headerValue == nil)
+    }
+
+    private func headerValue(environment: Environment) async throws -> String? {
         let subject = ServerClientFeatureFlagsHeadersMiddleware()
         let url = URL(string: "https://tuist.dev")!
         let request = HTTPRequest(method: .get, scheme: nil, authority: nil, path: "/")
@@ -34,6 +76,6 @@ struct ServerClientFeatureFlagsHeadersMiddlewareTests {
 
         let featureFlagsHeaderName = try #require(HTTPField.Name(ClientFeatureFlags.headerName))
         #expect(gotResponse == response)
-        #expect(gotRequest?.headerFields[featureFlagsHeaderName] == "A")
+        return gotRequest?.headerFields[featureFlagsHeaderName]
     }
 }


### PR DESCRIPTION
## What changed

Kura cache routing is now opt-out in the CLI instead of opt-in. `ClientFeatureFlags` gained a `defaultEnabled` set containing `kura`, so a client sends `x-tuist-feature-flags: KURA` unless something turns it off, and the server's `technology/1` in `TuistWeb.API.CacheController` resolves the Kura lane for it.

Turning it off needed a mechanism that could express "off", which the previous one could not.

## Why the value semantics had to change first

`featureName(from:)` read only the variable's *name* and ignored its value. Any `TUIST_FEATURE_FLAG_<NAME>` variable that existed enabled `<NAME>`, so `TUIST_FEATURE_FLAG_KURA=0` enabled Kura exactly as `=1` did. Flipping the default on top of that would have left no way to opt out at all.

Values are now meaningful for every client feature flag: `0`, `false`, `no`, `off` and empty (case-insensitive, trimmed) disable a flag, anything else enables it. Feature names are also normalised to upper case, which the server already did when decoding the header, so a lower-case `TUIST_FEATURE_FLAG_kura=0` turns the same flag off.

**This is a behaviour change to a shared mechanism, not just to `kura`.** Anyone who set `TUIST_FEATURE_FLAG_SOMETHING=0` expecting it off was silently getting it on; they now get what they asked for. The change corrects those callers rather than breaking them, but it is worth knowing it applies to every client feature flag, present and future.

## Subprocess forwarding

`ClientFeatureFlags.environmentVariables()` forwards the raw `TUIST_FEATURE_FLAG_*` variables to processes that do not inherit the caller's environment: the `cache-proxy` and the legacy per-project daemon, both installed as launchd agents by `tuist setup cache`.

A default that lives in code does not travel through that forwarding, so this was checked rather than assumed. Both directions hold:

- With nothing set, no variable is forwarded and the agent computes `kura` on from the same `defaultEnabled` set, because it is the same binary.
- With `TUIST_FEATURE_FLAG_KURA=0`, the variable is forwarded verbatim and the agent computes `kura` off.

Both are pinned by tests (`a_process_that_inherits_no_variables_computes_the_same_defaults`, `environment_variables_forward_an_opt_out_to_processes_that_do_not_inherit_the_environment`).

## Rollout shape: old clients are the ramp

A CLI that does not send the header stays on the legacy lane, so adoption follows version uptake rather than a server-side cohort. There is no cohorting to build and no flag to flip per account: accounts move as their CLI moves, and pinned or lagging versions keep their current behaviour until they upgrade. That is the whole ramp.

## What this removes, and what it needs next

**The client flag was the only per-plan control we had.** The rollout is planned as Enterprise, then Pro, then Air, and staging it that way worked only because Kura was reached exclusively by clients that opted in. Once the default is on, an account of any plan running a current CLI reaches `Accounts.get_cache_resolution_for_handle/3` with `technology == :kura`, which calls `Demand.record/1` and provisions an instance on demand. `Kura.AccountPolicies.resolve/1` computes the effective plan for sizing and region placement, but it does not refuse on plan, so nothing today orders the waves.

Ordering by plan therefore needs a server-side eligibility check: gate `hosted_kura_resolution/1` on the account's effective plan before `Demand.record/1`, so an ineligible account neither records demand nor provisions and simply resolves the default lane. **That is deliberately not built here.** Shipping this change without it means the wave plan needs a different mechanism, so it should land before, or together with, the default flip reaching production.

## Per-environment control is preserved

The flag is still read per client environment, so an account can keep Kura on in CI while developer machines opt out with `TUIST_FEATURE_FLAG_KURA=0`, or the reverse. That matters for migration: Kura is terminal storage, so a fresh instance is cold for everyone at once, and warming it from CI writes before any human depends on it is the smoothest cutover lever available. Making the opt-out a variable rather than a config field is what keeps that possible.

## User and developer impact

- A CLI at this version or later routes cache traffic through Kura by default, on the hosted service.
- `tuist setup cache` installs the machine-wide CAS proxy plus plugin by default, instead of the legacy per-project cache daemon.
- Generated projects get the CAS plugin build settings by default, instead of `COMPILATION_CACHE_REMOTE_SERVICE_PATH`.
- `TUIST_FEATURE_FLAG_KURA=0` restores all three legacy behaviours, per environment.
- Any other client feature flag set to a falsey value is now off rather than on.

## Validation

Tests were written first and observed failing against the old implementation (19 issues in `ClientFeatureFlagsTests`, 4 in `ServerClientFeatureFlagsHeadersMiddlewareTests`) before the change landed. They cover: the flag enabled with no variable set, falsey values disabling it, truthy values enabling it, a lower-case variable name, other flags continuing to work, a falsey value disabling only the flag it names, and the header the middleware sends reflecting all of the above including its own absence when everything is off.

Two existing tests asserted the old default and now state the opt-out explicitly: `SetupCacheCommandServiceTests.setupCache_withKuraDisabled_installsLegacyDaemon` (renamed from `setupCache_withoutKuraFlag_installsLegacyDaemon`) and `CacheURLStoreTests.separates_cached_endpoints_by_kura_feature_flag`, whose default leg would otherwise have shared a cache key with its Kura leg and stopped testing the separation.

Run locally:

- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` succeeded.
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistServerTests -only-testing TuistCASTests -only-testing TuistKitTests` succeeded.
- `mise run lint` clean, with only pre-existing warnings in the touched files.

No server change is included: `TuistWeb.Headers` already decodes the header case-insensitively and treats an absent header as no flags, which is what a client with Kura disabled now sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)