### PR TITLE
fix(infra): authenticate CI dependency fetches against GitHub's anonymous rate limit

### DIFF
--- a/.github/actions/github-deps-auth/action.yml
+++ b/.github/actions/github-deps-auth/action.yml
@@ -1,0 +1,34 @@
+name: Authenticate GitHub dependency fetches
+description: Route github.com git fetches through a token so they don't share the anonymous per-IP rate limit.
+
+inputs:
+  github-token:
+    description: GitHub token used to authenticate github.com git fetches
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    # `mix deps.get` fetches the `github:` / `git:` dependencies in mix.exs
+    # over anonymous https, which GitHub rate limits per source IP. The whole
+    # Linux runner fleet egresses from two bare-metal hosts, so that budget is
+    # shared across every job in the repo and, once crossed, whichever
+    # dependency happens to be fetched next fails with a credential prompt
+    # (`could not read Username for 'https://github.com'`) on a runner that
+    # has no tty. It is intermittent by nature: the repos and pinned SHAs are
+    # public and fetch fine from an unthrottled address.
+    #
+    # Authenticating lifts the fetches onto the token's own budget.
+    - name: Authenticate github.com dependency fetches
+      shell: bash
+      env:
+        GH_DEP_TOKEN: ${{ inputs.github-token || github.token }}
+      run: |
+        if [ -z "${GH_DEP_TOKEN}" ]; then
+          echo "::warning::No GitHub token available; dependency fetches stay anonymous."
+          exit 0
+        fi
+        git config --global \
+          url."https://x-access-token:${GH_DEP_TOKEN}@github.com/".insteadOf \
+          "https://github.com/"

--- a/.github/actions/setup-server-mix/action.yml
+++ b/.github/actions/setup-server-mix/action.yml
@@ -56,29 +56,9 @@ runs:
         key: ${{ inputs.mix-cache-key }}-${{ hashFiles('server/mix.lock') }}
         restore-keys: |
           ${{ inputs.mix-cache-restore-key }}
-    # `mix deps.get` fetches the `github:` / `git:` dependencies in mix.exs
-    # over anonymous https, which GitHub rate limits per source IP. The whole
-    # Linux runner fleet egresses from two bare-metal hosts, so that budget is
-    # shared across every job in the repo and, once crossed, whichever
-    # dependency happens to be fetched next fails with a credential prompt
-    # (`could not read Username for 'https://github.com'`) on a runner that
-    # has no tty. It is intermittent by nature: the repos and pinned SHAs are
-    # public and fetch fine from an unthrottled address.
-    #
-    # Authenticating lifts the fetches onto the token's own budget, the same
-    # reason `github-token` is already threaded to mise above.
-    - name: Authenticate github.com dependency fetches
-      shell: bash
-      env:
-        GH_DEP_TOKEN: ${{ inputs.github-token || env.MISE_GITHUB_TOKEN || github.token }}
-      run: |
-        if [ -z "${GH_DEP_TOKEN}" ]; then
-          echo "::warning::No GitHub token available; dependency fetches stay anonymous."
-          exit 0
-        fi
-        git config --global \
-          url."https://x-access-token:${GH_DEP_TOKEN}@github.com/".insteadOf \
-          "https://github.com/"
+    - uses: ./.github/actions/github-deps-auth
+      with:
+        github-token: ${{ inputs.github-token || env.MISE_GITHUB_TOKEN }}
     - name: Install dependencies
       shell: bash
       working-directory: server

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -85,6 +85,9 @@ jobs:
           distribution: temurin
           java-version: '21'
       - uses: android-actions/setup-android@v3
+      - uses: ./.github/actions/github-deps-auth
+        with:
+          github-token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Install server deps
         working-directory: server
         run: mix deps.get

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -381,6 +381,9 @@ jobs:
           cache: "true"
           working_directory: server
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
+      - uses: ./.github/actions/github-deps-auth
+        with:
+          github-token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Install mix dependencies
         run: mix deps.get
       - name: Install aube dependencies


### PR DESCRIPTION
## What changed

CI jobs that run `mix deps.get` now authenticate their `github.com` git dependency fetches with the workflow token instead of fetching anonymously.

