### PR TITLE
feat(kura): raise the outbox in-flight ceiling and split the backlog by lane

### DIFF
--- a/infra/grafana-dashboards/tuist-kura-details.json
+++ b/infra/grafana-dashboards/tuist-kura-details.json
@@ -20843,6 +20843,98 @@
             "version": "13.3.0-32457798232"
           }
         }
+      },
+      "panel-208": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "max by (pod, lane) (kura_outbox_lane_messages{cluster=~\"tuist-$env\", pod=~\"$pod\"})",
+                        "instant": false,
+                        "legendFormat": "{{pod}} · {{lane}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Replication outbox messages waiting to be processed, split by drain lane\n\nThe bulk lane (non-inline upserts, i.e. segment-backed artifacts) drains one delivery at a time, bounded by OUTBOX_MAX_INFLIGHT. The metadata lane (inline upserts and namespace deletes) is amortized by drain_metadata_batches, which carries many messages per request. A backlog sitting in the bulk lane points at the in-flight ceiling; one sitting in the metadata lane points at batching. The total in outbox_messages cannot separate them, and it is the total that the cap and the public write gate are enforced against.\n\nPrometheus name: `kura_outbox_lane_messages` · labels: lane",
+          "id": 208,
+          "links": [],
+          "title": "outbox_lane_messages",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "lineWidth": 1,
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "12.0.0"
+          }
+        }
       }
     },
     "layout": {
@@ -22843,11 +22935,24 @@
                         "x": 8,
                         "y": 14
                       }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-208"
+                        },
+                        "height": 7,
+                        "width": 8,
+                        "x": 16,
+                        "y": 14
+                      }
                     }
                   ]
                 }
               },
