### PR TITLE
fix(infra): stop one Linux runner shape from starving its siblings

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -85,13 +85,7 @@ env:
 jobs:
   check-releases:
     name: Check for releasable changes
-    # GitHub-hosted on purpose. This job gates the whole cascade, and the
-    # cascade is what deploys the runners fleet, so running it on that fleet
-    # makes a fleet incident block the deployment of its own fix. On
-    # 2026-09-02 it sat queued behind a starved Linux pool for over an hour
-    # while runners-controller 0.22.1 waited to roll. It only needs git,
-    # git-cliff and jq.
-    runs-on: ubuntu-latest
+    runs-on: tuist-linux
     timeout-minutes: 5
     # release:check only needs the git-cliff + jq installed below, but `mise run`
     # otherwise auto-installs the whole merged mise.toml toolset — including

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -85,7 +85,13 @@ env:
 jobs:
   check-releases:
     name: Check for releasable changes
-    runs-on: tuist-linux
+    # GitHub-hosted on purpose. This job gates the whole cascade, and the
+    # cascade is what deploys the runners fleet, so running it on that fleet
+    # makes a fleet incident block the deployment of its own fix. On
+    # 2026-09-02 it sat queued behind a starved Linux pool for over an hour
+    # while runners-controller 0.22.1 waited to roll. It only needs git,
+    # git-cliff and jq.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     # release:check only needs the git-cliff + jq installed below, but `mise run`
     # otherwise auto-installs the whole merged mise.toml toolset — including

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1352,17 +1352,23 @@ replica gap` with `creating: 0` for the starved pool. Cap the hog at the
 seat count (`kubectl patch runnerpool <pool> -n tuist-runners --type
 merge -p '{"spec":{"autoscaling":{"maxReplicas":N}}}'`); the autoscaler
 honours it after its 300-second scale-down cooldown, reaps the parked
-Pods, and the starved pool is admitted within seconds. Then re-adopt the
-value in `infra/helm/tuist/values-managed-production.yaml`, where every
-Linux shape now carries a `maxReplicas` bounded to what the fleet can
-seat, or Helm loses the field.
+Pods, and the starved pool is admitted within seconds. That patch is an
+incident lever only: it takes `maxReplicas` away from Helm until the
+next chart apply, so drop it once the fleet has recovered.
 
 Two changes made this shape of incident rarer rather than merely
-visible: per-shape `maxReplicas` in the production values, and the
-admission's per-pool share (`reason="pool_share"` in
+visible, and both are in the controller rather than in values. The
+autoscaler's shape placement cap now covers Linux, deriving per
+reconcile from live node allocatable how many Pods of each shape the
+fleet can actually seat, so a pool can no longer be targeted above what
+will fit. And the provisioning admission gives each pool a share of the
+Pending budget (`reason="pool_share"` in
 `infra/runners-controller/controllers/provisioning.go`), which stops a
 pool from topping the budget back up after a reap while a sibling with
-a gap holds nothing.
+a gap holds nothing. If a pool is still targeted far above its fleet's
+seats, suspect the cap rather than reaching for a values change:
+`tuist_runners_fleet_ready_nodes` going to zero, or a RuntimeClass the
+controller cannot read, both degrade it to the byte budget alone.
 
 ### Why there is no alert on withheld runner queue depth
 

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1294,6 +1294,76 @@ them:
 kubectl delete pod -n tuist-runners -l tuist.dev/runner=true --field-selector spec.nodeName=<node>
 ```
 
+### Runner pool starved
+
+The queue-age alert above says work is waiting; this one says why, and
+says it twenty minutes sooner. A Linux pool with dispatchable queued
+jobs and zero Pods of any phase for ten minutes is being refused
+creation, not waiting on capacity.
+
+On 2026-09-02 `linux-4vcpu-16gb`, with every Linux shape allowed
+`maxReplicas: 120`, was targeted at 67 replicas on a fleet that seats
+24 of that shape. The excess sat Pending on `Insufficient memory`,
+and because the provisioning admission budgets Pending Pods fleet-wide
+(`maxConcurrentPerFleetSelector`, default 4), those four dead Pods held
+the whole budget and every sibling shape was refused with
+`reason="fleet_cap"`. `linux-2vcpu-8gb` sat at zero Pods for over an
+hour with 143 `tuist-linux` jobs queued, one of them the production
+cascade's own first job, so nothing could deploy. The 300-second
+unschedulable reap did not help: the hog recreated each Pod the moment
+it was released.
+
+```promql
+(
+  max by (cluster, env, fleet) (tuist_runners_queue_length{env="production", fleet=~"tuist-tuist-runner-pool-linux-.*"})
+  - max by (cluster, env, fleet) (tuist_runners_queue_withheld{env="production", fleet=~"tuist-tuist-runner-pool-linux-.*"})
+) > 0
+unless on (cluster, fleet) (
+  max by (cluster, fleet) (
+    label_replace(tuist_runners_pool_replicas_observed{env="production", pool=~"tuist-tuist-runner-pool-linux-.*"}, "fleet", "$1", "pool", "(.*)")
+  ) > 0
+)
+```
+
+- Pending period: 10 minutes
+- Severity: critical
+- Summary: `Runner pool {{ $labels.fleet }} ({{ $labels.cluster }}) has
+  {{ $values.A.Value }} dispatchable queued job(s) and zero Pods`
+
+The queue side is the server's `tuist_runners_queue_length` minus
+`tuist_runners_queue_withheld` (labelled `fleet`), so an account parked
+at its concurrency limit does not count. The Pod side is the
+controller's `tuist_runners_pool_replicas_observed` (labelled `pool`,
+same value), which counts Pods of every phase, so a pool whose Pods are
+merely Pending does not fire this; only a pool that has been admitted
+nothing at all does.
+
+When it fires, find the hog:
+
+```bash
+kubectl get runnerpools -n tuist-runners
+kubectl get pods -n tuist-runners --field-selector status.phase=Pending
+```
+
+A sibling pool with `replicas` far above the fleet's seats for its shape
+and Pending Pods failing scheduling on `Insufficient memory` is the
+signature; the controller logs `Linux provisioning admission left
+replica gap` with `creating: 0` for the starved pool. Cap the hog at the
+seat count (`kubectl patch runnerpool <pool> -n tuist-runners --type
+merge -p '{"spec":{"autoscaling":{"maxReplicas":N}}}'`); the autoscaler
+honours it after its 300-second scale-down cooldown, reaps the parked
+Pods, and the starved pool is admitted within seconds. Then re-adopt the
+value in `infra/helm/tuist/values-managed-production.yaml`, where every
+Linux shape now carries a `maxReplicas` bounded to what the fleet can
+seat, or Helm loses the field.
+
+Two changes made this shape of incident rarer rather than merely
+visible: per-shape `maxReplicas` in the production values, and the
+admission's per-pool share (`reason="pool_share"` in
+`infra/runners-controller/controllers/provisioning.go`), which stops a
+pool from topping the budget back up after a reap while a sibling with
+a gap holds nothing.
+
 ### Why there is no alert on withheld runner queue depth
 
 `tuist_runners_queue_withheld` is deliberately **not** alerted on, and the

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -1419,11 +1419,40 @@ runnersFleetLinux:
   shapeAutoscaling:
     enabled: true
     minWarmPoolFloor: 0
