### PR TITLE
fix(cli): bump Rosalind to 0.7.96 so .aab analyses report the app label

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4c6897375e79ffa718a691c19c62ba3ee61dfadb9540342f26fdb8e3ff19f36b",
+  "originHash" : "55a682e76daa9e8811c8d1d4f59f7b71d06fb1b1d544defb38241917d31a020b",
   "pins" : [
     {
       "identity" : "1024jp.gzipswift",
@@ -187,7 +187,7 @@
       "location" : "",
       "originalLocation" : "https://github.com/apple/swift-protobuf",
       "state" : {
-        "version" : "1.35.1"
+        "version" : "1.38.1"
       }
     },
     {
@@ -461,7 +461,16 @@
       "location" : "",
       "originalLocation" : "https://github.com/p-x9/machokit",
       "state" : {
-        "version" : "0.46.1"
+        "version" : "0.52.2"
+      }
+    },
+    {
+      "identity" : "p-x9.objectarchivekit",
+      "kind" : "registry",
+      "location" : "",
+      "originalLocation" : "https://github.com/p-x9/ObjectArchiveKit.git",
+      "state" : {
+        "version" : "0.5.0"
       }
     },
     {
@@ -703,7 +712,7 @@
       "kind" : "registry",
       "location" : "",
       "state" : {
-        "version" : "0.7.22"
+        "version" : "0.7.96"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1880,7 +1880,7 @@ let package = Package(
             id: "frazer-rbsn.OrderedSet", .upToNextMajor(from: "2.0.0")
         ),
         .package(id: "grpc.grpc-swift-2", from: "2.0.0"),
-        .package(id: "apple.swift-protobuf", exact: "1.35.1"),
+        .package(id: "apple.swift-protobuf", exact: "1.38.1"),
         .package(id: "grpc.grpc-swift-protobuf", from: "2.0.0"),
         .package(id: "grpc.grpc-swift-nio-transport", from: "2.0.0"),
         .package(id: "facebook.zstd", from: "1.5.0"),
@@ -1889,7 +1889,7 @@ let package = Package(
         .package(id: "1024jp.gzipswift", .upToNextMajor(from: "5.2.0")),
         .package(path: "server/native/xcactivitylog_nif"),
         .package(id: "swiftyJSON.SwiftyJSON", .upToNextMajor(from: "5.0.2")),
-        .package(id: "tuist.Rosalind", .upToNextMajor(from: "0.7.22")),
+        .package(id: "tuist.Rosalind", .upToNextMajor(from: "0.7.96")),
         .package(id: "swiftGen.StencilSwiftKit", exact: "2.10.1"),
         .package(id: "swiftGen.SwiftGen", exact: "6.6.2"),
         .package(id: "sparkle-project.Sparkle", from: "2.6.4"),


### PR DESCRIPTION
## What changed

`tuist.Rosalind` moves from 0.7.22 to 0.7.96 and `apple.swift-protobuf` from 1.35.1 to 1.38.1. `p-x9.MachOKit` follows to 0.52.2 and `p-x9.objectarchivekit` 0.5.0 joins as a transitive pin.

## Why

`tuist inspect bundle` on an Android `.aab` reported the wrong app name. Rosalind never read the manifest label: it searched `base/resources.pb` for the first entry named `app_name`, across every package and every resource type, and took its first config value.

That table is the *merged* one, so every dependency's resources land in the app's package. The Android library template leaves a `string/app_name` behind and several widely used SDKs still ship one, so an app that labels itself with a differently named string resource got named after one of its dependencies. The same lookup explains the other reported symptom: with no `app_name` entry anywhere, the name fell back to the package name.

0.7.96 resolves the `<application>` element's `android:label` instead, taking a literal value as-is and otherwise splitting the compiled resource id into its package, type and entry ids to look the string up. Fix and its regression tests: [tuist/Rosalind#518](https://github.com/tuist/Rosalind/pull/518).

Three unrelated fixes ride along in the 74 releases between the two pins: macOS bundles now read `Info.plist` from `Contents/`, `LSMinimumSystemVersion` is accepted as the minimum OS version, and a pool-lock leak in `AssetUtilController` no longer wedges the next `assetutil` call after a failed one.

## Why swift-protobuf moves too

Rosalind 0.7.95 and newer require swift-protobuf 1.37.0 or newer, and the pin here was `exact: "1.35.1"`, so resolution failed outright:

```
error: Dependencies could not be resolved because root depends on 'apple.swift-protobuf' 1.35.1
and root depends on 'tuist.Rosalind' 0.7.95..<1.0.0.
'tuist.Rosalind' >= 0.7.95 practically depends on 'apple.swift-protobuf' 1.37.0..<2.0.0
```

1.38.1 is what Rosalind itself resolves. This is the same pairing [#9701](https://github.com/tuist/tuist/pull/9701) made when it moved Rosalind to 0.7.22 and swift-protobuf to 1.35.1. The generated code in `TuistCAS` and `TuistREAPI` asks for `ProtobufAPIVersion_2`, which is unchanged across the whole 1.x line, and `grpc.grpc-swift-protobuf` 2.1.1 accepts 1.38.1.

`Package.resolved` carries only the version lines and `originHash`. Resolving with a current toolchain also rewrites about 50 `originalLocation` strings to canonical casing with `.git` suffixes; that churn is stripped so the diff stays readable.

## Impact

Android `.aab` analyses report the app's actual label. Bundles already uploaded keep the name recorded at the time.

## Validation

`tuist install`, `tuist generate tuist`, then `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist` succeeds against the final pins (370s), which is what exercises the protobuf runtime bump across the generated CAS and REAPI code. The label resolution itself is covered in Rosalind by tests over bundles built by the Android Gradle Plugin, including one whose dependency ships its own `string/app_name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