-              "title": "Peer replication \u0026 outbox (8)"
+              "title": "Peer replication \u0026 outbox (9)"
             }
           },
           {

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -2021,9 +2021,10 @@ the label cannot grow with traffic. Grouping by it costs nothing and names the
 limit in the summary, which is what the on-call needs to pick the lever:
 
 - `outbox`: the replication outbox reached its 100,000 cap. The drain is
-  serial and node-wide (one message per peer round-trip, on the order of tens
-  of messages per second), so a backlog is normally ingest outrunning it, not
-  peers being unreachable: in the 2026-08-28 episode both
+  pipelined (`OUTBOX_MAX_INFLIGHT` deliveries at once) and the metadata lane is
+  additionally batched, but the bulk lane still costs one delivery per message,
+  so a backlog is normally ingest outrunning it, not peers being unreachable:
+  in the 2026-08-28 episode both
   `kura_peer_connection_failures_total` and
   `kura_replication_bandwidth_effective_limit_bytes_per_second` were healthy
   and bandwidth sat at its configured ceiling almost the whole time. It is
@@ -2095,6 +2096,14 @@ kind** above. That rule tells you writes are already being lost; this one is
 the window before it starts. When the retired outbox rule is deleted, update
 this rule's description, which still names it by its old title.
 
+The live description also still says the drain is "serial and node-wide, one
+delivery per peer round-trip". That stopped being true when the drain was
+pipelined and the metadata lane batched; it reads as an instruction to look for
+a slow peer when the question is which lane is deep. Correct it in the same
+edit, to: `Drain is pipelined and the metadata lane is batched, but the bulk
+lane costs one delivery per message, so a backlog is ingest outrunning it.
+Split it with max by (pod, lane) (kura_outbox_lane_messages).`
+
 #### Two terms: a forecast that leads, and a static backstop
 
 A depth threshold alone could not lead. In the 2026-08-31 episode one pod
@@ -2125,15 +2134,30 @@ the cap as a metric yet; when it does, divide by it.
 
 #### Why the drain falls behind
 
-Do not assume the peers are unreachable. Through the 2026-08-31 episode
-`kura_peer_connection_failures_total` was 0, apply errors were 0, and
+Do not assume the peers are unreachable. Through the 2026-08-31 and 2026-09-02
+episodes `kura_peer_connection_failures_total` was 0, apply errors were 0, and
 replication bandwidth sat at its configured ceiling. Bandwidth is not the
-constraint: `process_outbox` awaits one delivery at a time, node-wide, so
-drain throughput is one message per peer round-trip, on the order of tens of
-messages per second at the fleet's mean RTT, and the pod in that episode was
-running at about 94% of that ceiling against a burst ingest several times
-higher. One artifact write also enqueues one message *per target*, so depth
-is not a count of artifacts.
+constraint, and neither is the round trip.
+
+Start by splitting the backlog by lane:
+
+```promql
+max by (pod, lane) (kura_outbox_lane_messages)
+```
+
+The two lanes fail for different reasons and have different levers. The
+metadata lane (inline upserts, namespace deletes) is amortized by
+`drain_metadata_batches`, which carries up to `REPLICATION_BATCH_MAX_ITEMS`
+messages per request. The bulk lane (segment-backed artifacts) is skipped by
+that path entirely and drains one delivery per message, `OUTBOX_MAX_INFLIGHT`
+at a time, so it is bounded by per-delivery *body transfer* rather than by RTT.
+A runner-cache workload is almost all bulk lane, and on 2026-09-02 a
+write-primary replicating to two peers one region away sustained ~17.7
+messages/s against ingest peaking near 97 messages/s. A deep bulk lane points
+at the in-flight ceiling; a deep metadata lane points at batching.
+
+One artifact write also enqueues one message *per target*, so depth is not a
+count of artifacts.
 
 #### Aggregate by pod, not by series
 

--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -602,9 +602,10 @@ fn spawn_snapshot_task(state: Arc<AppState>) {
                 .await
                 {
                     Ok((Ok(snapshot), jemalloc)) => {
-                        state
-                            .metrics
-                            .update_outbox_messages(snapshot.outbox_messages);
+                        state.metrics.update_outbox_messages(
+                            snapshot.outbox_messages,
+                            snapshot.outbox_bulk_messages,
+                        );
                         state.runtime.update_outbox_depth(snapshot.outbox_messages);
                         state
                             .metrics

--- a/kura/src/constants.rs
+++ b/kura/src/constants.rs
@@ -49,20 +49,29 @@ pub const ROCKSDB_SOFT_PENDING_COMPACTION_BYTES: u64 = 64 * 1024 * 1024 * 1024;
 pub const ROCKSDB_HARD_PENDING_COMPACTION_BYTES: u64 = 256 * 1024 * 1024 * 1024;
 
 pub const DEFAULT_OUTBOX_MAX_DEPTH: usize = 100_000;
-// Outbox deliveries dispatched before the drain waits for one to finish. This
-// is what separates the queue's throughput from the round trip to a peer:
-// throughput is roughly this many messages per RTT, so at one the drain is
-// serial and delivers `1 / RTT` messages per second no matter how much
-// bandwidth it has been given, which leaves a write-primary whose peers sit on
-// another continent capped in the single digits. Every artifact enqueues one
-// message per peer, so the artifact rate is this divided again by the peer
-// count.
+// Outbox deliveries dispatched before the drain waits for one to finish, and
+// the only throughput knob the bulk lane has: the drain moves roughly this many
+// messages per per-delivery latency. Every artifact enqueues one message per
+// peer, so the artifact rate is this divided again by the peer count.
 //
-// The cost is per-delivery body residency — one `RESPONSE_STREAM_CHUNK_BYTES`
+// `drain_metadata_batches` amortizes the metadata lane over far fewer requests,
+// but it stops at `OUTBOX_BULK_LANE_PREFIX` and takes only inline upserts, so
+// segment-backed artifacts reach a peer one delivery at a time. A runner-cache
+// workload is almost entirely those, which is why this bounds it.
+//
+// Per-delivery latency is dominated by body transfer, not by the round trip: a
+// write-primary replicating to two peers one region away runs at hundreds of
+// milliseconds per delivery, so the ceiling this sets has to be read against
+// ingest measured in tens of messages per second. A ceiling below ingest does
+// not shave the peak, it fills the outbox to `DEFAULT_OUTBOX_MAX_DEPTH` and
+// starts refusing public writes.
+//
+// The cost is per-delivery body residency: one `RESPONSE_STREAM_CHUNK_BYTES`
 // chunk for a segment-backed artifact, or up to
-// `MAX_INLINE_REPLICATION_BODY_BYTES` for an inline one — so 8 buys an order
-// of magnitude of headroom for a few MiB.
-pub const OUTBOX_MAX_INFLIGHT: usize = 8;
+// `MAX_INLINE_REPLICATION_BODY_BYTES` for an inline one. That is a few MiB
+// times this number, which stays well inside the transient budget that bounds
+// concurrent writes.
+pub const OUTBOX_MAX_INFLIGHT: usize = 32;
 pub const DEFAULT_MULTIPART_UPLOAD_TTL_MS: u64 = 24 * 60 * 60 * 1000;
 pub const DEFAULT_MULTIPART_JANITOR_INTERVAL_MS: u64 = 10 * 60 * 1000;
 pub const DEFAULT_MULTIPART_MAX_ACTIVE_UPLOADS: usize = 128;

--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -4882,7 +4882,7 @@ mod tests {
         settle_backfill_cycle_over(&context.state, &peer, tokio::time::Instant::now());
         context.state.expire_readiness_settle_window().await;
         context.state.maybe_mark_serving().await;
-        context.state.metrics.update_outbox_messages(7);
+        context.state.metrics.update_outbox_messages(7, 5);
         context
             .state
             .metrics

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -101,6 +101,7 @@ pub struct Metrics {
     manifest_index_rebuilds: Family<ManifestIndexResultLabels, Counter>,
     manifest_index_rebuild_duration: Histogram,
     outbox_messages: Gauge,
+    outbox_lane_messages: Family<OutboxLaneLabels, Gauge>,
     multipart_uploads: Gauge,
     tmp_dir_bytes: Gauge,
     discovered_peer_nodes: Gauge,
@@ -366,6 +367,7 @@ impl Metrics {
         let manifest_index_rebuilds = Family::<ManifestIndexResultLabels, Counter>::default();
         let manifest_index_rebuild_duration = Histogram::new(exponential_buckets(0.0005, 2.0, 16));
         let outbox_messages = Gauge::default();
+        let outbox_lane_messages = Family::<OutboxLaneLabels, Gauge>::default();
         let multipart_uploads = Gauge::default();
         let tmp_dir_bytes = Gauge::default();
         let discovered_peer_nodes = Gauge::default();
@@ -788,6 +790,11 @@ impl Metrics {
             "kura_outbox_messages",
             "Replication outbox messages waiting to be processed",
             outbox_messages.clone(),
+        );
+        registry.register(
+            "kura_outbox_lane_messages",
+            "Replication outbox messages waiting to be processed, split by drain lane",
+            outbox_lane_messages.clone(),
         );
         registry.register(
             "kura_multipart_uploads",
@@ -1356,6 +1363,7 @@ impl Metrics {
             manifest_index_rebuilds,
             manifest_index_rebuild_duration,
             outbox_messages,
+            outbox_lane_messages,
             multipart_uploads,
             tmp_dir_bytes,
             discovered_peer_nodes,
@@ -1936,8 +1944,23 @@ impl Metrics {
             .observe(duration.as_secs_f64());
     }
 
-    pub fn update_outbox_messages(&self, count: usize) {
+    pub fn update_outbox_messages(&self, count: usize, bulk: usize) {
         self.outbox_messages.set(count as i64);
+        // The bulk lane drains one delivery at a time and the metadata lane is
+        // batched, so which lane a backlog sits in is what decides whether the
+        // lever is `OUTBOX_MAX_INFLIGHT` or `drain_metadata_batches`. The total
+        // alone cannot separate them.
+        let bulk = bulk.min(count);
+        self.outbox_lane_messages
+            .get_or_create(&OutboxLaneLabels {
+                lane: "bulk".to_owned(),
+            })
+            .set(bulk as i64);
+        self.outbox_lane_messages
+            .get_or_create(&OutboxLaneLabels {
+                lane: "metadata".to_owned(),
+            })
+            .set(count.saturating_sub(bulk) as i64);
         self.rollout_snapshot
             .outbox_messages
             .store(count as u64, Ordering::Relaxed);
@@ -2513,6 +2536,11 @@ fn records_public_http_metrics(route: &str) -> bool {
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct OutboxLaneLabels {
+    lane: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 struct HttpRequestLabels {
     route: String,
     status: u16,
@@ -2966,7 +2994,7 @@ mod tests {
         metrics.record_manifest_cache_admission("admitted");
         metrics.record_manifest_cache_evictions("capacity", 1);
         metrics.record_manifest_index_rebuild("ok", Duration::from_millis(3));
-        metrics.update_outbox_messages(4);
+        metrics.update_outbox_messages(4, 3);
         metrics.update_multipart_uploads(2);
         metrics.update_discovered_peer_nodes(3);
         metrics.update_analytics_queue(1000, 2);
@@ -3088,6 +3116,8 @@ mod tests {
         assert!(rendered.contains("kura_manifest_cache_evictions_total"));
         assert!(rendered.contains("kura_manifest_index_rebuilds_total"));
         assert!(rendered.contains("kura_outbox_messages"));
+        assert!(rendered.contains("kura_outbox_lane_messages{lane=\"bulk\"} 3"));
+        assert!(rendered.contains("kura_outbox_lane_messages{lane=\"metadata\"} 1"));
         assert!(rendered.contains("kura_multipart_uploads"));
         assert!(rendered.contains("kura_tmp_dir_bytes"));
         assert!(rendered.contains("kura_discovered_peer_nodes"));

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -167,6 +167,11 @@ pub struct Store {
     rocksdb_block_cache: Cache,
     rocksdb_write_buffer_manager: WriteBufferManager,
     outbox_depth: AtomicUsize,
+    // Depth of the bulk lane alone. `outbox_depth` is what the cap and the
+    // write gate are enforced against; this splits it so a backlog can be
+    // attributed to the lane that is actually deep, which decides whether the
+    // lever is `OUTBOX_MAX_INFLIGHT` or `drain_metadata_batches`.
+    outbox_bulk_depth: AtomicUsize,
     outbox_max_depth: usize,
     multipart_uploads: AtomicUsize,
     multipart_stored_bytes: AtomicU64,
@@ -367,6 +372,9 @@ const VOUCHED_PROMOTION_RESERVE: usize = 65_536;
 
 pub struct StoreSnapshot {
     pub outbox_messages: usize,
+    /// How many of `outbox_messages` sit in the bulk lane. The rest are the
+    /// metadata lane, which `drain_metadata_batches` amortizes separately.
+    pub outbox_bulk_messages: usize,
     pub multipart_uploads: usize,
     pub promotion_queue_depth: usize,
     pub segment_counts: Vec<(&'static str, usize)>,
@@ -620,6 +628,7 @@ struct PersistArtifactSpec<'a> {
 
 struct OutboxReservation<'a> {
     depth: &'a AtomicUsize,
+    bulk_depth: &'a AtomicUsize,
     slots: usize,
     committed: bool,
 }
@@ -665,8 +674,15 @@ impl Drop for MultipartByteReservation<'_> {
 }
 
 impl OutboxReservation<'_> {
-    fn commit(mut self) {
+    /// `bulk_slots` is how many of the reserved slots were written to the bulk
+    /// lane. It is taken here rather than at reservation time because the lane
+    /// is only known once the messages are built, and it is applied on success
+    /// so a dropped reservation leaves the split untouched.
+    fn commit(mut self, bulk_slots: usize) {
         self.committed = true;
+        if bulk_slots > 0 {
+            self.bulk_depth.fetch_add(bulk_slots, Ordering::AcqRel);
+        }
     }
 }
 
@@ -1054,6 +1070,7 @@ impl Store {
             rocksdb_block_cache,
             rocksdb_write_buffer_manager,
             outbox_depth: AtomicUsize::new(0),
+            outbox_bulk_depth: AtomicUsize::new(0),
             outbox_max_depth: config.outbox_max_depth,
             multipart_uploads: AtomicUsize::new(0),
             multipart_stored_bytes: AtomicU64::new(0),
@@ -1100,8 +1117,11 @@ impl Store {
         store.replace_segment_state_snapshot(segment_state);
         store.rederive_active_segment_max_version()?;
         store.init_backfill_index_state()?;
-        let outbox_depth = store.count_cf_entries_exact(ROCKSDB_CF_OUTBOX)?;
+        let (outbox_depth, outbox_bulk_depth) = store.count_outbox_entries_exact()?;
         store.outbox_depth.store(outbox_depth, Ordering::Release);
+        store
+            .outbox_bulk_depth
+            .store(outbox_bulk_depth, Ordering::Release);
         let (multipart_uploads, multipart_stored_bytes) = store.reconcile_multipart_storage()?;
         store
             .multipart_uploads
@@ -1131,10 +1151,20 @@ impl Store {
         self.outbox_depth.load(Ordering::Acquire)
     }
 
+    /// Bulk-lane depth. Capped at the total, because the two counters are read
+    /// separately and a delete landing between them could otherwise show a
+    /// bulk depth above the total and a negative metadata lane.
+    pub fn outbox_bulk_depth(&self) -> usize {
+        self.outbox_bulk_depth
+            .load(Ordering::Acquire)
+            .min(self.outbox_depth())
+    }
+
     fn reserve_outbox_slots(&self, slots: usize) -> Result<OutboxReservation<'_>, String> {
         if slots == 0 {
             return Ok(OutboxReservation {
                 depth: &self.outbox_depth,
+                bulk_depth: &self.outbox_bulk_depth,
                 slots,
                 committed: false,
             });
@@ -1158,6 +1188,7 @@ impl Store {
                 Ok(_) => {
                     return Ok(OutboxReservation {
                         depth: &self.outbox_depth,
+                        bulk_depth: &self.outbox_bulk_depth,
                         slots,
                         committed: false,
                     });
@@ -1542,15 +1573,23 @@ impl Store {
         outbox_reservation: OutboxReservation<'_>,
     ) -> Result<ArtifactManifest, String> {
         let mut batch = WriteBatch::default();
-        let manifest =
-            self.stage_segment_manifest(&mut batch, spec, artifact_id, existing, location, size)?;
+        let mut bulk_outbox = 0;
+        let manifest = self.stage_segment_manifest(
+            &mut batch,
+            spec,
+            artifact_id,
+            existing,
+            location,
+            size,
+            &mut bulk_outbox,
+        )?;
         self.write_batch_with_durability_off_runtime(
             batch,
             "manifest batch",
             ApplyDurability::Sync,
         )
         .await?;
-        outbox_reservation.commit();
+        outbox_reservation.commit(bulk_outbox);
         self.note_segment_manifest_committed(&manifest, &location.segment_id)
             .await?;
         Ok(manifest)
@@ -1563,6 +1602,7 @@ impl Store {
     /// `location` are durable before the write may reach the WAL: on the
     /// `Sync` path the append fsynced them; on the `DeferredBatch` path phase
     /// 2 of [`BackfillApplyBatch`] fsynced them before any phase-3 commit.
+    #[allow(clippy::too_many_arguments)]
     fn stage_segment_manifest(
         &self,
         batch: &mut WriteBatch,
@@ -1571,6 +1611,7 @@ impl Store {
         existing: Option<&ArtifactManifest>,
         location: &SegmentLocation,
         size: u64,
+        bulk_outbox: &mut usize,
     ) -> Result<ArtifactManifest, String> {
         let artifact_id = artifact_id.to_owned();
         let persisted_version_ms = persisted_version_ms(spec.version_ms);
@@ -1661,7 +1702,7 @@ impl Store {
             );
         }
         self.stage_backfill_index_update(batch, existing, &manifest);
-        self.append_artifact_replication_messages(
+        *bulk_outbox += self.append_artifact_replication_messages(
             batch,
             &manifest,
             spec.replication_targets,
@@ -2345,6 +2386,7 @@ impl Store {
         let outbox_reservation = self.reserve_outbox_slots(spec.replication_targets.len())?;
 
         let mut batch = WriteBatch::default();
+        let mut bulk_outbox = 0;
         let (manifest, wrote_action_cache_index) = self.stage_inline_manifest(
             &mut batch,
             &spec,
@@ -2352,6 +2394,7 @@ impl Store {
             existing.as_ref(),
             branch,
             bytes,
+            &mut bulk_outbox,
         )?;
 
         self.write_batch_with_durability_off_runtime(
@@ -2360,7 +2403,7 @@ impl Store {
             ApplyDurability::Sync,
         )
         .await?;
-        outbox_reservation.commit();
+        outbox_reservation.commit(bulk_outbox);
         self.note_inline_manifest_committed(&manifest, wrote_action_cache_index);
 
         self.hit_failpoint(FailpointName::AfterMetadataCommitBeforeReturn)
@@ -2411,6 +2454,7 @@ impl Store {
     /// action-cache index row was staged (whose generation bump the caller
     /// owes AFTER the batch commits — see
     /// [`Self::note_inline_manifest_committed`]).
+    #[allow(clippy::too_many_arguments)]
     fn stage_inline_manifest(
         &self,
         batch: &mut WriteBatch,
@@ -2419,6 +2463,7 @@ impl Store {
         existing: Option<&ArtifactManifest>,
         branch: Option<&str>,
         bytes: &[u8],
+        bulk_outbox: &mut usize,
     ) -> Result<(ArtifactManifest, bool), String> {
         let artifact_id = artifact_id.to_owned();
         let persisted_version_ms = persisted_version_ms(spec.version_ms);
@@ -2509,7 +2554,7 @@ impl Store {
             );
         }
         self.stage_backfill_index_update(batch, existing, &manifest);
-        self.append_artifact_replication_messages(
+        *bulk_outbox += self.append_artifact_replication_messages(
             batch,
             &manifest,
             spec.replication_targets,
@@ -4135,6 +4180,10 @@ impl Store {
                     {
                         SegmentApplyPrecheck::Ignored { .. } => {}
                         SegmentApplyPrecheck::Proceed { existing, .. } => {
+                            // Backfill specs carry no replication targets, so
+                            // this stages no outbox messages and the tally is
+                            // always zero.
+                            let mut bulk_outbox = 0;
                             let manifest = self.stage_segment_manifest(
                                 &mut batch,
                                 &spec,
@@ -4142,6 +4191,7 @@ impl Store {
                                 existing.as_ref(),
                                 &staged.location,
                                 staged.size,
+                                &mut bulk_outbox,
                             )?;
                             committed.push(CommittedGroupRecord::Segmented {
                                 manifest,
@@ -4163,6 +4213,7 @@ impl Store {
                             // re-read (backfill never forwards a trunk).
                             let branch =
                                 sticky_branch(existing.as_ref(), staged.branch.as_deref(), None);
+                            let mut bulk_outbox = 0;
                             let (manifest, wrote_action_cache_index) = self.stage_inline_manifest(
                                 &mut batch,
                                 &spec,
@@ -4170,6 +4221,7 @@ impl Store {
                                 existing.as_ref(),
                                 branch,
                                 &staged.bytes,
+                                &mut bulk_outbox,
                             )?;
                             committed.push(CommittedGroupRecord::Inline {
                                 manifest,
@@ -4396,8 +4448,9 @@ impl Store {
             Self::action_cache_index_marker_key(namespace_id).as_bytes(),
         );
 
+        let mut bulk_outbox = 0;
         if !delete_everything {
-            self.append_namespace_delete_messages(
+            bulk_outbox += self.append_namespace_delete_messages(
                 &mut batch,
                 namespace_id,
                 version_ms,
@@ -4411,7 +4464,7 @@ impl Store {
             ApplyDurability::Sync,
         )
         .await?;
-        outbox_reservation.commit();
+        outbox_reservation.commit(bulk_outbox);
         self.remove_manifest_cache_keys(&removed_artifact_ids);
 
         for path in blob_paths {
@@ -4883,7 +4936,7 @@ impl Store {
         let mut batch = WriteBatch::default();
         batch.put_cf(self.cf(ROCKSDB_CF_OUTBOX), key.as_bytes(), value);
         self.write_batch_sync(batch, "outbox message")?;
-        outbox_reservation.commit();
+        outbox_reservation.commit(usize::from(is_bulk_outbox_key(key.as_bytes())));
         Ok(())
     }
 
@@ -4985,6 +5038,7 @@ impl Store {
 
     pub fn snapshot(&self) -> Result<StoreSnapshot, String> {
         let outbox_messages = self.outbox_message_count()?;
+        let outbox_bulk_messages = self.outbox_bulk_depth();
         let multipart_uploads = self.count_cf_entries(ROCKSDB_CF_MULTIPART_UPLOADS)?;
         let promotion_queue_depth = self
             .promotion_queue
@@ -4999,6 +5053,7 @@ impl Store {
         ];
         Ok(StoreSnapshot {
             outbox_messages,
+            outbox_bulk_messages,
             multipart_uploads,
             promotion_queue_depth,
             segment_counts,
@@ -6392,6 +6447,9 @@ impl Store {
             .delete_cf(self.cf(ROCKSDB_CF_OUTBOX), key)
             .map_err(|error| format!("failed to delete outbox entry: {error}"))?;
         release_atomic_slots(&self.outbox_depth, 1);
+        if is_bulk_outbox_key(key) {
+            release_atomic_slots(&self.outbox_bulk_depth, 1);
+        }
         Ok(())
     }
 
@@ -6451,15 +6509,17 @@ impl Store {
             .expect("missing RocksDB column family")
     }
 
+    /// Returns how many of the appended messages went to the bulk lane.
     fn append_artifact_replication_messages(
         &self,
         batch: &mut WriteBatch,
         manifest: &ArtifactManifest,
         replication_targets: &[String],
         trunk: Option<&str>,
-    ) -> Result<(), String> {
+    ) -> Result<usize, String> {
+        let mut bulk = 0_usize;
         for target in replication_targets {
-            self.append_outbox_message(
+            bulk += usize::from(self.append_outbox_message(
                 batch,
                 OutboxMessage {
                     target: target.clone(),
@@ -6477,20 +6537,24 @@ impl Store {
                         trunk: trunk.map(str::to_owned),
                     },
                 },
-            )?;
+            )?);
         }
-        Ok(())
+        Ok(bulk)
     }
 
+    /// Returns how many of the appended messages went to the bulk lane. Namespace
+    /// deletes are metadata-lane by construction, so this is always zero; it is
+    /// reported anyway so the lane stays derived from the key rather than assumed.
     fn append_namespace_delete_messages(
         &self,
         batch: &mut WriteBatch,
         namespace_id: &str,
         version_ms: u64,
         replication_targets: &[String],
-    ) -> Result<(), String> {
+    ) -> Result<usize, String> {
+        let mut bulk = 0_usize;
         for target in replication_targets {
-            self.append_outbox_message(
+            bulk += usize::from(self.append_outbox_message(
                 batch,
                 OutboxMessage {
                     target: target.clone(),
@@ -6499,21 +6563,23 @@ impl Store {
                         version_ms,
                     },
                 },
-            )?;
+            )?);
         }
-        Ok(())
+        Ok(bulk)
     }
 
+    /// Returns whether the message went to the bulk lane, so the caller can
+    /// tally it for `OutboxReservation::commit`.
     fn append_outbox_message(
         &self,
         batch: &mut WriteBatch,
         message: OutboxMessage,
-    ) -> Result<(), String> {
+    ) -> Result<bool, String> {
         let key = outbox_message_key(&message);
         let value = serde_json::to_vec(&message)
             .map_err(|error| format!("failed to encode outbox message: {error}"))?;
         batch.put_cf(self.cf(ROCKSDB_CF_OUTBOX), key.as_bytes(), value);
-        Ok(())
+        Ok(is_bulk_outbox_key(key.as_bytes()))
     }
 
     fn write_batch_sync(&self, batch: WriteBatch, label: &str) -> Result<(), String> {
@@ -6789,6 +6855,27 @@ impl Store {
         self.existence_cache.insert(artifact_id);
     }
 
+    /// Total and bulk-lane outbox depth in one pass, for seeding both counters
+    /// at open. Runs once per process, so it iterates rather than keeping a
+    /// second persisted tally that could disagree with the entries on disk.
+    fn count_outbox_entries_exact(&self) -> Result<(usize, usize), String> {
+        let iter = self
+            .db
+            .iterator_cf(self.cf(ROCKSDB_CF_OUTBOX), IteratorMode::Start);
+        let mut total = 0_usize;
+        let mut bulk = 0_usize;
+        for item in iter {
+            let (key, _) =
+                item.map_err(|error| format!("failed to iterate {ROCKSDB_CF_OUTBOX}: {error}"))?;
+            total = total.saturating_add(1);
+            if is_bulk_outbox_key(&key) {
+                bulk = bulk.saturating_add(1);
+            }
+        }
+        Ok((total, bulk))
+    }
+
+    #[cfg(test)]
     fn count_cf_entries_exact(&self, name: &str) -> Result<usize, String> {
         let iter = self.db.iterator_cf(self.cf(name), IteratorMode::Start);
         let mut count = 0_usize;
@@ -7773,6 +7860,12 @@ fn persisted_version_ms(version_ms: u64) -> u64 {
 /// backlog instead of waiting out gigabytes of it — measured as ~30 minutes
 /// of cross-pod snapshot staleness during a cache populate.
 pub const OUTBOX_BULK_LANE_PREFIX: &str = "1-";
+
+/// Whether an outbox key belongs to the bulk lane. The lane is the key's first
+/// byte, so this reads it without decoding the message.
+pub fn is_bulk_outbox_key(key: &[u8]) -> bool {
+    key.starts_with(OUTBOX_BULK_LANE_PREFIX.as_bytes())
+}
 
 fn outbox_message_key(message: &OutboxMessage) -> String {
     let lane = if message.operation.is_bulk() {
@@ -14747,6 +14840,113 @@ mod tests {
         // lanes across a rolling upgrade.
         let legacy = format!("{:020}-legacy", crate::utils::now_ms());
         assert!(keys[0] < legacy.as_str() && legacy.as_str() < keys[1]);
+    }
+
+    fn bulk_outbox_message(key: &str) -> OutboxMessage {
+        OutboxMessage {
+            target: "http://peer".into(),
+            operation: ReplicationOperation::UpsertArtifact {
+                producer: ArtifactProducer::Reapi,
+                namespace_id: "ios".into(),
+                key: key.into(),
+                content_type: "application/octet-stream".into(),
+                artifact_id: format!("{key}-artifact"),
+                inline: false,
+                version_ms: 1,
+                branch: None,
+                trunk: None,
+            },
+        }
+    }
+
+    fn metadata_outbox_message(key: &str) -> OutboxMessage {
+        OutboxMessage {
+            target: "http://peer".into(),
+            operation: ReplicationOperation::UpsertArtifact {
+                producer: ArtifactProducer::Reapi,
+                namespace_id: "ios".into(),
+                key: key.into(),
+                content_type: "application/x-protobuf".into(),
+                artifact_id: format!("{key}-artifact"),
+                inline: true,
+                version_ms: 2,
+                branch: None,
+                trunk: None,
+            },
+        }
+    }
+
+    #[test]
+    fn outbox_lane_depth_tracks_enqueue_and_delete() {
+        let (_temp_dir, _config, store) = temp_store();
+
+        store
+            .enqueue(bulk_outbox_message("blob/aa"))
+            .expect("failed to enqueue bulk message");
+        store
+            .enqueue(bulk_outbox_message("blob/bb"))
+            .expect("failed to enqueue bulk message");
+        store
+            .enqueue(metadata_outbox_message("action_cache/cc"))
+            .expect("failed to enqueue metadata message");
+
+        assert_eq!(store.outbox_depth(), 3);
+        assert_eq!(store.outbox_bulk_depth(), 2);
+
+        // The metadata lane sorts first, so the head is the inline entry.
+        let (metadata_key, _) = store
+            .next_outbox_message(None)
+            .expect("outbox read")
+            .expect("queued message");
+        assert!(!is_bulk_outbox_key(&metadata_key));
+        store
+            .delete_outbox_message(&metadata_key)
+            .expect("outbox deletion");
+        assert_eq!(store.outbox_depth(), 2);
+        assert_eq!(store.outbox_bulk_depth(), 2);
+
+        let (bulk_key, _) = store
+            .next_outbox_message(None)
+            .expect("outbox read")
+            .expect("queued message");
+        assert!(is_bulk_outbox_key(&bulk_key));
+        store
+            .delete_outbox_message(&bulk_key)
+            .expect("outbox deletion");
+        assert_eq!(store.outbox_depth(), 1);
+        assert_eq!(store.outbox_bulk_depth(), 1);
+    }
+
+    #[test]
+    fn reopening_the_store_rebuilds_outbox_lane_depths() {
+        let (_temp_dir, config, store) = temp_store();
+        store
+            .enqueue(bulk_outbox_message("blob/aa"))
+            .expect("seed bulk lane");
+        store
+            .enqueue(bulk_outbox_message("blob/bb"))
+            .expect("seed bulk lane");
+        store
+            .enqueue(metadata_outbox_message("action_cache/cc"))
+            .expect("seed metadata lane");
+        drop(store);
+
+        let io = IoController::new(
+            Metrics::new(config.region.clone(), config.tenant_id.clone()),
+            config.file_descriptor_pool_size,
+            std::time::Duration::from_millis(config.file_descriptor_acquire_timeout_ms),
+            vec![config.tmp_dir.clone(), config.data_dir.clone()],
+        )
+        .expect("failed to recreate io controller");
+        let memory = MemoryController::new(
+            io.metrics(),
+            config.memory_soft_limit_bytes,
+            config.memory_hard_limit_bytes,
+        );
+        let reopened = Store::open(&config, io, memory).expect("failed to reopen store");
+
+        assert_eq!(reopened.outbox_depth(), 3);
+        assert_eq!(reopened.outbox_bulk_depth(), 2);
     }
 
     #[test]


### PR DESCRIPTION
### Purpose

`kura-tuist-scw-fr-par-0` reached its 100,000 outbox cap twice in 14 hours on 2026-09-02 and shed 2,520 `kind="outbox"` writes. The HTTP cache client installs `RetryMiddleware(retryableRequestMethods: ["GET"])`, so a refused upload POST is a dropped artifact rather than a delayed one.

The drain was already pipelined and the metadata lane already batched, so the previous explanation of this failure (a serial drain bounded by the round trip to a distant peer) no longer held. Re-measuring produced a different bottleneck.

### What the measurement showed

On a clean, near-zero-ingest hour the outbox drained 75,728 to 12,040, a sustained **~17.7 messages/s**. Ingest peaked at 48.6 artifact writes/s against two peers, so **~97 messages/s** enqueued. That gap fills 100,000 well inside an hour, and it is why the cap keeps being reached.

Three things it ruled out:

- **Not an unreachable peer.** `kura_peer_connection_failures_total` 0, no pod restarts in 14h.
- **Not bandwidth.** `kura_replication_bandwidth_effective_limit_bytes_per_second` sat pinned at its configured 512 MiB/s ceiling throughout.
- **Not memory pressure.** `kura_background_work_paused` was 0 for every worker, the outbox included.
- **Not the round trip.** The peers are one region away, not transatlantic. 8 in flight at 17.7 messages/s is ~444 ms per delivery, which at that distance is body transfer, not RTT.

### Why batching did not already cover this

`drain_metadata_batches` breaks at `OUTBOX_BULK_LANE_PREFIX` and `batchable_inline_upsert` accepts only `UpsertArtifact { inline: true }`. `is_bulk()` is exactly `inline: false`, so segment-backed artifacts are all bulk lane and the batch path never touches them. A runner-cache workload is almost entirely those, so its only throughput knob is `OUTBOX_MAX_INFLIGHT`.

### What changed

- **`OUTBOX_MAX_INFLIGHT` 8 to 32.** The constant's rationale was written when the drain was serial and argued the value from RTT; it now states the cost model that actually binds. Per-delivery body residency is one `RESPONSE_STREAM_CHUNK_BYTES` chunk (segment-backed) or up to `MAX_INLINE_REPLICATION_BODY_BYTES` (inline), so 32 is a few MiB times 32 and stays inside the transient budget that already bounds concurrent writes.
- **`kura_outbox_lane_messages{lane="bulk"|"metadata"}`**, a new gauge family. `kura_outbox_messages` is a single total, so during triage the bulk/metadata split, the number that picks between raising the in-flight ceiling and extending batching, was invisible. It is added as a **separate family rather than a label on the existing gauge** on purpose: `max by (cluster, pod) (kura_outbox_messages)` is what the cap alert evaluates, and adding a label would silently turn that into the larger lane instead of the total.
- Bulk depth is tracked as an `AtomicUsize` beside `outbox_depth`, following that counter's existing discipline: maintained on enqueue and delete, rebuilt exactly at open. The lane is always derived from the key rather than re-deriving `inline`, so there is one source of truth. `OutboxReservation::commit` now takes the bulk tally, which makes the compiler force every commit site to account for it, and the tally is applied only on success so a dropped reservation leaves the split untouched.
- The dashboard gains the matching panel, per `kura/AGENTS.md`.
- `infra/helm/k8s-monitoring/alerts.md` had three passages asserting the drain is serial and RTT-bound. They are corrected, and the lane split is now the documented first step in triage.

### Rollout safety

Additive on every surface. The new metric family is new, so a mixed-version fleet just has pods that do not export it yet; no existing metric, query, alert or dashboard panel changes meaning. No on-disk or wire format change: the outbox key already carried the lane in its first byte, and this only reads it.

### One thing this does not fix, and one to follow

Raising the ceiling narrows the gap, it does not close it by arithmetic alone at the observed peak. The structural fix is extending batching (or at least per-delivery overhead amortization) to the bulk lane, which the new metric is what sizes. Worth watching `kura_outbox_lane_messages` on the next CI peak before deciding how far to take that.

The live Grafana rule `afwtwlzgkderke` still carries the stale sentence "Drain is serial and node-wide, one delivery per peer round-trip" in its description, which reads as an instruction to go looking for a slow peer. `alerts.md` now records the replacement text; the rule itself is edited in Grafana and is not provisioned from this repo, so it is not part of this diff.

### Validation

- `cargo test --lib`: 814 passed, 0 failed.
- `cargo clippy --all-targets`: clean.
- `cargo fmt --check`: clean.
- Two new tests: `outbox_lane_depth_tracks_enqueue_and_delete` (the split follows enqueue and delete across both lanes) and `reopening_the_store_rebuilds_outbox_lane_depths` (it is rebuilt exactly from disk). The render assertion in `render_includes_recorded_metrics` caught a wrong assumption about the gauge's exposition name before it shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
