### PR TITLE
feat(infra): retire the Hetzner Linux runner fleet in favour of OVH

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -842,7 +842,14 @@ ovhFleets:
     # --atomic rollback; too low leaves an ordered box billing with nothing
     # adopting it. Growing the fleet is `baremetal:prep-ovh` on each new box,
     # then this number.
-    replicas: 1
+    #
+    # Four boxes carry the whole Linux runner fleet: 128 GB each at the chart's
+    # 1 vCPU / 4 GB slot size is 32 slots, so 128 in total, which is what the two
+    # AX162-R hosts provided before they were retired. Note the CPU ratio differs
+    # even though the slot count matches: an AX162-R backed 64 slots with 96
+    # threads, a RISE-L backs 32 with 32, so the fleet is packed closer to its
+    # thread count and leans on single-thread speed rather than oversubscription.
+    replicas: 4
     # The OVHcloud entity holding the account, not the box's geography: the RISE
     # range's EU-datacenter plan codes are orderable under OVHcloud US. Every OVH
     # fleet must share one value, because the reconciler resolves a single

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -843,12 +843,10 @@ ovhFleets:
     # adopting it. Growing the fleet is `baremetal:prep-ovh` on each new box,
     # then this number.
     #
-    # Four boxes carry the whole Linux runner fleet: 128 GB each at the chart's
-    # 1 vCPU / 4 GB slot size is 32 slots, so 128 in total, which is what the two
-    # AX162-R hosts provided before they were retired. Note the CPU ratio differs
-    # even though the slot count matches: an AX162-R backed 64 slots with 96
-    # threads, a RISE-L backs 32 with 32, so the fleet is packed closer to its
-    # thread count and leans on single-thread speed rather than oversubscription.
+    # Four boxes carry the Linux runner fleet: 128 GB each is 32 slots at the
+    # chart's 1 vCPU / 4 GB slot size, so 128 in total. Slots and threads are 1:1
+    # on this shape, so there is no oversubscription headroom to absorb a burst;
+    # capacity grows by box count rather than by packing slots tighter.
     replicas: 4
     # The OVHcloud entity holding the account, not the box's geography: the RISE
     # range's EU-datacenter plan codes are orderable under OVHcloud US. Every OVH

--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -32,9 +32,9 @@ clusters/
 
 | Cluster | CP | Workers |
 |---|---|---|
-| `tuist-staging` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); runners-linux: bare-metal Robot (`pool=runners-linux`) |
-| `tuist-canary` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`); runners-linux: bare-metal Robot (`pool=runners-linux`) |
-| `tuist` (production) | 3× cpx22 | md-0: 3× ccx23 (`pool=general`); md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); kura-us-east: 3× ccx13 in `ash` (`pool=kura-us-east`, autoscaled 3→32); kura-us-west: 3× ccx13 in `hil` (`pool=kura-us-west`, autoscaled 3→12); runners-linux: 2× AX162-R bare-metal Robot in `fsn1` (`pool=runners-linux`) |
+| `tuist-staging` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); runners-linux: 1× OVH RISE-S in `gra` (`pool=runners-linux`) |
+| `tuist-canary` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`); runners-linux: 1× OVH RISE-S in `gra` (`pool=runners-linux`) |
+| `tuist` (production) | 3× cpx22 | md-0: 3× ccx23 (`pool=general`); md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); kura-us-east: 3× ccx13 in `ash` (`pool=kura-us-east`, autoscaled 3→32); kura-us-west: 3× ccx13 in `hil` (`pool=kura-us-west`, autoscaled 3→12); runners-linux: 4× OVH RISE-L in `gra` (`pool=runners-linux`) |
 | `tuist-preview` | 1× cpx22 | md-0: 1× cpx42 |
 | `tuist-pentest` | 3× cpx22 | md-0: 2× cpx32 (`pool=general`) |
 

--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -114,25 +114,7 @@ spec:
               # can't OOM the egress gateway.
               - name: workerNodeTaints
                 value: tuist.dev/stable-egress=true:NoSchedule