+    # Fallback only. Every shape below carries its own `maxReplicas`, bounded
+    # to what this fleet can actually seat, so this value applies to nothing
+    # in production and stays as the documented default for the override.
     maxReplicas: 120
     scaleDownCooldownSeconds: 300
+  # Per-shape `maxReplicas` is bounded to the seats the fleet can hold, not
+  # to demand. The autoscaler sizes a pool from its queue and, left unbounded,
+  # drove `4vcpu-16gb` to a target of 67 on a fleet that seats 24 of them; the
+  # excess sat Pending on `Insufficient memory` forever, and because the
+  # provisioning admission budgets Pending Pods fleet-wide, those dead Pods
+  # blocked every sibling shape from creating any Pod at all. The default
+  # shape stayed at zero for an hour with 143 `tuist-linux` jobs queued, one
+  # of them the production cascade's own first job (2026-09-02).
+  #
+  # Seats per RISE-L (117 GiB / 31 vCPU allocatable, kata podFixed overhead
+  # 2.5 GiB / 0.25 vCPU) = min(floor(117 / (memoryGb + 2.5)),
+  # floor(31 / (vcpus + 0.25))). Non-default shapes get 3 of the 4 boxes:
+  # the default shape's warm floor (12 x 10.5 GiB) is about one box, and a
+  # shape that could take the whole fleet is exactly what starved it.
+  # Recompute when `ovhFleets.runners-linux.replicas` or the box SKU changes.
+  #
+  #   shape        seats/box   3 boxes   4 boxes
+  #   1vcpu-2gb    24 (cpu)    72        96
+  #   2vcpu-4gb    13 (cpu)    39        52
+  #   2vcpu-8gb    11 (mem)    33        44   <- default, whole fleet
+  #   4vcpu-8gb     7 (cpu)    21        28
+  #   4vcpu-16gb    6 (mem)    18        24
+  #   8vcpu-16gb    3 (cpu)     9        12
+  #   8vcpu-32gb    3 (mem)     9        12
+  #   16vcpu-32gb   1 (cpu)     3         4
+  #   16vcpu-64gb   1 (mem)     3         4
   shapes:
-    - { vcpus: 1, memoryGb: 2 }
-    - { vcpus: 2, memoryGb: 4 }
+    - { vcpus: 1, memoryGb: 2, autoscaling: { maxReplicas: 72 } }
+    - { vcpus: 2, memoryGb: 4, autoscaling: { maxReplicas: 39 } }
     # Default shape: all `tuist-default` + `linux` default-profile
     # (`tuist-linux`) traffic lands here, so it carries the fleet's warm
     # floor. Sized against RAM, not slots: request == limit == the
@@ -1440,11 +1469,12 @@ runnersFleetLinux:
       default: true
       autoscaling:
         minWarmPoolFloor: 12
-    - { vcpus: 4, memoryGb: 8 }
-    - { vcpus: 4, memoryGb: 16 }
-    - { vcpus: 8, memoryGb: 16 }
-    - { vcpus: 8, memoryGb: 32 }
-    - { vcpus: 16, memoryGb: 32 }
+        maxReplicas: 44
+    - { vcpus: 4, memoryGb: 8, autoscaling: { maxReplicas: 21 } }
+    - { vcpus: 4, memoryGb: 16, autoscaling: { maxReplicas: 18 } }
+    - { vcpus: 8, memoryGb: 16, autoscaling: { maxReplicas: 9 } }
+    - { vcpus: 8, memoryGb: 32, autoscaling: { maxReplicas: 9 } }
+    - { vcpus: 16, memoryGb: 32, autoscaling: { maxReplicas: 3 } }
     # Ceiling shape, production-only: 64 GiB + the kata RuntimeClass's
     # 2.5 GiB podFixed overhead is 66.5 GiB per Pod. That seats 3 to an
     # AX162-R and exactly 1 to the OVH RISE-L this fleet is moving to
@@ -1470,7 +1500,7 @@ runnersFleetLinux:
     # and 4 GB/vCPU, and kata pins guest RAM (request == limit == the
     # shape), so memory reservation is what runs out on this fleet while
     # CPU does not. This rung is bought for memory and priced for it.
-    - { vcpus: 16, memoryGb: 64 }
+    - { vcpus: 16, memoryGb: 64, autoscaling: { maxReplicas: 3 } }
 
 # In-cluster Valkey backs the auth rate limiter (Hammer.Redis). The
 # chart wires TUIST_REDIS_URL to the embedded Service; without it the

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -1419,40 +1419,16 @@ runnersFleetLinux:
   shapeAutoscaling:
     enabled: true
     minWarmPoolFloor: 0
-    # Fallback only. Every shape below carries its own `maxReplicas`, bounded
-    # to what this fleet can actually seat, so this value applies to nothing
-    # in production and stays as the documented default for the override.
+    # A per-pool safety ceiling, not a capacity bound. What the fleet can
+    # actually seat for each shape is derived per reconcile by the
+    # autoscaler's `shapePlacementCaps` from live node allocatable, so a
+    # hardcoded per-shape number here would be a second copy of that
+    # arithmetic, stale the moment a box is added, lost, or re-SKU'd.
     maxReplicas: 120
     scaleDownCooldownSeconds: 300