The rewrite step that already existed inside `setup-server-mix` is extracted into a `github-deps-auth` composite action, and applied to the two places that were still fetching anonymously:

- **Gradle Cache Acceptance** — runs `mix deps.get` directly for `server/` and again for `cache/`. One step covers both, since the git config is global.
- **`server.yml`'s Format job** — the one job in that workflow that skips `setup-server-mix`, installing tools with `mise-action` directly and then running a bare `deps.get`.

`setup-server-mix` now delegates to the shared action rather than keeping its own copy.

## Why

Gradle Cache Acceptance failed on `main` ([run 33614817920](https://github.com/tuist/tuist/actions/runs/33614817920/job/100198100507)) while installing server dependencies:

```
* Getting ex_aws_s3 (https://github.com/tuist/ex_aws_s3/ - 7f3278bef49cc3fa6b4138a4077804d328a41c9c)
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
** (Mix) Command "git --git-dir=.git fetch --force --quiet --progress" failed
```

While this PR was in flight the same failure hit the Format job on a different dependency, which is what prompted the second commit:

```
* Getting cachex (https://github.com/TBK145/cachex.git - 72822750eacef403135ad7413f654d40719fbd9f)
fatal: could not read Username for 'https://github.com': No such device or address
```

## Root cause

Not a bad URL and not a missing ref. `tuist/ex_aws_s3` is public, the pinned SHA is present on a branch there, and all three URL spellings resolve anonymously from an unthrottled address. This is GitHub's anonymous per-source-IP rate limit: the Linux runner fleet egresses from two bare-metal hosts, so that budget is shared across every job in the repo, and once it is crossed whichever dependency is fetched next gets a credential prompt on a runner with no tty.

In the original failure the immediately preceding dependency (`heroicons`, 9314 objects) cloned fine in the same step. That is what an IP-scoped throttle looks like, rather than a per-repo or per-ref problem. The dependency that fails is simply whichever one is next in line.

`server.yml` already fixed this in #12721, but the fix lived inside `setup-server-mix`, so it only ever protected the jobs that use it. Gradle Cache Acceptance does not, and neither does Format.

## Why this shape

A shared composite action rather than a copy of the block, so the next workflow that needs it does not fork the rationale again. The rewrite is set with `git config --global`, so one step covers every subsequent fetch in the job without threading anything through individual steps. `insteadOf` is applied at transport time, so no token is written into `deps/*/.git/config` and cached dependency trees stay clean.

Retrying `deps.get` was the obvious alternative and was not taken: it papers over the throttle instead of moving the fetches onto the token's own budget, and it would slow the failure case rather than remove it.

## Impact

Gradle Cache Acceptance and Format stop failing intermittently on a throttled fetch. `setup-server-mix` behaviour is unchanged; the token precedence it had (`inputs.github-token`, then `MISE_GITHUB_TOKEN`, then `github.token`) is preserved across the extraction.

Two workflows are knowingly left alone because they are outside this change's scope and were not failing: `l10n.yml` (fetches server dependencies) and `cache-migration-safety.yml` (fetches cache dependencies) still fetch anonymously and carry the same exposure. `noora.yml` and `tuist-ops.yml` do not: neither manifest has git dependencies.

## Validation

- `Credo` passes on this PR, which exercises `setup-server-mix` through the extracted action, confirming the nested composite resolves.
- `actionlint` on both workflows reports only pre-existing findings: the custom `tuist-linux*` runner labels, an SC1010 in the untouched `Setup main server` script, and an SC2046 in an untouched `server.yml` script.
- Confirmed against an isolated git config that `url.<token@github.com>.insteadOf` rewrites both URL spellings the manifests use: `https://github.com/tuist/ex_aws_s3/` (trailing slash, as `server/mix.exs` writes it) and `https://github.com/tuist/bandit` (no slash, as `cache/mix.exs` writes it).
- Confirmed an authenticated fetch of the pinned dependency succeeds, and that an invalid token still serves a public repo, so the step cannot regress a job whose token is absent.
- This PR touches `gradle-cache-acceptance.yml`, `server.yml` and `setup-server-mix/action.yml`, so it runs every job it changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)