-        # Linux runner pool on Hetzner Robot bare metal. The
-        # `hetzner-robot-controller` reflects `tuist-bm-canary-*`
-        # Robot servers into HBM CRs stamped
-        # `tuist.dev/cluster=canary`; caph claims them through the
-        # patched HBMM hostSelector. Each node ends up labeled
-        # `node.cluster.x-k8s.io/pool=runners-linux` +
-        # `tuist.dev/kata-runtime=true` and tainted
-        # `tuist.dev/runner-tier=bare-metal:NoSchedule`.
-        #
-        # Host count is operator-managed: order another
-        # `tuist-bm-canary-*` server in the Robot panel and bump
-        # `replicas:` here to grow capacity.
-        - class: bare-metal-worker
-          name: runners-linux
-          failureDomain: fsn1
-          metadata:
-            labels:
-              node.cluster.x-k8s.io/pool: runners-linux
-              # See cluster-staging.yaml for the rationale — keeps
-              # bare-metal Nodes out of HCCM's LB target set so a
-              # bad providerID can't break the ingress.
-              node.kubernetes.io/exclude-from-external-load-balancers: ""
+        # The Linux runner fleet moved to an OVH RISE-S in Gravelines,
+        # provisioned as the `runners-linux` fleet in the tuist chart (ovhFleets).
+        # The Robot host that served it is gone from this topology so caph
+        # releases it and the contract can be cancelled.

--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -114,7 +114,3 @@ spec:
               # can't OOM the egress gateway.
               - name: workerNodeTaints
                 value: tuist.dev/stable-egress=true:NoSchedule
-        # The Linux runner fleet moved to an OVH RISE-S in Gravelines,
-        # provisioned as the `runners-linux` fleet in the tuist chart (ovhFleets).
-        # The Robot host that served it is gone from this topology so caph
-        # releases it and the contract can be cancelled.

--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -175,31 +175,10 @@ spec:
         # kura-us-west fleets in the tuist chart (ovhFleets) and self-joined via
         # the CAPI provider — they are no longer Hetzner worker pools here, so the
         # region catalog reports no Hetzner location for them.
-        # Linux runner pool on Hetzner Robot bare metal. The
-        # `hetzner-robot-controller` reflects
-        # `tuist-bm-production-*` Robot servers into HBM CRs
-        # stamped `tuist.dev/cluster=production`; caph claims them
-        # through the patched HBMM hostSelector. Each node ends up
-        # labeled `node.cluster.x-k8s.io/pool=runners-linux` +
-        # `tuist.dev/kata-runtime=true` and tainted
-        # `tuist.dev/runner-tier=bare-metal:NoSchedule`.
-        #
-        # Host count is operator-managed: order another
-        # `tuist-bm-production-*` server in the Robot panel and
-        # bump `replicas:` here to grow capacity.
-        - class: bare-metal-worker
-          name: runners-linux
-          # Two pre-ordered AX162-R hosts (`tuist-bm-production-1` and
-          # `tuist-bm-production-2`) in FSN1. Each box hosts ~64 Kata-
-          # QEMU runner slots at the chart's 1 vCPU / 4 GB slot size;
-          # two boxes give ~128 runner slots + one host of HA headroom.
-          # Bump in lockstep with new Robot orders.
-          replicas: 2
-          failureDomain: fsn1
-          metadata:
-            labels:
-              node.cluster.x-k8s.io/pool: runners-linux
-              # See cluster-staging.yaml for the rationale — keeps
-              # bare-metal Nodes out of HCCM's LB target set so a
-              # bad providerID can't break the ingress.
-              node.kubernetes.io/exclude-from-external-load-balancers: ""
+        # The Linux runner fleet moved to OVH RISE-L bare metal in Gravelines,
+        # provisioned as the `runners-linux` fleet in the tuist chart (ovhFleets)
+        # and self-joined via the CAPI provider. The two AX162-R Robot hosts that
+        # served it are gone from this topology, so caph releases them and the
+        # contracts can be cancelled; the `bare-metal-worker` class and its
+        # templates stay in place so re-adding a Robot pool is a topology entry
+        # rather than a rebuild.