-  # Per-shape `maxReplicas` is bounded to the seats the fleet can hold, not
-  # to demand. The autoscaler sizes a pool from its queue and, left unbounded,
-  # drove `4vcpu-16gb` to a target of 67 on a fleet that seats 24 of them; the
-  # excess sat Pending on `Insufficient memory` forever, and because the
-  # provisioning admission budgets Pending Pods fleet-wide, those dead Pods
-  # blocked every sibling shape from creating any Pod at all. The default
-  # shape stayed at zero for an hour with 143 `tuist-linux` jobs queued, one
-  # of them the production cascade's own first job (2026-09-02).
-  #
-  # Seats per RISE-L (117 GiB / 31 vCPU allocatable, kata podFixed overhead
-  # 2.5 GiB / 0.25 vCPU) = min(floor(117 / (memoryGb + 2.5)),
-  # floor(31 / (vcpus + 0.25))). Non-default shapes get 3 of the 4 boxes:
-  # the default shape's warm floor (12 x 10.5 GiB) is about one box, and a
-  # shape that could take the whole fleet is exactly what starved it.
-  # Recompute when `ovhFleets.runners-linux.replicas` or the box SKU changes.
-  #
-  #   shape        seats/box   3 boxes   4 boxes
-  #   1vcpu-2gb    24 (cpu)    72        96
-  #   2vcpu-4gb    13 (cpu)    39        52
-  #   2vcpu-8gb    11 (mem)    33        44   <- default, whole fleet
-  #   4vcpu-8gb     7 (cpu)    21        28
-  #   4vcpu-16gb    6 (mem)    18        24
-  #   8vcpu-16gb    3 (cpu)     9        12
-  #   8vcpu-32gb    3 (mem)     9        12
-  #   16vcpu-32gb   1 (cpu)     3         4
-  #   16vcpu-64gb   1 (mem)     3         4
   shapes:
-    - { vcpus: 1, memoryGb: 2, autoscaling: { maxReplicas: 72 } }
-    - { vcpus: 2, memoryGb: 4, autoscaling: { maxReplicas: 39 } }
+    - { vcpus: 1, memoryGb: 2 }
+    - { vcpus: 2, memoryGb: 4 }
     # Default shape: all `tuist-default` + `linux` default-profile
     # (`tuist-linux`) traffic lands here, so it carries the fleet's warm
     # floor. Sized against RAM, not slots: request == limit == the
@@ -1469,12 +1445,11 @@ runnersFleetLinux:
       default: true
       autoscaling:
         minWarmPoolFloor: 12
-        maxReplicas: 44
-    - { vcpus: 4, memoryGb: 8, autoscaling: { maxReplicas: 21 } }
-    - { vcpus: 4, memoryGb: 16, autoscaling: { maxReplicas: 18 } }
-    - { vcpus: 8, memoryGb: 16, autoscaling: { maxReplicas: 9 } }
-    - { vcpus: 8, memoryGb: 32, autoscaling: { maxReplicas: 9 } }
-    - { vcpus: 16, memoryGb: 32, autoscaling: { maxReplicas: 3 } }
+    - { vcpus: 4, memoryGb: 8 }
+    - { vcpus: 4, memoryGb: 16 }
+    - { vcpus: 8, memoryGb: 16 }
+    - { vcpus: 8, memoryGb: 32 }
+    - { vcpus: 16, memoryGb: 32 }
     # Ceiling shape, production-only: 64 GiB + the kata RuntimeClass's
     # 2.5 GiB podFixed overhead is 66.5 GiB per Pod. That seats 3 to an
     # AX162-R and exactly 1 to the OVH RISE-L this fleet is moving to
@@ -1500,7 +1475,7 @@ runnersFleetLinux:
     # and 4 GB/vCPU, and kata pins guest RAM (request == limit == the
     # shape), so memory reservation is what runs out on this fleet while
     # CPU does not. This rung is bought for memory and priced for it.
-    - { vcpus: 16, memoryGb: 64, autoscaling: { maxReplicas: 3 } }
+    - { vcpus: 16, memoryGb: 64 }
 
 # In-cluster Valkey backs the auth rate limiter (Hammer.Redis). The
 # chart wires TUIST_REDIS_URL to the embedded Service; without it the

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -105,9 +105,29 @@ independent workqueues:
     capped at the two M4-XL hosts compose to ten. Inside the cap, seats
     go load first, then warm floor, then headroom, one Pod per pool per
     round (so contenders do not both lose a seat) in name order (so the
-    split is stable across reconciles). darwin only — Linux kata pins
-    memory and oversubscribes CPU by design, and those hosts are
-    homogeneous, so the byte budget is already exact there.
+    split is stable across reconciles).
+
+    Both platforms. It was darwin-only until 2026-09-02, on the grounds
+    that kata pins memory and oversubscribes CPU so the byte budget was
+    already exact on a homogeneous Linux fleet. Neither half held.
+    `podtemplate` sets the runner container's CPU request equal to its
+    limit equal to the shape, so kube-scheduler bin-packs on the full
+    vCPU and a 16 vCPU Pod costing 16.25 with kata's overhead seats
+    exactly once on a 31-vCPU RISE-L, where the byte budget reads three.
+    And a fleet-wide byte sum cannot see per-node packing at all: six
+    `4vcpu-16gb` Pods fill 111 of a box's 117 GiB, so the leftovers add
+    up to budget that seats nothing. On 2026-09-02 the autoscaler
+    targeted 67 of that shape where 24 fit, and the excess held the
+    provisioning ceiling against every sibling.
+
+    The seat divisor is the *placement* shape (`placementShapeOf`): the
+    Pod's own request plus the RuntimeClass `podFixed` overhead the
+    scheduler charges at admission. `perPodCost` reads the same overhead
+    through the same helper, so the byte budget and the seat cap can
+    never disagree about what one Pod costs. Deriving the cap from live
+    node allocatable is also why no per-shape `maxReplicas` belongs in
+    values: that would be a second copy of this arithmetic, stale the
+    moment a box is added, lost, or re-SKU'd.
 
     **Node reservation.** Runs on BOTH fleets. A shape needing more of a
     host than any single smaller Pod does cannot accumulate the room on

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -275,6 +275,21 @@ independent workqueues:
   never re-added, so a Pod that turns out to be unschedulable after
   ungating is back to holding a slot with no way to reclaim it.
 
+  The ceiling is shared, so it is also divided. A pool's own share
+  (`poolCap`) is the fleet ceiling minus one for every sibling pool that
+  has a replica gap and nothing provisioning; it never drops below one.
+  A pool at its share is refused with `reason="pool_share"` even when
+  the fleet count is under the ceiling. Without this, the first pool to
+  fill the budget kept it: on 2026-09-02 `linux-4vcpu-16gb`, targeted
+  far above what the fleet seats, held all four slots with Pods
+  Pending on `Insufficient memory`, recreated each one the instant the
+  unschedulable reap released it, and `linux-2vcpu-8gb` was refused
+  creation for over an hour with 143 jobs queued. The fleet count is
+  still what bounds the burst; the share only decides who may top it
+  back up after a reap, so the reap that already existed becomes the
+  moment a starved sibling gets its slot, within one
+  `startTimeoutSeconds`.
+
   Pod creates are visible to the cached client asynchronously. The
   reconciler therefore keeps a 30-second in-process reservation for each
   successful create and counts it until the cache observes the Pod. This

