### PR TITLE
fix(cli,server): accept enterprise-scoped GitHub Actions OIDC issuers

### DIFF
--- a/cli/Sources/TuistInspectCommand/Services/InspectBundleCommandService.swift
+++ b/cli/Sources/TuistInspectCommand/Services/InspectBundleCommandService.swift
@@ -24,7 +24,7 @@ public enum InspectBundleCommandServiceError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .missingFullHandle:
-            "To analyze the app bundle, run 'tuist init' to connect to the Tuist server."
+            "To analyze the app bundle, connect the project to the Tuist server by adding a 'tuist.toml' at the root of your repository with 'project = \"my-account/my-project\"'."
         }
     }
 }

--- a/cli/Sources/TuistInspectCommand/Services/InspectBundleCommandService.swift
+++ b/cli/Sources/TuistInspectCommand/Services/InspectBundleCommandService.swift
@@ -24,7 +24,7 @@ public enum InspectBundleCommandServiceError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .missingFullHandle:
-            "To analyze the app bundle, connect the project to the Tuist server by adding a 'tuist.toml' at the root of your repository with 'project = \"my-account/my-project\"'."
+            "To analyze the app bundle, run 'tuist init' to connect to the Tuist server."
         }
     }
 }

--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -5721,6 +5721,28 @@ public struct Client: APIProtocol {
                         preconditionFailure("bestContentType chose an invalid content type.")
                     }
                     return .ok(.init(body: body))
+                case 400:
+                    let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+                    let body: Operations.exchangeOIDCToken.Output.BadRequest.Body
+                    let chosenContentType = try converter.bestContentType(
+                        received: contentType,
+                        options: [
+                            "application/json"
+                        ]
+                    )
+                    switch chosenContentType {
+                    case "application/json":
+                        body = try await converter.getResponseBodyAsJSON(
+                            Components.Schemas._Error.self,
+                            from: responseBody,
+                            transforming: { value in
+                                .json(value)
+                            }
+                        )
+                    default:
+                        preconditionFailure("bestContentType chose an invalid content type.")
+                    }
+                    return .badRequest(.init(body: body))
                 case 401:
                     let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
                     let body: Operations.exchangeOIDCToken.Output.Unauthorized.Body

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -28633,6 +28633,57 @@ public enum Operations {
                     }
                 }
             }