--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -175,10 +175,3 @@ spec:
         # kura-us-west fleets in the tuist chart (ovhFleets) and self-joined via
         # the CAPI provider — they are no longer Hetzner worker pools here, so the
         # region catalog reports no Hetzner location for them.
-        # The Linux runner fleet moved to OVH RISE-L bare metal in Gravelines,
-        # provisioned as the `runners-linux` fleet in the tuist chart (ovhFleets)
-        # and self-joined via the CAPI provider. The two AX162-R Robot hosts that
-        # served it are gone from this topology, so caph releases them and the
-        # contracts can be cancelled; the `bare-metal-worker` class and its
-        # templates stay in place so re-adding a Robot pool is a topology entry
-        # rather than a rebuild.

--- a/infra/k8s/clusters/cluster-staging.yaml
+++ b/infra/k8s/clusters/cluster-staging.yaml
@@ -127,41 +127,7 @@ spec:
               # OOM the egress gateway.
               - name: workerNodeTaints
                 value: tuist.dev/stable-egress=true:NoSchedule
-        # Linux runner pool on Hetzner Robot bare metal. Each
-        # claimable `HetznerBareMetalHost` CR (see
-        # `bare-metal-staging.yaml`) gets picked up by caph, which
-        # runs the rescue + installimage + cloud-init kubeadm-join
-        # flow to register the host as a worker Node. Each node ends
-        # up labeled `node.cluster.x-k8s.io/pool=runners-linux` +
-        # `tuist.dev/kata-runtime=true` and tainted
-        # `tuist.dev/runner-tier=bare-metal:NoSchedule`.
-        #
-        # Host count is operator-managed: order another
-        # `tuist-bm-staging-*` server in the Robot panel and bump
-        # `replicas:` here to grow capacity. Pod-level autoscaling
-        # in `values-managed-staging.yaml`'s
-        # `runnersFleetLinux.pools[].autoscaling` floats Pod counts
-        # within the slot ceiling each host provides.
-        - class: bare-metal-worker
-          name: runners-linux
-          failureDomain: fsn1
-          metadata:
-            labels:
-              node.cluster.x-k8s.io/pool: runners-linux
-              # Tell the cloud-provider service controller to skip
-              # these Nodes when building Hetzner LoadBalancer target
-              # lists. Two reasons:
-              #   1. They're not hcloud VMs — they have no
-              #      `providerID: hcloud://<int>` HCCM can parse. A
-              #      stale install once left a Node with
-              #      `hcloud://nocloud` and HCCM aborted the entire
-              #      Service reconcile on that one bad target,
-              #      bringing the ingress LB down with it.
-              #   2. Even with a correct `hcloud://bm-<n>` providerID,
-              #      bare-metal hosts run runner Pods only — routing
-              #      ingress traffic through them just bounces it
-              #      back into the cluster network.
-              # The label is honored by the upstream Kubernetes
-              # cloud-provider library (see `nodeIncluded()` in
-              # `cloud-provider/controllers/service`).
-              node.kubernetes.io/exclude-from-external-load-balancers: ""
+        # The Linux runner fleet moved to an OVH RISE-S in Gravelines,
+        # provisioned as the `runners-linux` fleet in the tuist chart (ovhFleets).
+        # The Robot host that served it is gone from this topology so caph
+        # releases it and the contract can be cancelled.

--- a/infra/k8s/clusters/cluster-staging.yaml
+++ b/infra/k8s/clusters/cluster-staging.yaml
@@ -127,7 +127,3 @@ spec:
               # OOM the egress gateway.
               - name: workerNodeTaints
                 value: tuist.dev/stable-egress=true:NoSchedule
-        # The Linux runner fleet moved to an OVH RISE-S in Gravelines,
-        # provisioned as the `runners-linux` fleet in the tuist chart (ovhFleets).
-        # The Robot host that served it is gone from this topology so caph
-        # releases it and the contract can be cancelled.