--- a/infra/runners-controller/controllers/autoscaler_controller.go
+++ b/infra/runners-controller/controllers/autoscaler_controller.go
@@ -331,6 +331,57 @@ func podShapeOf(pool *tuistv1.RunnerPool) podShape {
 	return podShape{cpuMilli: pool.Spec.PodCPUMilli, memoryMB: pool.Spec.PodMemoryMB}
 }
 
+// placementShapeOf is podShapeOf plus the RuntimeClass overhead the
+// scheduler adds at admission, which is the footprint a node is actually
+// asked to seat. Under kata a 16 GiB shape costs 18.5 GiB and a 4 vCPU
+// shape costs 4.25, so dividing a node's allocatable by the bare shape
+// reports seats that do not exist: 117 GiB / 16 GiB is seven where the
+// truth is six. Runtimes without overhead (macOS Tart guests) return the
+// bare shape unchanged, so both platforms use one definition.
+//
+// This is also the right grouping key for capByShape: two pools whose
+// Pods request the same resources but run under different RuntimeClasses
+// do not compete for the same node slots.
+func (r *AutoscalerReconciler) placementShapeOf(ctx context.Context, pool *tuistv1.RunnerPool) (podShape, error) {
+	shape := podShapeOf(pool)
+
+	overheadCPU, overheadMemory, err := r.runtimeClassOverhead(ctx, pool)
+	if err != nil {
+		return podShape{}, err
+	}
+	shape.cpuMilli += int32(overheadCPU)
+	shape.memoryMB += int32(overheadMemory / (1024 * 1024))
+	return shape, nil
+}
+
+// runtimeClassOverhead reads the pool's RuntimeClass podFixed overhead as
+// (CPU milli, memory bytes). No RuntimeClass, or one without overhead,
+// is zero rather than an error. A RuntimeClass that is named but cannot
+// be read IS an error: scaling without known admission overhead
+// overcommits the fleet.
+func (r *AutoscalerReconciler) runtimeClassOverhead(ctx context.Context, pool *tuistv1.RunnerPool) (int64, int64, error) {
+	if pool.Spec.RuntimeClass == "" {
+		return 0, 0, nil
+	}
+
+	runtimeClass := &nodev1.RuntimeClass{}
+	if err := r.Get(ctx, client.ObjectKey{Name: pool.Spec.RuntimeClass}, runtimeClass); err != nil {
+		return 0, 0, fmt.Errorf("%w: get RuntimeClass %q: %w", errPodCostUnavailable, pool.Spec.RuntimeClass, err)
+	}
+	if runtimeClass.Overhead == nil {
+		return 0, 0, nil
+	}
+
+	var cpuMilli, memoryBytes int64
+	if cpu := runtimeClass.Overhead.PodFixed.Cpu(); cpu != nil {
+		cpuMilli = cpu.MilliValue()
+	}
+	if memory := runtimeClass.Overhead.PodFixed.Memory(); memory != nil {
+		memoryBytes = memory.Value()
+	}
+	return cpuMilli, memoryBytes, nil
+}
+
 func (s podShape) key() string {
 	return fmt.Sprintf("%dm-%dMi", s.cpuMilli, s.memoryMB)
 }
