### PR TITLE
feat(infra): add the Tuist Kura / Region Scalability dashboard

### DIFF
--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -1,0 +1,1487 @@
+{
+  "apiVersion": "dashboard.grafana.app/v1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "tuist-kura-region-scalability"
+  },
+  "spec": {
+    "title": "Tuist Kura / Region Scalability",
+    "uid": "tuist-kura-region-scalability",
+    "description": "How far each Kura region is from the point where it needs another node, per resource: instances the scheduler can still place, reservations versus capacity, and real host memory. RAM today; disk and egress columns to follow. Thresholds match the region capacity alerts in infra/helm/k8s-monitoring/alerts.md.",
+    "schemaVersion": 39,
+    "version": 1,
+    "editable": true,
+    "graphTooltip": 1,
+    "refresh": "1m",
+    "tags": [
+      "tuist",
+      "kura",
+      "capacity"
+    ],
+    "time": {
+      "from": "now-7d",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "links": [
+      {
+        "title": "Tuist Kura",
+        "type": "dashboards",
+        "tags": [
+          "kura"
+        ],
+        "asDropdown": true,
+        "includeVars": false,
+        "keepTime": true
+      }
+    ],
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "templating": {
+      "list": [
+        {
+          "type": "datasource",
+          "name": "datasource",
+          "label": "Data Source",
+          "query": "prometheus",
+          "current": {
+            "selected": false,
+            "text": "grafanacloud-prom",
+            "value": "grafanacloud-prom"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "options": [],
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false
+        },
+        {
+          "type": "query",
+          "name": "env",
+          "label": "Environment",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "query": {
+            "query": "label_values(kura_node_geo_info, env)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "definition": "label_values(kura_node_geo_info, env)",
+          "current": {
+            "selected": true,
+            "text": "production",
+            "value": "production"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "multi": false,
+          "options": [],
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1
+        },
+        {
+          "type": "textbox",
+          "name": "instance_ceiling_mib",
+          "query": "4096",
+          "hide": 0,
+          "skipUrlSync": false,
+          "current": {
+            "selected": false,
+            "text": "4096",
+            "value": "4096"
+          },
+          "options": [
+            {
+              "selected": true,
+              "text": "4096",
+              "value": "4096"
+            }
+          ],
+          "label": "Instance ceiling (MiB)",
+          "description": "Per-replica memory limit of the profile to size for; the enterprise profile requests 4096 MiB as the tuist.dev/memory-ceiling-mib extended resource. Multiplied by two replicas."
+        },
+        {
+          "type": "textbox",
+          "name": "instance_floor_mib",
+          "query": "1024",
+          "hide": 0,
+          "skipUrlSync": false,
+          "current": {
+            "selected": false,
+            "text": "1024",
+            "value": "1024"
+          },
+          "options": [
+            {
+              "selected": true,
+              "text": "1024",
+              "value": "1024"
+            }
+          ],
+          "label": "Instance floor (MiB)",
+          "description": "Per-replica memory request of the profile to size for (Tuist.Kura.Regions.memory_profile/1); 1024 MiB for enterprise. Multiplied by two replicas."
+        },
+        {
+          "type": "constant",
+          "name": "node_region",
+          "query": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))",
+          "hide": 2,
+          "skipUrlSync": false,
+          "current": {
+            "selected": false,
+            "text": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))",
+            "value": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))"
+          },
+          "options": [
+            {
+              "selected": true,
+              "text": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))",
+              "value": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))"
+            }
+          ],
+          "description": "The node → region join every query on this dashboard uses, kept in one place. Mirrors the kura:node_region recording rule in infra/helm/k8s-monitoring/alerts.md; swap this value for `kura:node_region` once that rule exists."
+        }
+      ]
+    },
+    "panels": [
+      {
+        "id": 100,
+        "type": "row",
+        "title": "RAM",
+        "collapsed": false,
+        "panels": [],
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        }
+      },
+      {
+        "id": 1,
+        "type": "table",
+        "title": "RAM by region",
+        "description": "One row per Kura region. **Fit (ceiling)** and **Fit (memory)** count how many more instances of the largest profile (two replicas of `$instance_ceiling_mib` MiB ceiling / `$instance_floor_mib` MiB floor, set in the variables above) the scheduler can still place; `floor()` is taken per node before the sum, so free memory fragmented across boxes reads as zero. The next provisioning is declined when either reaches 0 — the **Kura region cannot place another instance** alert. The ceiling binds first wherever `memory_ceiling_bin_packed` is on; a region with no ceiling advertised has an empty ceiling cell.\n\n**Ceiling reserved** / **Memory requested** are the scheduler's view (reservations, not usage); **Host memory used** is the kernel's (`1 - MemAvailable/MemTotal`, reclaimable cache counts as available) and is what **Kura region host memory low** watches. Reservations full while host memory is low means a node or a smaller ceiling profile; host memory high while reservations have room means pods living above their floors.\n\nRegion comes from joining each node to the Kura pods it hosts (`kura_node_geo_info`): a freshly added, still empty node is invisible here until its first placement lands on it.",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 1
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "A",
+            "expr": "count by (cluster, region) (max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+            "editorMode": "code",
+            "instant": true,
+            "range": false,
+            "format": "table"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "B",
+            "expr": "count by (cluster, region) (kube_pod_info{namespace=\"kura\", env=\"$env\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))",
+            "editorMode": "code",
+            "instant": true,
+            "range": false,
+            "format": "table"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "C",
+            "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"})) / (2 * $instance_ceiling_mib)) * on (cluster, node) group_left(region) $node_region)",
+            "editorMode": "code",
+            "instant": true,
+            "range": false,
+            "format": "table"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "D",
+            "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"})) / 1048576 / (2 * $instance_floor_mib)) * on (cluster, node) group_left(region) $node_region)",
+            "editorMode": "code",
+            "instant": true,
+            "range": false,
+            "format": "table"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "E",
+            "expr": "sum by (cluster, region) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+            "editorMode": "code",
+            "instant": true,
+            "range": false,
+            "format": "table"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "F",
+            "expr": "sum by (cluster, region) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+            "editorMode": "code",
+            "instant": true,
+            "range": false,
+            "format": "table"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "G",
+            "expr": "1 - sum by (cluster, region) (node_memory_MemAvailable_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region) (node_memory_MemTotal_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"))",
+            "editorMode": "code",
+            "instant": true,
+            "range": false,
+            "format": "table"
+          }
+        ],
+        "transformations": [
+          {
+            "id": "merge",
+            "options": {}
+          },
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "renameByName": {
+                "Value #A": "Nodes",
+                "Value #B": "Kura pods",
+                "Value #C": "Fit (ceiling)",
+                "Value #D": "Fit (memory)",
+                "Value #E": "Ceiling reserved",
+                "Value #F": "Memory requested",
+                "Value #G": "Host memory used"
+              },
+              "indexByName": {
+                "region": 0,
+                "cluster": 1,
+                "Nodes": 2,
+                "Kura pods": 3,
+                "Fit (ceiling)": 4,
+                "Fit (memory)": 5,
+                "Ceiling reserved": 6,
+                "Memory requested": 7,
+                "Host memory used": 8
+              }
+            }
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false,
+              "filterable": false
+            },
+            "color": {
+              "mode": "thresholds"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "text",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "region"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 180
+                },
+                {
+                  "id": "displayName",
+                  "value": "Region"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "cluster"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 150
+                },
+                {
+                  "id": "displayName",
+                  "value": "Cluster"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Nodes"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 90
+                },
+                {
+                  "id": "custom.align",
+                  "value": "center"
+                },
+                {
+                  "id": "decimals",
+                  "value": 0
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Kura pods"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 90
+                },
+                {
+                  "id": "custom.align",
+                  "value": "center"
+                },
+                {
+                  "id": "decimals",
+                  "value": 0
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Fit (ceiling)"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "color-background",
+                    "mode": "basic"
+                  }
+                },
+                {
+                  "id": "custom.align",
+                  "value": "center"
+                },
+                {
+                  "id": "custom.width",
+                  "value": 150
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      },
+                      {
+                        "color": "green",
+                        "value": 2
+                      }
+                    ]
+                  }
+                },
+                {
+                  "id": "decimals",
+                  "value": 0
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Fit (memory)"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "color-background",
+                    "mode": "basic"
+                  }
+                },
+                {
+                  "id": "custom.align",
+                  "value": "center"
+                },
+                {
+                  "id": "custom.width",
+                  "value": 150
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      },
+                      {
+                        "color": "green",
+                        "value": 2
+                      }
+                    ]
+                  }
+                },
+                {
+                  "id": "decimals",
+                  "value": 0
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Ceiling reserved"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "gauge",
+                    "mode": "gradient",
+                    "valueDisplayMode": "text"
+                  }
+                },
+                {
+                  "id": "custom.width",
+                  "value": 190
+                },
+                {
+                  "id": "unit",
+                  "value": "percentunit"
+                },
+                {
+                  "id": "min",
+                  "value": 0
+                },
+                {
+                  "id": "max",
+                  "value": 1
+                },
+                {
+                  "id": "decimals",
+                  "value": 1
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.8
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.95
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Memory requested"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "gauge",
+                    "mode": "gradient",
+                    "valueDisplayMode": "text"
+                  }
+                },
+                {
+                  "id": "custom.width",
+                  "value": 190
+                },
+                {
+                  "id": "unit",
+                  "value": "percentunit"
+                },
+                {
+                  "id": "min",
+                  "value": 0
+                },
+                {
+                  "id": "max",
+                  "value": 1
+                },
+                {
+                  "id": "decimals",
+                  "value": 1
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.8
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.95
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Host memory used"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "gauge",
+                    "mode": "gradient",
+                    "valueDisplayMode": "text"
+                  }
+                },
+                {
+                  "id": "custom.width",
+                  "value": 190
+                },
+                {
+                  "id": "unit",
+                  "value": "percentunit"
+                },
+                {
+                  "id": "min",
+                  "value": 0
+                },
+                {
+                  "id": "max",
+                  "value": 1
+                },
+                {
+                  "id": "decimals",
+                  "value": 1
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.85
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.92
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "options": {
+          "showHeader": true,
+          "cellHeight": "md",
+          "footer": {
+            "show": false,
+            "reducer": [
+              "sum"
+            ],
+            "fields": ""
+          },
+          "sortBy": [
+            {
+              "displayName": "Fit (ceiling)",
+              "desc": false
+            }
+          ]
+        }
+      },
+      {
+        "id": 2,
+        "type": "table",
+        "title": "RAM by node",
+        "description": "The per-box breakdown of the table above, for finding which box is full or fragmented. A region can read 0 fits while every box still has free memory if no single box has one instance's worth. **Host memory used** here is what **Kura cache box out of memory** watches (critical below 8% available).",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 10
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "A",
+            "expr": "sum by (cluster, region, node) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"})) / (2 * $instance_ceiling_mib)) * on (cluster, node) group_left(region) $node_region)",
+            "editorMode": "code",
+            "instant": true,
+            "range": false,
+            "format": "table"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "B",
+            "expr": "sum by (cluster, region, node) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"})) / 1048576 / (2 * $instance_floor_mib)) * on (cluster, node) group_left(region) $node_region)",
+            "editorMode": "code",
+            "instant": true,
+            "range": false,
+            "format": "table"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "C",
+            "expr": "sum by (cluster, region, node) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region, node) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+            "editorMode": "code",
+            "instant": true,
+            "range": false,
+            "format": "table"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "D",
+            "expr": "sum by (cluster, region, node) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region, node) (max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+            "editorMode": "code",
+            "instant": true,
+            "range": false,
+            "format": "table"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "E",
+            "expr": "1 - sum by (cluster, region, node) (label_replace(node_memory_MemAvailable_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"), \"node\", \"$1\", \"instance\", \"(.*)\")) / sum by (cluster, region, node) (label_replace(node_memory_MemTotal_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"), \"node\", \"$1\", \"instance\", \"(.*)\"))",
+            "editorMode": "code",
+            "instant": true,
+            "range": false,
+            "format": "table"
+          }
+        ],
+        "transformations": [
+          {
+            "id": "merge",
+            "options": {}
+          },
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "Time": true
+              },
+              "renameByName": {
+                "Value #A": "Fit (ceiling)",
+                "Value #B": "Fit (memory)",
+                "Value #C": "Ceiling reserved",
+                "Value #D": "Memory requested",
+                "Value #E": "Host memory used"
+              },
+              "indexByName": {
+                "region": 0,
+                "node": 1,
+                "cluster": 2,
+                "Fit (ceiling)": 3,
+                "Fit (memory)": 4,
+                "Ceiling reserved": 5,
+                "Memory requested": 6,
+                "Host memory used": 7
+              }
+            }
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "type": "auto"
+              },
+              "inspect": false,
+              "filterable": false
+            },
+            "color": {
+              "mode": "thresholds"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "text",
+                  "value": null
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "region"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 180
+                },
+                {
+                  "id": "displayName",
+                  "value": "Region"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "node"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 360
+                },
+                {
+                  "id": "displayName",
+                  "value": "Node"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "cluster"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 150
+                },
+                {
+                  "id": "displayName",
+                  "value": "Cluster"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Fit (ceiling)"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "color-background",
+                    "mode": "basic"
+                  }
+                },
+                {
+                  "id": "custom.align",
+                  "value": "center"
+                },
+                {
+                  "id": "custom.width",
+                  "value": 150
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      },
+                      {
+                        "color": "green",
+                        "value": 2
+                      }
+                    ]
+                  }
+                },
+                {
+                  "id": "decimals",
+                  "value": 0
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Fit (memory)"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "color-background",
+                    "mode": "basic"
+                  }
+                },
+                {
+                  "id": "custom.align",
+                  "value": "center"
+                },
+                {
+                  "id": "custom.width",
+                  "value": 150
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      },
+                      {
+                        "color": "green",
+                        "value": 2
+                      }
+                    ]
+                  }
+                },
+                {
+                  "id": "decimals",
+                  "value": 0
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Ceiling reserved"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "gauge",
+                    "mode": "gradient",
+                    "valueDisplayMode": "text"
+                  }
+                },
+                {
+                  "id": "custom.width",
+                  "value": 190
+                },
+                {
+                  "id": "unit",
+                  "value": "percentunit"
+                },
+                {
+                  "id": "min",
+                  "value": 0
+                },
+                {
+                  "id": "max",
+                  "value": 1
+                },
+                {
+                  "id": "decimals",
+                  "value": 1
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.8
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.95
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Memory requested"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "gauge",
+                    "mode": "gradient",
+                    "valueDisplayMode": "text"
+                  }
+                },
+                {
+                  "id": "custom.width",
+                  "value": 190
+                },
+                {
+                  "id": "unit",
+                  "value": "percentunit"
+                },
+                {
+                  "id": "min",
+                  "value": 0
+                },
+                {
+                  "id": "max",
+                  "value": 1
+                },
+                {
+                  "id": "decimals",
+                  "value": 1
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.8
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.95
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Host memory used"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "gauge",
+                    "mode": "gradient",
+                    "valueDisplayMode": "text"
+                  }
+                },
+                {
+                  "id": "custom.width",
+                  "value": 190
+                },
+                {
+                  "id": "unit",
+                  "value": "percentunit"
+                },
+                {
+                  "id": "min",
+                  "value": 0
+                },
+                {
+                  "id": "max",
+                  "value": 1
+                },
+                {
+                  "id": "decimals",
+                  "value": 1
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.85
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.92
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "options": {
+          "showHeader": true,
+          "cellHeight": "md",
+          "footer": {
+            "show": false,
+            "reducer": [
+              "sum"
+            ],
+            "fields": ""
+          },
+          "sortBy": [
+            {
+              "displayName": "Fit (ceiling)",
+              "desc": false
+            }
+          ]
+        }
+      },
+      {
+        "id": 101,
+        "type": "row",
+        "title": "RAM trends",
+        "collapsed": false,
+        "panels": [],
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 19
+        }
+      },
+      {
+        "id": 3,
+        "type": "timeseries",
+        "title": "Instances that still fit by ceiling",
+        "description": "Same count as the table's **Fit (ceiling)** column over time. Each provisioning steps it down by one; a new node steps it up. Dashed lines at 2 (warning) and 1 (critical).",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 20
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "A",
+            "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"})) / (2 * $instance_ceiling_mib)) * on (cluster, node) group_left(region) $node_region)",
+            "editorMode": "code",
+            "instant": false,
+            "range": true,
+            "legendFormat": "{{region}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2,
+              "fillOpacity": 0,
+              "showPoints": "never",
+              "spanNulls": true,
+              "axisPlacement": "auto",
+              "thresholdsStyle": {
+                "mode": "dashed"
+              }
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "orange",
+                  "value": 1
+                },
+                {
+                  "color": "green",
+                  "value": 2
+                }
+              ]
+            },
+            "min": 0,
+            "decimals": 0
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true,
+            "calcs": [
+              "lastNotNull",
+              "min"
+            ]
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "asc"
+          }
+        }
+      },
+      {
+        "id": 4,
+        "type": "timeseries",
+        "title": "Instances that still fit by memory",
+        "description": "Same count as the table's **Fit (memory)** column over time: placements the native memory request (the floor) still allows. The ceiling binds long before this one wherever it is advertised.",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 20
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "A",
+            "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"})) / 1048576 / (2 * $instance_floor_mib)) * on (cluster, node) group_left(region) $node_region)",
+            "editorMode": "code",
+            "instant": false,
+            "range": true,
+            "legendFormat": "{{region}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2,
+              "fillOpacity": 0,
+              "showPoints": "never",
+              "spanNulls": true,
+              "axisPlacement": "auto",
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "min": 0,
+            "decimals": 0
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true,
+            "calcs": [
+              "lastNotNull",
+              "min"
+            ]
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "asc"
+          }
+        }
+      },
+      {
+        "id": 5,
+        "type": "timeseries",
+        "title": "Ceiling reserved",
+        "description": "Share of the advertised `tuist.dev/memory-ceiling-mib` capacity already requested across the region's boxes. The slope is the onboarding rate; the gap to 100% is the runway.",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 28
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "A",
+            "expr": "sum by (cluster, region) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+            "editorMode": "code",
+            "instant": false,
+            "range": true,
+            "legendFormat": "{{region}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2,
+              "fillOpacity": 0,
+              "showPoints": "never",
+              "spanNulls": true,
+              "axisPlacement": "auto",
+              "thresholdsStyle": {
+                "mode": "dashed"
+              }
+            },
+            "unit": "percentunit",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "orange",
+                  "value": 0.8
+                },
+                {
+                  "color": "red",
+                  "value": 0.95
+                }
+              ]
+            },
+            "min": 0,
+            "max": 1
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true,
+            "calcs": [
+              "lastNotNull",
+              "min"
+            ]
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "asc"
+          }
+        }
+      },
+      {
+        "id": 6,
+        "type": "timeseries",
+        "title": "Host memory used",
+        "description": "`1 - MemAvailable/MemTotal` summed across the region's boxes. Dashed lines at 85% (warning, 15% available) and 92% (critical, 8% available) match the region and box alerts.",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 28
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "refId": "A",
+            "expr": "1 - sum by (cluster, region) (node_memory_MemAvailable_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region) (node_memory_MemTotal_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"))",
+            "editorMode": "code",
+            "instant": false,
+            "range": true,
+            "legendFormat": "{{region}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2,
+              "fillOpacity": 0,
+              "showPoints": "never",
+              "spanNulls": true,
+              "axisPlacement": "auto",
+              "thresholdsStyle": {
+                "mode": "dashed"
+              }
+            },
+            "unit": "percentunit",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "orange",
+                  "value": 0.85
+                },
+                {
+                  "color": "red",
+                  "value": 0.92
+                }
+              ]
+            },
+            "min": 0,
+            "max": 1
+          },
+          "overrides": []
+        },
+        "options": {
+          "legend": {
+            "displayMode": "table",
+            "placement": "right",
+            "showLegend": true,
+            "calcs": [
+              "lastNotNull",
+              "min"
+            ]
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "asc"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -39,10 +39,10 @@
     ],
     "links": [
       {
-        "title": "Tuist Kura",
+        "title": "Tuist Kura / Customer Overview",
         "type": "link",
         "icon": "dashboard",
-        "url": "/d/tuist-kura/tuist-kura",
+        "url": "/d/dbfwllgyul4o3kf/tuist-kura-customer-overview",
         "tags": [],
         "asDropdown": false,
         "includeVars": false,

--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -158,7 +158,7 @@
         "spec": {
           "id": 1,
           "title": "RAM by region",
-          "description": "One row per Kura region. **Fit (ceiling)** and **Fit (memory)** count how many more instances of the largest profile (two replicas of `$instance_ceiling_mib` MiB ceiling / `$instance_floor_mib` MiB floor, set in the variables above) the scheduler can still place; `floor()` is taken per node before the sum, so free memory fragmented across boxes reads as zero. The next provisioning is declined when either reaches 0 — the **Kura region cannot place another instance** alert. The ceiling binds first wherever `memory_ceiling_bin_packed` is on; a region with no ceiling advertised has an empty ceiling cell.\n\n**Ceiling reserved** / **Memory requested** are the scheduler's view (reservations, not usage); **Host memory used** is the kernel's (`1 - MemAvailable/MemTotal`, reclaimable cache counts as available) and is what **Kura region host memory low** watches. Reservations full while host memory is low means a node or a smaller ceiling profile; host memory high while reservations have room means pods living above their floors.\n\nRegion comes from joining each node to the Kura pods it hosts (`kura_node_geo_info`): a freshly added, still empty node is invisible here until its first placement lands on it.",
+          "description": "One row per Kura region. **Fit (ceiling)** and **Fit (memory)** count how many more instances of the largest profile (two replicas of `$instance_ceiling_mib` MiB ceiling / `$instance_floor_mib` MiB floor, set in the variables above) the scheduler can still place; `floor()` is taken per node before the sum, so free memory fragmented across boxes reads as zero. The next provisioning is declined when either reaches 0 — the **Kura region cannot place another instance** alert. The ceiling binds first wherever `memory_ceiling_bin_packed` is on; a region whose boxes advertise no ceiling (the private runner-cache pool on Elastic Metal, which the CAPI provider does not patch) reads **no ceiling** and is bound by memory alone.\n\n**Ceiling reserved** / **Memory requested** are the scheduler's view (reservations, not usage); **Host memory used** is the kernel's (`1 - MemAvailable/MemTotal`, reclaimable cache counts as available) and is what **Kura region host memory low** watches. Reservations full while host memory is low means a node or a smaller ceiling profile; host memory high while reservations have room means pods living above their floors.\n\nRegion comes from joining each node to the Kura pods it hosts (`kura_node_geo_info`): a freshly added, still empty node is invisible here until its first placement lands on it.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -471,6 +471,21 @@
                         "value": "Fit (ceiling)"
                       },
                       {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "type": "special",
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "text": "no ceiling",
+                                "color": "text"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
                         "id": "custom.cellOptions",
                         "value": {
                           "type": "color-background",
@@ -571,6 +586,21 @@
                       {
                         "id": "displayName",
                         "value": "Ceiling reserved"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "type": "special",
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "text": "no ceiling",
+                                "color": "text"
+                              }
+                            }
+                          }
+                        ]
                       },
                       {
                         "id": "custom.cellOptions",
@@ -997,6 +1027,21 @@
                         "value": "Fit (ceiling)"
                       },
                       {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "type": "special",
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "text": "no ceiling",
+                                "color": "text"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
                         "id": "custom.cellOptions",
                         "value": {
                           "type": "color-background",
@@ -1097,6 +1142,21 @@
                       {
                         "id": "displayName",
                         "value": "Ceiling reserved"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "type": "special",
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "text": "no ceiling",
+                                "color": "text"
+                              }
+                            }
+                          }
+                        ]
                       },
                       {
                         "id": "custom.cellOptions",

--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -6,7 +6,7 @@
   },
   "spec": {
     "title": "Tuist Kura / Region Scalability",
-    "description": "How far each Kura region is from the point where it needs another node, per resource: instances the scheduler can still place, reservations versus capacity, and real host memory. RAM and disk today; egress to follow. Thresholds match the region capacity alerts in infra/helm/k8s-monitoring/alerts.md.",
+    "description": "How far each Kura region is from the point where it needs another node, per resource: instances the scheduler can still place, reservations versus capacity, and real host memory. RAM, disk and egress. Thresholds match the region capacity alerts in infra/helm/k8s-monitoring/alerts.md.",
     "tags": [
       "tuist",
       "kura",
@@ -153,6 +153,21 @@
         }
       },
       {
+        "kind": "TextVariable",
+        "spec": {
+          "name": "instance_egress_mbps",
+          "label": "Instance egress floor (Mbps)",
+          "description": "Per-replica guaranteed egress floor of the profile to size for, requested as the tuist.dev/egress-mbps extended resource (Tuist.Kura.Regions egress_guaranteed_mbps, 25 on every governed region). Multiplied by two replicas.",
+          "query": "25",
+          "current": {
+            "text": "25",
+            "value": "25"
+          },
+          "hide": "dontHide",
+          "skipUrlSync": false
+        }
+      },
+      {
         "kind": "ConstantVariable",
         "spec": {
           "name": "node_region",
@@ -173,7 +188,7 @@
         "spec": {
           "id": 7,
           "title": "Instances that still fit",
-          "description": "How many more instances of the largest profile (two replicas of `$instance_ceiling_mib` MiB ceiling / `$instance_floor_mib` MiB floor) each region can still place, by placement constraint. A pod places only if the node satisfies both, so the lower of the two is the region's real headroom; 0 means the next provisioning is declined and the region needs a node. **no ceiling** = the region's boxes advertise no `tuist.dev/memory-ceiling-mib` budget, so memory and disk are its only constraints. Disk counts two replicas of `$instance_claim_gib` GiB ephemeral-storage claims against allocatable disk. The RAM and Disk sections below have the reservations, host usage and retention behind these counts.",
+          "description": "How many more instances of the largest profile (two replicas of `$instance_ceiling_mib` MiB ceiling / `$instance_floor_mib` MiB floor) each region can still place, by placement constraint. A pod places only if the node satisfies both, so the lower of the two is the region's real headroom; 0 means the next provisioning is declined and the region needs a node. **no ceiling** = the region's boxes advertise no `tuist.dev/memory-ceiling-mib` budget and **no budget** = no `tuist.dev/egress-mbps` budget (the private runner-cache pool), so those constraints do not apply there. Disk counts two replicas of `$instance_claim_gib` GiB ephemeral-storage claims against allocatable disk; egress counts two replicas of `$instance_egress_mbps` Mbps guaranteed floors against the advertised budget (the scheduler's arithmetic, per-replica double count included). The RAM, Disk and Egress sections below have the reservations, usage and customer-facing signals behind these counts.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -247,6 +262,29 @@
                       "version": "v0"
                     }
                   }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "D",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_egress_mbps\", env=\"$env\"})) / (2 * $instance_egress_mbps)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
                 }
               ],
               "queryOptions": {},
