### PR TITLE
feat(server): label the eu-central Kura region EU West

### DIFF
--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -229,7 +229,7 @@ defmodule Tuist.Kura.Regions do
       country: "US",
       subdivision: "US-OR"
     },
-    # EU Central runs on Scaleway Dedibox bare metal: the `kura-dedibox` node
+    # EU West runs on Scaleway Dedibox bare metal: the `kura-dedibox` node
     # pool (each environment's `dediboxFleet`), local-NVMe storage, a hostNetwork
     # regional gateway bound to the box's public IP (Dedibox has no Hetzner LB),
     # and two bounded-size replicas so a rolling deploy fails the cache Service
@@ -240,9 +240,17 @@ defmodule Tuist.Kura.Regions do
     # id, cluster_id,
     # ingress class, and public hostnames are unchanged from the former Hetzner
     # ccx13 backing, so the cutover is invisible to the customer.
+    #
+    # The id reads `eu-central` and the label reads EU West. The label is the
+    # accurate one: the boxes sit in Scaleway DC5 in the Paris region, which is
+    # the west of Europe rather than its centre, and eu-central conventionally
+    # names Frankfurt. The id cannot follow it: `cluster_id` is interpolated into
+    # the account's public cache hostname and `account_cache_endpoints` stores the
+    # resulting URLs, so changing it re-issues hostnames rather than renaming
+    # anything.
     %{
       id: "eu-central",
-      display_name: "EU Central",
+      display_name: "EU West",
       cluster_id: "eu-central-1",
       ingress_class_name: "kura-eu-central",
       node_pool: "kura-dedibox",

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -226,7 +226,7 @@ defmodule Tuist.Kura.RegionsTest do
       # Identity is unchanged so the cutover is invisible to the customer and CLI.
       assert config.cluster_id == "eu-central-1"
       assert config.ingress_class_name == "kura-eu-central"
-      assert Regions.get("eu-central").display_name == "EU Central"
+      assert Regions.get("eu-central").display_name == "EU West"
     end
 
     test "threads the per-region public peer failover IP from the environment" do

--- a/server/test/tuist_web/live/ops_account_live_test.exs
+++ b/server/test/tuist_web/live/ops_account_live_test.exs
@@ -285,7 +285,7 @@ defmodule TuistWeb.OpsAccountLiveTest do
       |> render_submit()
 
     assert html =~ "Egress limits updated in US East"
-    assert html =~ "EU Central was rejected and not saved"
+    assert html =~ "EU West was rejected and not saved"
     refute html =~ "Nothing was saved"
 
     assert Kura.egress_limits_override(user.account, us_east) == %{floor_mbps: 60, burst_mbps: 400}
@@ -327,7 +327,7 @@ defmodule TuistWeb.OpsAccountLiveTest do
       })
       |> render_submit()
 
-    assert html =~ "Egress limits updated in EU Central"
+    assert html =~ "Egress limits updated in EU West"
 
     assert Kura.egress_limits_override(user.account, Kura.region("eu-central")) ==
              %{floor_mbps: nil, burst_mbps: 200}
@@ -395,7 +395,7 @@ defmodule TuistWeb.OpsAccountLiveTest do
       |> render_submit()
 
     assert html =~ "kura-egress-limits-result"
-    assert html =~ "EU Central, US East"
+    assert html =~ "EU West, US East"
     assert html =~ "2 instances are recreated to pick them up"
   end
 


### PR DESCRIPTION
## What changed

`display_name` on the `eu-central` Kura region goes from "EU Central" to
"EU West", plus the three test assertions that render it and a comment recording
why the id and the label now disagree.

## Why

The region's boxes sit in Scaleway DC5, in the Paris region. Paris is the west of
Europe rather than its centre, and `eu-central` conventionally names Frankfurt,
so the label described something the hardware is not. The name has been wrong
since the region moved off Hetzner, and it came up while adding a second box to
the region.

## What deliberately did not change

`id`, `cluster_id`, `ingress_class_name` and the public hostnames all stay as
they are. `cluster_id` is interpolated into an account's public cache hostname
and `account_cache_endpoints` stores the resulting URLs, so renaming it re-issues
hostnames for every account in the region rather than renaming anything. The
module already documents the id as never renamed once published, and both
previous cutovers of this region held the identity constant for exactly this
reason.

If the id is ever genuinely worth changing, it is a migration in its own right:
a new region plus a tombstone for the old one, rewritten `account_cache_endpoints`
rows, and re-issued customer hostnames. That is not this.

The legacy strings in `cache_endpoint_formatter` are also untouched on purpose.
They format URLs of the form `cache-eu-central.tuist.dev`, which are the pre-Kura
cache endpoints seeded by migration and named after the hostname itself.
Relabelling them would make the UI disagree with both the hostname and the
seeded display names in the database, which is a different subsystem from the
Kura region catalog.

## Impact

Cosmetic and customer visible: the dashboard, the ops account page and the
egress-limit flash messages now say EU West. No instance is rescheduled, no URL
changes, nothing is re-provisioned. There is no reverse lookup by
`display_name`, so nothing resolves a region by the old string.

## Validation

`mix test test/tuist/kura/regions_test.exs test/tuist_web/live/ops_account_live_test.exs`
gives 100 passed, 0 failures. A repo-wide search confirms the only remaining
"EU Central" strings are the legacy cache-endpoint ones described above and the
historical migrations, which must not be edited. The ops account page joins
region names sorted, and "EU West" still sorts before "US East", which the
existing assertion covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)