### PR TITLE
feat(infra): let a write elevation scale a fleet

### DIFF
--- a/infra/helm/pomerium/templates/access-tiers.yaml
+++ b/infra/helm/pomerium/templates/access-tiers.yaml
@@ -335,8 +335,9 @@ subjects:
 #   * `machines` delete only. Every machine in the workload cluster is
 #     MachineSet-owned (the control plane lives in the mgmt cluster), so a
 #     delete can only recreate a worker host, never a control-plane node.
-#     machinesets/machinedeployments are untouched — scaling or tearing down a
-#     fleet stays a break-glass action.
+#     machinesets are untouched, and machinedeployments only through the
+#     `/scale` subresource granted by `tuist-fleet-scale` below — tearing down
+#     or redefining a fleet stays a break-glass action.
 #   * machines/status update/patch — the owning CAPI Machine keeps its own
 #     terminal failureReason/failureMessage, and clearing the infra machine's
 #     status does not clear the parent's. Without this the Machine reports
@@ -398,6 +399,63 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: tuist-fleet-unwedge
+subjects:
+  - kind: Group
+    name: tuist-{{ .Values.tuistEnv }}-write
+    apiGroup: rbac.authorization.k8s.io
+---
+# Capacity capability for a fleet whose node count is too low to run the deploy
+# that would raise it. Bound directly to the write-elevation group, like
+# `tuist-fleet-unwedge` above.
+#
+# Why it is not break-glass: a fleet's replica count is set by the chart, so the
+# supported way to change it is a deploy. That deploy runs on the fleet it is
+# changing. When a Linux runner fleet is short of nodes, its own release pipeline
+# queues behind the jobs the surviving nodes are already saturated with, and the
+# release that would add nodes is the one that cannot get a runner. Capacity is
+# therefore the one fleet property whose repair path can be blocked by the thing
+# it repairs, and an elevation that is requested with a stated intent, TTL-bounded
+# and audited is a better control for it than credentials reserved for incidents.
+#
+# Why the blast radius is small: `/scale` writes `.spec.replicas` and nothing
+# else (`specReplicasPath` on the CRD). The machine template, strategy, selector
+# and every other field stay immutable, so this cannot retarget a fleet, change
+# what a node is, or delete one. Raising it adds nodes from the provider's
+# pre-ordered pool; lowering it removes nodes the same way a chart change would,
+# through the MachineDeployment's own strategy rather than around it.
+#
+# The value is still the chart's to own. A scale applied here is reverted by the
+# next release that renders a different number, which is the intended behaviour:
+# the manual scale restores service, the chart remains the source of truth, and
+# the two converge rather than one silently winning.
+#
+# Deliberately narrow: the `/scale` subresource only, on machinedeployments only.
+# `machinesets` are excluded because scaling one directly fights its owning
+# MachineDeployment, and full `update` on machinedeployments is excluded because
+# that is fleet redefinition rather than capacity.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tuist-fleet-scale
+  labels:
+    {{- include "pomerium.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["cluster.x-k8s.io"]
+    resources: ["machinedeployments/scale"]
+    verbs: ["get", "update", "patch"]
+---
+# Per-env like the bindings above, so a prod elevation cannot scale a staging
+# fleet or vice versa.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tuist-{{ .Values.tuistEnv }}-write-fleet-scale
+  labels:
+    {{- include "pomerium.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tuist-fleet-scale
 subjects:
   - kind: Group
     name: tuist-{{ .Values.tuistEnv }}-write


### PR DESCRIPTION
Adds `tuist-fleet-scale`, bound directly to `tuist-<env>-write`, granting `update`/`patch` on the **`machinedeployments/scale`** subresource.

## The gap this closes

A fleet's replica count is set by the chart, so the supported way to change it is a deploy. That deploy runs on the fleet it is changing.

When a Linux runner fleet is short of nodes, its own release pipeline queues behind the jobs the surviving nodes are already saturated with — and the release that would add nodes is the one that cannot get a runner. Capacity is the one fleet property whose repair path can be blocked by the thing it repairs.

`tuist-fleet-unwedge` currently states that *"scaling or tearing down a fleet stays a break-glass action."* Tearing down should stay there. Scaling should not: leaving it break-glass-only does not make it safer, it means the routine fix for a capacity shortage runs on credentials reserved for emergencies, which inverts the access policy the same way `tuist-cnpg-decommission` was written to correct.

## Why the blast radius is small

The grant is the `/scale` subresource, not `update` on the resource. Per the CRD, `/scale` maps to `specReplicasPath: .spec.replicas`:

```
v1beta1 subresources: {"scale":{"specReplicasPath":".spec.replicas", ...}}
```

So it can change **how many nodes**, and nothing else. The machine template, strategy, selector and every other field stay immutable — it cannot retarget a fleet, change what a node is, or delete one. Raising it adds nodes from the provider's pre-ordered pool; lowering it removes them through the MachineDeployment's own strategy rather than around it.

Excluded deliberately:

- **`machinesets`** — scaling one directly fights its owning MachineDeployment.
- **full `update` on `machinedeployments`** — that is fleet redefinition, not capacity, and stays break-glass.

## Why a direct binding, not aggregation

Follows `tuist-fleet-unwedge`, `tuist-cnpg-decommission` and `tuist-volume-decommission`: bound straight to the per-env write group rather than aggregated into `edit`, so the capability is welded to an active, TTL-bounded, audited elevation and cannot be inherited by a service account or a team namespace through some later RoleBinding onto the generic `edit` role.

Per-env like every other binding here, so a production elevation cannot scale a staging fleet.

## The chart stays the source of truth

A scale applied by hand is reverted by the next release that renders a different number. That is the intended behaviour rather than a flaw: the manual scale restores service, the chart remains authoritative, and the two converge instead of one silently winning.

One caveat worth knowing at the terminal: `kubectl scale` writes through server-side apply and can take field ownership from Helm. Where the chart and the manual value agree they converge harmlessly; where they diverge, a later chart change to `replicas` may appear not to take.

## Validation

- `helm lint infra/helm/pomerium` passes
- Renders correctly for all three environments, producing `tuist-{production,staging,canary}-write-fleet-scale` bound to the matching group
- Verified against the live CRD that `machinedeployments/scale` exists on `v1alpha3`, `v1alpha4` and `v1beta1` with `specReplicasPath: .spec.replicas`
- The `tuist-fleet-unwedge` comment is updated so its statement of the boundary stays accurate

### How to test locally

```bash
helm template pomerium infra/helm/pomerium --set tuistEnv=production --set rbac.createImpersonatorRole=true -s templates/access-tiers.yaml
```

After deploying, with an active elevation:

```bash
kubectl -n tuist auth can-i update machinedeployments/scale   # yes
kubectl -n tuist auth can-i update machinedeployments         # still no
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
