### PR TITLE
feat(server): show the cache and usage dashboards to every account

### DIFF
--- a/server/lib/tuist/feature_flags.ex
+++ b/server/lib/tuist/feature_flags.ex
@@ -25,21 +25,6 @@ defmodule Tuist.FeatureFlags do
   defp runner_flag_required?, do: Environment.env() in [:can, :prod]
 
   @doc """
-  Whether the Kura surface (the per-account Kura servers, the
-  self-hosted cache management, and the Usage dashboard) should be
-  visible for the given account. Self-hosted deployments (including
-  dev/test, which are also not `tuist_hosted?`) always see it, mirroring
-  `Tuist.Billing.Entitlements` where the deployment's license is the
-  entitlement; the hosted server gates it behind the `:kura` FunWithFlags
-  toggle for the actor. Callers should use this rather than checking the
-  flag inline so the sidebar entry, the LiveView guards, and the settings
-  page all answer the same question.
-  """
-  def kura_enabled?(account) do
-    not Environment.tuist_hosted?() or FunWithFlags.enabled?(:kura, for: account)
-  end
-
-  @doc """
   Whether Kura runtime-image rollouts run through the rollout
   orchestration (`Tuist.Kura.Rollouts`): durable rollout records,
   account-grouped waves with the health gate in production, expedited

--- a/server/lib/tuist_web/components/app_layout_components.ex
+++ b/server/lib/tuist_web/components/app_layout_components.ex
@@ -414,10 +414,7 @@ defmodule TuistWeb.AppLayoutComponents do
         selected={String.starts_with?(@current_path, ~p"/#{@selected_account.name}/webhooks")}
       />
       <.sidebar_item
-        :if={
-          FeatureFlags.kura_enabled?(@selected_account) and
-            Authorization.authorize(:account_update, @current_user, @selected_account) == :ok
-        }
+        :if={Authorization.authorize(:account_update, @current_user, @selected_account) == :ok}
         label={dgettext("dashboard", "Cache")}
         icon="database"
         navigate={~p"/#{@selected_account.name}/cache"}
@@ -431,7 +428,6 @@ defmodule TuistWeb.AppLayoutComponents do
         selected={String.starts_with?(@current_path, ~p"/#{@selected_account.name}/billing")}
       />
       <.sidebar_item
-        :if={FeatureFlags.kura_enabled?(@selected_account)}
         label={dgettext("dashboard", "Usage")}
         icon="chart_column"
         navigate={~p"/#{@selected_account.name}/usage"}

--- a/server/lib/tuist_web/live/account_settings_live.ex
+++ b/server/lib/tuist_web/live/account_settings_live.ex
@@ -10,7 +10,6 @@ defmodule TuistWeb.AccountSettingsLive do
   alias Tuist.Accounts.Account
   alias Tuist.Accounts.AccountCacheEndpoint
   alias Tuist.Authorization
-  alias Tuist.FeatureFlags
   alias Tuist.Locale, as: SharedLocale
 
   @impl true
@@ -27,7 +26,6 @@ defmodule TuistWeb.AccountSettingsLive do
     add_cache_endpoint_form = to_form(AccountCacheEndpoint.create_changeset(%{}))
     cache_endpoints = Accounts.list_account_cache_endpoints(selected_account)
     custom_cache_endpoints_available = Accounts.custom_cache_endpoints_available?(selected_account)
-    kura_enabled = kura_enabled?(selected_account)
 
     preferred_locale_form =
       to_form(%{"preferred_locale" => current_user.preferred_locale || "browser"})
@@ -41,7 +39,6 @@ defmodule TuistWeb.AccountSettingsLive do
       |> assign(add_cache_endpoint_form: add_cache_endpoint_form)
       |> assign(cache_endpoints: cache_endpoints)
       |> assign(custom_cache_endpoints_available: custom_cache_endpoints_available)
-      |> assign(kura_enabled: kura_enabled)
       |> assign(preferred_locale_form: preferred_locale_form)
       |> assign(:head_title, "#{dgettext("dashboard_account", "Settings")} · #{selected_account.name} · Tuist")
 
@@ -226,10 +223,6 @@ defmodule TuistWeb.AccountSettingsLive do
       Accounts.update_account(selected_account, %{custom_cache_endpoints_enabled: checked})
 
     {:noreply, assign(socket, selected_account: updated_account)}
-  end
-
-  defp kura_enabled?(account) do
-    FeatureFlags.kura_enabled?(account)
   end
 
   defp delete_cache_endpoint(socket, endpoint_id) do

--- a/server/lib/tuist_web/live/cache_live.ex
+++ b/server/lib/tuist_web/live/cache_live.ex
@@ -9,7 +9,6 @@ defmodule TuistWeb.CacheLive do
   alias Tuist.Accounts
   alias Tuist.Authorization
   alias Tuist.Billing.Entitlements
-  alias Tuist.FeatureFlags
   alias Tuist.Kura.Registrations
   alias Tuist.Kura.SelfHostedClients
 
@@ -20,14 +19,12 @@ defmodule TuistWeb.CacheLive do
             dgettext("dashboard_account", "You are not authorized to perform this action.")
     end
 
-    cache_enabled = cache_enabled?(selected_account)
     # Self-hosting cache nodes is an Enterprise-only capability, gated by the
-    # plan entitlement rather than the (transient) :kura rollout flag.
-    self_hosted_enabled = cache_enabled and Entitlements.allows?(selected_account, :self_hosted_cache)
+    # plan entitlement.
+    self_hosted_enabled = Entitlements.allows?(selected_account, :self_hosted_cache)
 
     socket =
       socket
-      |> assign(:cache_enabled, cache_enabled)
       |> assign(:self_hosted_enabled, self_hosted_enabled)
       |> assign(:head_title, "#{dgettext("dashboard_account", "Cache")} · #{selected_account.name} · Tuist")
       |> assign(:new_self_hosted_client_form, to_form(%{"name" => ""}, as: :self_hosted_client))
@@ -141,20 +138,10 @@ defmodule TuistWeb.CacheLive do
     |> assign(:new_self_hosted_client_form, to_form(%{"name" => ""}, as: :self_hosted_client))
   end
 
-  defp load_self_hosted_state(%{assigns: %{cache_enabled: false}} = socket) do
-    socket
-    |> assign(:self_hosted_clients, [])
-    |> assign(:registered_endpoints, [])
-  end
-
   defp load_self_hosted_state(%{assigns: %{selected_account: account}} = socket) do
     socket
     |> assign(:self_hosted_clients, SelfHostedClients.list_self_hosted_clients(account))
     |> assign(:registered_endpoints, Registrations.list_endpoints(account))
-  end
-
-  defp cache_enabled?(account) do
-    FeatureFlags.kura_enabled?(account)
   end
 
   attr(:cache_write_policy, :atom, required: true)

--- a/server/lib/tuist_web/live/cache_live.html.heex
+++ b/server/lib/tuist_web/live/cache_live.html.heex
@@ -9,25 +9,12 @@
     </span>
   </div>
 
-  <%= if @cache_enabled do %>
-    <.cache_write_policy_section cache_write_policy={@selected_account.cache_write_policy} />
-    <.self_hosted_section
-      :if={@self_hosted_enabled}
-      self_hosted_clients={@self_hosted_clients}
-      new_self_hosted_client_form={@new_self_hosted_client_form}
-      new_self_hosted_client_secret={@new_self_hosted_client_secret}
-      registered_endpoints={@registered_endpoints}
-    />
-  <% else %>
-    <.card_section data-part="cache-disabled-card">
-      <.alert
-        status="information"
-        type="secondary"
-        size="small"
-        title={
-          dgettext("dashboard_account", "Cache servers are not enabled for this account yet.")
-        }
-      />
-    </.card_section>
-  <% end %>
+  <.cache_write_policy_section cache_write_policy={@selected_account.cache_write_policy} />
+  <.self_hosted_section
+    :if={@self_hosted_enabled}
+    self_hosted_clients={@self_hosted_clients}
+    new_self_hosted_client_form={@new_self_hosted_client_form}
+    new_self_hosted_client_secret={@new_self_hosted_client_secret}
+    registered_endpoints={@registered_endpoints}
+  />
 </div>

--- a/server/lib/tuist_web/live/gradle_build_live.ex
+++ b/server/lib/tuist_web/live/gradle_build_live.ex
@@ -326,7 +326,7 @@ defmodule TuistWeb.GradleBuildLive do
     |> assign(:artifact_transform_duration_ms, Enum.sum_by(all_artifact_transforms, & &1.duration_ms))
     |> assign(
       :configuration_timeline_operations,
-      configuration_timeline_operations(filtered_operations, socket.assigns.configuration_timeline_range)
+      configuration_timeline_operations(filtered_operations, configuration_timeline_range)
     )
     |> assign(:configuration_operations_table, configuration_operations)
     |> assign(:configuration_operations_filter, configuration_operations_filter)

--- a/server/lib/tuist_web/live/usage_live.ex
+++ b/server/lib/tuist_web/live/usage_live.ex
@@ -19,18 +19,13 @@ defmodule TuistWeb.UsageLive do
 
   @impl true
   def mount(_params, _session, %{assigns: %{selected_account: account, current_user: current_user}} = socket) do
-    runner_breakdown = Allowance.period_breakdown(account)
-
-    # The page used to exist only for accounts with cache traffic. Runner
-    # usage is billed the same way and belongs on the same page, so an
-    # account with runner time but no cache reaches it too.
-    runners_enabled = FeatureFlags.runners_enabled?(account)
-
-    if Authorization.authorize(:account_dashboard_read, current_user, account) != :ok or
-         (not FeatureFlags.kura_enabled?(account) and runner_breakdown.minutes == 0 and not runners_enabled) do
+    if Authorization.authorize(:account_dashboard_read, current_user, account) != :ok do
       raise TuistWeb.Errors.NotFoundError,
             dgettext("dashboard_usage", "The page you are looking for doesn't exist or has been moved.")
     end
+
+    runner_breakdown = Allowance.period_breakdown(account)
+    runners_enabled = FeatureFlags.runners_enabled?(account)
 
     # Twelve is enough history to look back a year without listing
     # periods the account did not exist for; empty ones simply report
@@ -48,8 +43,7 @@ defmodule TuistWeb.UsageLive do
      |> assign(:periods, periods)
      |> assign(:runner_breakdown, runner_breakdown)
      |> assign(:runners_enabled, runners_enabled)
-     |> assign(:prepaid_balance, prepaid_balance)
-     |> assign(:kura_enabled, FeatureFlags.kura_enabled?(account))}
+     |> assign(:prepaid_balance, prepaid_balance)}
   end
 
   @widgets ["egress", "ingress", "requests"]

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -58,7 +58,7 @@ msgstr ""
 msgid "Bad request"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:428
+#: lib/tuist_web/components/app_layout_components.ex:425
 #, elixir-autogen, elixir-format
 msgid "Billing"
 msgstr ""
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Download macOS app"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:548
+#: lib/tuist_web/components/app_layout_components.ex:544
 #, elixir-autogen, elixir-format
 msgid "Emails"
 msgstr ""
@@ -116,12 +116,12 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:563
+#: lib/tuist_web/components/app_layout_components.ex:559
 #, elixir-autogen, elixir-format
 msgid "Errors"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:541
+#: lib/tuist_web/components/app_layout_components.ex:537
 #, elixir-autogen, elixir-format
 msgid "Flags"
 msgstr ""
@@ -137,13 +137,13 @@ msgstr ""
 msgid "Go to dashboard"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:571
+#: lib/tuist_web/components/app_layout_components.ex:567
 #: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:52
 #, elixir-autogen, elixir-format
 msgid "Grafana"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:475
+#: lib/tuist_web/components/app_layout_components.ex:471
 #, elixir-autogen, elixir-format
 msgid "Integrations"
 msgstr ""
@@ -160,7 +160,7 @@ msgid "Invalid installation request. Please try again."
 msgstr ""
 
 #: lib/tuist_web/components/app_layout_components.ex:386
-#: lib/tuist_web/components/app_layout_components.ex:535
+#: lib/tuist_web/components/app_layout_components.ex:531
 #, elixir-autogen, elixir-format
 msgid "Jobs"
 msgstr ""
@@ -170,7 +170,7 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:529
+#: lib/tuist_web/components/app_layout_components.ex:525
 #, elixir-autogen, elixir-format
 msgid "LiveDashboard"
 msgstr ""
@@ -276,7 +276,7 @@ msgstr ""
 msgid "Server error"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:442
+#: lib/tuist_web/components/app_layout_components.ex:438
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Sorry, you made too many requests. Please try again later."
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:555
+#: lib/tuist_web/components/app_layout_components.ex:551
 #, elixir-autogen, elixir-format
 msgid "Storage"
 msgstr ""
@@ -387,8 +387,8 @@ msgstr ""
 msgid "Too many requests."
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:595
-#: lib/tuist_web/components/app_layout_components.ex:638
+#: lib/tuist_web/components/app_layout_components.ex:591
+#: lib/tuist_web/components/app_layout_components.ex:634
 #, elixir-autogen, elixir-format
 msgid "Tuist Icon"
 msgstr ""
@@ -497,8 +497,8 @@ msgstr ""
 msgid "Create project"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:421
-#: lib/tuist_web/components/app_layout_components.ex:498
+#: lib/tuist_web/components/app_layout_components.ex:418
+#: lib/tuist_web/components/app_layout_components.ex:494
 #: lib/tuist_web/live/ops_cache_live.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Cache"
@@ -631,7 +631,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:511
+#: lib/tuist_web/components/app_layout_components.ex:507
 #: lib/tuist_web/live/ops_accounts_live.ex:18
 #: lib/tuist_web/live/ops_accounts_live.html.heex:3
 #: lib/tuist_web/live/ops_accounts_live.html.heex:5
@@ -639,7 +639,7 @@ msgstr ""
 msgid "Accounts"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:484
+#: lib/tuist_web/components/app_layout_components.ex:480
 #, elixir-autogen, elixir-format
 msgid "Authentication"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Japan"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:504
+#: lib/tuist_web/components/app_layout_components.ex:500
 #: lib/tuist_web/live/ops_account_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "Kura"
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "Tuist could not resolve %{url}. Double-check the GitHub Enterprise Server URL is correct and publicly resolvable."
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:463
+#: lib/tuist_web/components/app_layout_components.ex:459
 #, elixir-autogen, elixir-format
 msgid "General"
 msgstr ""
@@ -1434,7 +1434,7 @@ msgstr ""
 msgid "Could not read the cluster's Backup resources from the Kubernetes API — check the server ServiceAccount's RBAC on postgresql.cnpg.io."
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:523
+#: lib/tuist_web/components/app_layout_components.ex:519
 #: lib/tuist_web/live/ops_database_live.html.heex:3
 #: lib/tuist_web/live/ops_database_live.html.heex:58
 #, elixir-autogen, elixir-format
@@ -1815,17 +1815,17 @@ msgstr ""
 msgid "Write lag (bytes)"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:435
+#: lib/tuist_web/components/app_layout_components.ex:431
 #, elixir-autogen, elixir-format
 msgid "Usage"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:619
+#: lib/tuist_web/components/app_layout_components.ex:615
 #, elixir-autogen, elixir-format
 msgid "Documentation"
 msgstr ""
 
-#: lib/tuist_web/components/app_layout_components.ex:469
+#: lib/tuist_web/components/app_layout_components.ex:465
 #, elixir-autogen, elixir-format
 msgid "Tokens"
 msgstr ""

--- a/server/priv/gettext/dashboard_account.pot
+++ b/server/priv/gettext/dashboard_account.pot
@@ -67,7 +67,7 @@ msgstr ""
 msgid "All members"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:313
+#: lib/tuist_web/live/account_settings_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "All regions"
 msgstr ""
@@ -94,8 +94,8 @@ msgstr ""
 msgid "Billing email"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:385
-#: lib/tuist_web/live/account_settings_live.ex:472
+#: lib/tuist_web/live/account_settings_live.ex:378
+#: lib/tuist_web/live/account_settings_live.ex:465
 #: lib/tuist_web/live/account_settings_live.html.heex:75
 #: lib/tuist_web/live/account_settings_live.html.heex:149
 #: lib/tuist_web/live/account_settings_live.html.heex:231
@@ -103,8 +103,8 @@ msgstr ""
 #: lib/tuist_web/live/account_token_live.html.heex:49
 #: lib/tuist_web/live/account_tokens_live.html.heex:250
 #: lib/tuist_web/live/authentication_settings_live.html.heex:773
-#: lib/tuist_web/live/cache_live.ex:389
-#: lib/tuist_web/live/cache_live.ex:454
+#: lib/tuist_web/live/cache_live.ex:376
+#: lib/tuist_web/live/cache_live.ex:441
 #: lib/tuist_web/live/create_organization_live.ex:84
 #: lib/tuist_web/live/members_live.ex:179
 #: lib/tuist_web/live/members_live.ex:227
@@ -126,7 +126,7 @@ msgstr ""
 msgid "Change your subscription to fit your needs."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:297
+#: lib/tuist_web/live/account_settings_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Choose where your artifacts, like module cache binaries, are stored for legal compliance."
 msgstr ""
@@ -214,9 +214,9 @@ msgstr ""
 msgid "Decline"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:446
-#: lib/tuist_web/live/account_settings_live.ex:480
-#: lib/tuist_web/live/account_settings_live.ex:492
+#: lib/tuist_web/live/account_settings_live.ex:439
+#: lib/tuist_web/live/account_settings_live.ex:473
+#: lib/tuist_web/live/account_settings_live.ex:485
 #: lib/tuist_web/live/account_settings_live.html.heex:157
 #: lib/tuist_web/live/account_settings_live.html.heex:311
 #, elixir-autogen, elixir-format
@@ -357,7 +357,7 @@ msgstr ""
 msgid "Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:314
+#: lib/tuist_web/live/account_settings_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "Europe"
 msgstr ""
@@ -503,8 +503,8 @@ msgstr ""
 #: lib/tuist_web/live/account_token_live.html.heex:74
 #: lib/tuist_web/live/account_tokens_live.html.heex:277
 #: lib/tuist_web/live/authentication_settings_live.html.heex:793
-#: lib/tuist_web/live/cache_live.ex:367
-#: lib/tuist_web/live/cache_live.ex:408
+#: lib/tuist_web/live/cache_live.ex:354
+#: lib/tuist_web/live/cache_live.ex:395
 #: lib/tuist_web/live/create_organization_live.ex:66
 #: lib/tuist_web/live/webhook_endpoint_form.ex:64
 #: lib/tuist_web/live/webhooks_live.html.heex:134
@@ -613,8 +613,8 @@ msgstr ""
 msgid "Pro"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:310
-#: lib/tuist_web/live/cache_live.ex:505
+#: lib/tuist_web/live/account_settings_live.ex:303
+#: lib/tuist_web/live/cache_live.ex:492
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr ""
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Search members..."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:305
+#: lib/tuist_web/live/account_settings_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "Select region"
 msgstr ""
@@ -712,7 +712,7 @@ msgstr ""
 msgid "Self-host your instance of Tuist"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:46
+#: lib/tuist_web/live/account_settings_live.ex:43
 #: lib/tuist_web/live/account_settings_live.html.heex:3
 #: lib/tuist_web/live/account_tokens_live.html.heex:3
 #: lib/tuist_web/live/authentication_settings_live.html.heex:3
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Standard support: Via Slack and email"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:508
+#: lib/tuist_web/live/cache_live.ex:495
 #: lib/tuist_web/live/members_live.ex:303
 #: lib/tuist_web/live/webhook_event_live.html.heex:28
 #: lib/tuist_web/live/webhook_live.ex:265
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:294
+#: lib/tuist_web/live/account_settings_live.ex:287
 #, elixir-autogen, elixir-format
 msgid "Storage region"
 msgstr ""
@@ -790,7 +790,7 @@ msgstr ""
 msgid "Tuist Logo"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:315
+#: lib/tuist_web/live/account_settings_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
@@ -906,13 +906,13 @@ msgstr ""
 msgid "Via shared Slack channel"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:20
+#: lib/tuist_web/live/account_settings_live.ex:19
 #: lib/tuist_web/live/account_token_live.ex:19
 #: lib/tuist_web/live/account_tokens_live.ex:27
 #: lib/tuist_web/live/authentication_settings_live.ex:30
 #: lib/tuist_web/live/authentication_settings_live.ex:75
 #: lib/tuist_web/live/billing_live.ex:18
-#: lib/tuist_web/live/cache_live.ex:20
+#: lib/tuist_web/live/cache_live.ex:19
 #: lib/tuist_web/live/members_live.ex:18
 #: lib/tuist_web/live/webhook_event_live.ex:22
 #: lib/tuist_web/live/webhook_live.ex:27
@@ -982,74 +982,74 @@ msgstr ""
 msgid "xxxx xxxx xxxx %{card_number}"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:393
+#: lib/tuist_web/live/account_settings_live.ex:386
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:355
+#: lib/tuist_web/live/account_settings_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Add cache endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:362
+#: lib/tuist_web/live/account_settings_live.ex:355
 #: lib/tuist_web/live/webhooks_live.html.heex:35
 #, elixir-autogen, elixir-format
 msgid "Add endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:375
+#: lib/tuist_web/live/account_settings_live.ex:368
 #: lib/tuist_web/live/webhook_endpoint_form.ex:75
 #: lib/tuist_web/live/webhook_live.html.heex:71
 #, elixir-autogen, elixir-format
 msgid "Endpoint URL"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:432
+#: lib/tuist_web/live/account_settings_live.ex:425
 #: lib/tuist_web/live/webhooks_live.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "URL"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:439
+#: lib/tuist_web/live/account_settings_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Delete last cache endpoint?"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:459
+#: lib/tuist_web/live/account_settings_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "Removing the last custom cache endpoint will switch your organization back to Tuist-hosted caching. This affects all builds across your organization."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:337
+#: lib/tuist_web/live/account_settings_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "Cache endpoints"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:341
+#: lib/tuist_web/live/account_settings_live.ex:334
 #, elixir-autogen, elixir-format
 msgid "Configure custom cache endpoints for self-hosted cache setups. When enabled, Tuist will read from and write to these endpoints instead of the default Tuist-hosted cache."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:409
+#: lib/tuist_web/live/account_settings_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "Custom cache endpoints are disabled. Tuist will use the default Tuist-hosted cache."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:421
+#: lib/tuist_web/live/account_settings_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "No custom cache endpoints configured. Tuist will use the default Tuist-hosted cache until endpoints are added."
 msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:476
-#: lib/tuist_web/live/cache_live.ex:321
-#: lib/tuist_web/live/cache_live.ex:411
+#: lib/tuist_web/live/cache_live.ex:308
+#: lib/tuist_web/live/cache_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Client ID"
 msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:495
-#: lib/tuist_web/live/cache_live.ex:341
+#: lib/tuist_web/live/cache_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "Client secret"
 msgstr ""
@@ -1179,23 +1179,23 @@ msgstr ""
 msgid "What's the name of your company or team? You can change this later in the settings"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:249
+#: lib/tuist_web/live/account_settings_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Browser default"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:259
+#: lib/tuist_web/live/account_settings_live.ex:252
 #, elixir-autogen, elixir-format
 msgid "Choose your preferred dashboard language."
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:256
+#: lib/tuist_web/live/account_settings_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Dashboard language"
 msgstr ""
 
-#: lib/tuist_web/live/account_settings_live.ex:264
-#: lib/tuist_web/live/account_settings_live.ex:269
+#: lib/tuist_web/live/account_settings_live.ex:257
+#: lib/tuist_web/live/account_settings_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -1267,7 +1267,7 @@ msgstr ""
 
 #: lib/tuist_web/live/account_tokens_live.html.heex:244
 #: lib/tuist_web/live/authentication_settings_live.html.heex:767
-#: lib/tuist_web/live/cache_live.ex:381
+#: lib/tuist_web/live/cache_live.ex:368
 #: lib/tuist_web/live/members_live.ex:467
 #: lib/tuist_web/live/webhook_live.html.heex:404
 #: lib/tuist_web/live/webhooks_live.html.heex:104
@@ -1277,7 +1277,7 @@ msgstr ""
 
 #: lib/tuist_web/live/account_tokens_live.html.heex:255
 #: lib/tuist_web/live/authentication_settings_live.html.heex:778
-#: lib/tuist_web/live/cache_live.ex:397
+#: lib/tuist_web/live/cache_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "Generate"
 msgstr ""
@@ -1760,23 +1760,23 @@ msgstr ""
 msgid "No invitations found"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:32
+#: lib/tuist_web/live/cache_live.ex:29
 #: lib/tuist_web/live/cache_live.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Cache"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:310
+#: lib/tuist_web/live/cache_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Client credentials"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:333
+#: lib/tuist_web/live/cache_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Copy client ID"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:355
+#: lib/tuist_web/live/cache_live.ex:342
 #, elixir-autogen, elixir-format
 msgid "Copy client secret"
 msgstr ""
@@ -1787,27 +1787,27 @@ msgstr ""
 msgid "Copy invite link"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:313
+#: lib/tuist_web/live/cache_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Copy the secret now. It will not be shown again after you close this dialog."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:269
+#: lib/tuist_web/live/cache_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Credentials"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:502
+#: lib/tuist_web/live/cache_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Endpoint"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:295
+#: lib/tuist_web/live/cache_live.ex:282
 #, elixir-autogen, elixir-format
 msgid "Generate credential"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:479
+#: lib/tuist_web/live/cache_live.ex:466
 #, elixir-autogen, elixir-format
 msgid "Generate one to authorize your self-hosted nodes."
 msgstr ""
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Invite"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:515
+#: lib/tuist_web/live/cache_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Last heartbeat"
 msgstr ""
@@ -1832,80 +1832,80 @@ msgstr ""
 msgid "Manage where build artifacts are cached for this account."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:477
+#: lib/tuist_web/live/cache_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "No credentials yet"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:520
+#: lib/tuist_web/live/cache_live.ex:507
 #, elixir-autogen, elixir-format
 msgid "No registered nodes"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:499
+#: lib/tuist_web/live/cache_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "Node"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:288
+#: lib/tuist_web/live/cache_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "Node credential"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:535
+#: lib/tuist_web/live/cache_live.ex:522
 #, elixir-autogen, elixir-format
 msgid "Not ready"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:368
+#: lib/tuist_web/live/cache_live.ex:355
 #, elixir-autogen, elixir-format
 msgid "Production mesh"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:534
+#: lib/tuist_web/live/cache_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:489
+#: lib/tuist_web/live/cache_live.ex:476
 #, elixir-autogen, elixir-format
 msgid "Registered nodes"
 msgstr ""
 
 #: lib/tuist_web/live/account_token_live.html.heex:28
 #: lib/tuist_web/live/account_token_live.html.heex:57
-#: lib/tuist_web/live/cache_live.ex:462
+#: lib/tuist_web/live/cache_live.ex:449
 #, elixir-autogen, elixir-format
 msgid "Revoke"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:444
+#: lib/tuist_web/live/cache_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Revoke %{name}? Self-hosted nodes using it will stop authenticating."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:422
-#: lib/tuist_web/live/cache_live.ex:433
+#: lib/tuist_web/live/cache_live.ex:409
+#: lib/tuist_web/live/cache_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "Revoke credential"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:259
+#: lib/tuist_web/live/cache_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Run your own cache nodes. Generate a credential they authenticate with, and they register themselves so the CLI can reach them directly."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:414
+#: lib/tuist_web/live/cache_live.ex:401
 #, elixir-autogen, elixir-format
 msgid "Secret"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:522
+#: lib/tuist_web/live/cache_live.ex:509
 #, elixir-autogen, elixir-format
 msgid "Self-hosted nodes appear here once they start sending registration heartbeats."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:491
+#: lib/tuist_web/live/cache_live.ex:478
 #, elixir-autogen, elixir-format
 msgid "Self-hosted nodes reporting in via registration heartbeats. The CLI routes cache traffic to each node's endpoint, and a node drops off this list when it stops heartbeating."
 msgstr ""
@@ -1915,7 +1915,7 @@ msgstr ""
 msgid "Share this link with %{email} so they can join. You'll also find it in the invitations list."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:271
+#: lib/tuist_web/live/cache_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "Tenant-scoped credentials your nodes present to Tuist. A credential only authorizes this account's traffic."
 msgstr ""
@@ -1945,22 +1945,22 @@ msgstr ""
 msgid "This invitation has expired. Please ask the inviter to resend it."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:230
+#: lib/tuist_web/live/cache_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "CI and account tokens only"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:169
+#: lib/tuist_web/live/cache_live.ex:156
 #, elixir-autogen, elixir-format
 msgid "Choose whether members can upload or CI is the trusted cache writer."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:233
+#: lib/tuist_web/live/cache_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Members can download, but uploads require CI OIDC tokens or account tokens with cache write scopes."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:208
+#: lib/tuist_web/live/cache_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Members using login sessions, CI OIDC tokens, and account tokens with cache write scopes can upload."
 msgstr ""
@@ -2489,35 +2489,30 @@ msgstr ""
 msgid "Add and verify a login email domain before enabling automatic enrollment. Until then, the provider cannot create or link accounts, including for invited users. Existing linked users can continue signing in."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:177
+#: lib/tuist_web/live/cache_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Learn how to authenticate CI"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:205
+#: lib/tuist_web/live/cache_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Members, CI and account tokens"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:73
+#: lib/tuist_web/live/cache_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Enter a name to identify this credential."
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:167
-#: lib/tuist_web/live/cache_live.ex:189
+#: lib/tuist_web/live/cache_live.ex:154
+#: lib/tuist_web/live/cache_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Upload access"
 msgstr ""
 
-#: lib/tuist_web/live/cache_live.ex:256
+#: lib/tuist_web/live/cache_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Self-hosted servers"
-msgstr ""
-
-#: lib/tuist_web/live/cache_live.html.heex:28
-#, elixir-autogen, elixir-format
-msgid "Cache servers are not enabled for this account yet."
 msgstr ""
 
 #: lib/tuist_web/live/authentication_settings_live.html.heex:186

--- a/server/priv/gettext/dashboard_usage.pot
+++ b/server/priv/gettext/dashboard_usage.pot
@@ -22,12 +22,12 @@ msgstr ""
 msgid "Requests"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:32
+#: lib/tuist_web/live/usage_live.ex:24
 #, elixir-autogen, elixir-format
 msgid "The page you are looking for doesn't exist or has been moved."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:47
+#: lib/tuist_web/live/usage_live.ex:42
 #: lib/tuist_web/live/usage_live.html.heex:4
 #, elixir-autogen, elixir-format
 msgid "Usage"
@@ -45,10 +45,10 @@ msgstr ""
 msgid "Ingress"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:359
-#: lib/tuist_web/live/usage_live.ex:360
-#: lib/tuist_web/live/usage_live.ex:488
-#: lib/tuist_web/live/usage_live.ex:489
+#: lib/tuist_web/live/usage_live.ex:353
+#: lib/tuist_web/live/usage_live.ex:354
+#: lib/tuist_web/live/usage_live.ex:482
+#: lib/tuist_web/live/usage_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Cache traffic"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:496
+#: lib/tuist_web/live/usage_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "No cache traffic in this window yet"
 msgstr ""
@@ -123,12 +123,12 @@ msgstr ""
 msgid "Usage value"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:468
+#: lib/tuist_web/live/usage_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Linux"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:467
+#: lib/tuist_web/live/usage_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "macOS"
 msgstr ""
@@ -178,37 +178,37 @@ msgstr ""
 msgid "Billing period:"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:443
+#: lib/tuist_web/live/usage_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "Last period came to %{count} minutes."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:463
+#: lib/tuist_web/live/usage_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "Last period came to %{count}."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:455
+#: lib/tuist_web/live/usage_live.ex:449
 #, elixir-autogen, elixir-format
 msgid "Nothing ran last period."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:449
+#: lib/tuist_web/live/usage_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "On track for about %{count} minutes this period."
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:86
+#: lib/tuist_web/live/usage_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "since the previous period"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:352
+#: lib/tuist_web/live/usage_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "Projected"
 msgstr ""
 
-#: lib/tuist_web/live/usage_live.ex:476
+#: lib/tuist_web/live/usage_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Current period %{from} – %{to}"
 msgstr ""

--- a/server/test/tuist_web/live/account_settings_live_test.exs
+++ b/server/test/tuist_web/live/account_settings_live_test.exs
@@ -39,11 +39,6 @@ defmodule TuistWeb.AccountSettingsLiveTest do
     account: account
   } do
     # Given
-    stub(FunWithFlags, :enabled?, fn
-      :kura, _ -> true
-      _, _ -> false
-    end)
-
     stub(Environment, :tuist_hosted?, fn -> true end)
     stub(Tuist.Billing, :get_current_active_subscription, fn _ -> %{plan: :enterprise} end)
 

--- a/server/test/tuist_web/live/cache_live_test.exs
+++ b/server/test/tuist_web/live/cache_live_test.exs
@@ -30,7 +30,7 @@ defmodule TuistWeb.CacheLiveTest do
   end
 
   test "sets the right title", %{conn: conn, account: account} do
-    enable_cache(account)
+    stub_non_hosted_deployment()
     stub(Kura, :latest_versions, fn 1 -> [] end)
 
     {:ok, _lv, html} = live(conn, ~p"/#{account.name}/cache")
@@ -39,7 +39,7 @@ defmodule TuistWeb.CacheLiveTest do
   end
 
   test "lists registered self-hosted nodes", %{conn: conn, account: account} do
-    enable_cache(account)
+    stub_non_hosted_deployment()
     stub(Kura, :latest_versions, fn 1 -> [] end)
 
     {:ok, _endpoint} =
@@ -69,29 +69,14 @@ defmodule TuistWeb.CacheLiveTest do
     end
   end
 
-  test "shows a disabled notice when cache is not enabled", %{conn: conn, account: account} do
-    disable_cache(account)
-
-    {:ok, _lv, html} = live(conn, ~p"/#{account.name}/cache")
-
-    assert html =~ "not enabled for this account"
-    refute html =~ "create_self_hosted_client"
-    refute html =~ "cache-servers-table"
-  end
-
-  test "is available on a self-hosted server without the kura flag", %{conn: conn, account: account} do
-    # Non-hosted deployments grant the Kura surface unconditionally, so the
-    # page and credential generation work even with the flag off.
+  test "renders on a hosted deployment without a feature flag", %{conn: conn, account: account} do
     stub(Environment, :dev?, fn -> false end)
-    stub(Environment, :tuist_hosted?, fn -> false end)
-    stub_cache_flag(account, false)
+    stub(Environment, :tuist_hosted?, fn -> true end)
     stub(Kura, :latest_versions, fn 1 -> [] end)
 
-    {:ok, _lv, html} = live(conn, ~p"/#{account.name}/cache")
+    {:ok, lv, _html} = live(conn, ~p"/#{account.name}/cache")
 
-    refute html =~ "not enabled for this account"
-    assert html =~ "Self-hosted servers"
-    assert html =~ "create_self_hosted_client"
+    assert has_element?(lv, "[data-part=cache-write-policy-card]")
   end
 
   test "hides the managed cache-servers section on a self-hosted server with no regions", %{
@@ -104,7 +89,6 @@ defmodule TuistWeb.CacheLiveTest do
     stub(Environment, :test?, fn -> false end)
     stub(Environment, :tuist_hosted?, fn -> false end)
     stub(Environment, :kura_available_region_ids, fn -> [] end)
-    stub_cache_flag(account, false)
     stub(Kura, :latest_versions, fn 1 -> [] end)
 
     {:ok, _lv, html} = live(conn, ~p"/#{account.name}/cache")
@@ -113,25 +97,10 @@ defmodule TuistWeb.CacheLiveTest do
     assert html =~ "Self-hosted servers"
   end
 
-  test "renders on the hosted server when the kura flag is on", %{conn: conn, account: account} do
-    # Positive coverage for the hosted branch: with tuist_hosted? true the
-    # `not tuist_hosted?()` disjunct is false, so the surface appears only
-    # because the :kura flag is on for the account.
-    stub(Environment, :dev?, fn -> false end)
-    stub(Environment, :tuist_hosted?, fn -> true end)
-    stub_cache_flag(account, true)
-    stub(Kura, :latest_versions, fn 1 -> [] end)
-
-    {:ok, lv, html} = live(conn, ~p"/#{account.name}/cache")
-
-    refute html =~ "not enabled for this account"
-    assert has_element?(lv, "[data-part=cache-write-policy-card]")
-  end
-
   test "tells the account nothing about where its cache runs", %{conn: conn, account: account} do
     # Placement is not a request the account can make, and not a status it is
     # given either: the page carries no managed-cache surface at all.
-    enable_cache(account)
+    stub_non_hosted_deployment()
     stub(Kura, :latest_versions, fn 1 -> [%{version: "0.5.2", released_at: DateTime.utc_now(:second)}] end)
 
     {:ok, lv, html} = live(conn, ~p"/#{account.name}/cache")
@@ -148,7 +117,7 @@ defmodule TuistWeb.CacheLiveTest do
   end
 
   test "updates the cache upload access", %{conn: conn, account: account} do
-    enable_cache(account)
+    stub_non_hosted_deployment()
     stub(Kura, :latest_versions, fn 1 -> [] end)
 
     {:ok, lv, html} = live(conn, ~p"/#{account.name}/cache")
@@ -187,7 +156,7 @@ defmodule TuistWeb.CacheLiveTest do
   end
 
   test "renders the self-hosted sections", %{conn: conn, account: account} do
-    enable_cache(account)
+    stub_non_hosted_deployment()
     stub(Kura, :latest_versions, fn 1 -> [] end)
 
     {:ok, _lv, html} = live(conn, ~p"/#{account.name}/cache")
@@ -198,7 +167,7 @@ defmodule TuistWeb.CacheLiveTest do
   end
 
   test "hides the self-hosted section without the enterprise entitlement", %{conn: conn, account: account} do
-    enable_cache(account)
+    stub_non_hosted_deployment()
     stub(Environment, :tuist_hosted?, fn -> true end)
     stub(Tuist.Billing, :effective_plan, fn _ -> :pro end)
     stub(Kura, :latest_versions, fn 1 -> [] end)
@@ -211,7 +180,7 @@ defmodule TuistWeb.CacheLiveTest do
   end
 
   test "shows the self-hosted section with the enterprise entitlement", %{conn: conn, account: account} do
-    enable_cache(account)
+    stub_non_hosted_deployment()
     stub(Environment, :tuist_hosted?, fn -> true end)
     stub(Tuist.Billing, :effective_plan, fn _ -> :enterprise end)
     stub(Kura, :latest_versions, fn 1 -> [] end)
@@ -222,7 +191,7 @@ defmodule TuistWeb.CacheLiveTest do
   end
 
   test "generates a tenant-scoped credential and reveals the secret once", %{conn: conn, account: account} do
-    enable_cache(account)
+    stub_non_hosted_deployment()
     stub(Kura, :latest_versions, fn 1 -> [] end)
 
     {:ok, lv, _html} = live(conn, ~p"/#{account.name}/cache")
@@ -243,7 +212,7 @@ defmodule TuistWeb.CacheLiveTest do
   end
 
   test "revokes a credential through the confirmation modal", %{conn: conn, account: account} do
-    enable_cache(account)
+    stub_non_hosted_deployment()
     stub(Kura, :latest_versions, fn 1 -> [] end)
     {:ok, {client, _secret}} = SelfHostedClients.create_self_hosted_client(account, %{name: "production"})
 
@@ -260,28 +229,11 @@ defmodule TuistWeb.CacheLiveTest do
     assert SelfHostedClients.list_self_hosted_clients(account) == []
   end
 
-  defp enable_cache(account) do
+  defp stub_non_hosted_deployment do
     stub(Environment, :dev?, fn -> false end)
     # Non-hosted deployments grant every entitlement, so this keeps the
-    # self-hosted (Enterprise-only) section available; gate tests override it.
+    # self-hosted (Enterprise-only) section available; the entitlement tests
+    # override it.
     stub(Environment, :tuist_hosted?, fn -> false end)
-    stub_cache_flag(account, true)
-  end
-
-  defp disable_cache(account) do
-    stub(Environment, :dev?, fn -> false end)
-    # The Cache surface is on by default on non-hosted deployments, so the
-    # only way it stays hidden is the hosted server with the flag off.
-    stub(Environment, :tuist_hosted?, fn -> true end)
-    stub_cache_flag(account, false)
-  end
-
-  defp stub_cache_flag(account, enabled?) do
-    account_id = account.id
-
-    stub(FunWithFlags, :enabled?, fn
-      :kura, [for: %{id: ^account_id}] -> enabled?
-      flag, opts -> Mimic.call_original(FunWithFlags, :enabled?, [flag, opts])
-    end)
   end
 end

--- a/server/test/tuist_web/live/usage_live_test.exs
+++ b/server/test/tuist_web/live/usage_live_test.exs
@@ -114,28 +114,6 @@ defmodule TuistWeb.UsageLiveTest do
     "/#{account.name}/usage?period=#{Date.to_iso8601(DateTime.to_date(previous))}"
   end
 
-  defp enable_kura(account) do
-    stub(Environment, :dev?, fn -> false end)
-    stub_kura_flag(account, true)
-  end
-
-  defp disable_kura(account) do
-    stub(Environment, :dev?, fn -> false end)
-    # Kura is on by default on non-hosted deployments, so the flag only gates
-    # visibility on the hosted server.
-    stub(Environment, :tuist_hosted?, fn -> true end)
-    stub_kura_flag(account, false)
-  end
-
-  defp stub_kura_flag(account, enabled?) do
-    account_id = account.id
-
-    stub(FunWithFlags, :enabled?, fn
-      :kura, [for: %{id: ^account_id}] -> enabled?
-      flag, opts -> Mimic.call_original(FunWithFlags, :enabled?, [flag, opts])
-    end)
-  end
-
   defp insert_event(attrs) do
     base = %{
       event_id: "evt-#{System.unique_integer([:positive])}",
@@ -163,7 +141,6 @@ defmodule TuistWeb.UsageLiveTest do
       # page is where it looks to see what it has used. Hiding the
       # section until the first minute lands leaves it with nothing to
       # look at during the trial the section exists to support.
-      disable_kura(account)
       stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
       stub(Trials, :on_trial?, fn _account -> true end)
 
@@ -175,7 +152,6 @@ defmodule TuistWeb.UsageLiveTest do
     test "shows what the trial covered rather than a receipt that does not add up", %{conn: conn, account: account} do
       # Without this the receipt reads "1,000 minutes run, 75.00$" and
       # then "Billed 0.00$", with nothing saying where the money went.
-      disable_kura(account)
       stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
 
       stub(Allowance, :period_breakdown, fn _account -> trial_breakdown() end)
@@ -195,7 +171,6 @@ defmodule TuistWeb.UsageLiveTest do
       # Linux has no agreed rate, so its value reads as a dash. Taking a
       # dash off a dash rendered "−—", which is not a number and not an
       # explanation.
-      disable_kura(account)
       stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
 
       breakdown = %{
@@ -228,7 +203,6 @@ defmodule TuistWeb.UsageLiveTest do
     end
 
     test "is hidden for an account with neither runners nor usage", %{conn: conn, account: account} do
-      enable_kura(account)
       stub(FeatureFlags, :runners_enabled?, fn _account -> false end)
 
       {:ok, lv, _html} = live(conn, ~p"/#{account.name}/usage")
@@ -238,8 +212,7 @@ defmodule TuistWeb.UsageLiveTest do
   end
 
   describe "runner usage with prepaid credit" do
-    setup %{account: account} do
-      disable_kura(account)
+    setup do
       stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
       stub(Allowance, :period_breakdown, fn _account -> billed_breakdown() end)
       stub(Allowance, :period_breakdown, fn _account, _period -> billed_breakdown() end)
@@ -280,7 +253,6 @@ defmodule TuistWeb.UsageLiveTest do
       # the trial's credit and the allowance's added together. A period
       # part-covered by a trial therefore subtracted the trial twice and
       # the receipt stopped adding up.
-      disable_kura(account)
       stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
 
       breakdown = %{
@@ -318,8 +290,7 @@ defmodule TuistWeb.UsageLiveTest do
   end
 
   describe "runner usage across billing periods" do
-    setup %{account: account} do
-      disable_kura(account)
+    setup do
       stub(FeatureFlags, :runners_enabled?, fn _account -> true end)
       stub(Allowance, :period_breakdown, fn _account -> billed_breakdown() end)
       stub(Allowance, :period_breakdown, fn _account, _period -> billed_breakdown() end)
@@ -362,20 +333,12 @@ defmodule TuistWeb.UsageLiveTest do
     end
   end
 
-  describe "Kura feature flag gate" do
-    test "raises 404 when Kura is not enabled for the account", %{conn: conn, account: account} do
-      disable_kura(account)
-      # Nor runners: the page exists for either, so both have to be off
-      # for it to be missing.
+  describe "access" do
+    test "renders the cache traffic for an account with neither cache nor runner usage", %{
+      conn: conn,
+      account: account
+    } do
       stub(FeatureFlags, :runners_enabled?, fn _account -> false end)
-
-      assert_raise TuistWeb.Errors.NotFoundError, fn ->
-        live(conn, ~p"/#{account.name}/usage")
-      end
-    end
-
-    test "renders the page when Kura is enabled", %{conn: conn, account: account} do
-      enable_kura(account)
 
       {:ok, _lv, html} = live(conn, ~p"/#{account.name}/usage")
 
@@ -386,26 +349,28 @@ defmodule TuistWeb.UsageLiveTest do
       assert html =~ "Requests"
     end
 
-    test "renders the page on the hosted server when the flag is on", %{conn: conn, account: account} do
-      # Positive coverage for the hosted branch: tuist_hosted? true disables
-      # the `not tuist_hosted?()` disjunct, so the page renders only because
-      # the :kura flag is on.
+    test "renders on a hosted deployment without a feature flag", %{conn: conn, account: account} do
       stub(Environment, :dev?, fn -> false end)
       stub(Environment, :tuist_hosted?, fn -> true end)
-      stub_kura_flag(account, true)
 
       {:ok, _lv, html} = live(conn, ~p"/#{account.name}/usage")
 
       assert html =~ "Usage"
+      assert html =~ "Cache traffic"
+    end
+
+    test "raises 404 when the user cannot read the account dashboard", %{conn: conn} do
+      organization = AccountsFixtures.organization_fixture(preload: [:account])
+      user = AccountsFixtures.user_fixture()
+      conn = log_in_user(conn, user)
+
+      assert_raise TuistWeb.Errors.NotFoundError, fn ->
+        live(conn, ~p"/#{organization.account.name}/usage")
+      end
     end
   end
 
   describe "rendering" do
-    setup %{account: account} do
-      enable_kura(account)
-      :ok
-    end
-
     test "scopes the page to a billing period rather than a free range", %{conn: conn, account: account} do
       {:ok, lv, html} = live(conn, ~p"/#{account.name}/usage")
 
@@ -454,8 +419,6 @@ defmodule TuistWeb.UsageLiveTest do
     # when its bytes/count is zero, so seed at least one event of each kind so
     # the click wrappers always render in this describe block.
     setup %{account: account} do
-      enable_kura(account)
-
       insert_event(%{account_id: account.id, direction: "egress", bytes: 1_000, request_count: 1})
       insert_event(%{account_id: account.id, direction: "ingress", bytes: 500, request_count: 1})
 


### PR DESCRIPTION
Cache routing through Kura became the default for every client in https://github.com/tuist/tuist/pull/12760, but the server-side dashboard was left as it was: opt-in behind the `:kura` FunWithFlags toggle.

### What changed

`Tuist.FeatureFlags.kura_enabled?/1` and all of its call sites are gone:

- The sidebar "Cache" entry now keys only off `:account_update`, and "Usage" is unconditional.
- `/{account}/cache` renders its upload-access section for anyone authorized to update the account. The disabled-state branch and its alert are deleted. The self-hosted section keeps its own Enterprise entitlement check, which was already independent of the flag.
- `/{account}/usage` is gated only by `:account_dashboard_read`. That check also moved ahead of the usage queries, so an unauthorized request stops before paying for `Allowance.period_breakdown/1`.
- The `kura_enabled` assign on the usage and account-settings LiveViews was never read by either template, so it went with the gate.
- `mix gettext.extract` dropped one msgid, "Cache servers are not enabled for this account yet.". `.pot` files only, no `.po` touched.

### Why

On the hosted server the flag's boolean gate is off, with a per-account actor override for a few dozen accounts. Every other account was routed through Kura by its CLI while the pages that describe that traffic were hidden from it: no Cache entry in the sidebar, no upload-access setting, and a 404 on `/usage` unless the account happened to have runner minutes. The data plane never consulted this flag, only the client feature-flag header, so the gate protected nothing on the request path and only withheld the dashboard.

Removing the check was chosen over enabling the flag globally because the flag no longer marks a rollout boundary. With Kura as the default there is no cohort for it to name, and leaving the check in place would keep a toggle that every environment has to remember to turn on.

### Impact

Two changes widen access rather than only deleting a branch:

- `/{account}/usage` is now reachable by any account passing `:account_dashboard_read`, including accounts with no cache traffic and no runner minutes. They see an empty Cache traffic card where they previously got a 404.
- The "Usage" sidebar item has no authorization condition of its own, and never did. The Kura flag was its only condition, so it now shows for every member, and a member without `:account_dashboard_read` gets a 404 on click. That was already the behaviour for flagged accounts.

The `:kura` rows left in the `feature_flags` table are now inert, as is the flag's entry in the ops flags UI. Nothing reads that toggle any more. The unrelated `:kura_rollout_orchestration_kill_switch` is untouched.

### How to test locally

Kura gating only ever applied to `tuist_hosted?` deployments, so a local server always showed these pages. To see what changed, stub the hosted branch:

1. `mise run dev`
2. Visit `/{account}/cache` and `/{account}/usage` for an account with no `:kura` override. Both render, and the Cache page shows the Upload access card rather than the "not enabled for this account yet" alert.
3. In `iex`, confirm the toggle is no longer consulted: `FunWithFlags.disable(:kura)` changes nothing on either page.

Automated coverage:

```
mix test test/tuist_web/live/cache_live_test.exs test/tuist_web/live/usage_live_test.exs test/tuist_web/live/account_settings_live_test.exs test/tuist/feature_flags_test.exs
```

### Validation

- 46 tests pass across the cache, usage, account-settings, and feature-flags suites, including new cases that pin the pages rendering on a hosted deployment with no flag at all.
- `mix credo` clean on the five changed modules; `mix format` applied.
- The wider `test/tuist_web/live` and `test/tuist_web/components` run is 741/744. The 3 failures were confirmed pre-existing by reverting the `lib/` changes and re-running them: the marketing Korean-locale test, `layout_live_test.exs:226` (a `connect_params outside mount` error in `TuistWeb.Locale.on_mount`), and `gradle_build_live_test.exs:218` (missing `:configuration_timeline_range` assign).

### Unrelated fix carried here

The second commit fixes a `KeyError: key :configuration_timeline_range not found` on the first render of a Gradle build's build-setup tab. `assign_tab_data/3` assigned the range and then read it back from `socket.assigns` on the socket as it was bound before the pipeline, where the key does not exist yet; later renders worked only because the assign survived from the previous one. It now passes the value it just computed.

This is pre-existing on main, which fails the same single test in its own CI. It is fixed on this branch because it blocks this PR's Test check, and it is a separate commit so it can be reviewed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