@@ -357,16 +408,16 @@ func (r *AutoscalerReconciler) shapePlacementCaps(
 	pool *tuistv1.RunnerPool,
 	shapes map[string]podShape,
 ) (map[string]int32, error) {
-	if pool.Spec.OS != macosNodeOSDarwin || len(shapes) == 0 {
+	if len(shapes) == 0 {
 		return nil, nil
 	}
 
+	// fleetNodeSelector mirrors the nodeSelector podtemplate stamps on
+	// these Pods, so the cap counts exactly the nodes the scheduler will
+	// consider.
 	var nodes corev1.NodeList
-	if err := r.List(ctx, &nodes, client.MatchingLabels{
-		macosFleetLabel: pool.Spec.FleetSelector,
-		nodeOSLabel:     macosNodeOSDarwin,
-	}); err != nil {
-		return nil, fmt.Errorf("list macOS fleet nodes for shape caps: %w", err)
+	if err := r.List(ctx, &nodes, fleetNodeSelector(pool)); err != nil {
+		return nil, fmt.Errorf("list %s fleet nodes for shape caps: %w", pool.Spec.OS, err)
 	}
 
 	caps := make(map[string]int32, len(shapes))
@@ -461,21 +512,11 @@ func (r *AutoscalerReconciler) fleetCapacity(ctx context.Context, pool *tuistv1.
 func (r *AutoscalerReconciler) perPodCost(ctx context.Context, pool *tuistv1.RunnerPool) (int64, error) {
 	cost := int64(pool.Spec.PodMemoryMB) * 1024 * 1024
 
-	if pool.Spec.RuntimeClass == "" {
-		return cost, nil
+	_, overheadMemory, err := r.runtimeClassOverhead(ctx, pool)
+	if err != nil {
+		return 0, err
 	}
-
-	runtimeClass := &nodev1.RuntimeClass{}
-	if err := r.Get(ctx, client.ObjectKey{Name: pool.Spec.RuntimeClass}, runtimeClass); err != nil {
-		return 0, fmt.Errorf("%w: get RuntimeClass %q: %w", errPodCostUnavailable, pool.Spec.RuntimeClass, err)
-	}
-	if runtimeClass.Overhead == nil {
-		return cost, nil
-	}
-	if memory := runtimeClass.Overhead.PodFixed.Memory(); memory != nil {
-		cost += memory.Value()
-	}
-	return cost, nil
+	return cost + overheadMemory, nil
 }
 
 // gatherFleetDemands builds the allocator input for every
@@ -555,7 +596,10 @@ func (r *AutoscalerReconciler) gatherFleetDemands(
 			continue
 		}
 
-		shape := podShapeOf(p)
+		shape, err := r.placementShapeOf(ctx, p)
+		if err != nil {
+			return nil, nil, fmt.Errorf("placement shape for %q: %w", p.Name, err)
+		}
 		shapes[shape.key()] = shape
 
 		demands = append(demands, scaling.PoolDemand{

--- a/infra/runners-controller/controllers/autoscaler_controller_test.go
+++ b/infra/runners-controller/controllers/autoscaler_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -999,22 +1000,145 @@ func TestAutoscaler_ShapePlacementCapsBindOnCPUNotOnlyMemory(t *testing.T) {
 	}
 }
 
-// Linux opts out: kata pins memory per sandbox and oversubscribes CPU,
-// so a CPU quotient would cap a fleet that is not CPU-bound.
-func TestAutoscaler_ShapePlacementCapsSkipLinux(t *testing.T) {
+// Linux is capped too. It used to opt out on the grounds that kata
+// oversubscribes CPU, so a CPU quotient would cap a fleet that is not
+// CPU-bound. That does not hold on this fleet: podtemplate sets the
+// runner container's CPU request equal to its limit equal to the shape,
+// so kube-scheduler bin-packs on the full vCPU and a 16 vCPU Pod costing
+// 16.25 with kata's overhead seats exactly once on a 31-vCPU RISE-L. The
+// min() of the two quotients is what the scheduler does, so taking it
+// here is agreement rather than pessimism.
+//
+// The production topology: 4 RISE-L at 31 vCPU / 117 GiB allocatable.
+func TestAutoscaler_ShapePlacementCapsCountLinuxSeats(t *testing.T) {
+	const fleet = "runners-linux"
+
+	objects := []client.Object{}
+	for i := 0; i < 4; i++ {
+		objects = append(objects, linuxNodeWithResources(fmt.Sprintf("rise-l-%d", i), fleet, 31, 117*1024))
+	}
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	r := &AutoscalerReconciler{Client: fakeClient, Scheme: scheme}
+
+	// Placement shapes: the advertised shape plus kata's 250m / 2560Mi.
+	small := podShape{cpuMilli: 2250, memoryMB: 8*1024 + 2560}
+	big := podShape{cpuMilli: 4250, memoryMB: 16*1024 + 2560}
+	ceiling := podShape{cpuMilli: 16250, memoryMB: 32*1024 + 2560}
+	pool := &tuistv1.RunnerPool{Spec: tuistv1.RunnerPoolSpec{OS: "linux", FleetSelector: fleet}}
+
+	caps, err := r.shapePlacementCaps(context.Background(), pool, map[string]podShape{
+		small.key(): small, big.key(): big, ceiling.key(): ceiling,
+	})
+	if err != nil {
+		t.Fatalf("shapePlacementCaps: %v", err)
+	}
+
+	if got := caps[small.key()]; got != 44 {
+		t.Fatalf("2vcpu-8gb seats = %d, want 44 (11 per box, memory-bound)", got)
+	}
+	// The shape that starved the fleet on 2026-09-02: the autoscaler
+	// targeted 67 of these where 24 fit.
+	if got := caps[big.key()]; got != 24 {
+		t.Fatalf("4vcpu-16gb seats = %d, want 24 (6 per box, memory-bound)", got)
+	}
+	// CPU binds this one: 117 GiB would suggest three per box, but two
+	// would need 32.5 of 31 vCPU.
+	if got := caps[ceiling.key()]; got != 4 {
+		t.Fatalf("16vcpu-32gb seats = %d, want 4 (1 per box, CPU-bound)", got)
+	}
+}
+
+// An unrecognised OS is left uncapped rather than capped against the
+// wrong node set: fleetNodeSelector falls through to darwin, which
+// matches no node in a Linux fleet, and a zero cap would freeze the pool
+// at zero replicas.
+func TestAutoscaler_ShapePlacementCapsNoNodesLeavesZero(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	r := &AutoscalerReconciler{Client: fakeClient, Scheme: scheme}
 
-	shape := podShape{cpuMilli: 2000, memoryMB: 8192}
+	shape := podShape{cpuMilli: 2250, memoryMB: 10752}
 	pool := &tuistv1.RunnerPool{Spec: tuistv1.RunnerPoolSpec{OS: "linux", FleetSelector: "runners-linux"}}
 
 	caps, err := r.shapePlacementCaps(context.Background(), pool, map[string]podShape{shape.key(): shape})
 	if err != nil {
 		t.Fatalf("shapePlacementCaps: %v", err)
 	}
-	if caps != nil {
-		t.Fatalf("Linux must not be capped, got %v", caps)
+	if got := caps[shape.key()]; got != 0 {
+		t.Fatalf("seats with no nodes = %d, want 0", got)
+	}
+}
+
+// The seat cap and the byte budget must charge a Pod the same overhead,
+// or the two halves of the allocator disagree about what fits.
+func TestAutoscaler_PlacementShapeIncludesRuntimeClassOverhead(t *testing.T) {
+	pool := linuxFleetPool("linux", 1, 16*1024, 1, 30)
+	pool.Spec.PodCPUMilli = 4000
+	pool.Spec.RuntimeClass = "kata-qemu"
+	runtimeClass := &nodev1.RuntimeClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "kata-qemu"},
+		Overhead: &nodev1.Overhead{
+			PodFixed: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+				corev1.ResourceMemory: resource.MustParse("2560Mi"),
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = nodev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(runtimeClass).Build()
+	r := &AutoscalerReconciler{Client: fakeClient, Scheme: scheme}
+
+	shape, err := r.placementShapeOf(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("placementShapeOf: %v", err)
+	}
+	if shape.cpuMilli != 4250 {
+		t.Fatalf("cpuMilli = %d, want 4250 (4000 + kata 250m)", shape.cpuMilli)
+	}
+	if shape.memoryMB != 16*1024+2560 {
+		t.Fatalf("memoryMB = %d, want %d (16 GiB + kata 2560Mi)", shape.memoryMB, 16*1024+2560)
+	}
+}
+
+// A named RuntimeClass that cannot be read freezes the pool rather than
+// silently sizing it as if the sandbox were free.
+func TestAutoscaler_PlacementShapeFailsOnUnreadableRuntimeClass(t *testing.T) {
+	pool := linuxFleetPool("linux", 1, 8192, 1, 30)
+	pool.Spec.RuntimeClass = "kata-qemu"
+
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = nodev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &AutoscalerReconciler{Client: fakeClient, Scheme: scheme}
+
+	if _, err := r.placementShapeOf(context.Background(), pool); !errors.Is(err, errPodCostUnavailable) {
+		t.Fatalf("err = %v, want errPodCostUnavailable", err)
+	}
+}
+
+func linuxNodeWithResources(name, fleetSelector string, cpu int64, memoryMB int64) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"node.cluster.x-k8s.io/pool": fleetSelector,
+				"kubernetes.io/os":           "linux",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewQuantity(cpu, resource.DecimalSI),
+				corev1.ResourceMemory: *resource.NewQuantity(memoryMB*1024*1024, resource.BinarySI),
+			},
+		},
 	}
 }

--- a/infra/runners-controller/controllers/provisioning.go
+++ b/infra/runners-controller/controllers/provisioning.go
@@ -82,6 +82,7 @@ type provisioningAdmission struct {
 	pendingForPool  int
 	pendingForFleet int
 	cap             int
+	poolCap         int
 	healthyNodes    int
 	blockedReason   string
 }
@@ -157,17 +158,23 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 	// rather than by being discounted here.
 	observed := make(map[string]struct{}, len(pods.Items))
 	pendingForFleet := 0
-	pendingForPool := 0
+	pendingByPool := make(map[string]int, len(poolNames))
+	aliveByPool := make(map[string]int, len(poolNames))
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 		observed[pod.Namespace+"/"+pod.Name] = struct{}{}
-		if _, ok := poolNames[pod.Labels["tuist.dev/runner-pool"]]; !ok || !isLinuxProvisioningPod(pod) {
+		owner := pod.Labels["tuist.dev/runner-pool"]
+		if _, ok := poolNames[owner]; !ok {
+			continue
+		}
+		if isAlive(pod) {
+			aliveByPool[owner]++
+		}
+		if !isLinuxProvisioningPod(pod) {
 			continue
 		}
 		pendingForFleet++
-		if pod.Labels["tuist.dev/runner-pool"] == pool.Name {
-			pendingForPool++
-		}
+		pendingByPool[owner]++
 	}
 
 	reserved, reservedByPool := r.creationReservations.reconcile(
@@ -177,7 +184,38 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 		r.now(),
 	)
 	pendingForFleet += reserved
-	pendingForPool += reservedByPool[pool.Name]
+	for name, count := range reservedByPool {
+		pendingByPool[name] += count
+	}
+	pendingForPool := pendingByPool[pool.Name]
+
+	// The ceiling is shared, so one pool can hold all of it. Four Pods of a
+	// shape no node can seat sit Unschedulable until unschedulableTimedOut
+	// reaps them, the pool recreates them at once, and every sibling shape
+	// is refused creation for as long as the shortfall lasts: the default
+	// shape stayed at zero Pods for an hour with a full queue while a
+	// larger shape held the whole budget with Pods that could never bind.
+	//
+	// So a pool's own share of the ceiling shrinks by one for each sibling
+	// that has a replica gap and nothing provisioning. The fleet count is
+	// untouched (the burst guarantee is that at most cap sandboxes can start
+	// together, and that still holds); what changes is who may top the count
+	// back up after a reap. A hog at its share cannot recreate the Pod the
+	// timeout released, so the slot goes to the sibling that had none.
+	siblingsNeedingSlot := 0
+	for i := range pools.Items {
+		sibling := &pools.Items[i]
+		if _, ok := poolNames[sibling.Name]; !ok || sibling.Name == pool.Name {
+			continue
+		}
+		if int(sibling.Spec.Replicas) > aliveByPool[sibling.Name] && pendingByPool[sibling.Name] == 0 {
+			siblingsNeedingSlot++
+		}
+	}
+	poolCap := capN - siblingsNeedingSlot
+	if poolCap < 1 {
+		poolCap = 1
+	}
 
 	var nodes corev1.NodeList
 	if err := r.List(ctx, &nodes, client.MatchingLabels{
@@ -193,6 +231,7 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 		pendingForPool:  pendingForPool,
 		pendingForFleet: pendingForFleet,
 		cap:             capN,
+		poolCap:         poolCap,
 		healthyNodes:    healthyNodes,
 	}
 	if healthyNodes == 0 {
@@ -203,7 +242,14 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 		admission.blockedReason = "fleet_cap"
 		return admission, nil
 	}
+	if pendingForPool >= poolCap {
+		admission.blockedReason = "pool_share"
+		return admission, nil
+	}
 	admission.available = capN - pendingForFleet
+	if share := poolCap - pendingForPool; share < admission.available {
+		admission.available = share
+	}
 	return admission, nil
 }
 

--- a/infra/runners-controller/controllers/provisioning_test.go
+++ b/infra/runners-controller/controllers/provisioning_test.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -57,8 +58,11 @@ func TestProvisioningAdmissionUsesLowestSiblingCap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("provisioningAdmission: %v", err)
 	}
-	if admission.cap != 2 || admission.available != 2 {
-		t.Fatalf("admission = %+v, want sibling minimum cap and availability 2", admission)
+	// The sibling also has a gap and nothing provisioning, so one of the two
+	// slots is reserved for it: the ceiling is the sibling minimum, the share
+	// is what this pool may take of it.
+	if admission.cap != 2 || admission.poolCap != 1 || admission.available != 1 {
+		t.Fatalf("admission = %+v, want sibling minimum cap 2 and a share of 1", admission)
 	}
 }
 
@@ -150,6 +154,91 @@ func TestProvisioningAdmissionHoldsCapAsUnschedulablePodsBecomeSchedulable(t *te
 	}
 	if admission.blockedReason != "fleet_cap" || admission.available != 0 {
 		t.Fatalf("admission = %+v, want the ceiling held across the transition", admission)
+	}
+}
+
+// The starvation seen on 2026-09-02: one shape holds the entire fleet ceiling
+// with Pods no node can seat, and every sibling with a replica gap is refused
+// creation for as long as the shortfall lasts. The fleet ceiling still holds
+// (burst guarantee), but the hog's own share shrinks by one per sibling that
+// has a gap and nothing provisioning, so it may not top the count back up
+// after unschedulableTimedOut reaps one of its Pods.
+func TestProvisioningAdmissionHogCannotRecreateAfterReapWhileSiblingStarves(t *testing.T) {
+	scheme := mustScheme(t)
+	hog := newLinuxKataPool("linux-big", 8, 4)
+	starved := newLinuxKataPool("linux-small", 8, 4)
+	node := readyLinuxRunnerNode("runner-node", hog.Spec.FleetSelector)
+	// After the reap: three of the hog's four parked Pods remain, so the fleet
+	// count (3) is under the ceiling (4) and the freed slot is up for grabs.
+	stuck := []*corev1.Pod{
+		unschedulableRunnerPod("linux-big-runner-1", hog.Name, time.Unix(1000, 0)),
+		unschedulableRunnerPod("linux-big-runner-2", hog.Name, time.Unix(1000, 0)),
+		unschedulableRunnerPod("linux-big-runner-3", hog.Name, time.Unix(1000, 0)),
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(hog, starved, node, stuck[0], stuck[1], stuck[2]).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	hogAdmission, err := r.provisioningAdmission(context.Background(), hog)
+	if err != nil {
+		t.Fatalf("provisioningAdmission(hog): %v", err)
+	}
+	if hogAdmission.poolCap != 3 || hogAdmission.blockedReason != "pool_share" || hogAdmission.available != 0 {
+		t.Fatalf("hog admission = %+v, want share 3 (cap 4 minus one starved sibling) and no availability", hogAdmission)
+	}
+
+	starvedAdmission, err := r.provisioningAdmission(context.Background(), starved)
+	if err != nil {
+		t.Fatalf("provisioningAdmission(starved): %v", err)
+	}
+	if starvedAdmission.blockedReason != "" || starvedAdmission.available != 1 {
+		t.Fatalf("starved admission = %+v, want the freed slot", starvedAdmission)
+	}
+}
+
+// A pool's share only shrinks for siblings that actually need a slot: one with
+// no replica gap, or one already provisioning something, takes nothing away.
+func TestProvisioningAdmissionShareIgnoresSiblingsWithoutAGap(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux-a", 8, 4)
+	satisfied := newLinuxKataPool("linux-b", 0, 4)
+	provisioning := newLinuxKataPool("linux-c", 8, 4)
+	node := readyLinuxRunnerNode("runner-node", pool.Spec.FleetSelector)
+	cPending := unschedulableRunnerPod("linux-c-runner-1", provisioning.Name, time.Unix(1000, 0))
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(pool, satisfied, provisioning, node, cPending).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	admission, err := r.provisioningAdmission(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.poolCap != 4 {
+		t.Fatalf("poolCap = %d, want the full cap: no sibling both has a gap and holds nothing", admission.poolCap)
+	}
+	if admission.available != 3 {
+		t.Fatalf("available = %d, want cap 4 minus the one sibling Pod already provisioning", admission.available)
+	}
+}
+
+// The share never drops below one, so a pool surrounded by starving siblings
+// can still make progress rather than deadlocking the fleet.
+func TestProvisioningAdmissionShareFloorsAtOne(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux-a", 8, 2)
+	objs := []client.Object{pool, readyLinuxRunnerNode("runner-node", pool.Spec.FleetSelector)}
+	for _, name := range []string{"linux-b", "linux-c", "linux-d"} {
+		objs = append(objs, newLinuxKataPool(name, 8, 2))
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	admission, err := r.provisioningAdmission(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.poolCap != 1 || admission.available != 1 {
+		t.Fatalf("admission = %+v, want a share floored at one", admission)
 	}
 }
 

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -497,6 +497,7 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					"pendingForPool", admission.pendingForPool,
 					"pendingForFleet", admission.pendingForFleet,
 					"cap", admission.cap,
+					"poolCap", admission.poolCap,
 					"healthyNodes", admission.healthyNodes,
 				)
 			}

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -1325,12 +1325,15 @@ func TestReconcileCapsLinuxKataProvisioningAcrossSiblingPools(t *testing.T) {
 		t.Fatalf("first pool requeue = %s, want %s while gap remains", result.RequeueAfter, provisioningRequeueAfter)
 	}
 
+	// The sibling has a gap and nothing provisioning, so the first pool's
+	// share of the ceiling is 3 of 4: one slot is left for the sibling rather
+	// than the first pool to reconcile taking the whole budget.
 	var pods corev1.PodList
 	if err := c.List(context.Background(), &pods); err != nil {
 		t.Fatalf("list first pool pods: %v", err)
 	}
-	if len(pods.Items) != 4 {
-		t.Fatalf("first reconcile created %d Pods, want shared cap 4", len(pods.Items))
+	if len(pods.Items) != 3 {
+		t.Fatalf("first reconcile created %d Pods, want its share of 3 under the shared cap 4", len(pods.Items))
 	}
 
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn(poolB.Namespace, poolB.Name)}); err != nil {
@@ -1341,15 +1344,24 @@ func TestReconcileCapsLinuxKataProvisioningAcrossSiblingPools(t *testing.T) {
 		t.Fatalf("list sibling pool pods: %v", err)
 	}
 	if len(pods.Items) != 4 {
-		t.Fatalf("sibling reconcile exceeded shared cap: got %d Pods, want 4", len(pods.Items))
+		t.Fatalf("sibling reconcile should take the reserved slot up to the shared cap: got %d Pods, want 4", len(pods.Items))
+	}
+	siblingPods := 0
+	for i := range pods.Items {
+		if pods.Items[i].Labels["tuist.dev/runner-pool"] == poolB.Name {
+			siblingPods++
+		}
+	}
+	if siblingPods != 1 {
+		t.Fatalf("sibling created %d Pods, want exactly the 1 slot reserved for it", siblingPods)
 	}
 
 	gotPool := &tuistv1.RunnerPool{}
 	if err := c.Get(context.Background(), nn(poolA.Namespace, poolA.Name), gotPool); err != nil {
 		t.Fatalf("get first pool: %v", err)
 	}
-	if gotPool.Status.ObservedReplicas != 4 {
-		t.Fatalf("ObservedReplicas = %d, want only the 4 Pods actually created", gotPool.Status.ObservedReplicas)
+	if gotPool.Status.ObservedReplicas != 3 {
+		t.Fatalf("ObservedReplicas = %d, want only the 3 Pods actually created", gotPool.Status.ObservedReplicas)
 	}
 }
 


### PR DESCRIPTION
## What changed

Three changes against the chain that starved the default Linux shape for over an hour on 2026-09-02, plus a runbook entry and an alert created directly in Grafana.

1. **A seat cap derived from live node capacity** (`infra/runners-controller/controllers/autoscaler_controller.go`). `shapePlacementCaps` already sums each Ready node's own `min(cpu, memory)` quotient per shape and hands it to `AllocateFleet`, which clamps every pool sharing that shape. It was gated to macOS. Ungating it for Linux means no pool can be targeted above what the fleet will actually seat, recomputed every reconcile from live allocatable rather than from a number in values.
2. **A per-pool share of the provisioning ceiling** (`infra/runners-controller/controllers/provisioning.go`). A pool's share is the fleet cap minus one for every sibling that has a replica gap and nothing provisioning, floored at one; a pool at its share is refused with `reason="pool_share"`. The fleet count is untouched, so the burst ceiling the admission exists for still holds; the share only decides who may top the count back up after a reap.
3. **Alert `Runner pool starved`** (Grafana uid `afx2w6cpurk00b`, folder Runners, severity critical, 10 minutes): a Linux pool with dispatchable queued jobs (queue length minus cap-withheld) and zero Pods of any phase. Runbook entry added to `infra/helm/k8s-monitoring/alerts.md`.

## Why, and the root cause

`linux-2vcpu-8gb`, the shape behind `tuist-linux`, sat at zero Pods from about 21:00 to 22:00 UTC with 143 jobs queued, while `linux-4vcpu-16gb` held all 24 seats. Not disk, not ghosts, not the account cap (the account used 92 of 512 vCPU). The chain:

- Every Linux shape allowed `maxReplicas: 120`, so the autoscaler drove `4vcpu-16gb` to a target of 67 on a fleet that seats 24 of that shape (16 GiB plus 2.5 GiB overhead, six per 117 GiB box). The excess sat Pending on `Insufficient memory`.
- The provisioning admission budgets Pending Pods fleet-wide (`maxConcurrentPerFleetSelector`, default 4) and counts every sibling's. Those four dead Pods held the whole budget, so every other shape logged `admission left replica gap, reason: fleet_cap, creating: 0` on every reconcile. The controller's own comment predicted it: "Left in place it starves every sibling shape sharing the FleetSelector".
- The 300s `unschedulableTimedOut` reap only cycled it: the hog recreated each Pod the instant it was released, so the starved pool never even entered the scheduler's race for a freed slot.
- The production cascade's first job, `Check for releasable changes`, runs on `tuist-linux`. It queued behind the starvation, so nothing could deploy, including `runners-controller@0.22.1` and the fix for the day's earlier incident. That job stays on the fleet: the three changes here are meant to keep the fleet able to serve it, rather than routing around it.

The incident lever was patching the hog's `maxReplicas` to 20. Within the hour the starvation mirrored: `2vcpu-8gb`, still targeted at 87, held the budget and `4vcpu-16gb` sat at zero Pods with 17 `tuist-linux-large` jobs queued (where the cascade's `release-server` runs), so the small pool was capped at 44 by hand as well. Any unbounded pool does this; the values in this PR are what re-adopt both patches. The autoscaler honoured it after its 300s scale-down cooldown, reaped the parked Pods, and the small pool went from zero to eight Pods within ten seconds; the gating job ran two minutes later.

## Why derived rather than hardcoded

The first version of this PR hardcoded a per-shape `maxReplicas` table in the production values. That was a stale duplicate: `shapePlacementCaps` computes the same arithmetic from live node allocatable, so the table would go wrong the moment a box is added, lost or re-SKU'd, and `fleetCapacity`'s own comment rejects exactly that ("a second number an operator has to remember to keep in sync"). `maxReplicas` goes back to being the loose per-pool backstop it was, at 120, which is also what gates whether the allocator runs at all.

The macOS-only gate was deliberate, with a test asserting it, on two grounds that do not hold on this fleet. Kata does not oversubscribe CPU here: `podtemplate` sets the runner container's CPU request equal to its limit equal to the shape, so kube-scheduler bin-packs on the full vCPU and a 16 vCPU Pod costing 16.25 with the RuntimeClass overhead seats exactly once on a 31-vCPU RISE-L, where the byte budget reads three. And the byte budget cannot see per-node packing on a homogeneous fleet either: six `4vcpu-16gb` Pods fill 111 of a box's 117 GiB, so the six-GiB remainders sum into fleet budget that seats nothing. Taking `min(cpu, memory)` per node is what the scheduler does, so it is agreement rather than pessimism. That test is replaced by one asserting the real seat counts for this fleet.

The seat divisor is the placement shape, the Pod's own request plus the RuntimeClass `podFixed` overhead the scheduler charges at admission. Dividing by the bare shape reports seats that do not exist (117 GiB / 16 GiB is seven where the truth is six). `perPodCost` now reads that overhead through the same helper, so the byte budget and the seat cap cannot disagree about what one Pod costs.

## Why the admission share as well

Bounding the target alone would have prevented this instance but leaves the admission unfair: any pool that legitimately fills the budget keeps it for as long as its Pods stay Pending. The share fixes the mechanism without weakening the burst guarantee, which is why it is a share and not a discount: discounting unschedulable Pods from the fleet count would let several pools each park a full budget and start together when capacity returns, exactly what the ceiling prevents, and the existing test `TestProvisioningAdmissionHoldsCapAsUnschedulablePodsBecomeSchedulable` guards that. With the share, the fleet count still caps concurrent sandbox starts; only the recreate after a reap is redistributed, so a starved sibling gets its slot within one `startTimeoutSeconds`.

The alert is deliberately narrower and earlier than `Runner queue age`, which did fire tonight but after 30 minutes and without naming the mechanism. "Queue but no Pods at all" is the signature of being refused creation rather than waiting on capacity; subtracting `queue_withheld` keeps a capped account from tripping it, and counting Pods of every phase keeps a pool that merely has Pending Pods from tripping it.

## Impact

On deploy: every Linux pool's target is clamped to the fleet's real seats for its shape, today 44 for the default `2vcpu-8gb`, 24 for `4vcpu-16gb`, 4 for `16vcpu-32gb`, and those numbers move on their own when the fleet does. The `maxReplicas: 20` and `44` patched onto the two pools during the incident can be dropped once this is live. A pool that fills the budget while a sibling has a gap is refused its recreate after a reap instead of holding the budget indefinitely. The alert is live now, independent of this PR.

## Validation

- `go vet ./...` and `go test ./...` in `infra/runners-controller` pass. Existing admission tests are kept, with two expectations updated to the share (the first pool to reconcile now takes 3 of a shared 4 and its sibling takes the 4th, rather than first-come-takes-all). New tests: a hog at its share is refused while its starved sibling is admitted the freed slot; siblings without a gap, or already provisioning, take nothing off the share; the share floors at one.
- `helm template` of `templates/runner-pool.yaml` with production's `runnersFleetLinux` block renders every Linux pool with the single `maxReplicas: 120` backstop and the default shape's floor of 12, i.e. the values are back to main apart from one comment.
- New autoscaler tests assert the seat counts for the production topology (4 RISE-L at 31 vCPU / 117 GiB): 44 for `2vcpu-8gb` and 24 for `4vcpu-16gb`, both memory-bound, and 4 for `16vcpu-32gb`, which CPU binds at one per box where memory alone would say three. Plus: the placement shape carries the RuntimeClass overhead, an unreadable RuntimeClass fails closed, and a fleet with no matching nodes caps at zero rather than erroring.
- The Grafana rule evaluates healthy (`health: ok`) against live production metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


