### PR TITLE
fix(server): refuse a Kura service region the deployment does not serve

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -186,6 +186,17 @@ server:
       # an implementation detail behind it (ovhFleet below, replicas 1) —
       # mirroring staging.
       value: eu-central,scw-fr-par-runners,ca-east
+    - name: TUIST_KURA_AIR_REGION
+      # Air is funded on the ca-east OVH validation box, as on staging.
+      # Without this the default names us-east, which this environment does not
+      # serve, so every Air account resolved into a region the lifecycle loop
+      # never iterates and no instance was ever provisioned.
+      value: ca-east
+    - name: TUIST_KURA_AIR_REGIONS
+      # Both public regions carry an Air budget, matching staging, so
+      # traffic-driven placement is observable rather than collapsing onto a
+      # single funded region.
+      value: ca-east,eu-central
     # Wave 0 (canary) of a progressive Kura runtime rollout (spec #79).
     # This environment's rollouts run expedited, so the value only shapes
     # interim-paced ordering here; kept aligned with production.

--- a/server/lib/tuist/kura/account_policies.ex
+++ b/server/lib/tuist/kura/account_policies.ex
@@ -252,12 +252,14 @@ defmodule Tuist.Kura.AccountPolicies do
   # Europe is today, and the refusal is counted: sustained refused demand is
   # what an Air budget in a new region gets decided from.
   defp effective_service_region(%Account{} = account, :air, lookups) do
-    # Funding is the gate, not availability: funding a region the deployment
-    # does not serve is a configuration error rather than a placement, and one
-    # the refusal counter and the unmet-preference counter both surface. Air
-    # has always resolved this way, and filtering here would instead refuse
-    # every Air account in a deployment that serves a narrowed region list.
-    case account |> permitted_regions() |> restrict_to_plan(:air) do
+    # Funding is the gate, and the deployment has to serve what it funds.
+    # Funding a region it does not serve is a configuration error, and
+    # resolving into one anyway is silent: demand lands in a region
+    # `Lifecycle.lifecycle_regions/0` never iterates, so the account reports as
+    # provisioning forever while nothing ever provisions it. Refusing surfaces
+    # it on the refusal counter instead, which is what quantifies the case for
+    # funding a region the deployment actually serves.
+    case account |> permitted_regions() |> restrict_to_plan(:air) |> Enum.filter(&Regions.available?/1) do
       [] ->
         {:error, :service_region_unavailable}
 
@@ -283,16 +285,20 @@ defmodule Tuist.Kura.AccountPolicies do
 
     case assignment do
       %AccountRegionPolicy{service_region: service_region} when honoured ->
-        assigned_service_region(service_region)
+        served_service_region(service_region)
 
       _assignment_absent_or_outside_residency ->
         # Only a served region can be chosen fresh. Resolving into one the
         # catalog lists but the deployment does not serve would record demand
         # in a region `Lifecycle.lifecycle_regions/0` never iterates, which is
-        # the same trap `assigned_service_region/1` guards against.
+        # the same trap `served_service_region/1` guards against. The filter
+        # covers what placement picks; the check below covers the residency
+        # default it falls back to, and a placer or live region that is still
+        # permitted but no longer served.
         placeable = Enum.filter(permitted, &Regions.available?/1)
+        service_region = place(account, permitted, placeable, lookups) || residency_default(account)
 
-        {:ok, place(account, permitted, placeable, lookups) || residency_default(account)}
+        served_service_region(service_region)
     end
   end
 
@@ -441,7 +447,7 @@ defmodule Tuist.Kura.AccountPolicies do
   # Refused rather than fallen back to the default region, because silently
   # relocating an explicitly assigned account is what an assignment exists to
   # prevent. The row is untouched and resolves once the region is served.
-  defp assigned_service_region(service_region) do
+  defp served_service_region(service_region) do
     if Regions.available?(service_region) do
       {:ok, service_region}
     else

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -5106,6 +5106,9 @@ defmodule Tuist.AccountsTest do
     test "reports provisioning while the account's instance is not serving yet" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      stub(Environment, :dev?, fn -> false end)
+      stub(Environment, :test?, fn -> false end)
+      stub(Environment, :kura_available_region_ids, fn -> ["us-east", "eu-central"] end)
       stub(Environment, :cache_endpoints, fn -> ["https://default.tuist.dev"] end)
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
@@ -5133,6 +5136,9 @@ defmodule Tuist.AccountsTest do
       # would answer `false` on the request where it matters most and leave the
       # client caching a stand-in lane for its full interval.
       stub(Environment, :tuist_hosted?, fn -> true end)
+      stub(Environment, :dev?, fn -> false end)
+      stub(Environment, :test?, fn -> false end)
+      stub(Environment, :kura_available_region_ids, fn -> ["us-east", "eu-central"] end)
       stub(Environment, :cache_endpoints, fn -> ["https://default.tuist.dev"] end)
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
@@ -5167,6 +5173,9 @@ defmodule Tuist.AccountsTest do
       # These accounts used to be refused a region outright, which left them on
       # a stand-in lane indefinitely with the client told nothing was coming.
       stub(Environment, :tuist_hosted?, fn -> true end)
