### PR TITLE
fix(infra): stop concurrent OVH adoption from double-claiming a box

### DIFF
--- a/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift_test.go
@@ -20,6 +20,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"sigs.k8s.io/cluster-api/util/patch"
+
 	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-tuist/api/v1alpha1"
 	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/credentials"
 	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/ovh"
@@ -114,7 +116,11 @@ func testFleetPrivateKey(t *testing.T) []byte {
 
 func (h *kataHarness) reconcile() {
 	h.t.Helper()
-	if _, err := h.r.reconcileNormal(context.Background(), h.machine); err != nil {
+	helper, err := patch.NewHelper(h.machine, h.client)
+	if err != nil {
+		h.t.Fatalf("patch helper: %v", err)
+	}
+	if _, err := h.r.reconcileNormal(context.Background(), h.machine, helper); err != nil {
 		h.t.Fatalf("reconcileNormal: %v", err)
 	}
 }

--- a/infra/cluster-api-provider-tuist/controllers/linux/ovh_adoption_claim_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/ovh_adoption_claim_test.go
@@ -1,0 +1,78 @@
+package linux
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-tuist/api/v1alpha1"
+)
+
+func claimScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := infrav1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add infrav1 to scheme: %v", err)
+	}
+	return scheme
+}
+
+func claimingMachine(ns, name, service string) *infrav1.OVHDedicatedMachine {
+	m := &infrav1.OVHDedicatedMachine{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, UID: types.UID(name)},
+	}
+	m.Status.ServiceName = service
+	return m
+}
+
+// A claim is only durable once its status patch lands, and the informer cache
+// lags that write. A sibling that reads through the cache therefore sees a box
+// as free after it was claimed and adopts it too, bootstrapping one host twice
+// and leaving two Nodes sharing a providerID, which wedges the CAPI node lookup
+// for both Machines. The claim read must bypass the cache.
+func TestClaimedServiceNamesReadsUncached(t *testing.T) {
+	const ns = "tuist"
+	scheme := claimScheme(t)
+
+	self := claimingMachine(ns, "adopter", "")
+	sibling := claimingMachine(ns, "sibling", "ns3048220.ip-51-255-75.eu")
+
+	// The cached client is behind: it has not observed the sibling's claim yet.
+	cached := fake.NewClientBuilder().WithScheme(scheme).WithObjects(self).Build()
+	live := fake.NewClientBuilder().WithScheme(scheme).WithObjects(self, sibling).Build()
+
+	r := &OVHDedicatedMachineReconciler{Client: cached, APIReader: live}
+
+	claimed, err := r.claimedServiceNames(context.Background(), self)
+	if err != nil {
+		t.Fatalf("claimedServiceNames: %v", err)
+	}
+	if !claimed["ns3048220.ip-51-255-75.eu"] {
+		t.Fatalf("claimedServiceNames = %v, want the sibling's claim; a cached read double-claims the box", claimed)
+	}
+}
+
+// Without an APIReader wired the reconciler still has to exclude siblings
+// rather than returning an empty set and adopting everything twice.
+func TestClaimedServiceNamesFallsBackToClient(t *testing.T) {
+	const ns = "tuist"
+	scheme := claimScheme(t)
+
+	self := claimingMachine(ns, "adopter", "")
+	sibling := claimingMachine(ns, "sibling", "ns3049612.ip-51-255-75.eu")
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(self, sibling).Build()
+
+	r := &OVHDedicatedMachineReconciler{Client: cl}
+
+	claimed, err := r.claimedServiceNames(context.Background(), self)
+	if err != nil {
+		t.Fatalf("claimedServiceNames: %v", err)
+	}
+	if !claimed["ns3049612.ip-51-255-75.eu"] {
+		t.Fatalf("claimedServiceNames = %v, want the sibling's claim", claimed)
+	}
+}

