### PR TITLE
fix(server): read the Gradle configuration timeline range from its local binding

### DIFF
--- a/server/lib/tuist_web/live/gradle_build_live.ex
+++ b/server/lib/tuist_web/live/gradle_build_live.ex
@@ -326,7 +326,7 @@ defmodule TuistWeb.GradleBuildLive do
     |> assign(:artifact_transform_duration_ms, Enum.sum_by(all_artifact_transforms, & &1.duration_ms))
     |> assign(
       :configuration_timeline_operations,
-      configuration_timeline_operations(filtered_operations, socket.assigns.configuration_timeline_range)
+      configuration_timeline_operations(filtered_operations, configuration_timeline_range)
     )
     |> assign(:configuration_operations_table, configuration_operations)
     |> assign(:configuration_operations_filter, configuration_operations_filter)

--- a/server/test/tuist_web/live/gradle_build_live_test.exs
+++ b/server/test/tuist_web/live/gradle_build_live_test.exs
@@ -79,7 +79,7 @@ defmodule TuistWeb.GradleBuildLiveTest do
     operations = Gradle.list_configuration_operations(build_id)
 
     assert length(operations) == 100
-    assert Enum.map(operations, & &1.duration_ms) == Enum.to_list(101..2)
+    assert Enum.map(operations, & &1.duration_ms) == Enum.to_list(101..2//-1)
   end
 
   test "shows build details", %{


### PR DESCRIPTION
`main` has been red since [#12737](https://github.com/tuist/tuist/pull/12737) landed as `85c7a08c`. That commit introduced two separate problems in the same area, and the first one masked the second. This PR fixes both.

## 1. KeyError on the Gradle build-setup tab

Both the `Test` and `Test (oldest supported ClickHouse)` jobs failed on exactly one test ([run 33672944692](https://github.com/tuist/tuist/actions/runs/33672944692/job/100390712992), `7900/7901 passed`, exit code 3):

```
1) test shows cache-miss diagnostics and setup telemetry (TuistWeb.GradleBuildLiveTest)
   ** (KeyError) key :configuration_timeline_range not found
   lib/tuist_web/live/gradle_build_live.ex:329: TuistWeb.GradleBuildLive.assign_tab_data/3
   lib/tuist_web/live/build_run_live.ex:254: TuistWeb.BuildRunLive.handle_params/3
```

### Root cause

`assign_tab_data/3` for the `build-setup` tab computes `configuration_timeline_range`, pipes the socket through `assign(:configuration_timeline_range, ...)`, and then one step later reads the value back out as `socket.assigns.configuration_timeline_range`:

```elixir
configuration_timeline_range = configuration_timeline_range(all_configuration_operations)

socket
|> assign(:configuration_timeline_range, configuration_timeline_range)
|> assign(:configuration_duration_ms, configuration_duration_ms)
|> assign(:artifact_transform_duration_ms, ...)
|> assign(
  :configuration_timeline_operations,
  configuration_timeline_operations(filtered_operations, socket.assigns.configuration_timeline_range)
)
```

In a pipeline the argument expression is evaluated against the original `socket` binding, not the socket returned by the preceding `assign/3`. The key is only ever written inside this same pipeline, so on the first `handle_params` (the disconnected static render, before any patch has populated the assign) it does not exist yet and the lookup raises.

This is deterministic rather than flaky: every first render of the Gradle build-setup tab crashed. It escaped review because the read looks like it is chained off the assign directly above it.

Passing the local `configuration_timeline_range` variable fixes it. Seeding a default assign at mount would also stop the crash, but it would leave the misleading read in place and paper over the fact that the pipeline never intended to consult prior state here.

**Impact:** the `build-setup` tab of a Gradle build run page was unreachable, returning a 500 instead of rendering.

## 2. Suite aborting under --warnings-as-errors

With the test above fixed, all 7904 tests pass but `mix test --warnings-as-errors` still exits 1:

```
Result: 7904 passed, 4 excluded
ERROR! Test suite aborted after successful execution due to warnings while using the --warnings-as-errors option
```

The only first-party warning in the whole run is this assertion, added by the same commit:

```
warning: 101..2 has a default step of -1, please write 101..2//-1 instead
  test/tuist_web/live/gradle_build_live_test.exs:82
```

It was invisible until now because ExUnit exits 3 on a test failure and only reports the warnings-as-errors abort "after successful execution". Fixing the KeyError is what surfaced it.

Worth recording for anyone who debugs this file later: the run also emits ~869 `Detected a form with phx-change but missing id` warnings, which look like the obvious culprit but are not. The last green run on `main` ([4526cceb](https://github.com/tuist/tuist/actions/runs/33621950036)) carried 842 of them and passed, and it had zero first-party warnings. That zero is the bar this restores.

## How to test locally

From `server/`:

```bash
mix test test/tuist_web/live/gradle_build_live_test.exs --warnings-as-errors
```

On `main` this reproduces the `KeyError` at `gradle_build_live_test.exs:296`. With only the first commit applied it passes the tests but still prints the abort. With both, it is clean.

## Validation

- Reproduced the exact `KeyError` locally against unfixed `main`, confirming it is deterministic and not an infra flake.
- Reproduced the warnings-as-errors abort locally and confirmed it no longer fires.
- `mix test test/tuist_web/live/gradle_build_live_test.exs test/tuist_web/live/build_run_live_test.exs` passes, 22 tests.
- `mix format --check-formatted` and `mix credo --strict` are clean on the changed files.
- Scanned all of `server/lib` for the same stale binding shape. The eight other hits all read assigns that already exist from mount, for example `assign(:cores, integer_parameter(params, "cores", socket.assigns.cores))`, so this was the only genuine instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)