@@ -257,7 +295,7 @@
                   "spec": {
                     "options": {
                       "include": {
-                        "pattern": "^(region|Value #[ABC])$"
+                        "pattern": "^(region|Value #[ABCD])$"
                       }
                     }
                   }
@@ -280,7 +318,8 @@
                         "region": 0,
                         "Value #A": 1,
                         "Value #B": 2,
-                        "Value #C": 3
+                        "Value #C": 3,
+                        "Value #D": 4
                       }
                     }
                   }
@@ -457,6 +496,72 @@
                       {
                         "id": "displayName",
                         "value": "Fit (disk)"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fit (egress)"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "type": "special",
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "text": "no budget",
+                                "color": "text"
+                              }
+                            }
+                          }
+                        ]
                       },
                       {
                         "id": "custom.cellOptions",
@@ -3666,6 +3771,2127 @@
             }
           }
         }
+      },
+      "panel-15": {
+        "kind": "Panel",
+        "spec": {
+          "id": 15,
+          "title": "Egress by region",
+          "description": "**Fit (egress)** counts how many more instances (two replicas of `$instance_egress_mbps` Mbps floors, requested as the `tuist.dev/egress-mbps` extended resource) the region's advertised budget still admits, `floor()` per node first; it is the `egress` row of **Kura region cannot place another instance**. **Floors reserved** is the scheduler's view. **Budget** is the provider's public cap for the boxes and the root of the egress-tree HTB tree; **Budget used** is the boxes' NIC transmit rate against it (5 m), **Peak** the highest 30 m rate over the dashboard range. A tenant above its own floor is fine, that is what ceilings are for; a region near its budget for a non-short period is not: above it every tenant is squeezed toward its floor at once (**Kura egress budget heavily used** warns at 75 %, pages at 85 %, 30 m sustained). **p95 TTFB** is the customer-facing symptom across every limit (**Kura public request latency high** at 1 s). Boxes without an advertised budget (the runner-cache pool) are out of scope by construction and read **no budget**.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_egress_mbps\", env=\"$env\"})) / (2 * $instance_egress_mbps)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "B",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "C",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "D",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (sum by (cluster, instance) (rate(node_network_transmit_bytes_total{device=~\"e(n|th).*\", env=\"$env\"}[5m])) * 8 / 1e6 * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "E",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "max_over_time((sum by (cluster, region) (sum by (cluster, instance) (rate(node_network_transmit_bytes_total{device=~\"e(n|th).*\", env=\"$env\"}[30m])) * 8 / 1e6 * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region))[$__range:5m])",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "F",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "histogram_quantile(0.95, sum by (cluster, region, le) (sum by (cluster, pod, le) (rate(kura_public_request_latency_seconds_bucket{env=\"$env\"}[5m])) * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info{env=\"$env\"})))",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "filterFieldsByName",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "pattern": "^(region|Value #[ABCDEF])$"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "merge",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {},
+                      "renameByName": {},
+                      "indexByName": {
+                        "region": 0,
+                        "Value #A": 1,
+                        "Value #B": 2,
+                        "Value #C": 3,
+                        "Value #D": 4,
+                        "Value #E": 5,
+                        "Value #F": 6
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "table",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": []
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "region"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Region"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 180
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fit (egress)"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "type": "special",
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "text": "no budget",
+                                "color": "text"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Floors reserved"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.8
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.95
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Budget"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 130
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "Mbits"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Budget used"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.85
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Peak budget used (30 m, range)"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.85
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "p95 TTFB"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 130
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 3
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "type": "special",
+                            "options": {
+                              "match": "nan",
+                              "result": {
+                                "text": "idle",
+                                "color": "text"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.5
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "showHeader": true,
+                "cellHeight": "md",
+                "sortBy": [
+                  {
+                    "displayName": "Fit (egress)",
+                    "desc": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-16": {
+        "kind": "Panel",
+        "spec": {
+          "id": 16,
+          "title": "Egress by account",
+          "description": "One row per account per box: the HTB class the egress tree shapes for every replica the account has there. **Sent** is the class's 10 m transmit rate, **Ceiling** what HTB is enforcing (`egress_burst_mbps` or the per-account override, clamps included), **Ceiling share** the ratio. A burst to the ceiling is expected; an hour within 10 % of it (**Kura account at its egress ceiling**) means the ceiling is the account's bottleneck and the lever is its per-region egress override, unless the box is near its budget too, in which case the box is the bottleneck. Sorted by ceiling share, so the accounts driving a box are on top.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "max by (cluster, region, account, node) (sum by (cluster, account, pod) (rate(kura_egress_tree_class_sent_bytes{env=\"$env\"}[10m])) * 8 / 1e6 * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "B",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "max by (cluster, region, account, node) (sum by (cluster, account, pod) (kura_egress_tree_class_ceil_bytes_per_second{env=\"$env\"}) * 8 / 1e6 * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "C",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "max by (cluster, region, account, node) ((sum by (cluster, account, pod) (rate(kura_egress_tree_class_sent_bytes{env=\"$env\"}[10m])) / sum by (cluster, account, pod) (kura_egress_tree_class_ceil_bytes_per_second{env=\"$env\"})) * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "filterFieldsByName",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "pattern": "^(region|account|node|Value #[ABC])$"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "merge",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {},
+                      "renameByName": {},
+                      "indexByName": {
+                        "region": 0,
+                        "account": 1,
+                        "node": 2,
+                        "Value #A": 3,
+                        "Value #B": 4,
+                        "Value #C": 5
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "table",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": []
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "region"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Region"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 180
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "account"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Account"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 180
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "node"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Node"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 360
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Sent"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 130
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "Mbits"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Ceiling"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 130
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "Mbits"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Ceiling share"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.9
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "showHeader": true,
+                "cellHeight": "md",
+                "sortBy": [
+                  {
+                    "displayName": "Ceiling share",
+                    "desc": true
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-17": {
+        "kind": "Panel",
+        "spec": {
+          "id": 17,
+          "title": "Response streams by region and protocol",
+          "description": "The only capacity view of the ByteStream (REAPI) read path, since gRPC never answers 429. **Not immediate** is the share of response-stream admission attempts that had to wait, degrade, hit a full queue or time out for pool bytes; the pool is sized from each pod's memory ceiling at startup, so a rising share is the egress pool nearing its byte capacity while requests still succeed (**Kura response streams waiting or degraded** warns above 5 % with at least one attempt per second). Per protocol on purpose: HTTP attempts outnumber ByteStream by two orders of magnitude and would dilute a saturated ByteStream pool to nothing. Lever: the account's memory profile, unless the box is near its egress budget too. Attempts, not requests: one read can count twice.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, protocol) (sum by (cluster, pod, protocol) (rate(kura_response_stream_admissions_total_total{env=\"$env\"}[5m])) * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info{env=\"$env\"}))",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "B",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, protocol) (sum by (cluster, pod, protocol) (rate(kura_response_stream_admissions_total_total{env=\"$env\", outcome=~\"waited|degraded|degraded_timeout|degraded_memory_unavailable|queue_full|timeout\"}[5m])) * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info{env=\"$env\"})) / sum by (cluster, region, protocol) (sum by (cluster, pod, protocol) (rate(kura_response_stream_admissions_total_total{env=\"$env\"}[5m])) * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info{env=\"$env\"}))",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "filterFieldsByName",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "pattern": "^(region|protocol|Value #[AB])$"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "merge",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {},
+                      "renameByName": {},
+                      "indexByName": {
+                        "region": 0,
+                        "protocol": 1,
+                        "Value #A": 2,
+                        "Value #B": 3
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "table",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": []
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "region"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Region"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 180
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "protocol"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Protocol"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 140
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Attempts/s"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 130
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "reqps"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Not immediate"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "type": "special",
+                            "options": {
+                              "match": "nan",
+                              "result": {
+                                "text": "idle",
+                                "color": "text"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.05
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.2
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "showHeader": true,
+                "cellHeight": "md",
+                "sortBy": [
+                  {
+                    "displayName": "Not immediate",
+                    "desc": true
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-18": {
+        "kind": "Panel",
+        "spec": {
+          "id": 18,
+          "title": "Egress by node",
+          "description": "The per-box breakdown of **Egress by region**. Every production region runs on one box today, so the rows read the same; once a region has boxes with different budgets, a single saturated box shapes its tenants whether or not the region total says so.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, node) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_egress_mbps\", env=\"$env\"})) / (2 * $instance_egress_mbps)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "B",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, node) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region, node) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "C",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, node) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "D",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, node) (label_replace(sum by (cluster, instance) (rate(node_network_transmit_bytes_total{device=~\"e(n|th).*\", env=\"$env\"}[5m])) * 8 / 1e6 * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"), \"node\", \"$1\", \"instance\", \"(.*)\")) / sum by (cluster, region, node) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "E",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "max_over_time((sum by (cluster, region, node) (label_replace(sum by (cluster, instance) (rate(node_network_transmit_bytes_total{device=~\"e(n|th).*\", env=\"$env\"}[30m])) * 8 / 1e6 * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"), \"node\", \"$1\", \"instance\", \"(.*)\")) / sum by (cluster, region, node) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region))[$__range:5m])",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "filterFieldsByName",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "pattern": "^(region|node|Value #[ABCDE])$"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "merge",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {},
+                      "renameByName": {},
+                      "indexByName": {
+                        "region": 0,
+                        "node": 1,
+                        "Value #A": 2,
+                        "Value #B": 3,
+                        "Value #C": 4,
+                        "Value #D": 5,
+                        "Value #E": 6
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "table",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": []
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "region"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Region"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 180
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "node"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Node"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 360
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fit (egress)"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "type": "special",
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "text": "no budget",
+                                "color": "text"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Floors reserved"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.8
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.95
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Budget"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 130
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "Mbits"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Budget used"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.85
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Peak budget used (30 m, range)"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.85
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "showHeader": true,
+                "cellHeight": "md",
+                "sortBy": [
+                  {
+                    "displayName": "Fit (egress)",
+                    "desc": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-19": {
+        "kind": "Panel",
+        "spec": {
+          "id": 19,
+          "title": "Instances that still fit by egress",
+          "description": "Same count as **Fit (egress)** over time: placements the guaranteed floors still allow against the advertised budget. Each provisioning steps it down, a budget change or a new node moves it.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_egress_mbps\", env=\"$env\"})) / (2 * $instance_egress_mbps)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "{{region}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      },
+                      {
+                        "color": "green",
+                        "value": 2
+                      }
+                    ]
+                  },
+                  "unit": "short",
+                  "min": 0,
+                  "decimals": 0
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "asc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "panel-20": {
+        "kind": "Panel",
+        "spec": {
+          "id": 20,
+          "title": "Egress budget used",
+          "description": "NIC transmit rate of the region's boxes against the advertised `tuist.dev/egress-mbps` budget (5 m). Dashed lines at 75 % (warning) and 85 % (critical), both 30 m sustained in the alerts.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (sum by (cluster, instance) (rate(node_network_transmit_bytes_total{device=~\"e(n|th).*\", env=\"$env\"}[5m])) * 8 / 1e6 * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_egress_mbps\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "{{region}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.75
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.85
+                      }
+                    ]
+                  },
+                  "unit": "percentunit",
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "asc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "panel-21": {
+        "kind": "Panel",
+        "spec": {
+          "id": 21,
+          "title": "Top accounts by egress",
+          "description": "The five accounts sending the most through their egress-tree classes (10 m rate), which is the \"who is driving it\" annotation behind the budget alerts.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "topk(5, max by (cluster, region, account, node) (sum by (cluster, account, pod) (rate(kura_egress_tree_class_sent_bytes{env=\"$env\"}[10m])) * 8 / 1e6 * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region))",
+                        "legendFormat": "{{account}} on {{node}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "Mbits",
+                  "min": 0,
+                  "decimals": 1
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "asc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "panel-22": {
+        "kind": "Panel",
+        "spec": {
+          "id": 22,
+          "title": "p95 time to first byte",
+          "description": "p95 of time to first response byte for public cache requests (HTTP and gRPC) across each region's instances. Dashed lines at 0.5 s and 1 s (the alert bar, 30 m sustained). Not a diagnosis: the panels above say why, this one says the customer feels it.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "histogram_quantile(0.95, sum by (cluster, region, le) (sum by (cluster, pod, le) (rate(kura_public_request_latency_seconds_bucket{env=\"$env\"}[5m])) * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info{env=\"$env\"})))",
+                        "legendFormat": "{{region}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.5
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "s",
+                  "min": 0,
+                  "decimals": 3
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "asc"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "layout": {
@@ -3912,6 +6138,138 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-14"
+                        },
+                        "x": 12,
+                        "y": 8,
+                        "width": 12,
+                        "height": 8
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Egress",
+              "collapse": true,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-15"
+                        },
+                        "x": 0,
+                        "y": 0,
+                        "width": 24,
+                        "height": 9
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-16"
+                        },
+                        "x": 0,
+                        "y": 9,
+                        "width": 24,
+                        "height": 12
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-17"
+                        },
+                        "x": 0,
+                        "y": 21,
+                        "width": 24,
+                        "height": 9
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-18"
+                        },
+                        "x": 0,
+                        "y": 30,
+                        "width": 24,
+                        "height": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Egress trends",
+              "collapse": true,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-19"
+                        },
+                        "x": 0,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-20"
+                        },
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-21"
+                        },
+                        "x": 0,
+                        "y": 8,
+                        "width": 12,
+                        "height": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-22"
                         },
                         "x": 12,
                         "y": 8,

--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -4372,7 +4372,7 @@
         "spec": {
           "id": 16,
           "title": "Egress by account",
-          "description": "One row per account per box: the HTB class the egress tree shapes for every replica the account has there. **Sent** is the class's 10 m transmit rate, **Ceiling** what HTB is enforcing (`egress_burst_mbps` or the per-account override, clamps included), **Ceiling share** the ratio. A burst to the ceiling is expected; an hour within 10 % of it (**Kura account at its egress ceiling**) means the ceiling is the account's bottleneck and the lever is its per-region egress override, unless the box is near its budget too, in which case the box is the bottleneck. Sorted by ceiling share, so the accounts driving a box are on top.",
+          "description": "One row per account per box: the HTB class the egress tree shapes for every replica the account has there. **Sent (10 m)** is the class's transmit rate averaged over the last ten minutes, the alert's window; **Peak sent** is the highest 5 m rate over the dashboard range, which is where a bursty account's real demand shows (a 10 m average reads several times lower than a two-minute burst; the class counter is refreshed once per 2 m reconcile, so windows under 5 m are not honest and the NIC's own 2 m peak in **Egress by node** runs higher still). **Ceiling** is what HTB is enforcing (`egress_burst_mbps` or the per-account override, clamps included), **Ceiling share** the 10 m ratio. A burst to the ceiling is expected; an hour within 10 % of it (**Kura account at its egress ceiling**) means the ceiling is the account's bottleneck and the lever is its per-region egress override, unless the box is near its budget too, in which case the box is the bottleneck. Sorted by peak, so the accounts driving a box are on top.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -4390,7 +4390,7 @@
                       "group": "prometheus",
                       "kind": "DataQuery",
                       "spec": {
-                        "expr": "max by (cluster, region, account, node) (sum by (cluster, account, pod) (rate(kura_egress_tree_class_sent_bytes{env=\"$env\"}[10m])) * 8 / 1e6 * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "expr": "max by (cluster, region, account, node) (sum by (cluster, account, pod) (rate(kura_egress_tree_class_sent_bytes{env=\"$env\", account!=\"\"}[10m])) * 8 / 1e6 * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region)",
                         "legendFormat": "__auto",
                         "instant": true,
                         "range": false,
@@ -4413,7 +4413,7 @@
                       "group": "prometheus",
                       "kind": "DataQuery",
                       "spec": {
-                        "expr": "max by (cluster, region, account, node) (sum by (cluster, account, pod) (kura_egress_tree_class_ceil_bytes_per_second{env=\"$env\"}) * 8 / 1e6 * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "expr": "max_over_time((max by (cluster, region, account, node) (sum by (cluster, account, pod) (rate(kura_egress_tree_class_sent_bytes{env=\"$env\", account!=\"\"}[5m])) * 8 / 1e6 * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region))[$__range:1m])",
                         "legendFormat": "__auto",
                         "instant": true,
                         "range": false,
@@ -4436,7 +4436,30 @@
                       "group": "prometheus",
                       "kind": "DataQuery",
                       "spec": {
-                        "expr": "max by (cluster, region, account, node) ((sum by (cluster, account, pod) (rate(kura_egress_tree_class_sent_bytes{env=\"$env\"}[10m])) / sum by (cluster, account, pod) (kura_egress_tree_class_ceil_bytes_per_second{env=\"$env\"})) * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "expr": "max by (cluster, region, account, node) (sum by (cluster, account, pod) (kura_egress_tree_class_ceil_bytes_per_second{env=\"$env\", account!=\"\"}) * 8 / 1e6 * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "D",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "max by (cluster, region, account, node) ((sum by (cluster, account, pod) (rate(kura_egress_tree_class_sent_bytes{env=\"$env\", account!=\"\"}[10m])) / sum by (cluster, account, pod) (kura_egress_tree_class_ceil_bytes_per_second{env=\"$env\", account!=\"\"})) * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region)",
                         "legendFormat": "__auto",
                         "instant": true,
                         "range": false,
@@ -4456,7 +4479,7 @@
                   "spec": {
                     "options": {
                       "include": {
-                        "pattern": "^(region|account|node|Value #[ABC])$"
+                        "pattern": "^(region|account|node|Value #[ABCD])$"
                       }
                     }
                   }
@@ -4481,7 +4504,8 @@
                         "node": 2,
                         "Value #A": 3,
                         "Value #B": 4,
-                        "Value #C": 5
+                        "Value #C": 5,
+                        "Value #D": 6
                       }
                     }
                   }
@@ -4572,7 +4596,7 @@
                     "properties": [
                       {
                         "id": "displayName",
-                        "value": "Sent"
+                        "value": "Sent (10 m)"
                       },
                       {
                         "id": "custom.width",
@@ -4600,6 +4624,34 @@
                     "properties": [
                       {
                         "id": "displayName",
+                        "value": "Peak sent (5 m, range)"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 170
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "Mbits"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
                         "value": "Ceiling"
                       },
                       {
@@ -4623,12 +4675,12 @@
                   {
                     "matcher": {
                       "id": "byName",
-                      "options": "Value #C"
+                      "options": "Value #D"
                     },
                     "properties": [
                       {
                         "id": "displayName",
-                        "value": "Ceiling share"
+                        "value": "Ceiling share (10 m)"
                       },
                       {
                         "id": "custom.cellOptions",
@@ -4687,7 +4739,7 @@
                 "cellHeight": "md",
                 "sortBy": [
                   {
-                    "displayName": "Ceiling share",
+                    "displayName": "Peak sent (5 m, range)",
                     "desc": true
                   }
                 ]
@@ -5700,7 +5752,7 @@
         "spec": {
           "id": 21,
           "title": "Top accounts by egress",
-          "description": "The five accounts sending the most through their egress-tree classes (10 m rate), which is the \"who is driving it\" annotation behind the budget alerts.",
+          "description": "The five accounts sending the most through their egress-tree classes (5 m rate; the class counter refreshes once per 2 m reconcile, so shorter windows are not honest and bursts under five minutes read lower than the NIC shows), which is the \"who is driving it\" annotation behind the budget alerts.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -5718,7 +5770,7 @@
                       "group": "prometheus",
                       "kind": "DataQuery",
                       "spec": {
-                        "expr": "topk(5, max by (cluster, region, account, node) (sum by (cluster, account, pod) (rate(kura_egress_tree_class_sent_bytes{env=\"$env\"}[10m])) * 8 / 1e6 * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region))",
+                        "expr": "topk(5, max by (cluster, region, account, node) (sum by (cluster, account, pod) (rate(kura_egress_tree_class_sent_bytes{env=\"$env\", account!=\"\"}[5m])) * 8 / 1e6 * on (cluster, pod) group_left(node) max by (cluster, pod, node) (kube_pod_info{namespace=\"kura\", pod=~\".*egress-tree-agent.*\"}) * on (cluster, node) group_left(region) $node_region))",
                         "legendFormat": "{{account}} on {{node}}",
                         "instant": false,
                         "range": true

--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -2056,7 +2056,7 @@
             "kind": "RowsLayoutRow",
             "spec": {
               "title": "RAM",
-              "collapse": false,
+              "collapse": true,
               "layout": {
                 "kind": "GridLayout",
                 "spec": {
@@ -2096,7 +2096,7 @@
             "kind": "RowsLayoutRow",
             "spec": {
               "title": "RAM trends",
-              "collapse": false,
+              "collapse": true,
               "layout": {
                 "kind": "GridLayout",
                 "spec": {

--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -153,6 +153,278 @@
       }
     ],
     "elements": {
+      "panel-7": {
+        "kind": "Panel",
+        "spec": {
+          "id": 7,
+          "title": "Instances that still fit",
+          "description": "How many more instances of the largest profile (two replicas of `$instance_ceiling_mib` MiB ceiling / `$instance_floor_mib` MiB floor) each region can still place, by placement constraint. A pod places only if the node satisfies both, so the lower of the two is the region's real headroom; 0 means the next provisioning is declined and the region needs a node. **no ceiling** = the region's boxes advertise no `tuist.dev/memory-ceiling-mib` budget, so memory is its only constraint. The RAM section below has the reservations and host memory behind these counts.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"})) / (2 * $instance_ceiling_mib)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "B",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"})) / 1048576 / (2 * $instance_floor_mib)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "filterFieldsByName",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "pattern": "^(region|Value #[AB])$"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "merge",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {},
+                      "renameByName": {},
+                      "indexByName": {
+                        "region": 0,
+                        "Value #A": 1,
+                        "Value #B": 2
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "table",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": []
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "region"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Region"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 220
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fit (ceiling)"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "type": "special",
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "text": "no ceiling",
+                                "color": "text"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fit (memory)"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "showHeader": true,
+                "cellHeight": "md",
+                "sortBy": [
+                  {
+                    "displayName": "Fit (ceiling)",
+                    "desc": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
       "panel-1": {
         "kind": "Panel",
         "spec": {
@@ -1753,6 +2025,33 @@
       "kind": "RowsLayout",
       "spec": {
         "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Overview",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-7"
+                        },
+                        "x": 0,
+                        "y": 0,
+                        "width": 24,
+                        "height": 7
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
           {
             "kind": "RowsLayoutRow",
             "spec": {

--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -334,7 +334,7 @@
                   "spec": {
                     "options": {
                       "include": {
-                        "pattern": "^(region|cluster|Value #[ABCDEFG])$"
+                        "pattern": "^(region|Value #[ABCDEFG])$"
                       }
                     }
                   }
@@ -355,14 +355,13 @@
                       "renameByName": {},
                       "indexByName": {
                         "region": 0,
-                        "cluster": 1,
-                        "Value #A": 2,
-                        "Value #B": 3,
-                        "Value #C": 4,
-                        "Value #D": 5,
-                        "Value #E": 6,
-                        "Value #F": 7,
-                        "Value #G": 8
+                        "Value #A": 1,
+                        "Value #B": 2,
+                        "Value #C": 3,
+                        "Value #D": 4,
+                        "Value #E": 5,
+                        "Value #F": 6,
+                        "Value #G": 7
                       }
                     }
                   }
@@ -410,22 +409,6 @@
                       {
                         "id": "custom.width",
                         "value": 180
-                      }
-                    ]
-                  },
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "options": "cluster"
-                    },
-                    "properties": [
-                      {
-                        "id": "displayName",
-                        "value": "Cluster"
-                      },
-                      {
-                        "id": "custom.width",
-                        "value": 150
                       }
                     ]
                   },
@@ -910,7 +893,7 @@
                   "spec": {
                     "options": {
                       "include": {
-                        "pattern": "^(region|node|cluster|Value #[ABCDE])$"
+                        "pattern": "^(region|node|Value #[ABCDE])$"
                       }
                     }
                   }
@@ -932,12 +915,11 @@
                       "indexByName": {
                         "region": 0,
                         "node": 1,
-                        "cluster": 2,
-                        "Value #A": 3,
-                        "Value #B": 4,
-                        "Value #C": 5,
-                        "Value #D": 6,
-                        "Value #E": 7
+                        "Value #A": 2,
+                        "Value #B": 3,
+                        "Value #C": 4,
+                        "Value #D": 5,
+                        "Value #E": 6
                       }
                     }
                   }
@@ -1001,22 +983,6 @@
                       {
                         "id": "custom.width",
                         "value": 360
-                      }
-                    ]
-                  },
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "options": "cluster"
-                    },
-                    "properties": [
-                      {
-                        "id": "displayName",
-                        "value": "Cluster"
-                      },
-                      {
-                        "id": "custom.width",
-                        "value": 150
                       }
                     ]
                   },

--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -1,1487 +1,1840 @@
 {
-  "apiVersion": "dashboard.grafana.app/v1",
+  "apiVersion": "dashboard.grafana.app/v2",
   "kind": "Dashboard",
   "metadata": {
     "name": "tuist-kura-region-scalability"
   },
   "spec": {
     "title": "Tuist Kura / Region Scalability",
-    "uid": "tuist-kura-region-scalability",
     "description": "How far each Kura region is from the point where it needs another node, per resource: instances the scheduler can still place, reservations versus capacity, and real host memory. RAM today; disk and egress columns to follow. Thresholds match the region capacity alerts in infra/helm/k8s-monitoring/alerts.md.",
-    "schemaVersion": 39,
-    "version": 1,
-    "editable": true,
-    "graphTooltip": 1,
-    "refresh": "1m",
     "tags": [
       "tuist",
       "kura",
       "capacity"
     ],
-    "time": {
-      "from": "now-7d",
-      "to": "now"
-    },
-    "timepicker": {},
-    "timezone": "browser",
-    "links": [
+    "editable": true,
+    "liveNow": false,
+    "preload": false,
+    "cursorSync": "Crosshair",
+    "annotations": [
       {
-        "title": "Tuist Kura",
-        "type": "dashboards",
-        "tags": [
-          "kura"
-        ],
-        "asDropdown": true,
-        "includeVars": false,
-        "keepTime": true
-      }
-    ],
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
           "enable": true,
           "hide": true,
           "iconColor": "rgba(0, 211, 255, 1)",
           "name": "Annotations & Alerts",
-          "type": "dashboard"
-        }
-      ]
-    },
-    "templating": {
-      "list": [
-        {
-          "type": "datasource",
-          "name": "datasource",
-          "label": "Data Source",
-          "query": "prometheus",
-          "current": {
-            "selected": false,
-            "text": "grafanacloud-prom",
-            "value": "grafanacloud-prom"
-          },
-          "hide": 0,
-          "includeAll": false,
-          "multi": false,
-          "options": [],
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false
-        },
-        {
-          "type": "query",
-          "name": "env",
-          "label": "Environment",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
           "query": {
-            "query": "label_values(kura_node_geo_info, env)",
-            "refId": "PrometheusVariableQueryEditor-VariableQuery"
-          },
-          "definition": "label_values(kura_node_geo_info, env)",
-          "current": {
-            "selected": true,
-            "text": "production",
-            "value": "production"
-          },
-          "hide": 0,
-          "includeAll": false,
-          "multi": false,
-          "options": [],
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 1
-        },
-        {
-          "type": "textbox",
-          "name": "instance_ceiling_mib",
-          "query": "4096",
-          "hide": 0,
-          "skipUrlSync": false,
-          "current": {
-            "selected": false,
-            "text": "4096",
-            "value": "4096"
-          },
-          "options": [
-            {
-              "selected": true,
-              "text": "4096",
-              "value": "4096"
-            }
-          ],
-          "label": "Instance ceiling (MiB)",
-          "description": "Per-replica memory limit of the profile to size for; the enterprise profile requests 4096 MiB as the tuist.dev/memory-ceiling-mib extended resource. Multiplied by two replicas."
-        },
-        {
-          "type": "textbox",
-          "name": "instance_floor_mib",
-          "query": "1024",
-          "hide": 0,
-          "skipUrlSync": false,
-          "current": {
-            "selected": false,
-            "text": "1024",
-            "value": "1024"
-          },
-          "options": [
-            {
-              "selected": true,
-              "text": "1024",
-              "value": "1024"
-            }
-          ],
-          "label": "Instance floor (MiB)",
-          "description": "Per-replica memory request of the profile to size for (Tuist.Kura.Regions.memory_profile/1); 1024 MiB for enterprise. Multiplied by two replicas."
-        },
-        {
-          "type": "constant",
-          "name": "node_region",
-          "query": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))",
-          "hide": 2,
-          "skipUrlSync": false,
-          "current": {
-            "selected": false,
-            "text": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))",
-            "value": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))"
-          },
-          "options": [
-            {
-              "selected": true,
-              "text": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))",
-              "value": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))"
-            }
-          ],
-          "description": "The node → region join every query on this dashboard uses, kept in one place. Mirrors the kura:node_region recording rule in infra/helm/k8s-monitoring/alerts.md; swap this value for `kura:node_region` once that rule exists."
-        }
-      ]
-    },
-    "panels": [
-      {
-        "id": 100,
-        "type": "row",
-        "title": "RAM",
-        "collapsed": false,
-        "panels": [],
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        }
-      },
-      {
-        "id": 1,
-        "type": "table",
-        "title": "RAM by region",
-        "description": "One row per Kura region. **Fit (ceiling)** and **Fit (memory)** count how many more instances of the largest profile (two replicas of `$instance_ceiling_mib` MiB ceiling / `$instance_floor_mib` MiB floor, set in the variables above) the scheduler can still place; `floor()` is taken per node before the sum, so free memory fragmented across boxes reads as zero. The next provisioning is declined when either reaches 0 — the **Kura region cannot place another instance** alert. The ceiling binds first wherever `memory_ceiling_bin_packed` is on; a region with no ceiling advertised has an empty ceiling cell.\n\n**Ceiling reserved** / **Memory requested** are the scheduler's view (reservations, not usage); **Host memory used** is the kernel's (`1 - MemAvailable/MemTotal`, reclaimable cache counts as available) and is what **Kura region host memory low** watches. Reservations full while host memory is low means a node or a smaller ceiling profile; host memory high while reservations have room means pods living above their floors.\n\nRegion comes from joining each node to the Kura pods it hosts (`kura_node_geo_info`): a freshly added, still empty node is invisible here until its first placement lands on it.",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 24,
-          "x": 0,
-          "y": 1
-        },
-        "targets": [
-          {
             "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
+              "name": "-- Grafana --"
             },
-            "refId": "A",
-            "expr": "count by (cluster, region) (max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
-            "editorMode": "code",
-            "instant": true,
-            "range": false,
-            "format": "table"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "B",
-            "expr": "count by (cluster, region) (kube_pod_info{namespace=\"kura\", env=\"$env\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))",
-            "editorMode": "code",
-            "instant": true,
-            "range": false,
-            "format": "table"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "C",
-            "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"})) / (2 * $instance_ceiling_mib)) * on (cluster, node) group_left(region) $node_region)",
-            "editorMode": "code",
-            "instant": true,
-            "range": false,
-            "format": "table"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "D",
-            "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"})) / 1048576 / (2 * $instance_floor_mib)) * on (cluster, node) group_left(region) $node_region)",
-            "editorMode": "code",
-            "instant": true,
-            "range": false,
-            "format": "table"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "E",
-            "expr": "sum by (cluster, region) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
-            "editorMode": "code",
-            "instant": true,
-            "range": false,
-            "format": "table"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "F",
-            "expr": "sum by (cluster, region) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
-            "editorMode": "code",
-            "instant": true,
-            "range": false,
-            "format": "table"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "G",
-            "expr": "1 - sum by (cluster, region) (node_memory_MemAvailable_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region) (node_memory_MemTotal_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"))",
-            "editorMode": "code",
-            "instant": true,
-            "range": false,
-            "format": "table"
-          }
-        ],
-        "transformations": [
-          {
-            "id": "merge",
-            "options": {}
-          },
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "Time": true
-              },
-              "renameByName": {
-                "Value #A": "Nodes",
-                "Value #B": "Kura pods",
-                "Value #C": "Fit (ceiling)",
-                "Value #D": "Fit (memory)",
-                "Value #E": "Ceiling reserved",
-                "Value #F": "Memory requested",
-                "Value #G": "Host memory used"
-              },
-              "indexByName": {
-                "region": 0,
-                "cluster": 1,
-                "Nodes": 2,
-                "Kura pods": 3,
-                "Fit (ceiling)": 4,
-                "Fit (memory)": 5,
-                "Ceiling reserved": 6,
-                "Memory requested": 7,
-                "Host memory used": 8
-              }
-            }
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "auto"
-              },
-              "inspect": false,
-              "filterable": false
-            },
-            "color": {
-              "mode": "thresholds"
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "text",
-                  "value": null
-                }
-              ]
-            }
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "region"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 180
-                },
-                {
-                  "id": "displayName",
-                  "value": "Region"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "cluster"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 150
-                },
-                {
-                  "id": "displayName",
-                  "value": "Cluster"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Nodes"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 90
-                },
-                {
-                  "id": "custom.align",
-                  "value": "center"
-                },
-                {
-                  "id": "decimals",
-                  "value": 0
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Kura pods"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 90
-                },
-                {
-                  "id": "custom.align",
-                  "value": "center"
-                },
-                {
-                  "id": "decimals",
-                  "value": 0
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Fit (ceiling)"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "color-background",
-                    "mode": "basic"
-                  }
-                },
-                {
-                  "id": "custom.align",
-                  "value": "center"
-                },
-                {
-                  "id": "custom.width",
-                  "value": 150
-                },
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "red",
-                        "value": null
-                      },
-                      {
-                        "color": "orange",
-                        "value": 1
-                      },
-                      {
-                        "color": "green",
-                        "value": 2
-                      }
-                    ]
-                  }
-                },
-                {
-                  "id": "decimals",
-                  "value": 0
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Fit (memory)"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "color-background",
-                    "mode": "basic"
-                  }
-                },
-                {
-                  "id": "custom.align",
-                  "value": "center"
-                },
-                {
-                  "id": "custom.width",
-                  "value": 150
-                },
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "red",
-                        "value": null
-                      },
-                      {
-                        "color": "orange",
-                        "value": 1
-                      },
-                      {
-                        "color": "green",
-                        "value": 2
-                      }
-                    ]
-                  }
-                },
-                {
-                  "id": "decimals",
-                  "value": 0
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Ceiling reserved"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "gauge",
-                    "mode": "gradient",
-                    "valueDisplayMode": "text"
-                  }
-                },
-                {
-                  "id": "custom.width",
-                  "value": 190
-                },
-                {
-                  "id": "unit",
-                  "value": "percentunit"
-                },
-                {
-                  "id": "min",
-                  "value": 0
-                },
-                {
-                  "id": "max",
-                  "value": 1
-                },
-                {
-                  "id": "decimals",
-                  "value": 1
-                },
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": null
-                      },
-                      {
-                        "color": "orange",
-                        "value": 0.8
-                      },
-                      {
-                        "color": "red",
-                        "value": 0.95
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Memory requested"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "gauge",
-                    "mode": "gradient",
-                    "valueDisplayMode": "text"
-                  }
-                },
-                {
-                  "id": "custom.width",
-                  "value": 190
-                },
-                {
-                  "id": "unit",
-                  "value": "percentunit"
-                },
-                {
-                  "id": "min",
-                  "value": 0
-                },
-                {
-                  "id": "max",
-                  "value": 1
-                },
-                {
-                  "id": "decimals",
-                  "value": 1
-                },
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": null
-                      },
-                      {
-                        "color": "orange",
-                        "value": 0.8
-                      },
-                      {
-                        "color": "red",
-                        "value": 0.95
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Host memory used"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "gauge",
-                    "mode": "gradient",
-                    "valueDisplayMode": "text"
-                  }
-                },
-                {
-                  "id": "custom.width",
-                  "value": 190
-                },
-                {
-                  "id": "unit",
-                  "value": "percentunit"
-                },
-                {
-                  "id": "min",
-                  "value": 0
-                },
-                {
-                  "id": "max",
-                  "value": 1
-                },
-                {
-                  "id": "decimals",
-                  "value": 1
-                },
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": null
-                      },
-                      {
-                        "color": "orange",
-                        "value": 0.85
-                      },
-                      {
-                        "color": "red",
-                        "value": 0.92
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "options": {
-          "showHeader": true,
-          "cellHeight": "md",
-          "footer": {
-            "show": false,
-            "reducer": [
-              "sum"
-            ],
-            "fields": ""
-          },
-          "sortBy": [
-            {
-              "displayName": "Fit (ceiling)",
-              "desc": false
-            }
-          ]
-        }
-      },
-      {
-        "id": 2,
-        "type": "table",
-        "title": "RAM by node",
-        "description": "The per-box breakdown of the table above, for finding which box is full or fragmented. A region can read 0 fits while every box still has free memory if no single box has one instance's worth. **Host memory used** here is what **Kura cache box out of memory** watches (critical below 8% available).",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 24,
-          "x": 0,
-          "y": 10
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "A",
-            "expr": "sum by (cluster, region, node) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"})) / (2 * $instance_ceiling_mib)) * on (cluster, node) group_left(region) $node_region)",
-            "editorMode": "code",
-            "instant": true,
-            "range": false,
-            "format": "table"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "B",
-            "expr": "sum by (cluster, region, node) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"})) / 1048576 / (2 * $instance_floor_mib)) * on (cluster, node) group_left(region) $node_region)",
-            "editorMode": "code",
-            "instant": true,
-            "range": false,
-            "format": "table"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "C",
-            "expr": "sum by (cluster, region, node) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region, node) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
-            "editorMode": "code",
-            "instant": true,
-            "range": false,
-            "format": "table"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "D",
-            "expr": "sum by (cluster, region, node) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region, node) (max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
-            "editorMode": "code",
-            "instant": true,
-            "range": false,
-            "format": "table"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "E",
-            "expr": "1 - sum by (cluster, region, node) (label_replace(node_memory_MemAvailable_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"), \"node\", \"$1\", \"instance\", \"(.*)\")) / sum by (cluster, region, node) (label_replace(node_memory_MemTotal_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"), \"node\", \"$1\", \"instance\", \"(.*)\"))",
-            "editorMode": "code",
-            "instant": true,
-            "range": false,
-            "format": "table"
-          }
-        ],
-        "transformations": [
-          {
-            "id": "merge",
-            "options": {}
-          },
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "Time": true
-              },
-              "renameByName": {
-                "Value #A": "Fit (ceiling)",
-                "Value #B": "Fit (memory)",
-                "Value #C": "Ceiling reserved",
-                "Value #D": "Memory requested",
-                "Value #E": "Host memory used"
-              },
-              "indexByName": {
-                "region": 0,
-                "node": 1,
-                "cluster": 2,
-                "Fit (ceiling)": 3,
-                "Fit (memory)": 4,
-                "Ceiling reserved": 5,
-                "Memory requested": 6,
-                "Host memory used": 7
-              }
-            }
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "auto"
-              },
-              "inspect": false,
-              "filterable": false
-            },
-            "color": {
-              "mode": "thresholds"
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "text",
-                  "value": null
-                }
-              ]
-            }
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "region"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 180
-                },
-                {
-                  "id": "displayName",
-                  "value": "Region"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "node"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 360
-                },
-                {
-                  "id": "displayName",
-                  "value": "Node"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "cluster"
-              },
-              "properties": [
-                {
-                  "id": "custom.width",
-                  "value": 150
-                },
-                {
-                  "id": "displayName",
-                  "value": "Cluster"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Fit (ceiling)"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "color-background",
-                    "mode": "basic"
-                  }
-                },
-                {
-                  "id": "custom.align",
-                  "value": "center"
-                },
-                {
-                  "id": "custom.width",
-                  "value": 150
-                },
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "red",
-                        "value": null
-                      },
-                      {
-                        "color": "orange",
-                        "value": 1
-                      },
-                      {
-                        "color": "green",
-                        "value": 2
-                      }
-                    ]
-                  }
-                },
-                {
-                  "id": "decimals",
-                  "value": 0
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Fit (memory)"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "color-background",
-                    "mode": "basic"
-                  }
-                },
-                {
-                  "id": "custom.align",
-                  "value": "center"
-                },
-                {
-                  "id": "custom.width",
-                  "value": 150
-                },
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "red",
-                        "value": null
-                      },
-                      {
-                        "color": "orange",
-                        "value": 1
-                      },
-                      {
-                        "color": "green",
-                        "value": 2
-                      }
-                    ]
-                  }
-                },
-                {
-                  "id": "decimals",
-                  "value": 0
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Ceiling reserved"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "gauge",
-                    "mode": "gradient",
-                    "valueDisplayMode": "text"
-                  }
-                },
-                {
-                  "id": "custom.width",
-                  "value": 190
-                },
-                {
-                  "id": "unit",
-                  "value": "percentunit"
-                },
-                {
-                  "id": "min",
-                  "value": 0
-                },
-                {
-                  "id": "max",
-                  "value": 1
-                },
-                {
-                  "id": "decimals",
-                  "value": 1
-                },
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": null
-                      },
-                      {
-                        "color": "orange",
-                        "value": 0.8
-                      },
-                      {
-                        "color": "red",
-                        "value": 0.95
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Memory requested"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "gauge",
-                    "mode": "gradient",
-                    "valueDisplayMode": "text"
-                  }
-                },
-                {
-                  "id": "custom.width",
-                  "value": 190
-                },
-                {
-                  "id": "unit",
-                  "value": "percentunit"
-                },
-                {
-                  "id": "min",
-                  "value": 0
-                },
-                {
-                  "id": "max",
-                  "value": 1
-                },
-                {
-                  "id": "decimals",
-                  "value": 1
-                },
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": null
-                      },
-                      {
-                        "color": "orange",
-                        "value": 0.8
-                      },
-                      {
-                        "color": "red",
-                        "value": 0.95
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "Host memory used"
-              },
-              "properties": [
-                {
-                  "id": "custom.cellOptions",
-                  "value": {
-                    "type": "gauge",
-                    "mode": "gradient",
-                    "valueDisplayMode": "text"
-                  }
-                },
-                {
-                  "id": "custom.width",
-                  "value": 190
-                },
-                {
-                  "id": "unit",
-                  "value": "percentunit"
-                },
-                {
-                  "id": "min",
-                  "value": 0
-                },
-                {
-                  "id": "max",
-                  "value": 1
-                },
-                {
-                  "id": "decimals",
-                  "value": 1
-                },
-                {
-                  "id": "thresholds",
-                  "value": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": null
-                      },
-                      {
-                        "color": "orange",
-                        "value": 0.85
-                      },
-                      {
-                        "color": "red",
-                        "value": 0.92
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        "options": {
-          "showHeader": true,
-          "cellHeight": "md",
-          "footer": {
-            "show": false,
-            "reducer": [
-              "sum"
-            ],
-            "fields": ""
-          },
-          "sortBy": [
-            {
-              "displayName": "Fit (ceiling)",
-              "desc": false
-            }
-          ]
-        }
-      },
-      {
-        "id": 101,
-        "type": "row",
-        "title": "RAM trends",
-        "collapsed": false,
-        "panels": [],
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 19
-        }
-      },
-      {
-        "id": 3,
-        "type": "timeseries",
-        "title": "Instances that still fit by ceiling",
-        "description": "Same count as the table's **Fit (ceiling)** column over time. Each provisioning steps it down by one; a new node steps it up. Dashed lines at 2 (warning) and 1 (critical).",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 20
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "A",
-            "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"})) / (2 * $instance_ceiling_mib)) * on (cluster, node) group_left(region) $node_region)",
-            "editorMode": "code",
-            "instant": false,
-            "range": true,
-            "legendFormat": "{{region}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "drawStyle": "line",
-              "lineWidth": 2,
-              "fillOpacity": 0,
-              "showPoints": "never",
-              "spanNulls": true,
-              "axisPlacement": "auto",
-              "thresholdsStyle": {
-                "mode": "dashed"
-              }
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "red",
-                  "value": null
-                },
-                {
-                  "color": "orange",
-                  "value": 1
-                },
-                {
-                  "color": "green",
-                  "value": 2
-                }
-              ]
-            },
-            "min": 0,
-            "decimals": 0
-          },
-          "overrides": []
-        },
-        "options": {
-          "legend": {
-            "displayMode": "table",
-            "placement": "right",
-            "showLegend": true,
-            "calcs": [
-              "lastNotNull",
-              "min"
-            ]
-          },
-          "tooltip": {
-            "mode": "multi",
-            "sort": "asc"
-          }
-        }
-      },
-      {
-        "id": 4,
-        "type": "timeseries",
-        "title": "Instances that still fit by memory",
-        "description": "Same count as the table's **Fit (memory)** column over time: placements the native memory request (the floor) still allows. The ceiling binds long before this one wherever it is advertised.",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 20
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "A",
-            "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"})) / 1048576 / (2 * $instance_floor_mib)) * on (cluster, node) group_left(region) $node_region)",
-            "editorMode": "code",
-            "instant": false,
-            "range": true,
-            "legendFormat": "{{region}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "drawStyle": "line",
-              "lineWidth": 2,
-              "fillOpacity": 0,
-              "showPoints": "never",
-              "spanNulls": true,
-              "axisPlacement": "auto",
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "min": 0,
-            "decimals": 0
-          },
-          "overrides": []
-        },
-        "options": {
-          "legend": {
-            "displayMode": "table",
-            "placement": "right",
-            "showLegend": true,
-            "calcs": [
-              "lastNotNull",
-              "min"
-            ]
-          },
-          "tooltip": {
-            "mode": "multi",
-            "sort": "asc"
-          }
-        }
-      },
-      {
-        "id": 5,
-        "type": "timeseries",
-        "title": "Ceiling reserved",
-        "description": "Share of the advertised `tuist.dev/memory-ceiling-mib` capacity already requested across the region's boxes. The slope is the onboarding rate; the gap to 100% is the runway.",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 28
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "A",
-            "expr": "sum by (cluster, region) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
-            "editorMode": "code",
-            "instant": false,
-            "range": true,
-            "legendFormat": "{{region}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "drawStyle": "line",
-              "lineWidth": 2,
-              "fillOpacity": 0,
-              "showPoints": "never",
-              "spanNulls": true,
-              "axisPlacement": "auto",
-              "thresholdsStyle": {
-                "mode": "dashed"
-              }
-            },
-            "unit": "percentunit",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "orange",
-                  "value": 0.8
-                },
-                {
-                  "color": "red",
-                  "value": 0.95
-                }
-              ]
-            },
-            "min": 0,
-            "max": 1
-          },
-          "overrides": []
-        },
-        "options": {
-          "legend": {
-            "displayMode": "table",
-            "placement": "right",
-            "showLegend": true,
-            "calcs": [
-              "lastNotNull",
-              "min"
-            ]
-          },
-          "tooltip": {
-            "mode": "multi",
-            "sort": "asc"
-          }
-        }
-      },
-      {
-        "id": 6,
-        "type": "timeseries",
-        "title": "Host memory used",
-        "description": "`1 - MemAvailable/MemTotal` summed across the region's boxes. Dashed lines at 85% (warning, 15% available) and 92% (critical, 8% available) match the region and box alerts.",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 28
-        },
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${datasource}"
-            },
-            "refId": "A",
-            "expr": "1 - sum by (cluster, region) (node_memory_MemAvailable_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region) (node_memory_MemTotal_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"))",
-            "editorMode": "code",
-            "instant": false,
-            "range": true,
-            "legendFormat": "{{region}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "drawStyle": "line",
-              "lineWidth": 2,
-              "fillOpacity": 0,
-              "showPoints": "never",
-              "spanNulls": true,
-              "axisPlacement": "auto",
-              "thresholdsStyle": {
-                "mode": "dashed"
-              }
-            },
-            "unit": "percentunit",
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "orange",
-                  "value": 0.85
-                },
-                {
-                  "color": "red",
-                  "value": 0.92
-                }
-              ]
-            },
-            "min": 0,
-            "max": 1
-          },
-          "overrides": []
-        },
-        "options": {
-          "legend": {
-            "displayMode": "table",
-            "placement": "right",
-            "showLegend": true,
-            "calcs": [
-              "lastNotNull",
-              "min"
-            ]
-          },
-          "tooltip": {
-            "mode": "multi",
-            "sort": "asc"
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
           }
         }
       }
