### PR TITLE
fix(swifterpm,cli): clear the workspace state before a fresh resolve so update actually updates

### DIFF
--- a/swifterpm/Sources/swifterpm/Resolve.swift
+++ b/swifterpm/Sources/swifterpm/Resolve.swift
@@ -97,11 +97,23 @@ enum PackageResolver {
         forwardOutput: Bool
     ) async throws -> ResolvedPins {
         let resolvedPath = packageDir.appendingPathComponent("Package.resolved")
-        let snapshot =
+        // `swift package resolve` also reads pins from
+        // `<scratch>/workspace-state.json` when Package.resolved is missing,
+        // so a stale workspace state silently pins the resolve at whatever
+        // the previous install had checked out — the exact scenario `update`
+        // exists to escape. Clear both together and let SwiftPM rewrite each
+        // from the fresh solver output.
+        let workspaceStatePath = (scratchDir ?? packageDir.appendingPathComponent(".build"))
+            .appendingPathComponent("workspace-state.json")
+        let resolvedSnapshot =
             (!writeResolvedFile || !useExistingResolvedFile)
                 ? try await snapshotResolvedFile(at: resolvedPath) : nil
+        let workspaceStateSnapshot =
+            !useExistingResolvedFile
+                ? try await snapshotResolvedFile(at: workspaceStatePath) : nil
         if !useExistingResolvedFile {
             try? await fileSystem.removePath(resolvedPath)
+            try? await fileSystem.removePath(workspaceStatePath)
         }
 
         do {
@@ -125,13 +137,19 @@ enum PackageResolver {
             let resolved = resolvedPathExists
                 ? try await ResolvedFile.read(packageDir: packageDir)
                 : ResolvedPins(originHash: nil, pins: [], version: 3)
-            if !writeResolvedFile, let snapshot {
-                try await restoreResolvedFile(snapshot, at: resolvedPath)
+            if !writeResolvedFile, let resolvedSnapshot {
+                try await restoreResolvedFile(resolvedSnapshot, at: resolvedPath)
+                if let workspaceStateSnapshot {
+                    try await restoreResolvedFile(workspaceStateSnapshot, at: workspaceStatePath)
+                }
             }
             return resolved
         } catch {
-            if let snapshot {
-                try? await restoreResolvedFile(snapshot, at: resolvedPath)
+            if let resolvedSnapshot {
+                try? await restoreResolvedFile(resolvedSnapshot, at: resolvedPath)
+            }
+            if let workspaceStateSnapshot {
+                try? await restoreResolvedFile(workspaceStateSnapshot, at: workspaceStatePath)
             }
             throw error
         }

--- a/swifterpm/Tests/swifterpmTests/ResolveTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ResolveTests.swift
@@ -303,6 +303,62 @@ struct ResolveTests {
     }
 
     @Test
+    func updateReresolvesFreshEvenWhenTheWorkspaceStatePinsAnOldVersion() async throws {
+        // swifterpm implements update as "delete Package.resolved, run
+        // `swift package resolve`", but SwiftPM's `resolve` falls back to the
+        // pins recorded in `.build/workspace-state.json` when Package.resolved
+        // is missing. Leaving that file in place silently pinned the resolve
+        // at whatever the previous install had checked out — so `tuist install
+        // -u` never actually updated the graph. Update has to clear both.
+        try await withTemporaryDirectory { root in
+            let dependency = root.appendingPathComponent("Dependency")
+            try await writeLibraryPackageManifest(at: dependency, name: "Dependency")
+            try await initGitDependency(at: dependency, tags: ["1.0.0"])
+
+            let package = root.appendingPathComponent("App")
+            try await writeAppPackageManifest(
+                at: package,
+                dependencyURL: dependency.path,
+                exactVersion: "1.0.0"
+            )
+
+            let cacheDirectory = root.appendingPathComponent("cache")
+            let scratch = root.appendingPathComponent("scratch")
+
+            let initial = try await SwifterPM().resolve(
+                .init(
+                    packageDirectory: package,
+                    cacheDirectory: cacheDirectory,
+                    scratchDirectory: scratch,
+                    disableSandbox: true,
+                    quiet: true
+                )
+            )
+            try #require(initial.pins.first?.version == "1.0.0", "expected initial pin at 1.0.0")
+
+            // Publish a newer version at its own commit and widen the manifest
+            // so both 1.0.0 and 1.5.0 satisfy it. Update has to pick 1.5.0.
+            try await addCommitAndTag(at: dependency, tag: "1.5.0")
+            try await writeAppPackageManifest(
+                at: package,
+                dependencyURL: dependency.path,
+                fromVersion: "1.0.0"
+            )
+
+            let updated = try await SwifterPM().update(
+                .init(
+                    packageDirectory: package,
+                    cacheDirectory: cacheDirectory,
+                    scratchDirectory: scratch,
+                    disableSandbox: true,
+                    quiet: true
+                )
+            )
+            #expect(updated.pins.first?.version == "1.5.0")
+        }
+    }
+
+    @Test
     func nativeColdPathIsUsedWhenTheSharedCacheOnlyContainsOtherPackages() async throws {
         try await withTemporaryDirectory { root in
             let package = root.appendingPathComponent("App")
@@ -338,6 +394,21 @@ struct ResolveTests {
                 )
             )
         }
+    }
+
+    private func addCommitAndTag(at dependency: URL, tag: String) async throws {
+        // Move the working tree forward by a commit so the new tag points at a
+        // distinct commit — SwiftPM collapses same-commit tags into a single
+        // version, and never advances past the earliest one.
+        try await fileSystem.atomicWrite(
+            "public struct Marker_\(tag.replacingOccurrences(of: ".", with: "_")) {}\n",
+            to: dependency.appendingPathComponent("Sources/Dependency/Marker_\(tag).swift")
+        )
+        try await SystemProcess.run("git", ["add", "Sources"], workingDirectory: dependency)
+        try await SystemProcess.run(
+            "git", ["commit", "-m", "bump to \(tag)"], workingDirectory: dependency
+        )
+        try await SystemProcess.run("git", ["tag", tag], workingDirectory: dependency)
     }
 
     private func initGitDependency(at dependency: URL, tags: [String]) async throws {
@@ -385,12 +456,19 @@ struct ResolveTests {
     private func writeAppPackageManifest(
         at packageDir: URL,
         dependencyURL: String,
-        exactVersion: String = "1.0.0"
+        exactVersion: String = "1.0.0",
+        fromVersion: String? = nil
     ) async throws {
         try await fileSystem.makeDirectory(
             at: packageDir.appendingPathComponent("Sources/App").absolutePath,
             options: [.createTargetParentDirectories]
         )
+        let dependencyLine =
+            if let fromVersion {
+                #".package(url: "\#(dependencyURL)", from: "\#(fromVersion)"),"#
+            } else {
+                #".package(url: "\#(dependencyURL)", exact: "\#(exactVersion)"),"#
+            }
         try await fileSystem.atomicWrite(
             """
             // swift-tools-version: 6.0
@@ -402,7 +480,7 @@ struct ResolveTests {
                     .library(name: "App", targets: ["App"]),
                 ],
                 dependencies: [
-                    .package(url: "\(dependencyURL)", exact: "\(exactVersion)"),
+                    \(dependencyLine)
                 ],
                 targets: [
                     .target(name: "App", dependencies: [


### PR DESCRIPTION
A user running a swifterpm rollout internally reported that `tuist
install -u` never actually updates dependencies while
`TUIST_USE_SWIFTERPM` is on — the graph regenerates against the old
versions, and unsetting the env var makes the update take effect. This
PR fixes that under swifterpm.

### Root cause

`SwifterPM.update` implements "update" as "delete `Package.resolved`,
then shell out to `swift package resolve`". That was meant to be
equivalent to `swift package update`, but it isn't: SwiftPM's resolver
falls back to the pins recorded in `<scratch>/workspace-state.json`
when `Package.resolved` is missing, so `swift package resolve` silently
pinned each fresh resolve at whatever the previous install had checked
out. `swift package update` (the fallback path when swifterpm is off)
invalidates the workspace state itself, which is why disabling the env
var made the bug go away.

I reproduced it against `apple/swift-argument-parser`:

- `Package.resolved` + `workspace-state.json` both pinned to `1.2.2`.
- Delete `Package.resolved`, keep `workspace-state.json`, run
  `swift package resolve` → still `1.2.2` (bug).
- Delete both, run `swift package resolve` → `1.8.2` (newest).
- Keep both, run `swift package update` → `1.8.2`.

### Approach

In `PackageResolver.resolveWithSwiftPackageManagerProcess`, when
`useExistingResolvedFile == false` (the update path, and the
Package.resolved-missing branch of resolve), also snapshot and delete
`<scratch>/workspace-state.json` before invoking `swift package
resolve`. Restore both files on error, and on the print-only path
(`writeResolvedFile == false`) so nothing observable changes when the
resolve isn't meant to persist. The rest of the shape — the snapshot
dance, the swiftpm invocation, the `dedupePinsByIdentity` +
`normalizedForResolvedFile` handling in the caller — stays the same,
because the SwiftPM invocation already writes fresh pins once the
workspace state is out of the way.

Both the hot (`resolveOrLoad`) and cold (`shouldUseNativeColdPath`)
paths funnel through `resolveWithSwiftPackageManagerProcess`, so the
single change covers every entry point (the public library API used by
`SwiftPackageManagerController` and the `swifterpm` CLI's `update` and
`resolve` commands).

### Impact

- `tuist install -u` picks up newer allowed versions again under
  `TUIST_USE_SWIFTERPM=1`, matching the behavior with the env var off.
- No user-visible change on `tuist install` (resolve path) when
  `Package.resolved` exists and is honored — `useExistingResolvedFile`
  is true there, so nothing gets deleted.

### Validation

TDD:

- Added `ResolveTests/updateReresolvesFreshEvenWhenTheWorkspaceStatePinsAnOldVersion`
  in `swifterpm/Tests/swifterpmTests/ResolveTests.swift`: it resolves
  a local git dep pinned `exact: "1.0.0"`, publishes a `1.5.0` tag at a
  new commit, widens the manifest to `from: "1.0.0"`, calls
  `SwifterPM().update(...)`, and asserts the new pin is `1.5.0`.
  Verified the test fails against `main` (`updated.pins.first?.version
  → "1.0.0"`) and passes with the fix.
- Ran the surrounding suites too: `ResolveTests` (10 tests),
  `RestoreTests`, `CLITests`, `CLIRunnerTests`, `ManifestTests` — all
  green (36 tests across `Restore|CLI*|Manifest*`).

### How to test locally

```bash
cd swifterpm
swift test --filter ResolveTests/updateReresolvesFreshEvenWhenTheWorkspaceStatePinsAnOldVersion
```

Or end-to-end against a project where a newer allowed version has
shipped since the last install:

```bash
TUIST_USE_SWIFTERPM=1 tuist install -u
tuist generate --no-open  # should pick up the new versions
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014e2U18sNFV3xZj5zMV2oa5