+      stub(Environment, :dev?, fn -> false end)
+      stub(Environment, :test?, fn -> false end)
+      stub(Environment, :kura_available_region_ids, fn -> ["us-east", "eu-central"] end)
       stub(Environment, :cache_endpoints, fn -> ["https://default.tuist.dev"] end)
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
@@ -5218,6 +5227,9 @@ defmodule Tuist.AccountsTest do
     test "records cache demand for the account when a Kura client resolves endpoints" do
       # Given
       stub(Environment, :tuist_hosted?, fn -> true end)
+      stub(Environment, :dev?, fn -> false end)
+      stub(Environment, :test?, fn -> false end)
+      stub(Environment, :kura_available_region_ids, fn -> ["us-east", "eu-central"] end)
       stub(Environment, :cache_endpoints, fn -> ["https://default.tuist.dev"] end)
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)

--- a/server/test/tuist/kura/account_policies_test.exs
+++ b/server/test/tuist/kura/account_policies_test.exs
@@ -16,6 +16,15 @@ defmodule Tuist.Kura.AccountPoliciesTest do
 
   setup :set_mimic_from_context
 
+  # Resolution refuses a region the deployment does not serve, so every test
+  # states the deployment it assumes rather than inheriting the test env's
+  # local-controller-only catalog. `ap-southeast` is deliberately absent: it is
+  # assignment-only, and its tests turn it on where they need it.
+  setup do
+    serving(["us-east", "us-west", "eu-central"])
+    :ok
+  end
+
   describe "resolve/1" do
     test "resolves an account without a subscription to Air in United States East" do
       account = organization_account()
@@ -495,6 +504,59 @@ defmodule Tuist.Kura.AccountPoliciesTest do
     stub(Environment, :kura_available_region_ids, fn -> region_ids end)
   end
 
+  describe "residency admits no served region" do
+    test "refuses rather than resolving into the residency default the deployment does not serve" do
+      # The trap the availability filter on `placeable` exists to close, reached
+      # through the fallback instead of through placement: a US-residency account
+      # in a deployment that serves neither American region has nothing placeable,
+      # and the residency default (`us-east`) names a region nothing provisions in.
+      # Resolving it records demand under a region `Lifecycle.lifecycle_regions/0`
+      # never iterates, so the account reports as provisioning forever while no
+      # instance is ever created.
+      account = organization_account()
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise)
+      account = update_region!(account, :usa)
+      serving(["eu-central", "ca-east"])
+
+      assert AccountPolicies.resolve(account) == {:error, :service_region_unavailable}
+    end
+
+    test "resolves again once the deployment serves a region the residency admits" do
+      account = organization_account()
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :enterprise)
+      account = update_region!(account, :usa)
+      serving(["eu-central", "us-east"])
+
+      assert AccountPolicies.resolve(account) == {:ok, %{plan: :enterprise, service_region: "us-east"}}
+    end
+  end
+
+  describe "Air funded in a region the deployment does not serve" do
+    test "refuses rather than resolving into an unserved funded region" do
+      # What canary was doing for 63 days: Air is funded in `us-east` by
+      # default, canary serves `eu-central`/`ca-east`, and resolution handed
+      # back `us-east` anyway. Demand landed in a region the lifecycle loop
+      # never iterates, no instance was ever created, and the endpoints API
+      # reported the account as provisioning on every poll.
+      account = organization_account()
+      account = update_region!(account, :all)
+      serving(["eu-central", "ca-east"])
+      stub(Environment, :kura_air_region_ids, fn -> ["us-east"] end)
+
+      assert AccountPolicies.resolve(account) == {:error, :service_region_unavailable}
+    end
+
+    test "places Air in a funded region the deployment serves" do
+      account = organization_account()
+      account = update_region!(account, :all)
+      serving(["eu-central", "ca-east"])
+      stub(Environment, :kura_air_region_ids, fn -> ["ca-east", "eu-central"] end)
+
+      assert {:ok, %{plan: :air, service_region: service_region}} = AccountPolicies.resolve(account)
+      assert service_region in ["ca-east", "eu-central"]
+    end
+  end
+
   describe "placement by origin" do
     test "places a new account in the region nearest its traffic" do
       account = organization_account()
@@ -673,6 +735,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       account = Accounts.get_account_from_user(user)
 
       stub(Environment, :kura_air_region_ids, fn -> ["ca-east"] end)
+      serving(["ca-east"])
 
       assert {:ok, %{plan: :air, service_region: "ca-east"}} = AccountPolicies.resolve(account)
     end

--- a/server/test/tuist/kura/demand_test.exs
+++ b/server/test/tuist/kura/demand_test.exs
@@ -12,6 +12,16 @@ defmodule Tuist.Kura.DemandTest do
 
   setup :set_mimic_from_context
 