-    ]
+    ],
+    "links": [
+      {
+        "title": "Tuist Kura",
+        "type": "link",
+        "icon": "dashboard",
+        "url": "/d/tuist-kura/tuist-kura",
+        "tags": [],
+        "asDropdown": false,
+        "includeVars": false,
+        "keepTime": true,
+        "targetBlank": false,
+        "tooltip": ""
+      }
+    ],
+    "timeSettings": {
+      "autoRefresh": "1m",
+      "autoRefreshIntervals": [
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-7d",
+      "to": "now",
+      "hideTimepicker": false,
+      "timezone": "browser"
+    },
+    "variables": [
+      {
+        "kind": "DatasourceVariable",
+        "spec": {
+          "name": "datasource",
+          "label": "Data Source",
+          "pluginId": "prometheus",
+          "allowCustomValue": true,
+          "current": {
+            "text": "grafanacloud-tuist-prom",
+            "value": "grafanacloud-prom"
+          },
+          "hide": "dontHide",
+          "includeAll": false,
+          "multi": false,
+          "options": [],
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false
+        }
+      },
+      {
+        "kind": "CustomVariable",
+        "spec": {
+          "name": "env",
+          "label": "Environment",
+          "allowCustomValue": false,
+          "current": {
+            "text": "production",
+            "value": "production"
+          },
+          "hide": "dontHide",
+          "includeAll": false,
+          "multi": false,
+          "options": [],
+          "query": "production,canary,staging",
+          "skipUrlSync": false,
+          "valuesFormat": "csv"
+        }
+      },
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "name": "instance_ceiling_mib",
+          "label": "Instance ceiling (MiB)",
+          "description": "Per-replica memory limit of the profile to size for; the enterprise profile requests 4096 MiB as the tuist.dev/memory-ceiling-mib extended resource. Multiplied by two replicas.",
+          "query": "4096",
+          "current": {
+            "text": "4096",
+            "value": "4096"
+          },
+          "hide": "dontHide",
+          "skipUrlSync": false
+        }
+      },
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "name": "instance_floor_mib",
+          "label": "Instance floor (MiB)",
+          "description": "Per-replica memory request of the profile to size for (Tuist.Kura.Regions.memory_profile/1); 1024 MiB for enterprise. Multiplied by two replicas.",
+          "query": "1024",
+          "current": {
+            "text": "1024",
+            "value": "1024"
+          },
+          "hide": "dontHide",
+          "skipUrlSync": false
+        }
+      },
+      {
+        "kind": "ConstantVariable",
+        "spec": {
+          "name": "node_region",
+          "query": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))",
+          "description": "The node → region join every query on this dashboard uses, kept in one place. Mirrors the kura:node_region recording rule in infra/helm/k8s-monitoring/alerts.md; swap this value for `kura:node_region` once that rule exists.",
+          "current": {
+            "text": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))",
+            "value": "max by (cluster, node, region) (kube_pod_info{namespace=\"kura\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))"
+          },
+          "hide": "hideVariable",
+          "skipUrlSync": true
+        }
+      }
+    ],
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "RAM by region",
+          "description": "One row per Kura region. **Fit (ceiling)** and **Fit (memory)** count how many more instances of the largest profile (two replicas of `$instance_ceiling_mib` MiB ceiling / `$instance_floor_mib` MiB floor, set in the variables above) the scheduler can still place; `floor()` is taken per node before the sum, so free memory fragmented across boxes reads as zero. The next provisioning is declined when either reaches 0 — the **Kura region cannot place another instance** alert. The ceiling binds first wherever `memory_ceiling_bin_packed` is on; a region with no ceiling advertised has an empty ceiling cell.\n\n**Ceiling reserved** / **Memory requested** are the scheduler's view (reservations, not usage); **Host memory used** is the kernel's (`1 - MemAvailable/MemTotal`, reclaimable cache counts as available) and is what **Kura region host memory low** watches. Reservations full while host memory is low means a node or a smaller ceiling profile; host memory high while reservations have room means pods living above their floors.\n\nRegion comes from joining each node to the Kura pods it hosts (`kura_node_geo_info`): a freshly added, still empty node is invisible here until its first placement lands on it.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "count by (cluster, region) (max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "B",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "count by (cluster, region) (kube_pod_info{namespace=\"kura\", env=\"$env\"} * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info))",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "C",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"})) / (2 * $instance_ceiling_mib)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "D",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"})) / 1048576 / (2 * $instance_floor_mib)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "E",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "F",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "G",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "1 - sum by (cluster, region) (node_memory_MemAvailable_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region) (node_memory_MemTotal_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"))",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "filterFieldsByName",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "pattern": "^(region|cluster|Value #[ABCDEFG])$"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "merge",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {},
+                      "renameByName": {},
+                      "indexByName": {
+                        "region": 0,
+                        "cluster": 1,
+                        "Value #A": 2,
+                        "Value #B": 3,
+                        "Value #C": 4,
+                        "Value #D": 5,
+                        "Value #E": 6,
+                        "Value #F": 7,
+                        "Value #G": 8
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "table",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": []
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "region"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Region"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 180
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "cluster"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Cluster"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Nodes"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 90
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Kura pods"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 90
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fit (ceiling)"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fit (memory)"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Ceiling reserved"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.8
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.95
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #F"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Memory requested"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.8
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.95
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #G"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Host memory used"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.85
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.92
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "showHeader": true,
+                "cellHeight": "md",
+                "sortBy": [
+                  {
+                    "displayName": "Fit (ceiling)",
+                    "desc": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "RAM by node",
+          "description": "The per-box breakdown of the table above, for finding which box is full or fragmented. A region can read 0 fits while every box still has free memory if no single box has one instance's worth. **Host memory used** here is what **Kura cache box out of memory** watches (critical below 8% available).",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, node) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"})) / (2 * $instance_ceiling_mib)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "B",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, node) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"})) / 1048576 / (2 * $instance_floor_mib)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "C",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, node) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region, node) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "D",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, node) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region, node) (max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "E",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "1 - sum by (cluster, region, node) (label_replace(node_memory_MemAvailable_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"), \"node\", \"$1\", \"instance\", \"(.*)\")) / sum by (cluster, region, node) (label_replace(node_memory_MemTotal_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"), \"node\", \"$1\", \"instance\", \"(.*)\"))",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "filterFieldsByName",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "pattern": "^(region|node|cluster|Value #[ABCDE])$"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "merge",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {},
+                      "renameByName": {},
+                      "indexByName": {
+                        "region": 0,
+                        "node": 1,
+                        "cluster": 2,
+                        "Value #A": 3,
+                        "Value #B": 4,
+                        "Value #C": 5,
+                        "Value #D": 6,
+                        "Value #E": 7
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "table",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": []
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "region"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Region"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 180
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "node"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Node"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 360
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "cluster"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Cluster"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fit (ceiling)"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fit (memory)"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Ceiling reserved"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.8
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.95
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Memory requested"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.8
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.95
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Host memory used"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.85
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.92
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "showHeader": true,
+                "cellHeight": "md",
+                "sortBy": [
+                  {
+                    "displayName": "Fit (ceiling)",
+                    "desc": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "Instances that still fit by ceiling",
+          "description": "Same count as the table's **Fit (ceiling)** column over time. Each provisioning steps it down by one; a new node steps it up. Dashed lines at 2 (warning) and 1 (critical).",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"})) / (2 * $instance_ceiling_mib)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "{{region}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      },
+                      {
+                        "color": "green",
+                        "value": 2
+                      }
+                    ]
+                  },
+                  "unit": "short",
+                  "min": 0,
+                  "decimals": 0
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "asc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "id": 4,
+          "title": "Instances that still fit by memory",
+          "description": "Same count as the table's **Fit (memory)** column over time: placements the native memory request (the floor) still allows. The ceiling binds long before this one wherever it is advertised.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"memory\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"memory\", env=\"$env\"})) / 1048576 / (2 * $instance_floor_mib)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "{{region}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      }
+                    ]
+                  },
+                  "unit": "short",
+                  "min": 0,
+                  "decimals": 0
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "asc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "id": 5,
+          "title": "Ceiling reserved",
+          "description": "Share of the advertised `tuist.dev/memory-ceiling-mib` capacity already requested across the region's boxes. The slope is the onboarding rate; the gap to 100% is the runway.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_capacity{resource=\"tuist_dev_memory_ceiling_mib\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "{{region}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.8
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.95
+                      }
+                    ]
+                  },
+                  "unit": "percentunit",
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "asc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "id": 6,
+          "title": "Host memory used",
+          "description": "`1 - MemAvailable/MemTotal` summed across the region's boxes. Dashed lines at 85% (warning, 15% available) and 92% (critical, 8% available) match the region and box alerts.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "1 - sum by (cluster, region) (node_memory_MemAvailable_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region) (node_memory_MemTotal_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"))",
+                        "legendFormat": "{{region}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.85
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.92
+                      }
+                    ]
+                  },
+                  "unit": "percentunit",
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "asc"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "RAM",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-1"
+                        },
+                        "x": 0,
+                        "y": 0,
+                        "width": 24,
+                        "height": 9
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-2"
+                        },
+                        "x": 0,
+                        "y": 9,
+                        "width": 24,
+                        "height": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "RAM trends",
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-3"
+                        },
+                        "x": 0,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-4"
+                        },
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-5"
+                        },
+                        "x": 0,
+                        "y": 8,
+                        "width": 12,
+                        "height": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-6"
+                        },
+                        "x": 12,
+                        "y": 8,
+                        "width": 12,
+                        "height": 8
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
   }
 }

