### PR TITLE
fix(server): bump the fast-uri override past the new SSRF advisories

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,7 @@
       "mdast-util-to-hast": "13.2.1",
       "ajv": "8.18.0",
       "dompurify": "3.4.13",
-      "fast-uri": "3.1.5",
+      "fast-uri": "3.1.7",
       "flatted": "3.4.2",
       "yaml": "2.8.3",
       "defu": "6.1.5",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   axios: 1.18.0
   defu: 6.1.5
   dompurify: 3.4.13
-  fast-uri: 3.1.5
+  fast-uri: 3.1.7
   flatted: 3.4.2
   follow-redirects: 1.16.0
   form-data: 4.0.6
@@ -38,7 +38,7 @@ time:
   cytoscape@3.33.4: 2026-05-19T13:42:50.534Z
   dompurify@3.4.13: 2026-08-03T14:16:00.210Z
   echarts@6.1.0: 2026-05-19T17:52:11.076Z
-  fast-uri@3.1.5: 2026-07-31T09:16:56.212Z
+  fast-uri@3.1.7: 2026-09-02T11:06:41.962Z
   form-data@4.0.6: 2026-06-12T17:37:53.689Z
   hasown@2.0.4: 2026-05-28T18:11:39.940Z
   https-proxy-agent@5.0.1: 2022-04-14T18:42:00.761Z
@@ -808,8 +808,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
@@ -2421,7 +2421,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2565,7 +2565,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fflate@0.4.8: {}
 


### PR DESCRIPTION
## What changed

Bumped the `fast-uri` pnpm override in `server/package.json` from 3.1.5 to 3.1.7 and regenerated `server/pnpm-lock.yaml`.

## Why

The server's `Security` job started failing with four HIGH findings from Trivy:

| CVE | Summary |
| --- | --- |
| CVE-2026-75899 | SSRF via repeated hostname percent-decoding |
| CVE-2026-75931 | Host confusion via skipped IDN canonicalization |
| CVE-2026-75975 | SSRF via malformed IPv6 normalization |
| CVE-2026-76172 | Host confusion via percent-encoded scheme normalization |

All four were published on 2026-09-02 between 15:41 and 15:44 UTC and all four cover the 3.1.5 we pin. `fast-uri` reaches us transitively through `ajv`, which is itself pulled in by `@scalar/api-reference`, so the override is the only place the version is decided.

## Root cause

Not a regression in any branch. Trivy's vulnerability DB is rebuilt on a schedule, so main's `Security` runs at 20:24 and 20:25 UTC still passed against a DB built before the advisories landed, while the 20:48 run on a PR pulled a rebuilt DB and failed. Main fails the same way on its next run once its DB refreshes; this is a repo-wide break, not a PR-specific one.

## Why 3.1.7 and not 3.1.6

The advisories name 3.1.6 as the first patched version in the 3.x line, so 3.1.6 would clear the check today. But the maintainers published 3.1.7, 2.4.6 and 4.1.4 within 40 seconds of each other on 2026-09-02, which is the same coordinated-release shape that preceded each earlier advisory batch for this package (3.1.5/2.4.4/4.1.2 on 08-03, 3.1.4/2.4.3/4.1.1 on 07-21). Taking the head of the 3.x line rather than the minimum patched version means we do not pay for this bump a second time when those advisories are published. Staying inside 3.x keeps the change a patch bump for `ajv`, which accepts the whole range.

## Impact

No behavior change for the server. The only functional difference is the URI parser used by `ajv`'s schema `$ref` resolution, which now rejects the malformed authority forms the advisories describe.

## Validation

- `trivy fs --exit-code 1 --skip-files "mix.exs,mix.lock" --skip-dirs "priv/static,node_modules,deps,_build" ./` against a freshly downloaded DB that contains all four advisories: exit 0, with `pnpm-lock.yaml`, `native/xcactivitylog_nif/Package.resolved` and `native/xcresult_nif/Package.resolved` all at zero findings. The same command reproduced the four findings before the bump.
- `aube install` resolves and links the lock cleanly, materializing `fast-uri@3.1.7` and re-using the other 390 packages unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)