+  # Resolution refuses a region the deployment does not serve, so these tests
+  # state the deployment they assume rather than inheriting the test env's
+  # local-controller-only catalog.
+  setup do
+    stub(Environment, :dev?, fn -> false end)
+    stub(Environment, :test?, fn -> false end)
+    stub(Environment, :kura_available_region_ids, fn -> ["us-east", "us-west", "eu-central"] end)
+    :ok
+  end
+
   # Tests run with the buffer bypassed by default so async tests cannot flush
   # each other's demand (see `config/test.exs`). These tests are about the
   # buffer itself, so they turn it back on. Safe because the case is

--- a/server/test/tuist/kura/workers/backfill_cache_demand_worker_test.exs
+++ b/server/test/tuist/kura/workers/backfill_cache_demand_worker_test.exs
@@ -18,6 +18,16 @@ defmodule Tuist.Kura.Workers.BackfillCacheDemandWorkerTest do
 
   setup :set_mimic_from_context
 
+  # Resolution refuses a region the deployment does not serve, so these tests
+  # state the deployment they assume rather than inheriting the test env's
+  # local-controller-only catalog.
+  setup do
+    stub(Environment, :dev?, fn -> false end)
+    stub(Environment, :test?, fn -> false end)
+    stub(Environment, :kura_available_region_ids, fn -> ["us-east", "us-west", "eu-central"] end)
+    :ok
+  end
+
   defp account_with_project do
     user = AccountsFixtures.user_fixture()
     account = Accounts.get_account_from_user(user)


### PR DESCRIPTION
## What changed

`AccountPolicies.resolve/1` no longer returns a Kura service region the deployment does not serve. Both plan branches check `Regions.available?/1`, so an account whose funded or default region is unserved is refused with `:service_region_unavailable` instead of resolved.

Canary also gains the Air budget staging already carries.

## Why

Resolution's answer is treated as provisionable by everything downstream. When it named an unserved region:

- `Demand` recorded a lifecycle row for a region `Lifecycle.lifecycle_regions/0` never iterates, so nothing ever picked it up.
- `Demand.instance_expected?/1` reported true off the same `{:ok, _}`, so `/api/cache/endpoints` answered `provisioning` with a 30-second max-age indefinitely.
- Clients re-polled every 30 seconds and kept getting the stand-in endpoint.

Nothing logged, nothing counted. The state is indistinguishable from "an instance is on its way".

## Root cause, as found on canary

Canary serves `eu-central`, `scw-fr-par-runners` and `ca-east`, but sets neither `TUIST_KURA_AIR_REGION` nor `TUIST_KURA_AIR_REGIONS`, so `kura_air_region_ids/0` defaults to `us-east` alone. Every Air account there resolved to `us-east`, a region canary does not serve.

Observed before changing anything:

- The reconciler Oban cron ran every minute and succeeded, ~50ms per tick.
- `[Kura.Lifecycle]` produced zero log lines in 7 days (19M lines scanned in Loki). `cold_provision` logs on both success and failure, so the loop never reached it.
- The whole cluster had one KuraInstance, `kura-tuist-scw-fr-par`, in the private runner-cache region. The `ca-east` OVH box has been Ready and idle for 63 days.
- A read-only eval Job confirmed the account's lifecycle row: `[{"us-east", ~U[2026-09-03 01:31:03Z], false, nil}]`, plan `:air`, residency `:all`, no region-policy rows.

Config was not the problem in isolation: available regions and the runtime image tag were both set correctly.

## Why this shape over the alternatives

Guarding only `Demand.instance_expected?/1` would stop the "provisioning forever" answer while still letting demand rows land in a region nothing iterates. The wrong answer originates in resolution, so that is where it is refused.

The Air branch previously documented the opposite choice, that funding is the gate and not availability. That reasoning assumed the mismatch would surface on the refusal counter, but resolving successfully is exactly what keeps it off that counter. Funding a region the deployment does not serve is a configuration error, and refusing is what makes it visible.

`assigned_service_region/1` is renamed to `served_service_region/1` because it now guards more than the assignment path.

## Impact

Production is unaffected: it serves `eu-central`, `us-east`, `us-west` and `ap-southeast`, and every account resolves into one of those today. The change only bites a deployment whose funded or default region is not served, which is the bug.

For canary, the code change alone would make the failure honest but still leave the box idle, so this also funds Air in `ca-east,eu-central`, mirroring staging. That is what actually places an instance on the validation box.

## Validation

- `mix test test/tuist/kura/ test/tuist/accounts_test.exs` - 1011 passed.
- Both new cases were observed failing against the old implementation first. The Air one reproduces the canary shape and returned `{:ok, %{plan: :air, service_region: "us-east"}}`; the paid one covers the residency-default fallback and returned `{:ok, %{plan: :enterprise, service_region: "us-east"}}`.
- `mix credo` clean on the changed module, `mix format` applied.

Resolution now depends on what the deployment serves, so suites exercising it state the deployment they assume rather than inheriting the test env's local-controller-only catalog. That is the test churn in this diff: a default `serving/1` in the affected setups, plus `ap-southeast` deliberately left out of it so the assignment-only tests keep asserting refusal.

## Follow-up

`ca-east` maps to `residency_group: :other`, and no account residency value equals `:other`, so it is reachable only for accounts whose residency is `:all`. Worth deciding separately whether that is intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