--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -378,7 +378,7 @@
                     "properties": [
                       {
                         "id": "displayName",
-                        "value": "Fit (ceiling)"
+                        "value": "Fit (memory ceiling)"
                       },
                       {
                         "id": "mappings",
@@ -444,7 +444,7 @@
                     "properties": [
                       {
                         "id": "displayName",
-                        "value": "Fit (memory)"
+                        "value": "Fit (memory floor)"
                       },
                       {
                         "id": "custom.cellOptions",
@@ -611,7 +611,7 @@
                 "cellHeight": "md",
                 "sortBy": [
                   {
-                    "displayName": "Fit (ceiling)",
+                    "displayName": "Fit (memory ceiling)",
                     "desc": false
                   }
                 ]
@@ -625,7 +625,7 @@
         "spec": {
           "id": 1,
           "title": "RAM by region",
-          "description": "One row per Kura region. **Fit (ceiling)** and **Fit (memory)** count how many more instances of the largest profile (two replicas of `$instance_ceiling_mib` MiB ceiling / `$instance_floor_mib` MiB floor, set in the variables above) the scheduler can still place; `floor()` is taken per node before the sum, so free memory fragmented across boxes reads as zero. The next provisioning is declined when either reaches 0 — the **Kura region cannot place another instance** alert. The ceiling binds first wherever `memory_ceiling_bin_packed` is on; a region whose boxes advertise no ceiling (the private runner-cache pool on Elastic Metal, which the CAPI provider does not patch) reads **no ceiling** and is bound by memory alone.\n\n**Ceiling reserved** / **Memory requested** are the scheduler's view (reservations, not usage); **Host memory used** is the kernel's (`1 - MemAvailable/MemTotal`, reclaimable cache counts as available) and is what **Kura region host memory low** watches. Reservations full while host memory is low means a node or a smaller ceiling profile; host memory high while reservations have room means pods living above their floors.\n\nRegion comes from joining each node to the Kura pods it hosts (`kura_node_geo_info`): a freshly added, still empty node is invisible here until its first placement lands on it.",
+          "description": "One row per Kura region. **Fit (memory ceiling)** and **Fit (memory floor)** count how many more instances of the largest profile (two replicas of `$instance_ceiling_mib` MiB ceiling / `$instance_floor_mib` MiB floor, set in the variables above) the scheduler can still place; `floor()` is taken per node before the sum, so free memory fragmented across boxes reads as zero. The next provisioning is declined when either reaches 0 — the **Kura region cannot place another instance** alert. The ceiling binds first wherever `memory_ceiling_bin_packed` is on; a region whose boxes advertise no ceiling (the private runner-cache pool on Elastic Metal, which the CAPI provider does not patch) reads **no ceiling** and is bound by memory alone.\n\n**Ceiling reserved** / **Memory requested** are the scheduler's view (reservations, not usage); **Host memory used** is the kernel's (`1 - MemAvailable/MemTotal`, reclaimable cache counts as available) and is what **Kura region host memory low** watches. Reservations full while host memory is low means a node or a smaller ceiling profile; host memory high while reservations have room means pods living above their floors.\n\nRegion comes from joining each node to the Kura pods it hosts (`kura_node_geo_info`): a freshly added, still empty node is invisible here until its first placement lands on it.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -935,7 +935,7 @@
                     "properties": [
                       {
                         "id": "displayName",
-                        "value": "Fit (ceiling)"
+                        "value": "Fit (memory ceiling)"
                       },
                       {
                         "id": "mappings",
@@ -1001,7 +1001,7 @@
                     "properties": [
                       {
                         "id": "displayName",
-                        "value": "Fit (memory)"
+                        "value": "Fit (memory floor)"
                       },
                       {
                         "id": "custom.cellOptions",
@@ -1246,7 +1246,7 @@
                 "cellHeight": "md",
                 "sortBy": [
                   {
-                    "displayName": "Fit (ceiling)",
+                    "displayName": "Fit (memory ceiling)",
                     "desc": false
                   }
                 ]
@@ -1491,7 +1491,7 @@
                     "properties": [
                       {
                         "id": "displayName",
-                        "value": "Fit (ceiling)"
+                        "value": "Fit (memory ceiling)"
                       },
                       {
                         "id": "mappings",
@@ -1557,7 +1557,7 @@
                     "properties": [
                       {
                         "id": "displayName",
-                        "value": "Fit (memory)"
+                        "value": "Fit (memory floor)"
                       },
                       {
                         "id": "custom.cellOptions",
@@ -1802,7 +1802,7 @@
                 "cellHeight": "md",
                 "sortBy": [
                   {
-                    "displayName": "Fit (ceiling)",
+                    "displayName": "Fit (memory ceiling)",
                     "desc": false
                   }
                 ]
@@ -1816,7 +1816,7 @@
         "spec": {
           "id": 3,
           "title": "Instances that still fit by ceiling",
-          "description": "Same count as the table's **Fit (ceiling)** column over time. Each provisioning steps it down by one; a new node steps it up. Dashed lines at 2 (warning) and 1 (critical).",
+          "description": "Same count as the table's **Fit (memory ceiling)** column over time. Each provisioning steps it down by one; a new node steps it up. Dashed lines at 2 (warning) and 1 (critical).",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -1919,7 +1919,7 @@
         "spec": {
           "id": 4,
           "title": "Instances that still fit by memory",
-          "description": "Same count as the table's **Fit (memory)** column over time: placements the native memory request (the floor) still allows. The ceiling binds long before this one wherever it is advertised.",
+          "description": "Same count as the table's **Fit (memory floor)** column over time: placements the native memory request (the floor) still allows. The ceiling binds long before this one wherever it is advertised.",
           "links": [],
           "data": {
             "kind": "QueryGroup",

--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -2,7 +2,7 @@
   "apiVersion": "dashboard.grafana.app/v2",
   "kind": "Dashboard",
   "metadata": {
-    "name": "tuist-kura-region-scalability"
+    "name": "dcfx32a3wucav4d"
   },
   "spec": {
     "title": "Tuist Kura / Region Scalability",
@@ -408,7 +408,7 @@
                       },
                       {
                         "id": "custom.width",
-                        "value": 150
+                        "value": 190
                       },
                       {
                         "id": "thresholds",
@@ -459,7 +459,7 @@
                       },
                       {
                         "id": "custom.width",
-                        "value": 150
+                        "value": 193
                       },
                       {
                         "id": "thresholds",

--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -509,7 +509,7 @@
                           "steps": [
                             {
                               "color": "red",
-                              "value": null
+                              "value": 0
                             },
                             {
                               "color": "orange",
@@ -560,7 +560,7 @@
                           "steps": [
                             {
                               "color": "red",
-                              "value": null
+                              "value": 0
                             },
                             {
                               "color": "orange",
@@ -624,7 +624,7 @@
                           "steps": [
                             {
                               "color": "green",
-                              "value": null
+                              "value": 0
                             },
                             {
                               "color": "orange",
@@ -684,7 +684,7 @@
                           "steps": [
                             {
                               "color": "green",
-                              "value": null
+                              "value": 0
                             },
                             {
                               "color": "orange",
@@ -744,7 +744,7 @@
                           "steps": [
                             {
                               "color": "green",
-                              "value": null
+                              "value": 0
                             },
                             {
                               "color": "orange",
@@ -1052,7 +1052,7 @@
                           "steps": [
                             {
                               "color": "red",
-                              "value": null
+                              "value": 0
                             },
                             {
                               "color": "orange",
@@ -1103,7 +1103,7 @@
                           "steps": [
                             {
                               "color": "red",
-                              "value": null
+                              "value": 0
                             },
                             {
                               "color": "orange",
@@ -1167,7 +1167,7 @@
                           "steps": [
                             {
                               "color": "green",
-                              "value": null
+                              "value": 0
                             },
                             {
                               "color": "orange",
@@ -1227,7 +1227,7 @@
                           "steps": [
                             {
                               "color": "green",
-                              "value": null
+                              "value": 0
                             },
                             {
                               "color": "orange",
@@ -1287,7 +1287,7 @@
                           "steps": [
                             {
                               "color": "green",
-                              "value": null
+                              "value": 0
                             },
                             {
                               "color": "orange",
@@ -1384,7 +1384,7 @@
                     "steps": [
                       {
                         "color": "red",
-                        "value": null
+                        "value": 0
                       },
                       {
                         "color": "orange",
@@ -1487,7 +1487,7 @@
                     "steps": [
                       {
                         "color": "green",
-                        "value": null
+                        "value": 0
                       }
                     ]
                   },
@@ -1582,7 +1582,7 @@
                     "steps": [
                       {
                         "color": "green",
-                        "value": null
+                        "value": 0
                       },
                       {
                         "color": "orange",
@@ -1685,7 +1685,7 @@
                     "steps": [
                       {
                         "color": "green",
-                        "value": null
+                        "value": 0
                       },
                       {
                         "color": "orange",

--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -6,7 +6,7 @@
   },
   "spec": {
     "title": "Tuist Kura / Region Scalability",
-    "description": "How far each Kura region is from the point where it needs another node, per resource: instances the scheduler can still place, reservations versus capacity, and real host memory. RAM today; disk and egress columns to follow. Thresholds match the region capacity alerts in infra/helm/k8s-monitoring/alerts.md.",
+    "description": "How far each Kura region is from the point where it needs another node, per resource: instances the scheduler can still place, reservations versus capacity, and real host memory. RAM and disk today; egress to follow. Thresholds match the region capacity alerts in infra/helm/k8s-monitoring/alerts.md.",
     "tags": [
       "tuist",
       "kura",
@@ -138,6 +138,21 @@
         }
       },
       {
+        "kind": "TextVariable",
+        "spec": {
+          "name": "instance_claim_gib",
+          "label": "Instance claim (GiB)",
+          "description": "Per-replica storage claim of the profile to size for, requested as ephemeral-storage; 50 GiB on nearly every live instance today (Tuist.Kura.ClaimSizing proposes changes). Multiplied by two replicas.",
+          "query": "50",
+          "current": {
+            "text": "50",
+            "value": "50"
+          },
+          "hide": "dontHide",
+          "skipUrlSync": false
+        }
+      },
+      {
         "kind": "ConstantVariable",
         "spec": {
           "name": "node_region",
@@ -158,7 +173,7 @@
         "spec": {
           "id": 7,
           "title": "Instances that still fit",
-          "description": "How many more instances of the largest profile (two replicas of `$instance_ceiling_mib` MiB ceiling / `$instance_floor_mib` MiB floor) each region can still place, by placement constraint. A pod places only if the node satisfies both, so the lower of the two is the region's real headroom; 0 means the next provisioning is declined and the region needs a node. **no ceiling** = the region's boxes advertise no `tuist.dev/memory-ceiling-mib` budget, so memory is its only constraint. The RAM section below has the reservations and host memory behind these counts.",
+          "description": "How many more instances of the largest profile (two replicas of `$instance_ceiling_mib` MiB ceiling / `$instance_floor_mib` MiB floor) each region can still place, by placement constraint. A pod places only if the node satisfies both, so the lower of the two is the region's real headroom; 0 means the next provisioning is declined and the region needs a node. **no ceiling** = the region's boxes advertise no `tuist.dev/memory-ceiling-mib` budget, so memory and disk are its only constraints. Disk counts two replicas of `$instance_claim_gib` GiB ephemeral-storage claims against allocatable disk. The RAM and Disk sections below have the reservations, host usage and retention behind these counts.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -209,6 +224,29 @@
                       "version": "v0"
                     }
                   }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "C",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"ephemeral_storage\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"ephemeral_storage\", env=\"$env\"})) / (2 * $instance_claim_gib * 1073741824)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
                 }
               ],
               "queryOptions": {},
@@ -219,7 +257,7 @@
                   "spec": {
                     "options": {
                       "include": {
-                        "pattern": "^(region|Value #[AB])$"
+                        "pattern": "^(region|Value #[ABC])$"
                       }
                     }
                   }
@@ -241,7 +279,8 @@
                       "indexByName": {
                         "region": 0,
                         "Value #A": 1,
-                        "Value #B": 2
+                        "Value #B": 2,
+                        "Value #C": 3
                       }
                     }
                   }
@@ -367,6 +406,57 @@
                       {
                         "id": "displayName",
                         "value": "Fit (memory)"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fit (disk)"
                       },
                       {
                         "id": "custom.cellOptions",
@@ -2019,6 +2109,1563 @@
             }
           }
         }
+      },
+      "panel-8": {
+        "kind": "Panel",
+        "spec": {
+          "id": 8,
+          "title": "Disk by region",
+          "description": "**Fit (disk)** counts how many more instances (two replicas of `$instance_claim_gib` GiB) the region's allocatable ephemeral-storage still admits, `floor()` per node first; each replica requests its storage claim as an `ephemeral-storage` request with no limit, so the request is the only admission control the claim has and it is what **Kura region cannot place another instance** counts as its `disk` row. **Disk requested** is the scheduler's view (claims against allocatable, the disk minus kubelet's eviction reserve); **Host disk used** is the filesystem holding the local-path cache. Rings run full by design, so usage says little: **Shortest retention** is the lowest one-day median of `kura_segment_shed_age_seconds` among the region's full rings (how soon after being written an artifact can be evicted), the number the customer feels; under two days warns, under a day pages (**Kura instance retention horizon**). Its lever is the account's storage claim (`Tuist.Kura.ClaimSizing`), and the region only enters when the claim cannot grow because the boxes are full.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"ephemeral_storage\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"ephemeral_storage\", env=\"$env\"})) / (2 * $instance_claim_gib * 1073741824)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "B",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"ephemeral_storage\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_allocatable{resource=\"ephemeral_storage\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "C",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "1 - sum by (cluster, region) (max by (cluster, instance) (node_filesystem_avail_bytes{env=\"$env\", mountpoint=\"/opt/local-path-provisioner\"} or on (cluster, instance) node_filesystem_avail_bytes{env=\"$env\", mountpoint=\"/\"}) * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region) (max by (cluster, instance) (node_filesystem_size_bytes{env=\"$env\", mountpoint=\"/opt/local-path-provisioner\"} or on (cluster, instance) node_filesystem_size_bytes{env=\"$env\", mountpoint=\"/\"}) * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"))",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "D",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "count by (cluster, region) (max by (cluster, pod, region, tenant_id) (kura_node_geo_info{env=\"$env\"}) and on (cluster, pod) (max by (cluster, pod) (kura_backfill_ring_fullness_percent{env=\"$env\"}) >= 100))",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "E",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "min by (cluster, region) (histogram_quantile(0.5, sum by (cluster, region, tenant_id, pod, le) (increase(kura_segment_shed_age_seconds_bucket{env=\"$env\"}[1d]) * on (cluster, pod) group_left(region, tenant_id) max by (cluster, pod, region, tenant_id) (kura_node_geo_info{env=\"$env\"}))) and on (cluster, pod) (max by (cluster, pod) (kura_backfill_ring_fullness_percent{env=\"$env\"}) >= 100))",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "filterFieldsByName",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "pattern": "^(region|Value #[ABCDE])$"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "merge",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {},
+                      "renameByName": {},
+                      "indexByName": {
+                        "region": 0,
+                        "Value #A": 1,
+                        "Value #B": 2,
+                        "Value #C": 3,
+                        "Value #D": 4,
+                        "Value #E": 5
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "table",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": []
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "region"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Region"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 180
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fit (disk)"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Disk requested"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.85
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.95
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Host disk used"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.85
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.95
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #D"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Full rings"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 90
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #E"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Shortest retention"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "type": "special",
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "text": "no full ring",
+                                "color": "text"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 170
+                      },
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 86400
+                            },
+                            {
+                              "color": "green",
+                              "value": 172800
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "showHeader": true,
+                "cellHeight": "md",
+                "sortBy": [
+                  {
+                    "displayName": "Fit (disk)",
+                    "desc": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-9": {
+        "kind": "Panel",
+        "spec": {
+          "id": 9,
+          "title": "Retention by instance",
+          "description": "One row per Kura instance replica. **Ring fullness** is the segment count against the ring's desired total; 100% is steady state, not an alarm, and anything lower is a ring still filling after a bootstrap or a claim change. **Median shed age** is the one-day median of the youngest content in every segment the ring rotated out, computed only for full rings: how long an artifact survives before eviction. Under two days a build that reuses yesterday's artifacts starts to miss; under a day, overnight and weekend builds miss. The lever is this account's storage claim, not the region.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "max by (cluster, region, tenant_id, pod) (max by (cluster, pod) (kura_backfill_ring_fullness_percent{env=\"$env\"}) * on (cluster, pod) group_left(region, tenant_id) max by (cluster, pod, region, tenant_id) (kura_node_geo_info{env=\"$env\"}))",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "B",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "histogram_quantile(0.5, sum by (cluster, region, tenant_id, pod, le) (increase(kura_segment_shed_age_seconds_bucket{env=\"$env\"}[1d]) * on (cluster, pod) group_left(region, tenant_id) max by (cluster, pod, region, tenant_id) (kura_node_geo_info{env=\"$env\"}))) and on (cluster, pod) (max by (cluster, pod) (kura_backfill_ring_fullness_percent{env=\"$env\"}) >= 100)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "filterFieldsByName",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "pattern": "^(region|tenant_id|pod|Value #[AB])$"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "merge",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {},
+                      "renameByName": {},
+                      "indexByName": {
+                        "region": 0,
+                        "tenant_id": 1,
+                        "pod": 2,
+                        "Value #A": 3,
+                        "Value #B": 4
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "table",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": []
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "region"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Region"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 180
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "tenant_id"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Account"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 180
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "pod"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Instance"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 320
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Ring fullness"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 130
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Median shed age"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "type": "special",
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "text": "ring not full",
+                                "color": "text"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 170
+                      },
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 86400
+                            },
+                            {
+                              "color": "green",
+                              "value": 172800
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "showHeader": true,
+                "cellHeight": "md",
+                "sortBy": [
+                  {
+                    "displayName": "Median shed age",
+                    "desc": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-10": {
+        "kind": "Panel",
+        "spec": {
+          "id": 10,
+          "title": "Disk by node",
+          "description": "The per-box breakdown of **Disk by region**: a region reads 0 fits while every box still has free disk if no single box has one instance's worth of claim left.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, node) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"ephemeral_storage\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"ephemeral_storage\", env=\"$env\"})) / (2 * $instance_claim_gib * 1073741824)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "B",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, node) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"ephemeral_storage\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region, node) (max by (cluster, node) (kube_node_status_allocatable{resource=\"ephemeral_storage\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "C",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "1 - sum by (cluster, region, node) (label_replace(max by (cluster, instance) (node_filesystem_avail_bytes{env=\"$env\", mountpoint=\"/opt/local-path-provisioner\"} or on (cluster, instance) node_filesystem_avail_bytes{env=\"$env\", mountpoint=\"/\"}) * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"), \"node\", \"$1\", \"instance\", \"(.*)\")) / sum by (cluster, region, node) (label_replace(max by (cluster, instance) (node_filesystem_size_bytes{env=\"$env\", mountpoint=\"/opt/local-path-provisioner\"} or on (cluster, instance) node_filesystem_size_bytes{env=\"$env\", mountpoint=\"/\"}) * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"), \"node\", \"$1\", \"instance\", \"(.*)\"))",
+                        "legendFormat": "__auto",
+                        "instant": true,
+                        "range": false,
+                        "format": "table",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "Transformation",
+                  "group": "filterFieldsByName",
+                  "spec": {
+                    "options": {
+                      "include": {
+                        "pattern": "^(region|node|Value #[ABC])$"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "merge",
+                  "spec": {
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "Transformation",
+                  "group": "organize",
+                  "spec": {
+                    "options": {
+                      "excludeByName": {},
+                      "renameByName": {},
+                      "indexByName": {
+                        "region": 0,
+                        "node": 1,
+                        "Value #A": 2,
+                        "Value #B": 3,
+                        "Value #C": 4
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "table",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": []
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "region"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Region"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 180
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "node"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Node"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 360
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Fit (disk)"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background",
+                          "mode": "basic"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 150
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            },
+                            {
+                              "color": "green",
+                              "value": 2
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Disk requested"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.85
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.95
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #C"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Host disk used"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge",
+                          "mode": "gradient",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 190
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 0.85
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.95
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "showHeader": true,
+                "cellHeight": "md",
+                "sortBy": [
+                  {
+                    "displayName": "Fit (disk)",
+                    "desc": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-11": {
+        "kind": "Panel",
+        "spec": {
+          "id": 11,
+          "title": "Instances that still fit by disk",
+          "description": "Same count as **Fit (disk)** over time: placements the ephemeral-storage claims still allow. Each provisioning steps it down by one, a claim change moves it, a new node steps it up.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (floor((max by (cluster, node) (kube_node_status_allocatable{resource=\"ephemeral_storage\", env=\"$env\"}) - sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"ephemeral_storage\", env=\"$env\"})) / (2 * $instance_claim_gib * 1073741824)) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "{{region}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      },
+                      {
+                        "color": "green",
+                        "value": 2
+                      }
+                    ]
+                  },
+                  "unit": "short",
+                  "min": 0,
+                  "decimals": 0
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "asc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "panel-12": {
+        "kind": "Panel",
+        "spec": {
+          "id": 12,
+          "title": "Disk requested",
+          "description": "Share of allocatable ephemeral-storage already claimed across the region's boxes. The slope is the onboarding and claim-growth rate; the gap to 100% is the runway.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region) (sum by (cluster, node) (kube_pod_container_resource_requests{resource=\"ephemeral_storage\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region) / sum by (cluster, region) (max by (cluster, node) (kube_node_status_allocatable{resource=\"ephemeral_storage\", env=\"$env\"}) * on (cluster, node) group_left(region) $node_region)",
+                        "legendFormat": "{{region}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.85
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.95
+                      }
+                    ]
+                  },
+                  "unit": "percentunit",
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "asc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "panel-13": {
+        "kind": "Panel",
+        "spec": {
+          "id": 13,
+          "title": "Host disk used",
+          "description": "Used share of the filesystem holding the local-path cache, summed across the region's boxes. Rings fill to their claims by design, so this trends toward **Disk requested** as instances mature.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "1 - sum by (cluster, region) (max by (cluster, instance) (node_filesystem_avail_bytes{env=\"$env\", mountpoint=\"/opt/local-path-provisioner\"} or on (cluster, instance) node_filesystem_avail_bytes{env=\"$env\", mountpoint=\"/\"}) * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region) (max by (cluster, instance) (node_filesystem_size_bytes{env=\"$env\", mountpoint=\"/opt/local-path-provisioner\"} or on (cluster, instance) node_filesystem_size_bytes{env=\"$env\", mountpoint=\"/\"}) * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"))",
+                        "legendFormat": "{{region}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.85
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.95
+                      }
+                    ]
+                  },
+                  "unit": "percentunit",
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "asc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "panel-14": {
+        "kind": "Panel",
+        "spec": {
+          "id": 14,
+          "title": "Shortest retention",
+          "description": "Lowest one-day median shed age among each region's full rings. Dashed lines at 2 days (warning) and 1 day (critical) match the retention alerts.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "min by (cluster, region) (histogram_quantile(0.5, sum by (cluster, region, tenant_id, pod, le) (increase(kura_segment_shed_age_seconds_bucket{env=\"$env\"}[1d]) * on (cluster, pod) group_left(region, tenant_id) max by (cluster, pod, region, tenant_id) (kura_node_geo_info{env=\"$env\"}))) and on (cluster, pod) (max by (cluster, pod) (kura_backfill_ring_fullness_percent{env=\"$env\"}) >= 100))",
+                        "legendFormat": "{{region}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 86400
+                      },
+                      {
+                        "color": "green",
+                        "value": 172800
+                      }
+                    ]
+                  },
+                  "unit": "s",
+                  "min": 0
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "asc"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "layout": {
@@ -2146,6 +3793,125 @@
                         "element": {
                           "kind": "ElementReference",
                           "name": "panel-6"
+                        },
+                        "x": 12,
+                        "y": 8,
+                        "width": 12,
+                        "height": 8
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Disk",
+              "collapse": true,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-8"
+                        },
+                        "x": 0,
+                        "y": 0,
+                        "width": 24,
+                        "height": 9
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-9"
+                        },
+                        "x": 0,
+                        "y": 9,
+                        "width": 24,
+                        "height": 12
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-10"
+                        },
+                        "x": 0,
+                        "y": 21,
+                        "width": 24,
+                        "height": 9
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Disk trends",
+              "collapse": true,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-11"
+                        },
+                        "x": 0,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-12"
+                        },
+                        "x": 12,
+                        "y": 0,
+                        "width": 12,
+                        "height": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-13"
+                        },
+                        "x": 0,
+                        "y": 8,
+                        "width": 12,
+                        "height": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-14"
                         },
                         "x": 12,
                         "y": 8,


### PR DESCRIPTION
## What

Adds `infra/grafana-dashboards/tuist-kura-region-scalability.json`, a Git-Sync-managed dashboard titled **Tuist Kura / Region Scalability** (uid `dcfx32a3wucav4d`, the one Grafana assigned when the dashboard was first saved from the UI on branch `dashboard/2026-09-03-vj9hp`, so merging updates that dashboard rather than creating a second one). It answers, per Kura region, "how far is this region from needing another node?" — RAM, disk and egress.

Panels:

| Panel | What it shows |
|---|---|
| **Instances that still fit** (Overview table) | Region + **Fit (memory ceiling)** / **Fit (memory floor)** / **Fit (disk)** / **Fit (egress)**, the add-a-node answer first; regions whose boxes advertise no ceiling read **no ceiling** |
| **RAM by region** (table, sorted worst-first) | One row per region: nodes, Kura pods, **Fit (memory ceiling)**, **Fit (memory floor)**, **Ceiling reserved**, **Memory requested**, **Host memory used** |
| **RAM by node** (table) | The same columns per box, for telling a full region from a fragmented one |
| **Instances that still fit by ceiling / by memory** (time series) | The two fit counts over time, dashed lines at 2 (warning) and 1 (critical) |
| **Ceiling reserved / Host memory used** (time series) | Runway and slope per region, dashed lines at the alert thresholds |
| **Disk by region** (table) | **Fit (disk)**, **Disk requested** (ephemeral-storage claims vs allocatable), **Host disk used** (the filesystem holding the local-path cache), **Full rings**, **Shortest retention** (lowest one-day median shed age among the region's full rings) |
| **Retention by instance** (table) | Region, account, instance, **Ring fullness**, **Median shed age** — the per-instance view #12784 alerts on |
| **Disk by node** (table) | Fit / requested / used per box |
| **Disk trends** (4 time series) | Fit by disk, disk requested, host disk used, shortest retention, with dashed alert lines |
| **Egress by region** (table) | **Fit (egress)**, **Floors reserved**, **Budget** (advertised `tuist.dev/egress-mbps`), **Budget used** (NIC transmit vs budget, 5 m), **Peak budget used** (30 m rate, max over the dashboard range), **p95 TTFB** |
| **Egress by account** (table) | Account × box: **Sent (10 m)**, **Peak sent** (highest 5 m rate over the range), **Ceiling** (what HTB enforces), **Ceiling share** — the grain of the account-at-ceiling alert, sorted by peak |
| **Response streams by region and protocol** (table) | Attempts/s and **Not immediate** share per protocol — the only capacity view of the ByteStream read path |
| **Egress by node** (table) | Fit / floors / budget / used / peak per box |
| **Egress trends** (4 time series) | Fit by egress, budget used, top accounts by egress, p95 TTFB, with dashed alert lines |

Variables: `Environment`, and four text boxes, `Instance ceiling (MiB)` = 4096, `Instance floor (MiB)` = 1024, `Instance claim (GiB)` = 50 and `Instance egress floor (Mbps)` = 25, so the fit count can be re-sized for a different profile without editing queries.

## Why

The three capacity limits before onboarding more customers are RAM, disk and egress, and nothing today shows the per-region headroom at a glance. #12771 defines the alerts for RAM, #12784 the disk placement constraint and retention alerts, and #12793 the egress capacity alerts; this dashboard is the same maths as tables, so a region's distance from the "add a node" alert is visible before the alert fires, and the trend panels show how fast it is closing.

## Design points

- **Egress mirrors #12793.** `Fit (egress)` is the `egress` row of the placement rule (floors against the advertised budget, `floor()` per node, two replicas; the scheduler's arithmetic, per-replica double count included, because that is what decides placement). Budget used is the budget query's region and node rows split across the two tables, plus a `max_over_time(...[$__range:5m])` of the 30 m rate so the sustained peak the alert keys on is visible without scrolling a graph. The account table is the account-at-ceiling query with sent and ceiling shown alongside the share, plus a peak column: the alert's 10 m average flattens the bursts that are an account's real demand (one account reads ~100 Mbit/s averaged while its 5 m peak over the week is ~1.1 Gbit/s and the NIC's 2 m peak ~4.6 Gbit/s), and the class counter refreshes once per 2 m reconcile, so 5 m is the shortest honest window; series from agent pods that predate the `account` label are dropped with `account!=""`; the streams table is the admissions query per protocol with the volume shown rather than filtered, and `NaN` (no attempts) reads **idle**. Boxes with no advertised budget read **no budget**.
- **Disk mirrors #12784.** `Fit (disk)` is the `disk` row of the placement rule (ephemeral-storage requests against allocatable, `floor()` per node, two replicas of the claim). Retention is the alert query verbatim, per instance, with `min by (region)` as the region's headline; the `and` on `kura_backfill_ring_fullness_percent >= 100` keeps filling rings out, and their empty cells read **ring not full** / **no full ring**. Host disk reads the filesystem mounted at `/opt/local-path-provisioner`, falling back to `/` on boxes where the cache is not a separate mount (the OVH and Scaleway fleets today).
- **Queries mirror #12771 exactly.** `Fit (memory ceiling)` / `Fit (memory floor)` are the two arms of **Kura region cannot place another instance** (per-node `floor()` before the sum, sized for two replicas of the largest profile); `Host memory used` is `1 - MemAvailable/MemTotal` from **Kura region host memory low**, shown as used rather than available so every gauge fills toward the limit. Cell thresholds match the alert thresholds (fit `< 2` orange, `< 1` red; host memory `≥ 85 %` orange, `≥ 92 %` red).
- **The node → region join lives in one hidden constant variable, `$node_region`.** No `kura_*` or kube series carries `region`; the PR's `kura:node_region` recording rule does not exist yet, so every query would otherwise repeat the `kube_pod_info × kura_node_geo_info` join. The variable holds it once and is the single edit to swap for `kura:node_region` when the rule is created. The join's documented limit applies: an empty, freshly added node is invisible until its first placement (today `ap-southeast` has a node and no row).
- **Reservations and usage side by side on purpose.** Reservations full with host memory low means add a node or a smaller ceiling profile; host memory high with reservations free means pods living above their floors. The panel description says so.
- **v2 dashboard resource** (`dashboard.grafana.app/v2`, RowsLayout + `elements`) like `tuist-kura-customer-overview.json`, the format Git Sync writes back for the Kura dashboards; self-hosters can still `jq .spec` it.

## Impact

New dashboard in the `Tuist Dashboards` folder on merge; no alerts or existing dashboards change.

## Validation

- Every table and trend query was executed against the `grafanacloud-prom` datasource on 2026-09-02 with the variables substituted (`env="production"`, 4096 / 1024 / 50 / 25, `$__range` = 7d), the disk and egress ones included: fit-by-disk matches the counts #12784 quotes, retention returns one row per full production ring with the same medians, and the egress budget shares (now and 7-day peak), per-account ceiling shares, per-protocol admission shares and p95 latencies match the figures #12793 quotes for the three governed regions, with the runner-cache box dropped by the budget join. All four production regions return a row in every column that applies to them; the ceiling columns are empty for the region whose boxes advertise no ceiling, as intended. The fit-by-ceiling numbers match the instant values quoted in #12771.
- JSON validated with `jq`; `metadata.name` equals `spec.uid` as Git Sync requires.
- Not yet rendered in Grafana (the file provisions on merge); the table transformations follow the standard multi-instant-query `merge` + `organize` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







