### PR TITLE
fix(server): reap stamped runner pods whose job GitHub already completed

### DIFF
--- a/server/lib/tuist/runners/workers/orphaned_stamped_pods_worker.ex
+++ b/server/lib/tuist/runners/workers/orphaned_stamped_pods_worker.ex
@@ -116,6 +116,31 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorker do
   Pod for one more reconcile cycle (the Pool reconciler will
   eventually reap it once the runner exits) over killing a live
   build.
+
+  ## Finished-job override
+
+  Both shields assume the runner eventually exits and the Pod
+  reaches a terminal phase, which is what closes the session and
+  hands the Pod to the Pool reconciler. On 2026-09-02 that
+  assumption broke: runner processes died mid-job (ENOSPC inside
+  the microVM) without the `runner` container ever terminating, so
+  `started=true` stayed set, the controller never reported
+  `pods/stopped`, the session stayed open, and nine Pods sat
+  Running for five hours holding their slots and their
+  writable-layer snapshots. Nothing in the system had an exit for
+  a Running Pod whose runner was dead.
+
+  The one fact that survives that failure is GitHub's: it marked
+  each job `completed` within seconds, and the `workflow_job`
+  webhook recorded it. A Pod runs exactly one job, so a session
+  whose job has been terminal for longer than `@finished_seconds`
+  is not executing anything, whatever its container reports. Such
+  a Pod loses the session and container-started shields and is
+  reaped. It keeps the claim shield: a live claim on a finished
+  job is a database inconsistency for the claim sweeps to resolve,
+  and over-reaping is the worse error. The window is wide enough
+  that a runner finishing normally is long reaped by the Pool
+  reconciler before this ever looks at it.
   """
 
   use Oban.Worker, queue: :default, max_attempts: 1
@@ -125,11 +150,18 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorker do
   alias Tuist.Runners.Claims
   alias Tuist.Runners.RunnerSessions
   alias Tuist.Runners.Telemetry
+  alias Tuist.Runners.WorkflowJobs
 
   require Logger
 
   @owner_label "tuist.dev/runner-pool-owner"
   @grace_seconds 300
+  # How long a session's job must have been terminal on GitHub before
+  # the Pod is treated as finished regardless of its container state.
+  # A runner that finishes normally exits within seconds and is reaped
+  # by the Pool reconciler within a minute; this leaves an order of
+  # magnitude for a slow teardown before a Pod is judged dead.
+  @finished_seconds 900
 
   @impl Oban.Worker
   def perform(_job) do
@@ -149,43 +181,89 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorker do
   end
 
   defp reap_orphans(namespace, pods) do
+    now = DateTime.utc_now()
+    cutoff = DateTime.add(now, -@grace_seconds, :second)
+
+    # Pods whose session's job GitHub has already closed. These are done
+    # whatever their containers say, so they get neither the session nor
+    # the container-started shield below.
+    finished = finished_pod_names(now, cutoff)
+
     # Two independent "this Pod is in flight" signals, unioned. Claims
     # cover the normal busy state; sessions cover the gap where the
     # claim was released after dispatch committed but before the Pod
     # actually stopped (the silent-delete class this worker has been
     # observed to produce on a `Claims.release` race). Pods is read
     # *before* both sets — same race-safety argument as `live`.
-    live = MapSet.union(Claims.live_pod_names(), RunnerSessions.live_pod_names())
-    cutoff = DateTime.add(DateTime.utc_now(), -@grace_seconds, :second)
+    live =
+      MapSet.union(
+        Claims.live_pod_names(),
+        MapSet.difference(RunnerSessions.live_pod_names(), finished)
+      )
 
-    reaped =
+    {finished_reaped, wedged_reaped} =
       pods
-      |> Enum.filter(&orphaned?(&1, live, cutoff))
-      |> Enum.count(&reap(namespace, &1))
+      |> Enum.filter(&(orphaned?(&1, live, finished, cutoff) and reap(namespace, &1)))
+      |> Enum.split_with(&MapSet.member?(finished, get_in(&1, ["metadata", "name"])))
 
-    if reaped > 0 do
-      Logger.warning("runners: reaped orphaned stamped pods",
-        count: reaped,
-        grace_seconds: @grace_seconds
-      )
+    record_reaped(length(wedged_reaped), "orphaned_stamped_pod", "runners: reaped orphaned stamped pods")
 
-      :telemetry.execute(
-        Telemetry.event_name_recovery(),
-        %{count: reaped},
-        %{kind: "orphaned_stamped_pod"}
-      )
-    end
+    record_reaped(
+      length(finished_reaped),
+      "finished_job_pod",
+      "runners: reaped stamped pods whose job GitHub already completed"
+    )
 
     :ok
   end
 
-  defp orphaned?(pod, live, cutoff) do
+  defp record_reaped(0, _kind, _message), do: :ok
+
+  defp record_reaped(count, kind, message) do
+    Logger.warning(message, count: count, grace_seconds: @grace_seconds)
+
+    :telemetry.execute(
+      Telemetry.event_name_recovery(),
+      %{count: count},
+      %{kind: kind}
+    )
+  end
+
+  # Open sessions whose job reached a terminal status on GitHub more
+  # than @finished_seconds ago. The job that actually ran outranks the
+  # one the claim was minted for: GitHub hands a queued job to any
+  # eligible runner, so the two can differ, and `executed_workflow_job_id`
+  # is nil when GitHub never told us (a job that failed before its
+  # in_progress webhook, as on a wedged box).
+  defp finished_pod_names(now, session_threshold) do
+    sessions = RunnerSessions.list_open_for_pod_reconciliation(session_threshold)
+
+    completions =
+      sessions
+      |> Enum.flat_map(&[&1.executed_workflow_job_id, &1.workflow_job_id])
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+      |> WorkflowJobs.terminal_completions()
+
+    finished_before = DateTime.add(now, -@finished_seconds, :second)
+
+    sessions
+    |> Enum.filter(fn session ->
+      case Map.get(completions, session.executed_workflow_job_id) || Map.get(completions, session.workflow_job_id) do
+        nil -> false
+        completed_at -> DateTime.before?(completed_at, finished_before)
+      end
+    end)
+    |> MapSet.new(& &1.pod_name)
+  end
+
+  defp orphaned?(pod, live, finished, cutoff) do
     name = get_in(pod, ["metadata", "name"])
 
     is_binary(name) and
       not MapSet.member?(live, name) and
       created_before?(pod, cutoff) and
-      not linux_runner_executing?(pod)
+      (MapSet.member?(finished, name) or not linux_runner_executing?(pod))
   end
 
   # True if the Pod is a Linux split-container runner whose `runner`

--- a/server/test/tuist/runners/workers/orphaned_stamped_pods_worker_test.exs
+++ b/server/test/tuist/runners/workers/orphaned_stamped_pods_worker_test.exs
@@ -8,6 +8,7 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
   alias Tuist.Runners.Claims
   alias Tuist.Runners.RunnerSessions
   alias Tuist.Runners.Workers.OrphanedStampedPodsWorker
+  alias Tuist.Runners.WorkflowJobs
 
   setup :verify_on_exit!
 
@@ -76,8 +77,26 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
     # Default: no open sessions. Tests that exercise the session
     # guard override this per-case.
     stub(RunnerSessions, :live_pod_names, fn -> MapSet.new() end)
+    # Default: no session has a finished job. Tests for the
+    # finished-job override stub both per-case.
+    stub(RunnerSessions, :list_open_for_pod_reconciliation, fn _threshold -> [] end)
+    stub(WorkflowJobs, :terminal_completions, fn _ids -> %{} end)
     :ok
   end
+
+  # An open session as the worker reads it, for a pod whose claim was
+  # minted for `workflow_job_id` and whose runner GitHub actually ran
+  # `executed_workflow_job_id` on (nil until the in_progress webhook).
+  defp open_session(pod_name, workflow_job_id, executed_workflow_job_id) do
+    %{
+      id: System.unique_integer([:positive]),
+      pod_name: pod_name,
+      workflow_job_id: workflow_job_id,
+      executed_workflow_job_id: executed_workflow_job_id
+    }
+  end
+
+  defp ago(seconds), do: DateTime.add(DateTime.utc_now(), -seconds, :second)
 
   describe "perform/1" do
     test "reaps a stamped pod with no live claim that is older than the grace window" do
@@ -302,6 +321,120 @@ defmodule Tuist.Runners.Workers.OrphanedStampedPodsWorkerTest do
       end)
 
       expect(Claims, :live_pod_names, fn -> MapSet.new(["runner-macos-busy"]) end)
+
+      reject(&K8sClient.delete_runner/2)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "reaps a Linux pod whose runner is reported executing and whose session is open once GitHub finished its job" do
+      # The 2026-09-02 shape: the runner process died mid-job inside
+      # the microVM, the container never terminated, so `started=true`
+      # held, the controller never reported pods/stopped, and the
+      # session stayed open. Both shields say "live"; GitHub says the
+      # job completed 20 minutes ago. GitHub wins: a Pod runs one job.
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [linux_pod("runner-dead-mid-job", aged(), runner_executing())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new() end)
+      expect(RunnerSessions, :live_pod_names, fn -> MapSet.new(["runner-dead-mid-job"]) end)
+
+      expect(RunnerSessions, :list_open_for_pod_reconciliation, fn _threshold ->
+        [open_session("runner-dead-mid-job", 100, 200)]
+      end)
+
+      expect(WorkflowJobs, :terminal_completions, fn ids ->
+        assert Enum.sort(ids) == [100, 200]
+        %{200 => ago(1200)}
+      end)
+
+      expect(K8sClient, :delete_runner, fn @namespace, "runner-dead-mid-job" -> :ok end)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "resolves the finished job from the claimed id when GitHub never reported which job ran" do
+      # A job that failed before its in_progress webhook leaves
+      # executed_workflow_job_id nil; the completion still lands on
+      # the job the claim was minted for.
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [linux_pod("runner-dead-early", aged(), runner_executing())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new() end)
+      expect(RunnerSessions, :live_pod_names, fn -> MapSet.new(["runner-dead-early"]) end)
+
+      expect(RunnerSessions, :list_open_for_pod_reconciliation, fn _threshold ->
+        [open_session("runner-dead-early", 100, nil)]
+      end)
+
+      expect(WorkflowJobs, :terminal_completions, fn [100] -> %{100 => ago(1200)} end)
+
+      expect(K8sClient, :delete_runner, fn @namespace, "runner-dead-early" -> :ok end)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "leaves a pod whose job finished inside the finished window" do
+      # Normal post-job teardown: the runner is exiting and the Pool
+      # reconciler will reap it in a minute. Reaping here would race
+      # it and lose the runner's exit code.
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [linux_pod("runner-just-finished", aged(), runner_executing())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new() end)
+      expect(RunnerSessions, :live_pod_names, fn -> MapSet.new(["runner-just-finished"]) end)
+
+      expect(RunnerSessions, :list_open_for_pod_reconciliation, fn _threshold ->
+        [open_session("runner-just-finished", 100, 200)]
+      end)
+
+      expect(WorkflowJobs, :terminal_completions, fn _ids -> %{200 => ago(60)} end)
+
+      reject(&K8sClient.delete_runner/2)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "leaves a pod whose job is still in progress" do
+      # An open session with no terminal completion is a live build,
+      # exactly what the session shield exists to protect.
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [linux_pod("runner-long-build", aged(), runner_executing())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new() end)
+      expect(RunnerSessions, :live_pod_names, fn -> MapSet.new(["runner-long-build"]) end)
+
+      expect(RunnerSessions, :list_open_for_pod_reconciliation, fn _threshold ->
+        [open_session("runner-long-build", 100, 200)]
+      end)
+
+      expect(WorkflowJobs, :terminal_completions, fn _ids -> %{} end)
+
+      reject(&K8sClient.delete_runner/2)
+
+      assert :ok = OrphanedStampedPodsWorker.perform(%Oban.Job{})
+    end
+
+    test "a live claim still protects a pod whose job finished" do
+      # A claim on a finished job is a database inconsistency for the
+      # claim sweeps, not evidence about the Pod. Over-reaping is the
+      # worse error, so the claim shield is kept.
+      expect(K8sClient, :list_pods, fn @namespace, _selector ->
+        {:ok, [linux_pod("runner-claimed-finished", aged(), runner_executing())]}
+      end)
+
+      expect(Claims, :live_pod_names, fn -> MapSet.new(["runner-claimed-finished"]) end)
+      expect(RunnerSessions, :live_pod_names, fn -> MapSet.new(["runner-claimed-finished"]) end)
+
+      expect(RunnerSessions, :list_open_for_pod_reconciliation, fn _threshold ->
+        [open_session("runner-claimed-finished", 100, 200)]
+      end)
+
+      expect(WorkflowJobs, :terminal_completions, fn _ids -> %{200 => ago(1200)} end)
 
       reject(&K8sClient.delete_runner/2)
 


### PR DESCRIPTION
## What changed

`OrphanedStampedPodsWorker` gains a third signal. A stamped pod whose session's job has been terminal on GitHub for longer than 15 minutes is reaped even though its session is still open and its `runner` container still reports `started=true`. The claim shield is unchanged. Reaps under this signal are counted separately as `tuist_runners_recovery_count{kind="finished_job_pod"}`.

## Why

The worker already reaps owner-stamped pods with no live claim, and it deliberately shields two shapes it must never kill: a pod with an open `RunnerSession` (dispatch committed, JIT delivered) and a Linux pod whose `runner` container has started. Both shields rest on one assumption, stated in the worker's own doc: the runner eventually exits, the pod reaches a terminal phase, the controller reports `pods/stopped`, the session closes, and the Pool reconciler reaps.

On 2026-09-02 that assumption broke. Runner processes died mid-job with ENOSPC inside the microVM (the Listener aborted with exit 134 and wrote "Exiting runner..."), yet the `runner` container never terminated. So `started=true` held, the controller never reported the stop, the session stayed open, and nine pods on two production nodes sat `Running` for five hours. I checked every exit a Running pod has in the system, in the Pool reconciler (container terminated, terminal phase, idle, poller never started), in `PodLifecycleReconciler` (reports terminal transitions only), in `PodReconciliationWorker` (acts when a pod is *absent*), and in the `workflow_job.completed` webhook (releases the claim, never touches the pod). None applied. A Running pod with a dead runner had no exit at all.

Those pods were not idle. They held 24 of a node's 31 allocatable vCPU (six of the eight `observedReplicas` in one pool), and they held the writable-layer snapshots inside containerd's store, which is what kept both nodes pinned at their image-store quota to the byte for hours while the disk was 94% free. The lifecycle gap is what turned one transient ENOSPC into a permanently poisoned node.

## Why this signal

The one fact that survives that failure is GitHub's. Every one of the nine jobs was recorded `completed/failure` by the `workflow_job` webhook within seconds of the crash, between 15:19 and 17:55, while the sessions still read `ended_at = NULL` (verified against production `runner_sessions` joined to `runner_workflow_jobs`). A pod runs exactly one job under its JIT, so a session whose job has been terminal for a quarter of an hour is not executing anything, whatever the container says. This override would have reaped each of the nine within 15 minutes of GitHub closing its job.

The job that actually ran outranks the one the claim was minted for, mirroring `PodReconciliationWorker.completed_at_for/2`: GitHub hands a queued job to any eligible runner, so the two can differ, and `executed_workflow_job_id` is nil when the job failed before its `in_progress` webhook, which is exactly the wedged-box case (one of the nine).

## Why not the alternatives

A max pod lifetime (`activeDeadlineSeconds`) is blind to the job: it would have to exceed the longest legitimate build, so it would have fired hours later than this does, and it kills a live build that merely runs long.

A liveness probe or watchdog inside the pod cannot be trusted for this case. The stdout trail shows the guest stopped executing userland at the crash, so nothing inside it would have fired. The reap has to be external.

A new arm in `PodReconciliationWorker` would work but would spread the "is this pod live" judgement across two workers. This worker already owns that judgement and its shields; the new signal belongs beside them. The `runners.ex` guidance against adding edge-keyed sweeps does not apply: this is level-triggered, comparing pods that exist against jobs that are terminal.

The window is 15 minutes, the same as `PodReconciliationWorker`'s session-absence threshold. A runner that finishes normally exits within seconds and is reaped by the Pool reconciler within a minute, so this is an order of magnitude of headroom before a pod is judged dead, and it preserves the reconciler's chance to record the runner's exit code (#11109) on the normal path.

The claim shield is kept on purpose. A live claim on a finished job is a database inconsistency for `StaleClaimsWorker` and `OrphanedRunnersWorker` to resolve, not evidence about the pod, and the worker's existing bias applies: over-reaping is the worse error.

## Impact

Pods whose runner dies without the container terminating are reaped within ~16 minutes of GitHub closing the job instead of never. Their slots and snapshots return to the node. Normal runs, long builds, and the post-job teardown window are unaffected: the first has no terminal completion, the last is inside the window.

This does not change why those runners died (the image-store quota filling with job workspaces, addressed by #12769), only how long the fleet pays for it afterwards. #12787 was closed in favour of this and #12769.

## Validation

`mix test` on `test/tuist/runners/workers/orphaned_stamped_pods_worker_test.exs` and `pod_reconciliation_worker_test.exs`: 46 passed. `mix credo --strict` on the worker: no issues. `mix format` applied.

New tests cover: the production shape (open session, `started=true`, job completed 20 minutes ago, reaped); resolution through the claimed job id when `executed_workflow_job_id` is nil; a job completed 60 seconds ago left alone; an in-progress job left alone; and a live claim still protecting a finished pod. Existing tests are untouched; the setup stubs the two new lookups to their empty defaults so every prior case runs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)