### PR DESCRIPTION
Takes production to four OVH RISE-L boxes and removes the Hetzner Robot `runners-linux` MachineDeployment from all three cluster topologies, so caph releases the hosts and the Robot contracts can be cancelled.

> [!IMPORTANT]
> **Do not merge until the three new production boxes are prepped and marked.** `replicas: 4` against fewer adoptable boxes parks the MachineDeployment at N/4 and wedges `helm --wait` into an `--atomic` rollback. Prep is `PREP_NAMESPACE=tuist-production mise run baremetal:prep-ovh <service> tuist-tuist-ovh-fleet-runners-linux` per box, then confirm each displayName reads `tuist-runners-ovh-production`.

## Capacity: a straight swap

A RISE-L carries 128 GB, which is 32 slots at the chart's 1 vCPU / 4 GB slot size, so four give the same ~128 slots the two AX162-R hosts provided.

The CPU ratio does change, and it is worth being explicit about it. An AX162-R backed 64 slots with 96 threads; a RISE-L backs 32 with 32. The fleet now sits close to its thread count rather than 1.5x oversubscribed, so it leans on single-thread speed instead of headroom. That is the trade the migration was chosen for, not an oversight.

Staging and canary each run one RISE-S, the same 16-thread / 64 GB shape as the Robot host it replaces, so those are one-for-one.

## The performance case is measured, not projected

Across **715 node-attributed production jobs**, the RISE-L beat the AX162-R on **all eleven** workload pairings. The two best-powered — `Server` at 4/16 and 2/8, 96 of the OVH jobs — came in at **1.34x and 1.54x**, bracketing the 1.58x predicted from single-thread alone (4,728 vs 2,988 PassMark).

It held while carrying about **40% less thread headroom per running job** than the hosts it beat (8.2 threads per job versus 13.4–13.9), so it is not an artifact of an idle box. Full analysis, including the four results I do *not* trust: https://claude.ai/code/artifact/2b4b3479-6e09-468d-8fce-95f230d71d7b

## What this deliberately does not remove

The `bare-metal-worker` class and its templates in `clusterclass-tuist.yaml` and `bare-metal.yaml` stay. Nothing references them once these topologies drop the MDs, so they are dead code by the letter — but keeping them makes re-adding a Robot pool a topology entry rather than a rebuild, which is cheap insurance to hold while the OVH fleet is three days old. Deleting them is a clean follow-up once it is not.

Also unchanged: `runnersFleetLinux` needs no edit. Its `name: runners-linux` is the pool selector, and the OVH fleet already carries `nodePool: runners-linux`, so Runner Profiles keep dispatching to the same pool label throughout.

## Ordering, and the one environment that is not ready

Production and canary run provider `0.29.1`, which carries the kata drift repair from #12732. Their OVH nodes are healthy and kata-labelled.

**Staging was behind on the provider (`0.28.0`) and its OVH node had bootstrapped without kata** — Ready, in the pool, and unable to run a single runner Pod. Removing its Robot host in that state would have left staging with no working Linux runner capacity at all. I dispatched a staging deploy from `main` so it picks up `0.29.1` and the drift repair heals the node; confirm `katacontainers.io/kata-runtime=true` on the staging OVH node before this merges.

## Validation

- All three cluster topologies parse and contain zero `bare-metal-worker` MachineDeployments; the remaining pools are unchanged (`md-0`, `md-egress`, and `md-processor` in production)
- The removal diff touches only the three MD blocks and the production `replicas`; no other topology entry moved
- All four CI `helm lint` configurations pass, and the CI production overlay renders
- `infra/k8s/clusters/README.md` fleet table updated for all three environments

## After this deploys

The Robot hosts (`tuist-bm-production-1`, `tuist-bm-production-2`, `tuist-bm-staging-*`, `tuist-bm-canary-*`) become unclaimed. The `hetzner-robot-controller` selects on the `tuist-bm-` prefix generically, so there is no per-env list to trim — the contracts can be cancelled in the Robot panel once the nodes are gone from the clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
