### PR TITLE
feat(infra): add a second Dedibox to the eu-central Kura region

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -704,12 +704,27 @@ kuraFleet:
 # self-joins it as the kura-dedibox pool that backs eu-central. PREREQ before
 # merge: the DEDIBOX_SCW_API 1Password item exists in the production vault, and a
 # box is delivered + tagged tuist-kura-production; an enabled fleet with no
-# adoptable box hangs helm --wait. NOTE: eu-central is a shared public region
-# (many accounts, each with its own storageSize cache), so size the box for the
-# account count; Start-9-M is the staging-validated shape, but a larger Dedibox
-# offer may be needed for production.
+# adoptable box hangs helm --wait.
+#
+# eu-central is a shared public region, so its capacity is the sum of its boxes
+# and replicas is how it grows. What runs out first on a Pro-9-XS is the memory
+# ceiling, not the disk: tuist.dev/memory-ceiling-mib is twice the node's
+# allocatable memory, so 32 GB admits six enterprise accounts (two pods each at
+# 4096 MiB) while the 2x1 TB NVMe would hold eight.
+#
+# Every box in this fleet must be the same offer AND datacenter: Dedibox
+# adoption matches both exactly (FindAdoptableServer), unlike the ovhFleets
+# entries, which substring-match the offer and prefix-match the datacenter. A
+# box of any other shape is never adopted, and nothing reports why.
+#
+# Raise replicas only once each box reports `installed`. Prep is
+# `PREP_NAMESPACE=tuist-production mise run baremetal:prep-dedibox <server-id>`,
+# which lays down the mirrored root plus the separate XFS /data that carries the
+# per-account project quota, then tags the box into the pool.
 dediboxFleet:
   enabled: true
+  # Two boxes: the original plus sd-184776 (DC5, delivered 2026-09-02).
+  replicas: 2
   machine:
     adoptTag: tuist-kura-production
     offer: Pro-9-XS


### PR DESCRIPTION
> **Box is ready; merge is gated on something unrelated.** sd-184776 finished
> installing at 19:53 UTC+2 and is tagged `tuist-kura-production`, so this is no
> longer a draft.
>
> Do not merge while `tuist-tuist-ovh-fleet-runners-linux` is `Ready=False`.
> Two Machines in that fleet have claimed the same OVH box
> (`ovh://gra1/ns3048220.ip-51-255-75.eu`), and MachineDeployments are in the
> `helm upgrade --atomic --wait` set, so the deploy would fail on that fleet
> rather than on anything here.

## What changed

`dediboxFleet.replicas: 2` in the production values, plus the comment block that
explains what governs the number.

## Why

eu-central ran out of admission headroom on its single Pro-9-XS. The binding
resource is the memory ceiling, not the disk:

| Resource | Allocatable | Requested | Committed |
|---|---|---|---|
| `tuist.dev/memory-ceiling-mib` | 56,744 | 49,152 | 86.6% |
| `ephemeral-storage` | 824.8 GiB | 600 GiB | 72.8% |
| `tuist.dev/egress-mbps` | 1,000 | 300 | 30% |
| `cpu` | 31 | 6.44 | 21% |

`tuist.dev/memory-ceiling-mib` is twice the node's allocatable memory
(`MemoryCeilingOversubscription`), so a 32 GB box advertises 56,744 MiB. The six
enterprise accounts already there hold 49,152 of it at 4,096 MiB per pod, two
co-located pods each. A seventh account needs 8,192 MiB against 7,592 free, so
the region could not admit one at all, while a quarter of its NVMe and two
thirds of its NIC budget sat unused.

Physical usage is not the issue: `/data` is 189 GB used of 984 GB. This is an
admission wall, and there are no open claim proposals, so the pressure is new
accounts rather than the sizing worker.

## Why a second box rather than a bigger one

Adding is non-disruptive. `replicas` is additive, the strategy is `OnDelete`, and
the controller keeps each account's two replicas co-located, so no existing cache
moves and new accounts simply land on whichever box has room. Replacing would
have cold-started all six accounts for less total capacity.

It also gives eu-central its first box redundancy. Until now a single box meant
any loss took the entire region cold, since the warm standby is co-located with
its primary by design.

A larger shape was considered and rejected for now. Dedibox adoption
exact-matches offer and datacenter, so a mixed-shape fleet needs the offer pin
blanked, and the shapes that would have paid for that (Pro-11-L) are out of
stock. Same offer, same datacenter keeps the change to one line.

At the measured growth rate of about 0.8 accounts per month, six more accounts
is roughly seven months of runway.

## Impact

eu-central goes from 6 to about 12 enterprise accounts of capacity. No customer
facing change: region id, cluster_id, ingress class and hostnames are all
untouched, and no existing instance is rescheduled.

## Validation

- `helm template` renders the MachineDeployment at `replicas: 2` with the
  `OnDelete` strategy and the `kura-dedibox` pool label intact.
- Capacity figures above read from kube-state-metrics on the live production
  node, not estimated.
- sd-184776 is delivered in DC5, matching the pinned `datacenter: DC5`, and its
  offer reads `Pro-9-XS`, matching the pinned `offer`.
- Prepped with `baremetal:prep-dedibox`, which installed a raid1 mirrored root
  plus a separate XFS `/data` of 954.6 GB. The incumbent box predates that
  layout and runs ext4, so this box is the first in the region that can carry
  the per-account project quota.
- Tagged `tuist-kura-production`. Safe to tag ahead of merge: the existing
  Machine holds its claim and `FindAdoptableServer` skips claimed boxes, so
  nothing adopts sd-184776 until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