+            public struct BadRequest: Sendable, Hashable {
+                /// - Remark: Generated from `#/paths/api/auth/oidc/token/POST/responses/400/content`.
+                @frozen public enum Body: Sendable, Hashable {
+                    /// - Remark: Generated from `#/paths/api/auth/oidc/token/POST/responses/400/content/application\/json`.
+                    case json(Components.Schemas._Error)
+                    /// The associated value of the enum case if `self` is `.json`.
+                    ///
+                    /// - Throws: An error if `self` is not `.json`.
+                    /// - SeeAlso: `.json`.
+                    public var json: Components.Schemas._Error {
+                        get throws {
+                            switch self {
+                            case let .json(body):
+                                return body
+                            }
+                        }
+                    }
+                }
+                /// Received HTTP response body
+                public var body: Operations.exchangeOIDCToken.Output.BadRequest.Body
+                /// Creates a new `BadRequest`.
+                ///
+                /// - Parameters:
+                ///   - body: Received HTTP response body
+                public init(body: Operations.exchangeOIDCToken.Output.BadRequest.Body) {
+                    self.body = body
+                }
+            }
+            /// Unsupported CI provider or missing repository claim
+            ///
+            /// - Remark: Generated from `#/paths//api/auth/oidc/token/post(exchangeOIDCToken)/responses/400`.
+            ///
+            /// HTTP response code: `400 badRequest`.
+            case badRequest(Operations.exchangeOIDCToken.Output.BadRequest)
+            /// The associated value of the enum case if `self` is `.badRequest`.
+            ///
+            /// - Throws: An error if `self` is not `.badRequest`.
+            /// - SeeAlso: `.badRequest`.
+            public var badRequest: Operations.exchangeOIDCToken.Output.BadRequest {
+                get throws {
+                    switch self {
+                    case let .badRequest(response):
+                        return response
+                    default:
+                        try throwUnexpectedResponseStatus(
+                            expectedStatus: "badRequest",
+                            response: self
+                        )
+                    }
+                }
+            }
             public struct Unauthorized: Sendable, Hashable {
                 /// - Remark: Generated from `#/paths/api/auth/oidc/token/POST/responses/401/content`.
                 @frozen public enum Body: Sendable, Hashable {

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -12038,6 +12038,12 @@ paths:
                 x-struct:
                 x-validate:
           description: Token exchange successful
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unsupported CI provider or missing repository claim
         '401':
           content:
             application/json:

--- a/cli/Sources/TuistServer/Services/ExchangeOIDCTokenService.swift
+++ b/cli/Sources/TuistServer/Services/ExchangeOIDCTokenService.swift
@@ -9,6 +9,7 @@ public protocol ExchangeOIDCTokenServicing {
 
 enum ExchangeOIDCTokenServiceError: LocalizedError {
     case unknownError(Int)
+    case badRequest(String)
     case unauthorized(String)
     case forbidden(String)
 
@@ -16,6 +17,8 @@ enum ExchangeOIDCTokenServiceError: LocalizedError {
         switch self {
         case let .unknownError(statusCode):
             "OIDC token exchange failed with status \(statusCode)."
+        case let .badRequest(message):
+            message
         case let .unauthorized(message):
             message
         case let .forbidden(message):
@@ -39,6 +42,11 @@ public struct ExchangeOIDCTokenService: ExchangeOIDCTokenServicing {
             switch okResponse.body {
             case let .json(tokenResponse):
                 return tokenResponse.access_token
+            }
+        case let .badRequest(badRequest):
+            switch badRequest.body {
+            case let .json(error):
+                throw ExchangeOIDCTokenServiceError.badRequest(error.message)
             }
         case let .unauthorized(unauthorized):
             switch unauthorized.body {

--- a/server/lib/tuist/oidc.ex
+++ b/server/lib/tuist/oidc.ex
@@ -13,16 +13,19 @@ defmodule Tuist.OIDC do
   @jwks_cache_ttl to_timeout(minute: 15)
 
   @github_actions_issuer "https://token.actions.githubusercontent.com"
+  @github_actions_enterprise_issuer_prefix "https://token.actions.githubusercontent.com/"
+  @github_actions_jwks_uri "https://token.actions.githubusercontent.com/.well-known/jwks"
   @bitrise_issuer "https://token.builds.bitrise.io"
   @circleci_issuer_prefix "https://oidc.circleci.com/org/"
   @audience "tuist"
 
   def claims(token) when is_binary(token) do
     with {:ok, issuer} <- peek_issuer(token),
-         {:ok, jwks_uri} <- get_jwks_uri(issuer),
+         {:ok, provider} <- provider(issuer),
+         {:ok, jwks_uri} <- jwks_uri(provider, issuer),
          {:ok, claims} <- verify(token, jwks_uri),
-         :ok <- validate_audience(claims, issuer),
-         {:ok, repository} <- get_repository_from_claims(claims, issuer) do
+         :ok <- validate_audience(claims, provider),
+         {:ok, repository} <- repository_from_claims(claims, provider) do
       {:ok, %{repository: repository}}
     end
   end
@@ -36,28 +39,45 @@ defmodule Tuist.OIDC do
     _ -> {:error, :invalid_token}
   end
 
-  defp get_jwks_uri(@github_actions_issuer) do
-    {:ok, "https://token.actions.githubusercontent.com/.well-known/jwks"}
+  defp provider(@github_actions_issuer), do: {:ok, :github_actions}
+
+  # Enterprises that enable `include_enterprise_slug` get tokens scoped to their
+  # own issuer, `https://token.actions.githubusercontent.com/<enterprise-slug>`.
+  # They are signed by the same keys as the default issuer.
+  defp provider(@github_actions_enterprise_issuer_prefix <> slug = issuer) do
+    if slug != "" and not String.contains?(slug, "/") do
+      {:ok, :github_actions}
+    else
+      {:error, :unsupported_provider, issuer}
+    end
   end
 
-  defp get_jwks_uri(@bitrise_issuer) do
-    {:ok, "https://token.builds.bitrise.io/.well-known/jwks"}
+  defp provider(@bitrise_issuer), do: {:ok, :bitrise}
+
+  defp provider(@circleci_issuer_prefix <> org_id = issuer) do
+    if org_id == "" do
+      {:error, :unsupported_provider, issuer}
+    else
+      {:ok, :circleci}
+    end
   end
 
-  defp get_jwks_uri(@circleci_issuer_prefix <> _org_id = issuer) do
-    {:ok, "#{issuer}/.well-known/jwks-pub.json"}
-  end
+  defp provider(issuer), do: {:error, :unsupported_provider, issuer}
 
-  defp get_jwks_uri(issuer), do: {:error, :unsupported_provider, issuer}
+  defp jwks_uri(:github_actions, _issuer), do: {:ok, @github_actions_jwks_uri}
 
-  defp get_repository_from_claims(claims, @github_actions_issuer) do
+  defp jwks_uri(:bitrise, _issuer), do: {:ok, "#{@bitrise_issuer}/.well-known/jwks"}
+
+  defp jwks_uri(:circleci, issuer), do: {:ok, "#{issuer}/.well-known/jwks-pub.json"}
+
+  defp repository_from_claims(claims, :github_actions) do
     case claims["repository"] do
       nil -> {:error, :missing_repository_claim}
       repository -> {:ok, repository}
     end
   end
 
-  defp get_repository_from_claims(claims, @bitrise_issuer) do
+  defp repository_from_claims(claims, :bitrise) do
     owner = claims["repository_owner"]
     slug = claims["repository_slug"]
     repo_url = claims["repository_url"] || ""
@@ -69,14 +89,12 @@ defmodule Tuist.OIDC do
     end
   end
 
-  defp get_repository_from_claims(claims, @circleci_issuer_prefix <> _org_id) do
+  defp repository_from_claims(claims, :circleci) do
     case claims["oidc.circleci.com/vcs-origin"] do
       "github.com/" <> repo -> {:ok, repo}
       _ -> {:error, :missing_repository_claim}
     end
   end
-
-  defp get_repository_from_claims(_, _), do: {:error, :missing_repository_claim}
 
   defp github_repository_url?(url) do
     String.starts_with?(url, "https://github.com/") or
@@ -144,12 +162,12 @@ defmodule Tuist.OIDC do
 
   defp validate_expiration(_), do: {:error, :token_expired}
 
-  defp validate_audience(%{"aud" => @audience}, issuer) when issuer in [@github_actions_issuer, @bitrise_issuer] do
+  defp validate_audience(%{"aud" => @audience}, provider) when provider in [:github_actions, :bitrise] do
     :ok
   end
 
-  defp validate_audience(%{"aud" => audiences}, issuer)
-       when is_list(audiences) and issuer in [@github_actions_issuer, @bitrise_issuer] do
+  defp validate_audience(%{"aud" => audiences}, provider)
+       when is_list(audiences) and provider in [:github_actions, :bitrise] do
     if @audience in audiences do
       :ok
     else
@@ -157,9 +175,9 @@ defmodule Tuist.OIDC do
     end
   end
 
-  defp validate_audience(_claims, issuer) when issuer in [@github_actions_issuer, @bitrise_issuer] do
+  defp validate_audience(_claims, provider) when provider in [:github_actions, :bitrise] do
     {:error, :invalid_audience}
   end
 
-  defp validate_audience(_claims, _issuer), do: :ok
+  defp validate_audience(_claims, _provider), do: :ok
 end

--- a/server/lib/tuist_web/controllers/api/oidc_controller.ex
+++ b/server/lib/tuist_web/controllers/api/oidc_controller.ex
@@ -63,6 +63,7 @@ defmodule TuistWeb.API.OIDCController do
            },
            required: [:access_token, :expires_in]
          }},
+      bad_request: {"Unsupported CI provider or missing repository claim", "application/json", Error},
       unauthorized: {"Invalid or expired OIDC token", "application/json", Error},
       forbidden: {"No projects linked to the repository", "application/json", Error}
     }

--- a/server/priv/docs/en/guides/features/bundle-size.md
+++ b/server/priv/docs/en/guides/features/bundle-size.md
@@ -79,11 +79,19 @@ The per-device rows in App Store Connect are smaller again, because app thinning
 
 To track bundle size over time, you will need to analyze the bundle on the CI. First, you will need to ensure that your CI is <.localized_link href="/guides/integrations/continuous-integration#authentication">authenticated</.localized_link>.
 
-Tuist also needs to know which project to report the bundle to. Add a <.localized_link href="/references/tuist-toml">`tuist.toml`</.localized_link> at the root of your repository:
+Tuist also needs to know which project to report the bundle to. If you have not connected the project yet, run `tuist init`, or declare the handle yourself:
 
-```toml
+::: code-group
+```swift [Tuist.swift]
+let tuist = Tuist(fullHandle: "my-account/my-project")
+```
+```toml [tuist.toml]
 project = "my-account/my-project"
 ```
+<!-- -->
+:::
+
+Use <.localized_link href="/references/tuist-toml">`tuist.toml`</.localized_link> for projects without a Swift manifest, such as Gradle projects. When both files are present, `Tuist.swift` takes precedence.
 
 An example workflow for GitHub Actions could then look like this:
 

--- a/server/priv/docs/en/guides/features/bundle-size.md
+++ b/server/priv/docs/en/guides/features/bundle-size.md
@@ -77,7 +77,13 @@ The per-device rows in App Store Connect are smaller again, because app thinning
 
 ## Continuous integration {#continuous-integration}
 
-To track bundle size over time, you will need to analyze the bundle on the CI. First, you will need to ensure that your CI is <.localized_link href="/guides/integrations/continuous-integration#authentication">authenticated</.localized_link>:
+To track bundle size over time, you will need to analyze the bundle on the CI. First, you will need to ensure that your CI is <.localized_link href="/guides/integrations/continuous-integration#authentication">authenticated</.localized_link>.
+
+Tuist also needs to know which project to report the bundle to. Add a <.localized_link href="/references/tuist-toml">`tuist.toml`</.localized_link> at the root of your repository:
+
+```toml
+project = "my-account/my-project"
+```
 
 An example workflow for GitHub Actions could then look like this:
 

--- a/server/test/tuist/oidc_test.exs
+++ b/server/test/tuist/oidc_test.exs
@@ -154,6 +154,41 @@ defmodule Tuist.OIDCTest do
 
       assert {:error, :missing_repository_claim} = OIDC.claims(token)
     end
+
+    test "successfully verifies a GitHub Actions token from an enterprise-scoped issuer" do
+      {token, jwks} =
+        generate_test_token_and_jwks(issuer: "https://token.actions.githubusercontent.com/my-enterprise")
+
+      stub(Req, :get, fn url, _opts ->
+        assert url == "https://token.actions.githubusercontent.com/.well-known/jwks"
+        {:ok, %{status: 200, body: jwks}}
+      end)
+
+      assert {:ok, claims} = OIDC.claims(token)
+      assert claims.repository == "tuist/tuist"
+    end
+
+    test "returns error for an enterprise-scoped GitHub Actions token with invalid audience" do
+      {token, jwks} =
+        generate_test_token_and_jwks(
+          issuer: "https://token.actions.githubusercontent.com/my-enterprise",
+          claims: %{"aud" => "other-service"}
+        )
+
+      stub(Req, :get, fn _url, _opts ->
+        {:ok, %{status: 200, body: jwks}}
+      end)
+
+      assert {:error, :invalid_audience} = OIDC.claims(token)
+    end
+
+    test "returns error for a GitHub Actions issuer with a multi-segment path" do
+      {token, _jwks} =
+        generate_test_token_and_jwks(issuer: "https://token.actions.githubusercontent.com/my-enterprise/evil")
+
+      assert {:error, :unsupported_provider, "https://token.actions.githubusercontent.com/my-enterprise/evil"} =
+               OIDC.claims(token)
+    end
   end
 
   defp generate_test_token_and_jwks(opts \\ []) do


### PR DESCRIPTION
### What changed

Two independent failures a customer hit while wiring `tuist inspect bundle` into an Android GitHub Actions workflow.

**1. Enterprise-scoped GitHub Actions OIDC issuers were rejected (HTTP 400).**

GitHub Enterprise Cloud organizations can enable `include_enterprise_slug`, documented as a [security hardening step](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/oidc). It changes the issuer from `https://token.actions.githubusercontent.com` to `https://token.actions.githubusercontent.com/<enterprise-slug>`. `Tuist.OIDC` matched the issuer by exact string equality, so those tokens fell straight through `get_jwks_uri/1` to the unsupported-provider branch, before any JWKS fetch or signature check.

**2. The CLI discarded the server's explanation.** The operation documented only 200, 401 and 403, so the generated client fell into `.undocumented` and rendered `OIDC token exchange failed with status 400.` The server had actually replied with a sentence naming the offending issuer.

**3. The bundle-size guide never mentioned the project handle.** `tuist inspect bundle` requires one, and the guide's continuous integration section listed `TUIST_TOKEN` as the only setup. A project following it verbatim fails with a missing full handle. The section now shows both ways to declare it, `fullHandle` in `Tuist.swift` and `project` in `tuist.toml`, and states that `Tuist.swift` wins when both are present.

### Why this shape

The obvious fix for the issuer is to widen the one pattern that failed. That would have been wrong. The issuer string was being re-matched in three places, and only `get_jwks_uri/1` and `get_repository_from_claims/2` can express a prefix match in a function head. `validate_audience/2` guards on an issuer list, and a guard cannot do prefix matching, so widening the other two alone would have dropped enterprise tokens into its `:ok` catch-all and silently stopped enforcing the `aud` claim for exactly the tokens being added. That is a worse outcome than the 400.

So `claims/1` now resolves the issuer to a provider atom once and every downstream function dispatches on that atom, which makes the three agree by construction rather than by three separate patterns staying in sync.

Accepting an arbitrary enterprise slug is safe. The JWKS URI stays a constant, verified against the discovery document, so nothing is derived from the token and there is no SSRF surface. Authorization still rests on the `repository` claim, which GitHub sets from the repository actually running the workflow, so a token minted under another enterprise cannot claim someone else's repository. Issuers with a multi-segment path are rejected.

### Impact

Any customer on a GitHub enterprise with a scoped issuer currently cannot use OIDC authentication at all, and the error tells them nothing actionable. This was diagnosed from production logs: exactly three HTTP 400s on the endpoint across the fleet in three days, all sub-millisecond, meaning the request died before any I/O.

### How to test locally

Server, from `server/`:

```
mix test test/tuist/oidc_test.exs test/tuist_web/controllers/api/oidc_controller_test.exs
```

The three new cases cover an enterprise-scoped issuer verifying end to end against the shared JWKS URI, the audience check still firing for that issuer (the regression guard described above), and a multi-segment issuer being rejected. The first two fail on `main` with `{:error, :unsupported_provider, ...}`, which is the reported failure reproduced as a unit test.

### Validation performed

- Wrote the tests first and confirmed both fail against `main`'s implementation with the exact production error, then pass with the change. 21 tests green across both suites.
- `mix credo` clean on the changed module, `mix format` applied.
- Regenerated the OpenAPI client with `mise run generate-api-cli-code`; the spec diff is additive and confined to this operation.

### Note on the commit history

The second commit rewrote the `missingFullHandle` error to point at `tuist.toml`, and the third reverts it. That rewrite was wrong: `ConfigLoader` reads `Tuist.swift` first on macOS, so an Apple project holding a `Tuist.swift` without a `fullHandle` would have added the suggested `tuist.toml` and seen it ignored. `tuist init` already handles both, writing `Tuist.swift` for Xcode and Swift package workflows and `tuist.toml` for Gradle, so the original message was correct. The documentation gap it was compensating for is real and stays fixed.

### Note on the local build

The Swift changes could not be compiled locally: the build failed with `No space left on device` with the machine at 100%, and retrying risked taking the volume to zero. CI has since covered it. `Linux Build`, `Build Acceptance Tests` and the macOS `TuistAcceptanceTests` build all pass on this branch, so the regenerated client and the new `.badRequest` arm compile on both platforms.