--- a/infra/cluster-api-provider-tuist/controllers/linux/ovhdedicatedmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/ovhdedicatedmachine_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -78,6 +79,12 @@ type OVHDedicatedMachineReconciler struct {
 	CredentialsManager *credentials.Manager
 	Kubeconfig         *kubeconfig.Builder
 
+	// adoptMu serializes the claim window across the controller's concurrent
+	// workers (see --machine-max-concurrent-reconciles). Leader election means
+	// one manager reconciles at a time, so a process-local lock is the whole
+	// mutual exclusion this needs.
+	adoptMu sync.Mutex
+
 	// KubernetesMinor is the pkgs.k8s.io channel the self-join installs kubelet
 	// from (e.g. "v1.34"); keep in step with the control plane.
 	KubernetesMinor string
@@ -144,10 +151,10 @@ func (r *OVHDedicatedMachineReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	return r.reconcileNormal(ctx, machine)
+	return r.reconcileNormal(ctx, machine, patchHelper)
 }
 
-func (r *OVHDedicatedMachineReconciler) reconcileNormal(ctx context.Context, machine *infrav1.OVHDedicatedMachine) (ctrl.Result, error) {
+func (r *OVHDedicatedMachineReconciler) reconcileNormal(ctx context.Context, machine *infrav1.OVHDedicatedMachine, patchHelper *patch.Helper) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	datacenter := firstNonEmpty(machine.Spec.Datacenter, r.DefaultDatacenter)
 
@@ -166,6 +173,14 @@ func (r *OVHDedicatedMachineReconciler) reconcileNormal(ctx context.Context, mac
 		}
 		// Adopt: claim a free pre-ordered box not already held by a sibling CR.
 		if machine.Status.ServiceName == "" {
+			// A claim only becomes visible to siblings once its status patch
+			// lands, so the read-pick-persist window has to be atomic: two
+			// workers that both list before either writes will pick the same
+			// box, bootstrap it twice, and leave two Nodes sharing one
+			// providerID, which wedges the CAPI node lookup for both.
+			r.adoptMu.Lock()
+			defer r.adoptMu.Unlock()
+
 			claimed, claimErr := r.claimedServiceNames(ctx, machine)
 			if claimErr != nil {
 				return ctrl.Result{}, claimErr
@@ -191,12 +206,15 @@ func (r *OVHDedicatedMachineReconciler) reconcileNormal(ctx context.Context, mac
 			machine.Status.Phase = "Adopting"
 			r.event(machine, "Adopted", "Adopted OVH server %s in %s", server.Name, datacenter)
 			logger.Info("adopted OVH server", "service", server.Name, "datacenter", datacenter)
-			// Persist the claim before the long bootstrap that follows (mint
-			// identity, SSH self-join): a crash or leader failover before the
-			// deferred status patch would drop the in-memory claim and let a sibling
-			// Machine adopt the same box. Requeue so the deferred patch flushes
-			// Status.ServiceName now; the next reconcile resumes from the durable
-			// claim (re-fetching the box via GetServer).
+			// Persist inside the lock: the deferred patch flushes only after the
+			// lock is released, which would reopen the window it exists to close.
+			if patchErr := patchHelper.Patch(ctx, machine); patchErr != nil {
+				return ctrl.Result{}, fmt.Errorf("persist adoption claim for %s: %w", server.Name, patchErr)
+			}
+			// Requeue rather than bootstrapping inline: the next reconcile
+			// resumes from the now-durable claim (re-fetching the box via
+			// GetServer), so a crash or leader failover during the long
+			// bootstrap that follows never drops the claim.
 			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
 
@@ -360,6 +378,13 @@ func (r *OVHDedicatedMachineReconciler) hostOptions(machine *infrav1.OVHDedicate
 	}
 }
 
+func (r *OVHDedicatedMachineReconciler) reader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
+
 // claimedServiceNames is the set of OVH service names already held by other
 // OVHDedicatedMachines in the namespace, so adoption never double-claims a box.
 // Claim state lives in the CR status rather than OVH-side because the cluster
@@ -367,7 +392,10 @@ func (r *OVHDedicatedMachineReconciler) hostOptions(machine *infrav1.OVHDedicate
 // claim marker the way Scaleway names do.
 func (r *OVHDedicatedMachineReconciler) claimedServiceNames(ctx context.Context, self *infrav1.OVHDedicatedMachine) (map[string]bool, error) {
 	list := &infrav1.OVHDedicatedMachineList{}
-	if err := r.List(ctx, list, client.InNamespace(self.Namespace)); err != nil {
+	// Uncached: the informer cache lags its own writes by long enough that a
+	// sibling that already claimed a box still reads as unclaimed, which is a
+	// double-claim rather than a stale view a later reconcile repairs.
+	if err := r.reader().List(ctx, list, client.InNamespace(self.Namespace)); err != nil {
 		return nil, fmt.Errorf("list OVHDedicatedMachines: %w", err)
 	}
 	claimed := make(map[string]bool, len(list.Items))


### PR DESCRIPTION
## What changed

`OVHDedicatedMachineReconciler` adoption now reads the sibling claim set through the uncached `APIReader`, and holds a process-local lock across the whole read-pick-persist window, flushing the claim with an explicit patch inside the lock rather than leaving it to the deferred status patch.

## Why

Scaling a fleet MachineDeployment from 1 to 4 in a single step put three adoptions in flight at once and two of them claimed the same physical server.

## Root cause

Two compounding defects, both in the claim path:

1. `claimedServiceNames` listed sibling CRs through the manager's client, which reads from the informer cache. The cache lags its own writes, so a sibling that had already recorded `Status.ServiceName` still read as unclaimed.
2. The claim only became durable when the deferred `patchHelper.Patch` ran at the end of the reconcile, which widened the window further.

`--machine-max-concurrent-reconciles` defaults to 4, so several workers pass the free-box check before any of them persists. Every fleet had run at `replicas: 1` until now, which is why this had never fired.

The failure is not a wasted box. Both Machines bootstrap the same host, and the second join re-registers it under a new node name and kills the first kubelet. That leaves two Node objects sharing one providerID, and the CAPI Machine controller then fails closed with `NodeInspectionFailed: Failed to get the Node for this Machine by ProviderID`. With no `nodeRef` it never propagates `node.cluster.x-k8s.io/pool` onto the Node, so a healthy, correctly tainted, kata-enabled box sits outside its runner pool taking zero work, and does not appear in a listing filtered by pool label.

## Why this approach

A conflict-retry on the claim write does not help: each Machine writes its own status, so the writes never conflict with each other. The contention is over an external resource, not over a Kubernetes object, so the exclusion has to cover the read and the pick as well as the write.

Setting `MaxConcurrentReconciles: 1` would also close it, but it would serialize every reconcile in the controller, including the multi-minute SSH bootstraps, and badly slow a fleet bringup. The lock is scoped to the claim block, which runs once per machine and is short.

The provider is leader-elected, so exactly one manager reconciles at a time and a `sync.Mutex` is the full extent of the mutual exclusion required. The uncached read is what keeps the fix correct across a leader failover, where the lock does not carry over but the persisted claim does.

## Impact

Fleets can be scaled by more than one replica in a single step. `replicas: N` in the values files becomes safe to set directly rather than needing to be walked up one at a time.

## Validation

- `TestClaimedServiceNamesReadsUncached` fails against the previous cached read with `claimedServiceNames = map[]` and passes with the fix.
- `TestClaimedServiceNamesFallsBackToClient` covers a reconciler built without an `APIReader`.
- `go build ./...` and `go test ./...` pass for the provider module.
- Verified against the live production fleet: after recovering the wedged node, scaling the MachineDeployment by one adopted the remaining unclaimed box on the first reconcile with no race, and the fleet now runs four boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)