### PR TITLE
fix(cli): stop redefinition-of-module and unable-to-resolve-module on full binary cache with static-objc xcframeworks

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -36,6 +36,10 @@ public class GraphTraverser: GraphTraversing {
     private let embeddableFrameworksCache = GraphCache<GraphDependency, Set<GraphDependencyReference>>()
     private let staticXCFrameworksBehindXCFrameworkCache = GraphCache<GraphDependency, Set<GraphDependency>>()
     private let staticObjcXCFrameworksBehindXCFrameworkCache = GraphCache<GraphDependency, Set<GraphDependency>>()
+    private let staticObjcXCFrameworksReachableViaCachedTargetsCache =
+        GraphCache<GraphDependency, Set<GraphDependency>>()
+    private let staticSwiftXCFrameworksReachableViaCachedTargetsCache =
+        GraphCache<GraphDependency, Set<GraphDependency>>()
 
     struct LinkableDependenciesKey: Hashable {
         let target: GraphDependency
@@ -993,32 +997,118 @@ public class GraphTraverser: GraphTraversing {
         name: String,
         currentGraph: Graph
     ) -> Set<GraphDependency> {
-        let sourceTargetDep: GraphDependency = .target(name: name, path: path)
-        guard graph.dependencies[sourceTargetDep] != nil else { return [] }
-        return filterDependencies(
-            from: sourceTargetDep,
-            test: { dependency in
-                guard case let .xcframework(xcframework) = dependency else { return false }
-                return xcframework.linking == .static
+        reachableStaticXCFrameworksViaCachedTargets(
+            path: path,
+            name: name,
+            currentGraph: currentGraph,
+            cache: staticObjcXCFrameworksReachableViaCachedTargetsCache,
+            includes: { xcframework in
+                xcframework.linking == .static
                     && xcframework.swiftModules.isEmpty
                     && !xcframework.moduleMaps.isEmpty
-            },
-            skip: { dependency in
-                // Don't traverse beyond static xcframeworks (their module contents are terminal).
-                if case let .xcframework(xcframework) = dependency, xcframework.linking == .static {
-                    return true
-                }
-                // Only traverse into targets that got replaced by cached xcframeworks in the
-                // substituted graph. Targets that survive generation contribute their own
-                // static-behind-dynamic settings through the current-graph walker; walking
-                // through them here would double-count and could add vendor Headers for
-                // xcframeworks that the current graph still exposes via a dynamic route.
-                if case let .target(dependencyName, dependencyPath, _) = dependency {
-                    return currentGraph.projects[dependencyPath]?.targets[dependencyName] != nil
-                }
-                return false
             }
         )
+    }
+
+    /// Static Swift xcframeworks reachable in *this* graph from the target through targets
+    /// that no longer exist in `currentGraph`. Sister to `staticObjcXCFrameworksReachableViaCachedTargets`
+    /// for the Swift-module flavour: the mapper wires `FRAMEWORK_SEARCH_PATHS` for consumers of a
+    /// cached dynamic xcframework whose `.swiftmodule` interface still `import`s a static Swift
+    /// xcframework, and the same substitution edge-drop can happen on that route too.
+    public func staticSwiftXCFrameworksReachableViaCachedTargets(
+        path: Path.AbsolutePath,
+        name: String,
+        currentGraph: Graph
+    ) -> Set<GraphDependency> {
+        reachableStaticXCFrameworksViaCachedTargets(
+            path: path,
+            name: name,
+            currentGraph: currentGraph,
+            cache: staticSwiftXCFrameworksReachableViaCachedTargetsCache,
+            includes: { xcframework in
+                xcframework.linking == .static && !xcframework.swiftModules.isEmpty
+            }
+        )
+    }
+
+    /// Iterative, per-node memoised walk from a source-graph target. Traversal stops at static
+    /// xcframeworks (terminal) and at descendant targets that survive in `currentGraph` (they
+    /// contribute their own settings through the current-graph walkers; walking through them
+    /// here would double-count). The starting target itself always contributes its children —
+    /// it's the surviving root we're walking from; the check gates whether we recurse INTO
+    /// surviving descendants, not whether the walk starts.
+    ///
+    /// The cache stores the standard per-node reachable set (with the terminal check applied),
+    /// so a node cached during one target's walk can be reused as a descendant of another
+    /// target's walk. Every visited node is visited once across all sibling targets, so the
+    /// mapper's cost stays linear in the graph, not in (targets × graph).
+    private func reachableStaticXCFrameworksViaCachedTargets(
+        path: Path.AbsolutePath,
+        name: String,
+        currentGraph: Graph,
+        cache: GraphCache<GraphDependency, Set<GraphDependency>>,
+        includes: (GraphDependency.XCFramework) -> Bool
+    ) -> Set<GraphDependency> {
+        let root: GraphDependency = .target(name: name, path: path)
+        guard let rootChildren = graph.dependencies[root] else { return [] }
+
+        func terminal(_ node: GraphDependency) -> Bool {
+            if case let .xcframework(xcframework) = node, xcframework.linking == .static {
+                return true
+            }
+            if case let .target(dependencyName, dependencyPath, _) = node {
+                return currentGraph.projects[dependencyPath]?.targets[dependencyName] != nil
+            }
+            return false
+        }
+
+        // First pass: iterative DFS from each root child, collecting the reachable subgraph in
+        // visit order. Stops at terminals (their subtrees are irrelevant beyond their own
+        // inclusion) and at nodes already cached (we reuse their memoised result in the second
+        // pass). The root itself is not enqueued — we compute its result at the end from its
+        // children's cached sets, so the cache always holds the "descendant" semantics.
+        var order: [GraphDependency] = []
+        var visited = Set<GraphDependency>()
+        var stack: [GraphDependency] = []
+        for child in rootChildren where cache[child] == nil {
+            stack.append(child)
+        }
+        while let node = stack.popLast() {
+            guard visited.insert(node).inserted else { continue }
+            guard cache[node] == nil else { continue }
+            order.append(node)
+            guard !terminal(node) else { continue }
+            for child in graph.dependencies[node, default: []] where cache[child] == nil {
+                stack.append(child)
+            }
+        }
+
+        // Second pass: reverse-visit order guarantees children are cached before their parents
+        // in a DAG. Each node's set is its own inclusion plus its (non-terminal) children's.
+        for node in order.reversed() where cache[node] == nil {
+            var result: Set<GraphDependency> = []
+            if case let .xcframework(xcframework) = node, includes(xcframework) {
+                result.insert(node)
+            }
+            if !terminal(node) {
+                for child in graph.dependencies[node, default: []] {
+                    if let childResult = cache[child] {
+                        result.formUnion(childResult)
+                    }
+                }
+            }
+            cache[node] = result
+        }
+
+        // Combine the root's children's cached sets. The root itself never matches `includes`
+        // (roots are targets, not xcframeworks) and it's never terminal for its own traversal.
+        var result: Set<GraphDependency> = []
+        for child in rootChildren {
+            if let childResult = cache[child] {
+                result.formUnion(childResult)
+            }
+        }
+        return result
     }
 
     public func schemeRunnableTarget(scheme: Scheme) -> GraphTarget? {

--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -982,6 +982,45 @@ public class GraphTraverser: GraphTraversing {
         return result
     }
 
+    /// Static Objective-C xcframeworks (that ship their own module map) reachable in *this* graph
+    /// from the target through targets that no longer exist in `currentGraph`. Those targets
+    /// were replaced by cached xcframeworks; their `.swiftmodule` still imports the static
+    /// xcframework's module, but the cache substitution can drop the graph edge that pointed
+    /// at the static xcframework, so `staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies`
+    /// on the substituted graph misses it. Walking from the source graph recovers it.
+    public func staticObjcXCFrameworksReachableViaCachedTargets(
+        path: Path.AbsolutePath,
+        name: String,
+        currentGraph: Graph
+    ) -> Set<GraphDependency> {
+        let sourceTargetDep: GraphDependency = .target(name: name, path: path)
+        guard graph.dependencies[sourceTargetDep] != nil else { return [] }
+        return filterDependencies(
+            from: sourceTargetDep,
+            test: { dependency in
+                guard case let .xcframework(xcframework) = dependency else { return false }
+                return xcframework.linking == .static
+                    && xcframework.swiftModules.isEmpty
+                    && !xcframework.moduleMaps.isEmpty
+            },
+            skip: { dependency in
+                // Don't traverse beyond static xcframeworks (their module contents are terminal).
+                if case let .xcframework(xcframework) = dependency, xcframework.linking == .static {
+                    return true
+                }
+                // Only traverse into targets that got replaced by cached xcframeworks in the
+                // substituted graph. Targets that survive generation contribute their own
+                // static-behind-dynamic settings through the current-graph walker; walking
+                // through them here would double-count and could add vendor Headers for
+                // xcframeworks that the current graph still exposes via a dynamic route.
+                if case let .target(dependencyName, dependencyPath, _) = dependency {
+                    return currentGraph.projects[dependencyPath]?.targets[dependencyName] != nil
+                }
+                return false
+            }
+        )
+    }
+
     public func schemeRunnableTarget(scheme: Scheme) -> GraphTarget? {
         let specifiedExecutableTarget = scheme.runAction?.executable
         let defaultTarget = scheme.buildAction?.targets.first

--- a/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -361,6 +361,25 @@ public protocol GraphTraversing {
         name: String
     ) -> Set<GraphDependency>
 
+    /// Static Objective-C xcframeworks (that ship their own module map) reachable in this graph
+    /// from the target through targets that no longer exist in `currentGraph`. Used to recover
+    /// module visibility after a binary-cache substitution drops the graph edge to the static
+    /// xcframework a cached dynamic dependency still imports in its `.swiftmodule`.
+    func staticObjcXCFrameworksReachableViaCachedTargets(
+        path: AbsolutePath,
+        name: String,
+        currentGraph: Graph
+    ) -> Set<GraphDependency>
+
+    /// Static Swift xcframeworks reachable in this graph from the target through targets
+    /// that no longer exist in `currentGraph`. Sister to
+    /// `staticObjcXCFrameworksReachableViaCachedTargets` for the Swift-module flavour.
+    func staticSwiftXCFrameworksReachableViaCachedTargets(
+        path: AbsolutePath,
+        name: String,
+        currentGraph: Graph
+    ) -> Set<GraphDependency>
+
     /// Given a scheme, it returns the runnable target.
     /// - Parameter scheme: Scheme to check against.
     /// - Returns: The runnable target if any.

--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -44,9 +44,10 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
         var sideEffects: [SideEffectDescriptor] = []
         let graphTraverser = GraphTraverser(graph: graph)
         let sourceGraphTraverser = environment.initialGraphWithSources.map { GraphTraverser(graph: $0) }
-        let unconditionallyDirectlyLinkedXCFrameworkPaths = Self.unconditionallyDirectlyLinkedXCFrameworkPaths(
+        let xcframeworkPlatformsProcessedByGeneratedTargets = Self.xcframeworkPlatformsProcessedByGeneratedTargets(
             in: graph,
-            initialGraphWithSources: environment.initialGraphWithSources
+            initialGraphWithSources: environment.initialGraphWithSources,
+            traverser: graphTraverser
         )
 
         let graph = try await mapGraph(
@@ -55,6 +56,18 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
             let target = graphTarget.target
             let project = graphTarget.project
             let targetDependency = GraphDependency.target(name: target.name, path: project.path)
+            let targetPlatforms = target.supportedPlatforms
+            // Xcode's `ProcessXCFramework` publishes `include/<Module>/module.modulemap` in the
+            // per-SDK `$(BUILT_PRODUCTS_DIR)/include`, so a producing target only covers a consumer
+            // whose platform matches. Adding the vendor `Headers/` copy on top of the `include/`
+            // copy on the SAME SDK is what triggers `redefinition of module`; on a different SDK
+            // the consumer has neither map without the vendor copy, and we hit
+            // `unable to resolve module dependency`.
+            let publishesModuleMapOnConsumerSDK: (GraphDependency.XCFramework) -> Bool = { xcframework in
+                guard let producingPlatforms = xcframeworkPlatformsProcessedByGeneratedTargets[xcframework.path]
+                else { return false }
+                return !producingPlatforms.isDisjoint(with: targetPlatforms)
+            }
             var staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies = graphTraverser
                 .staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies(
                     path: project.path,
@@ -70,40 +83,65 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
                     else { return nil }
                     return ConditionedXCFramework(xcframework: xcframework, condition: condition)
                 }
-            // Focus + binary cache can prune a static-objc xcframework out of the substituted
-            // graph even though a cached dynamic dependency of this target still imports it in
-            // its `.swiftmodule`. Recover those xcframeworks from the source graph so the
-            // consumer keeps module visibility. The direct-link suppression below still applies
-            // in the graph shapes where Xcode's `ProcessXCFramework` would produce a competing
-            // module map, so this cannot introduce a redefinition.
+            // Focus + binary cache can prune a static xcframework out of the substituted graph
+            // even though a cached dynamic dependency of this target still imports it in its
+            // `.swiftmodule`. Recover those xcframeworks from the source graph so the consumer
+            // keeps module visibility. The suppression below still fires when Xcode's
+            // `ProcessXCFramework` publishes the map on this consumer's SDK, so recovering here
+            // cannot re-introduce a redefinition; conversely, when the producing target is on a
+            // different SDK (or the graph does not have one at all), suppression correctly stands
+            // down and this addition is what keeps the module resolvable.
+            var staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies: [ConditionedXCFramework] = []
             if let sourceGraphTraverser {
-                let alreadyIncluded = Set(
+                let alreadyIncludedObjc = Set(
                     staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies.map(\.xcframework.path)
                 )
-                let sourceReachable = sourceGraphTraverser.staticObjcXCFrameworksReachableViaCachedTargets(
-                    path: project.path,
-                    name: target.name,
-                    currentGraph: graph
-                )
-                .sorted()
-                .compactMap { dependency -> ConditionedXCFramework? in
-                    guard case let .xcframework(xcframework) = dependency,
-                          !alreadyIncluded.contains(xcframework.path),
-                          case let .condition(condition) = sourceGraphTraverser.combinedCondition(
-                              to: dependency,
-                              from: targetDependency
-                          )
-                    else { return nil }
-                    return ConditionedXCFramework(xcframework: xcframework, condition: condition)
-                }
-                staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies += sourceReachable
+                let sourceReachableObjc = sourceGraphTraverser
+                    .staticObjcXCFrameworksReachableViaCachedTargets(
+                        path: project.path,
+                        name: target.name,
+                        currentGraph: graph
+                    )
+                    .sorted()
+                    .compactMap { dependency -> ConditionedXCFramework? in
+                        guard case let .xcframework(xcframework) = dependency,
+                              !alreadyIncludedObjc.contains(xcframework.path),
+                              case let .condition(condition) = sourceGraphTraverser.combinedCondition(
+                                  to: dependency,
+                                  from: targetDependency
+                              )
+                        else { return nil }
+                        return ConditionedXCFramework(xcframework: xcframework, condition: condition)
+                    }
+                staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies += sourceReachableObjc
+
+                let sourceReachableSwift = sourceGraphTraverser
+                    .staticSwiftXCFrameworksReachableViaCachedTargets(
+                        path: project.path,
+                        name: target.name,
+                        currentGraph: graph
+                    )
+                    .sorted()
+                    .compactMap { dependency -> ConditionedXCFramework? in
+                        guard case let .xcframework(xcframework) = dependency,
+                              case let .condition(condition) = sourceGraphTraverser.combinedCondition(
+                                  to: dependency,
+                                  from: targetDependency
+                              )
+                        else { return nil }
+                        return ConditionedXCFramework(xcframework: xcframework, condition: condition)
+                    }
+                staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies += sourceReachableSwift
             }
 
             // Static Swift xcframeworks reached through a dynamic xcframework are not relinked
             // at the consumer level (their symbols are already absorbed into the dynamic
             // xcframework's binary). They still need module visibility for the compiler to
             // resolve `import` statements that the dynamic xcframework's swiftinterface references.
-            let staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies = graphTraverser
+            let alreadyIncludedSwift = Set(
+                staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies.map(\.xcframework.path)
+            )
+            staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies += graphTraverser
                 .staticXCFrameworksLinkedByDynamicXCFrameworkDependencies(
                     path: project.path,
                     name: target.name
@@ -111,6 +149,7 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
                 .sorted()
                 .compactMap { dependency -> ConditionedXCFramework? in
                     guard case let .xcframework(xcframework) = dependency,
+                          !alreadyIncludedSwift.contains(xcframework.path),
                           case let .condition(condition) = graphTraverser.combinedCondition(
                               to: dependency,
                               from: targetDependency
@@ -127,7 +166,7 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
                 staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies
                     .filter {
                         $0.xcframework.containsLibrary()
-                            && !unconditionallyDirectlyLinkedXCFrameworkPaths.contains($0.xcframework.path)
+                            && !publishesModuleMapOnConsumerSDK($0.xcframework)
                     }
                     .map(\.xcframework)
 
@@ -276,65 +315,52 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
         return moduleMap.parentDirectory.basename == xcframework.path.basenameWithoutExt ? moduleMap : nil
     }
 
-    /// Xcode processes every unconditionally direct xcframework into the build products directory. That copy is
-    /// visible to the target graph, so adding the same vendor module map from a dynamic route would define the module
-    /// twice. A platform-qualified direct dependency cannot prove that it covers the dynamic route. The original graph
-    /// is retained in the mapper environment before binary-cache replacement, which can otherwise remove the direct
-    /// dependency from the graph being generated. Only the targets that survive into the generated projects count
-    /// there: a target replaced by a cached binary, or dropped by tree shaking, no longer references the xcframework,
-    /// so Xcode never produces the copy that would define the module.
+    /// For each xcframework whose `include/<Module>/module.modulemap` copy Xcode's `ProcessXCFramework`
+    /// will publish in some generated target's build-products directory, the set of platforms that
+    /// produce the copy. Consumers on those platforms already resolve the module through
+    /// `$(BUILT_PRODUCTS_DIR)/include`, so the mapper must not add the vendor `Headers/` copy on top —
+    /// two module maps for the same module on the search path is what triggers Clang's
+    /// `redefinition of module`.
     ///
-    /// The set also includes xcframeworks that reach a generated target's Frameworks build phase through a
-    /// transitive-static relink — Tuist's `linkableDependencies` walks static consumers and relinks their precompiled
-    /// deps at the outermost linkable, and Xcode's `ProcessXCFramework` fires for every xcframework in that phase.
-    /// The direct graph-edge walk misses this shape (the xcframework is not a direct dep of the linker), so a static
-    /// SwiftPM shim like `GoogleMapsTarget` that wraps `GoogleMaps.xcframework` slips through it: the App ends up
-    /// linking the xcframework transitively and Xcode still writes `include/<Module>/module.modulemap`, but the
-    /// mapper would add the vendor `Headers/` copy on top and consumers hit `redefinition of module`.
-    private static func unconditionallyDirectlyLinkedXCFrameworkPaths(
+    /// The set is keyed by platform because `include/` lives per-SDK: `Debug-iphonesimulator/include`
+    /// and `Debug/include` (macOS) are different directories, so a macOS target that publishes the
+    /// map cannot cover an iOS consumer's search path. Suppressing globally, blind to platform,
+    /// strips module visibility from consumers on other platforms and reintroduces the
+    /// `unable to resolve module dependency` failure this mapper is meant to prevent.
+    ///
+    /// Contributors, unioned per-platform:
+    /// * Direct graph-edge links from generated targets (the pre-existing narrow set).
+    /// * Direct graph-edge links from source-graph targets that survive generation (recovers the
+    ///   binary-cache substitution case where the linker was a source target that got cached; only
+    ///   counted when the linking target is still in the substituted graph, since a target replaced
+    ///   by a cached binary never runs `ProcessXCFramework`).
+    /// * `linkableDependencies` of every generated target — the actual set of xcframeworks that
+    ///   land in the target's Frameworks build phase, including the ones a static consumer relinks
+    ///   transitively through `LinkGenerator.staticDependenciesPrecompiledLibrariesAndFrameworks`.
+    ///   The direct-edge walk misses this shape (a static SwiftPM shim like `GoogleMapsTarget` that
+    ///   wraps `GoogleMaps.xcframework` isn't a direct graph edge for its consumer, but Xcode still
+    ///   processes the transitively-relinked xcframework), which is exactly the redefinition path
+    ///   this mapper needs to cover.
+    private static func xcframeworkPlatformsProcessedByGeneratedTargets(
         in graph: Graph,
-        initialGraphWithSources: Graph?
-    ) -> Set<AbsolutePath> {
-        var paths = unconditionallyDirectlyLinkedXCFrameworkPaths(in: graph)
-        if let initialGraphWithSources {
-            paths.formUnion(
-                unconditionallyDirectlyLinkedXCFrameworkPaths(in: initialGraphWithSources) { name, path in
-                    graph.projects[path]?.targets[name] != nil
-                }
-            )
-        }
-        paths.formUnion(xcframeworkPathsProcessedByGeneratedTargets(in: graph))
-        return paths
-    }
+        initialGraphWithSources: Graph?,
+        traverser: GraphTraverser
+    ) -> [AbsolutePath: Set<Platform>] {
+        var platformsByPath: [AbsolutePath: Set<Platform>] = [:]
 
-    private static func unconditionallyDirectlyLinkedXCFrameworkPaths(
-        in graph: Graph,
-        isGenerated: (String, AbsolutePath) -> Bool = { _, _ in true }
-    ) -> Set<AbsolutePath> {
-        var paths = Set<AbsolutePath>()
-        for (source, dependencies) in graph.dependencies {
-            guard case let .target(name, path, _) = source, isGenerated(name, path) else { continue }
-            for dependency in dependencies {
-                guard graph.dependencyConditions[(source, dependency)] == nil,
-                      case let .xcframework(xcframework) = dependency
-                else { continue }
-                paths.insert(xcframework.path)
-            }
+        func record(_ path: AbsolutePath, on platforms: Set<Platform>) {
+            platformsByPath[path, default: []].formUnion(platforms)
         }
-        return paths
-    }
 
-    /// Xcframeworks that a generated target's Frameworks build phase links — including the ones a static consumer
-    /// relinks transitively through `LinkGenerator`'s `staticDependenciesPrecompiledLibrariesAndFrameworks`. Xcode
-    /// runs `ProcessXCFramework` for every one of them and writes `include/<Module>/module.modulemap` under
-    /// `$(BUILT_PRODUCTS_DIR)/include`. `linkableDependencies` already excludes static xcframeworks reached through
-    /// a dynamic xcframework (the dynamic wrapper absorbed them at its own build), so this set is disjoint from the
-    /// static-behind-dynamic scenarios the walker adds vendor `Headers/` for.
-    private static func xcframeworkPathsProcessedByGeneratedTargets(in graph: Graph) -> Set<AbsolutePath> {
-        var paths = Set<AbsolutePath>()
-        let traverser = GraphTraverser(graph: graph)
         for project in graph.projects.values {
             for target in project.targets.values {
+                let sourceDependency: GraphDependency = .target(name: target.name, path: project.path)
+                for dependency in graph.dependencies[sourceDependency, default: []] {
+                    guard graph.dependencyConditions[(sourceDependency, dependency)] == nil,
+                          case let .xcframework(xcframework) = dependency
+                    else { continue }
+                    record(xcframework.path, on: target.supportedPlatforms)
+                }
                 guard let references = try? traverser.linkableDependencies(
                     path: project.path,
                     name: target.name,
@@ -344,11 +370,26 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
                     guard case let .xcframework(path, _, _, _, condition) = reference,
                           condition == nil
                     else { continue }
-                    paths.insert(path)
+                    record(path, on: target.supportedPlatforms)
                 }
             }
         }
-        return paths
+
+        if let initialGraphWithSources {
+            for (source, dependencies) in initialGraphWithSources.dependencies {
+                guard case let .target(name, path, _) = source,
+                      let survivingTarget = graph.projects[path]?.targets[name]
+                else { continue }
+                for dependency in dependencies {
+                    guard initialGraphWithSources.dependencyConditions[(source, dependency)] == nil,
+                          case let .xcframework(xcframework) = dependency
+                    else { continue }
+                    record(xcframework.path, on: survivingTarget.supportedPlatforms)
+                }
+            }
+        }
+
+        return platformsByPath
     }
 
     /// Only called for flat layouts, which point at the derived module map whose umbrella header was

--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -43,6 +43,7 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
         let derivedDirectory = try await derivedDirectory(for: graph)
         var sideEffects: [SideEffectDescriptor] = []
         let graphTraverser = GraphTraverser(graph: graph)
+        let sourceGraphTraverser = environment.initialGraphWithSources.map { GraphTraverser(graph: $0) }
         let unconditionallyDirectlyLinkedXCFrameworkPaths = Self.unconditionallyDirectlyLinkedXCFrameworkPaths(
             in: graph,
             initialGraphWithSources: environment.initialGraphWithSources
@@ -54,7 +55,7 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
             let target = graphTarget.target
             let project = graphTarget.project
             let targetDependency = GraphDependency.target(name: target.name, path: project.path)
-            let staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies = graphTraverser
+            var staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies = graphTraverser
                 .staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies(
                     path: project.path,
                     name: target.name
@@ -69,6 +70,34 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
                     else { return nil }
                     return ConditionedXCFramework(xcframework: xcframework, condition: condition)
                 }
+            // Focus + binary cache can prune a static-objc xcframework out of the substituted
+            // graph even though a cached dynamic dependency of this target still imports it in
+            // its `.swiftmodule`. Recover those xcframeworks from the source graph so the
+            // consumer keeps module visibility. The direct-link suppression below still applies
+            // in the graph shapes where Xcode's `ProcessXCFramework` would produce a competing
+            // module map, so this cannot introduce a redefinition.
+            if let sourceGraphTraverser {
+                let alreadyIncluded = Set(
+                    staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies.map(\.xcframework.path)
+                )
+                let sourceReachable = sourceGraphTraverser.staticObjcXCFrameworksReachableViaCachedTargets(
+                    path: project.path,
+                    name: target.name,
+                    currentGraph: graph
+                )
+                .sorted()
+                .compactMap { dependency -> ConditionedXCFramework? in
+                    guard case let .xcframework(xcframework) = dependency,
+                          !alreadyIncluded.contains(xcframework.path),
+                          case let .condition(condition) = sourceGraphTraverser.combinedCondition(
+                              to: dependency,
+                              from: targetDependency
+                          )
+                    else { return nil }
+                    return ConditionedXCFramework(xcframework: xcframework, condition: condition)
+                }
+                staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies += sourceReachable
+            }
 
             // Static Swift xcframeworks reached through a dynamic xcframework are not relinked
             // at the consumer level (their symbols are already absorbed into the dynamic

--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -283,6 +283,14 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
     /// dependency from the graph being generated. Only the targets that survive into the generated projects count
     /// there: a target replaced by a cached binary, or dropped by tree shaking, no longer references the xcframework,
     /// so Xcode never produces the copy that would define the module.
+    ///
+    /// The set also includes xcframeworks that reach a generated target's Frameworks build phase through a
+    /// transitive-static relink — Tuist's `linkableDependencies` walks static consumers and relinks their precompiled
+    /// deps at the outermost linkable, and Xcode's `ProcessXCFramework` fires for every xcframework in that phase.
+    /// The direct graph-edge walk misses this shape (the xcframework is not a direct dep of the linker), so a static
+    /// SwiftPM shim like `GoogleMapsTarget` that wraps `GoogleMaps.xcframework` slips through it: the App ends up
+    /// linking the xcframework transitively and Xcode still writes `include/<Module>/module.modulemap`, but the
+    /// mapper would add the vendor `Headers/` copy on top and consumers hit `redefinition of module`.
     private static func unconditionallyDirectlyLinkedXCFrameworkPaths(
         in graph: Graph,
         initialGraphWithSources: Graph?
@@ -295,6 +303,7 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
                 }
             )
         }
+        paths.formUnion(xcframeworkPathsProcessedByGeneratedTargets(in: graph))
         return paths
     }
 
@@ -310,6 +319,33 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
                       case let .xcframework(xcframework) = dependency
                 else { continue }
                 paths.insert(xcframework.path)
+            }
+        }
+        return paths
+    }
+
+    /// Xcframeworks that a generated target's Frameworks build phase links — including the ones a static consumer
+    /// relinks transitively through `LinkGenerator`'s `staticDependenciesPrecompiledLibrariesAndFrameworks`. Xcode
+    /// runs `ProcessXCFramework` for every one of them and writes `include/<Module>/module.modulemap` under
+    /// `$(BUILT_PRODUCTS_DIR)/include`. `linkableDependencies` already excludes static xcframeworks reached through
+    /// a dynamic xcframework (the dynamic wrapper absorbed them at its own build), so this set is disjoint from the
+    /// static-behind-dynamic scenarios the walker adds vendor `Headers/` for.
+    private static func xcframeworkPathsProcessedByGeneratedTargets(in graph: Graph) -> Set<AbsolutePath> {
+        var paths = Set<AbsolutePath>()
+        let traverser = GraphTraverser(graph: graph)
+        for project in graph.projects.values {
+            for target in project.targets.values {
+                guard let references = try? traverser.linkableDependencies(
+                    path: project.path,
+                    name: target.name,
+                    shouldExcludeHostAppDependencies: false
+                ) else { continue }
+                for reference in references {
+                    guard case let .xcframework(path, _, _, _, condition) = reference,
+                          condition == nil
+                    else { continue }
+                    paths.insert(path)
+                }
             }
         }
         return paths

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
@@ -423,6 +423,89 @@ struct TuistCacheEEAcceptanceTests {
         )
     }
 
+    /// A consumer that links a cached STATIC framework wrapping a nested-header xcframework and
+    /// also links a cached DYNAMIC framework that reaches the same xcframework. `LinkGenerator`'s
+    /// `staticDependenciesPrecompiledLibrariesAndFrameworks` relinks the wrapped xcframework at
+    /// the consumer, so Xcode's `ProcessXCFramework` writes `include/<Module>/module.modulemap`
+    /// into `$(BUILT_PRODUCTS_DIR)/include/`. Without widening the mapper's direct-link
+    /// suppression to see `linkableDependencies` (not just direct graph edges), the mapper still
+    /// added the vendor `Headers/<Module>/module.modulemap` on the search path for the dynamic
+    /// route, and Clang's dependency scanner rejected both maps with `redefinition of module`.
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment(inheritingVariables: ["PATH"]),
+        .withMockedNoora,
+        .withMockedLogger(forwardLogs: true),
+        .withFixture("generated_macos_tool_with_cached_nested_header_xcframework")
+    ) func generated_macos_tool_linking_cached_static_and_dynamic_wrappers_over_nested_header_xcframework() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let xcodeprojPath = fixtureDirectory.appending(component: "NestedHeaderXCFramework.xcodeproj")
+
+        try await TuistTest.run(
+            CacheCommand.self,
+            ["Library", "StaticWrapper", "--path", fixtureDirectory.pathString]
+        )
+
+        try await TuistTest.run(
+            GenerateCommand.self,
+            ["--no-open", "--path", fixtureDirectory.pathString, "ToolLinkingStaticAndDynamicWrappers"]
+        )
+
+        try TuistAcceptanceTest.expectXCFrameworkLinked(
+            "Library",
+            by: "ToolLinkingStaticAndDynamicWrappers",
+            xcodeprojPath: xcodeprojPath
+        )
+        try TuistAcceptanceTest.expectXCFrameworkLinked(
+            "StaticWrapper",
+            by: "ToolLinkingStaticAndDynamicWrappers",
+            xcodeprojPath: xcodeprojPath
+        )
+
+        // The mapper's contract: the vendor `Headers/` path from the nested static xcframeworks
+        // must NOT land on `HEADER_SEARCH_PATHS` for the consumer, because Xcode's
+        // `ProcessXCFramework` already publishes `include/<Module>/module.modulemap` under
+        // `$(BUILT_PRODUCTS_DIR)/include`. Two module maps for the same module on the search
+        // path is exactly what triggers Clang's `redefinition of module` failure. Whether
+        // Clang actually rejects the pair at build time depends on the toolchain's tolerance
+        // for byte-identical duplicates (Xcode 26.3 does; some later versions don't), so we
+        // guard the invariant at the settings level — it holds regardless of Clang version.
+        let xcodeproj = try XcodeProj(pathString: xcodeprojPath.pathString)
+        let target = try #require(
+            xcodeproj.pbxproj.projects.flatMap(\.targets)
+                .first(where: { $0.name == "ToolLinkingStaticAndDynamicWrappers" })
+        )
+        let configurations = try #require(target.buildConfigurationList?.buildConfigurations)
+        #expect(configurations.isEmpty == false)
+        for configuration in configurations {
+            let headerSearchPaths = configuration.buildSettings["HEADER_SEARCH_PATHS"]?.arrayValue
+                ?? configuration.buildSettings["HEADER_SEARCH_PATHS"].map { [$0.stringValue ?? ""] }
+                ?? []
+            for xcframework in ["NestedObjC.xcframework", "NestedObjCKit.xcframework"] {
+                #expect(
+                    headerSearchPaths.contains(where: { $0.contains("\(xcframework)/") }) == false,
+                    "The \(configuration.name) HEADER_SEARCH_PATHS must not contain the vendor \(xcframework) Headers path; the include/ copy from ProcessXCFramework already covers module resolution."
+                )
+            }
+        }
+
+        try await TuistTest.run(
+            XcodeBuildBuildCommand.self,
+            [
+                "-project",
+                xcodeprojPath.pathString,
+                "-scheme",
+                "ToolLinkingStaticAndDynamicWrappers",
+                "-derivedDataPath",
+                temporaryDirectory.pathString,
+                "CODE_SIGN_IDENTITY=",
+                "CODE_SIGNING_REQUIRED=NO",
+                "CODE_SIGNING_ALLOWED=NO",
+            ]
+        )
+    }
+
     @Test(
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -2423,6 +2423,126 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         XCTAssertEmpty(gotSideEffects)
     }
 
+    // Regression: focused generation on a scheme whose only tie to a static-objc xcframework is
+    // via a source dynamic framework that becomes a cached xcframework can drop the graph edge to
+    // the static xcframework in the substituted graph. Without recovering it from the source
+    // graph the consumer's dependency scan fails with `unable to resolve module dependency: 'X'`
+    // for every `import X` recorded in the cached module's `.swiftmodule`.
+    func test_map_when_static_xcframework_is_reachable_only_through_a_source_target_that_gets_cached() async throws {
+        // Given
+        let projectPath = try temporaryPath()
+            .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
+        let googleMapsPath = projectPath
+            .parentDirectory
+            .appending(component: "GoogleMaps.xcframework")
+        let googleMapsHeadersPath = googleMapsPath.appending(components: "ios-arm64", "Headers", "GoogleMaps")
+        try await fileSystem.makeDirectory(at: googleMapsHeadersPath)
+        try await fileSystem.writeText(
+            "modulemap",
+            at: googleMapsHeadersPath.appending(component: "module.modulemap")
+        )
+
+        let googleMaps: GraphDependency = .testXCFramework(
+            path: googleMapsPath,
+            infoPlist: .test(
+                libraries: [
+                    .test(
+                        path: try RelativePath(validating: "GoogleMaps.a")
+                    ),
+                ]
+            ),
+            linking: .static,
+            moduleMaps: [
+                googleMapsHeadersPath.appending(component: "module.modulemap"),
+            ]
+        )
+        let cachedSharedUI: GraphDependency = .testXCFramework(
+            path: try temporaryPath().appending(component: "SharedUI.xcframework"),
+            linking: .dynamic
+        )
+
+        // Source graph: AppTestsIndirect → SharedUI (source dynamic target) → GoogleMaps.
+        let graphWithSources: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(name: "AppTestsIndirect"),
+                        .test(name: "SharedUI"),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "AppTestsIndirect", path: projectPath): [
+                    .target(name: "SharedUI", path: projectPath),
+                ],
+                .target(name: "SharedUI", path: projectPath): [
+                    googleMaps,
+                ],
+            ]
+        )
+        // Substituted graph: SharedUI became a cached dynamic xcframework, and the edge to
+        // GoogleMaps.xcframework is no longer present at the AppTestsIndirect reach.
+        let graphWithBinaryCache: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(name: "AppTestsIndirect"),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "AppTestsIndirect", path: projectPath): [
+                    cachedSharedUI,
+                ],
+            ]
+        )
+        var environment = MapperEnvironment()
+        environment.initialGraphWithSources = graphWithSources
+
+        // The GoogleMaps xcframework uses a nested `Headers/GoogleMaps/module.modulemap` layout,
+        // so the mapper adds the `Headers` root to `HEADER_SEARCH_PATHS` and lets clang discover
+        // the module map from there (no `-fmodule-map-file`).
+        var expectedGraph = graphWithBinaryCache
+        expectedGraph.projects = [
+            projectPath: .test(
+                path: projectPath,
+                targets: [
+                    .test(
+                        name: "AppTestsIndirect",
+                        settings: .test(
+                            base: [
+                                "HEADER_SEARCH_PATHS": [
+                                    "\"$(SRCROOT)/../GoogleMaps.xcframework/ios-arm64/Headers\"",
+                                ],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+        ]
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try await subject.map(
+            graph: graphWithBinaryCache,
+            environment: environment
+        )
+
+        // Then
+        XCTAssertBetterEqual(expectedGraph, gotGraph)
+        XCTAssertBetterEqual([], gotSideEffects)
+    }
+
     func test_removeOtherSwithDuplicates() {
         // Given
         let settings: SettingsDictionary = [

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -2543,6 +2543,108 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         XCTAssertBetterEqual([], gotSideEffects)
     }
 
+    // Regression: an app that directly links a cached STATIC xcframework which itself wraps a static
+    // xcframework with a module map (the SwiftPM package-shim pattern — a source `staticLibrary`
+    // target that wraps a `.binaryTarget` xcframework) relinks the wrapped xcframework transitively
+    // at the app level. Xcode runs `ProcessXCFramework` for it and writes
+    // `$(BUILT_PRODUCTS_DIR)/include/<Module>/module.modulemap`. If another consumer reaches the
+    // same xcframework via a cached dynamic wrapper, the mapper must NOT add the vendor `Headers/`
+    // copy — the `include/` copy is already reachable — or Clang's dependency scanner fails with
+    // `redefinition of module`.
+    func test_map_when_static_xcframework_is_transitively_relinked_by_a_static_consumer() async throws {
+        // Given
+        let projectPath = try temporaryPath()
+            .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
+        let googleMapsPath = projectPath
+            .parentDirectory
+            .appending(component: "GoogleMaps.xcframework")
+        let googleMapsHeadersPath = googleMapsPath.appending(components: "ios-arm64", "Headers", "GoogleMaps")
+        try await fileSystem.makeDirectory(at: googleMapsHeadersPath)
+        try await fileSystem.writeText(
+            "modulemap",
+            at: googleMapsHeadersPath.appending(component: "module.modulemap")
+        )
+
+        let googleMaps: GraphDependency = .testXCFramework(
+            path: googleMapsPath,
+            infoPlist: .test(
+                libraries: [
+                    .test(
+                        path: try RelativePath(validating: "GoogleMaps.a")
+                    ),
+                ]
+            ),
+            linking: .static,
+            moduleMaps: [
+                googleMapsHeadersPath.appending(component: "module.modulemap"),
+            ]
+        )
+        // SwiftPM `GoogleMapsTarget` shim, cached as a static xcframework. It relinks
+        // `GoogleMaps.xcframework` transitively into every consumer.
+        let cachedGoogleMapsShim: GraphDependency = .testXCFramework(
+            path: try temporaryPath().appending(component: "GoogleMapsTarget.xcframework"),
+            infoPlist: .test(
+                libraries: [
+                    .test(
+                        path: try RelativePath(validating: "GoogleMapsTarget.a")
+                    ),
+                ]
+            ),
+            linking: .static
+        )
+        // Dynamic wrapper that also links `GoogleMaps.xcframework`. Reaching `GoogleMaps` through
+        // this route is exactly what the mapper's per-target walker fires on.
+        let cachedSharedUI: GraphDependency = .testXCFramework(
+            path: try temporaryPath().appending(component: "SharedUI.xcframework"),
+            linking: .dynamic
+        )
+        let graph: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(name: "App"),
+                        .test(name: "Consumer"),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "App", path: projectPath): [
+                    cachedGoogleMapsShim,
+                    cachedSharedUI,
+                ],
+                cachedGoogleMapsShim: [
+                    googleMaps,
+                ],
+                .target(name: "Consumer", path: projectPath): [
+                    cachedSharedUI,
+                ],
+                cachedSharedUI: [
+                    googleMaps,
+                ],
+            ]
+        )
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try await subject.map(
+            graph: graph,
+            environment: MapperEnvironment()
+        )
+
+        // Then. Both App and Consumer keep their empty settings — the App because it directly links
+        // the shim (no dynamic-behind route to add), the Consumer because `GoogleMaps.xcframework`
+        // is already reachable via `$(BUILT_PRODUCTS_DIR)/include` from the App's transitive relink.
+        XCTAssertBetterEqual(graph, gotGraph)
+        XCTAssertBetterEqual([], gotSideEffects)
+    }
+
     func test_removeOtherSwithDuplicates() {
         // Given
         let settings: SettingsDictionary = [

--- a/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/Project.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/Project.swift
@@ -60,5 +60,53 @@ let project = Project(
                 .xcframework(path: "NestedObjCKit.xcframework"),
             ]
         ),
+        // A `.staticFramework` that links the same static nested-header xcframeworks. When it's
+        // cached and a consumer links it, `LinkGenerator`'s transitive-static relink pulls the
+        // wrapped xcframeworks into the consumer's Frameworks build phase — Xcode then runs
+        // `ProcessXCFramework` on them and copies `Headers/<Module>/` into
+        // `$(BUILT_PRODUCTS_DIR)/include/<Module>/`. The direct-graph-edge suppression walker
+        // never saw this shape, so a sibling target reaching the same xcframework via the
+        // cached dynamic `Library` still got vendor `Headers/` on `HEADER_SEARCH_PATHS`
+        // added by `StaticXCFrameworkModuleMapGraphMapper`, and Clang's dep scanner rejected
+        // both maps with `redefinition of module`.
+        .target(
+            name: "StaticWrapper",
+            destinations: .macOS,
+            product: .staticFramework,
+            bundleId: "io.tuist.NestedHeaderXCFramework.StaticWrapper",
+            infoPlist: .default,
+            sources: ["StaticWrapper/Sources/**"],
+            dependencies: [
+                .xcframework(path: "NestedObjC.xcframework"),
+                .xcframework(path: "NestedObjCKit.xcframework"),
+            ]
+        ),
+        // Consumes both the cached `StaticWrapper` (which transitively relinks the nested
+        // xcframeworks at this level) and the cached dynamic `Library` (which routes the
+        // same xcframeworks through the mapper's dynamic-behind walker). Without the
+        // linkable-dependencies suppression widening, this target sees both the
+        // `include/<Module>/module.modulemap` copy from `ProcessXCFramework` and the
+        // vendor `Headers/<Module>/module.modulemap` on the search path, and Clang's
+        // dep scanner fails with `redefinition of module`.
+        .target(
+            name: "ToolLinkingStaticAndDynamicWrappers",
+            destinations: .macOS,
+            product: .commandLineTool,
+            bundleId: "io.tuist.NestedHeaderXCFramework.ToolLinkingStaticAndDynamicWrappers",
+            infoPlist: .default,
+            sources: ["ToolLinkingStaticAndDynamicWrappers/Sources/**"],
+            dependencies: [
+                .target(name: "Library"),
+                .target(name: "StaticWrapper"),
+            ],
+            // `redefinition of module` fires from Clang's explicit-modules dependency scanner.
+            // The project-level default disables explicit modules to keep the earlier fixtures
+            // focused on the umbrella-header / shadowed-module class of failures; override it
+            // here so this test actually exercises the dep-scan path where the redefinition
+            // surfaces.
+            settings: .settings(base: [
+                "SWIFT_ENABLE_EXPLICIT_MODULES": "YES",
+            ])
+        ),
     ]
 )

--- a/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/StaticWrapper/Sources/StaticWrapper.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/StaticWrapper/Sources/StaticWrapper.swift
@@ -1,0 +1,10 @@
+import NestedObjC
+import NestedObjCKit
+
+public enum StaticWrapper {
+    public static func trackingState() -> Int {
+        let feature = NestedFeature()
+        feature.anchor = NestedAnchor()
+        return Int(feature.anchor?.trackingState.rawValue ?? 0)
+    }
+}

--- a/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/ToolLinkingStaticAndDynamicWrappers/Sources/main.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/ToolLinkingStaticAndDynamicWrappers/Sources/main.swift
@@ -1,0 +1,16 @@
+import Library
+// Importing `NestedObjC` / `NestedObjCKit` here forces the compiler to build the
+// clang modules for the nested-header xcframeworks. With Clang's explicit-modules
+// dep scanner, the scan fails if the same module is defined by two module maps —
+// which is exactly what happens if the mapper adds vendor `Headers/` on the
+// search path while `ProcessXCFramework` has already copied the map into
+// `$(BUILT_PRODUCTS_DIR)/include/`.
+import NestedObjC
+import NestedObjCKit
+import StaticWrapper
+
+let feature = NestedFeature()
+feature.anchor = NestedAnchor()
+print(feature.anchor?.trackingState.rawValue ?? 0)
+print(Library.trackingState())
+print(StaticWrapper.trackingState())


### PR DESCRIPTION
### How to test locally

1. Use a project with SwiftPM native integration and a static Objective-C xcframework that ships its own `module.modulemap` (like `GoogleMaps.xcframework`), where the App target links the SDK's SwiftPM shim (a static ObjC library that wraps the xcframework) and other consumers reach the xcframework via a dynamic framework that gets cached.
2. Warm the local binary cache: `tuist install && tuist cache`.
3. Focus a scheme whose consumers reach the xcframework transitively through the cached dynamic wrapper, e.g. `tuist test AllUnitTests --binary-cache --no-selective-testing`.

**Before the fix (canary.13):**

- On the App, the SwiftPM shim relinks `GoogleMaps.xcframework` transitively so Xcode runs `ProcessXCFramework` and writes `$(BUILT_PRODUCTS_DIR)/include/GoogleMaps/module.modulemap`. The mapper's direct-link suppression walked only direct graph edges and missed this shape, so it still added the vendor `Headers/` copy to consumers of the cached dynamic wrapper. Clang's dependency scanner rejected both maps: `error: redefinition of module 'GoogleMaps'`, cascading into `could not build module '<PublicWrapperModule>'` across the module graph and inflating the CI log to gigabytes of repeated errors.
- On a focused scheme with no direct-linker surviving substitution (e.g. `tuist test AppTestsIndirect --binary-cache`), the mapper's per-target walker missed the static xcframework entirely and failed the Swift dep scan with `error: unable to resolve module dependency: 'GoogleMaps'` — the consumer chain's cached `.swiftmodule` records `import GoogleMaps` but nothing wired the module in.

**After the fix:** both scenarios succeed. Existing shapes (`AppTestsDirect`, `AllTests`, `FeatureA`, `FeatureB`, from-source `AllTests --no-binary-cache`) still pass. All 25 tests in `StaticXCFrameworkModuleMapGraphMapperTests` pass, including two new regression tests, and `GraphTraverserTests` still passes green.

## What changed

- Replaced `unconditionallyDirectlyLinkedXCFrameworkPaths` in `StaticXCFrameworkModuleMapGraphMapper.swift` with `xcframeworkPlatformsProcessedByGeneratedTargets` returning `[AbsolutePath: Set<Platform>]`. The map collects, per xcframework, the exact set of SDKs on which a surviving generated target processes it — via a graph-direct link, via a `linkableDependencies` transitive-static relink, or via a source-graph edge dropped by focused substitution. A consumer target only opts out of the vendor `Headers/` addition when its own platforms intersect the producing platforms, so a macOS-only survivor no longer suppresses on an iOS-only consumer.
- Added a public traversal `GraphTraverser.staticObjcXCFrameworksReachableViaCachedTargets(path:name:currentGraph:)` (plus a sister `staticSwiftXCFrameworksReachableViaCachedTargets` for the Swift-flavour recovery path) that walks the source graph from a target through target-dependencies that no longer exist in `currentGraph.projects`, collecting the static xcframeworks reachable behind them. Both methods are declared on `GraphTraversing` alongside the existing walkers.
- The walker is iterative post-order DFS with per-node memoisation on the outer traverser. Sibling targets that share subtrees walk each node once total, and a deep transitive chain doesn't blow the stack.
- Updated `StaticXCFrameworkModuleMapGraphMapper.map(graph:environment:)` to build a source-graph traverser from `environment.initialGraphWithSources`, reuse the outer `GraphTraverser` (not a fresh instance per invocation), invoke the recovery methods per target, and merge the results into the existing walkers' per-target sets, deduped by xcframework path. Conditions are recomputed against the source graph so platform filters remain accurate.
- Added two regression tests. `test_map_when_static_xcframework_is_transitively_relinked_by_a_static_consumer` covers the `redefinition` shape from a static SwiftPM shim: App directly links a cached static xcframework that wraps `GoogleMaps.xcframework`, another consumer reaches `GoogleMaps` via a cached dynamic wrapper, and the mapper must not add vendor `Headers/`. `test_map_when_static_xcframework_is_reachable_only_through_a_source_target_that_gets_cached` covers the `unable to resolve` shape: a focused scheme whose only path to the static xcframework is through a source target that got cached, and the mapper must add vendor `Headers/`.

## Why

Downstream users of native SwiftPM integration hit both classes of failure whenever their build (a) links an SDK's static SwiftPM shim into the App and (b) exposes the underlying static xcframework's module publicly through some other cached dynamic wrapper. The failures are silent about the true cause: the redefinition mimics the earlier `include/` collision class fought several times over (#11290 → #11472 → #11506 → #12683 → #12691 → #12745 → #12757), and the missing-module mimics a broken cache. Neither error message points at the cache-substitution + transitive-relink interaction that actually produces them.

## Root cause

Two independent gaps in the same mapper's understanding of what Xcode actually processes after cache substitution + graph focus:

1. **Direct-link suppression missed transitive-static relinks.** The prior `unconditionallyDirectlyLinkedXCFrameworkPaths` walked `graph.dependencies` direct edges only. `LinkGenerator.linkableDependencies` in `GraphTraverser.swift` also pulls precompiled xcframeworks reached through static consumers to the outermost linkable, and Xcode's `ProcessXCFramework` fires for every one of them (this matches swift-build's `XCFrameworkTaskProducer` at `Sources/SWBTaskConstruction/TaskProducers/WorkspaceTaskProducers/XCFrameworkTaskProducer.swift:39-140`, which recurses through `PackageProductTarget.frameworksBuildPhase` for SwiftPM package products). A static SwiftPM shim like the one Google's `ios-maps-sdk` package ships for `GoogleMaps` — a source `.target` wrapping a `.binaryTarget` xcframework — is exactly that shape: the App links the shim, the xcframework rides along transitively, `include/GoogleMaps/module.modulemap` appears in `BUILT_PRODUCTS_DIR`, and the mapper's suppression never sees it.
2. **Focused-generation dropped the walker's graph edge.** `TargetsToCacheBinariesGraphMapper` plus `TreeShakePrunedTargetsGraphMapper` can drop the graph edge to a static xcframework when the source dynamic-framework target that reached it becomes a cached xcframework and no surviving target still directly links the static xcframework. `staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies` then returns empty and the mapper skips wiring vendor `Headers/`, so the consumer's Swift dependency scan cannot resolve `import GoogleMaps` recorded in the cached wrapper's `.swiftmodule`.

## Approach

Two complementary changes, one per gap, both scoped per SDK so cross-platform graphs never bleed:

- Widen the suppression set to `xcframeworkPlatformsProcessedByGeneratedTargets`: for every generated target and every `linkableDependencies` edge to an xcframework, record the target's supported platforms against that xcframework's path. Consumers check for a platform intersection before opting out. `linkableDependencies` already excludes static xcframeworks reached through a dynamic xcframework (see `GraphTraverser.swift:657-682`, "statics behind a dynamic xcframework are intentionally NOT linked at the consumer level"), so this cannot recreate the missing-module bug.
- Recover the walker's graph edge by walking `environment.initialGraphWithSources` from the target through target-dependencies missing from the substituted graph (the ones that got cached), only for static xcframeworks that ship their own module map. The existing per-platform suppression still applies to the result, so this cannot introduce a new `redefinition` shape. Both the Objective-C and Swift walker paths route through this recovery.

An alternative — extending the substitution mapper to preserve edges to static xcframeworks — would touch closed-source code and every consumer that relies on tree-shaken deps. That's higher blast radius for a narrower gain.

## Impact

- Users on SwiftPM native integration who see either `redefinition of module '<X>'` or `unable to resolve module dependency: '<X>'` on `--binary-cache` builds involving a static Objective-C xcframework that ships its own `module.modulemap`, now build cleanly.
- No behavior change for the from-source path (`--no-binary-cache`), non-focused schemes, or graphs whose static xcframework survives as a graph-direct link on every consumer of the walker.
- Both changes gate on state the mapper already has (`graph`, `environment.initialGraphWithSources`); no new inputs or configuration.
- On large graphs, the recovery walker's per-node memo makes the mapper's cost linear in the source graph rather than in `targets × graph`.

## Validation

- Reproduced both failures locally against a minimal fixture matching the reported graph shape with `tuist@4.207.0-canary.14` (last shipped canary; identical mapper to canary.13). Applied both fixes and re-verified with the same locally built binary:
  - `tuist test AppTestsIndirect --binary-cache --no-selective-testing --build-only` — succeeds (was failing with `unable to resolve module dependency: 'GoogleMaps'`).
  - `tuist test AppTestsDirect --binary-cache --no-selective-testing --build-only` — succeeds.
  - `tuist test AllTests --binary-cache --no-selective-testing --build-only` — succeeds.
  - `tuist test FeatureA --binary-cache --no-selective-testing --build-only`, `tuist test FeatureB --binary-cache --no-selective-testing --build-only` — succeed.
  - `tuist test AllTests --no-binary-cache --no-selective-testing --build-only` — succeeds (from-source unchanged).
- `xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing TuistKitTests/StaticXCFrameworkModuleMapGraphMapperTests` — 25 tests passed, 0 failed. Full pre-existing suite in that file still passes; both new regression tests pass.
- `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing TuistCoreTests/GraphTraverserTests` — 166 tests passed, 0 failed.
- Cross-checked against [swift-build](https://github.com/swiftlang/swift-build)'s xcframework processing model (`XCFrameworkTaskProducer.swift:39-140` + `ProcessXCFrameworkLibrarySpec`): the widened suppression matches the exact set swift-build processes, including SwiftPM package products' recursive frameworks phase entries. The `linkableDependencies` boundary between "processed and gets `include/`" and "static behind dynamic, needs vendor `Headers/`" is the same boundary swift-build enforces.

## Related

#11290 (introduced the vendor `Headers/` addition on the search path for cached static-objc-behind-dynamic deps) · #11472 · #11506 · #11537 · #11872 · #12683 (introduced `unconditionallyDirectlyLinkedXCFrameworkPaths`) · #12745 · #12757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLfrY52sRfUazwMiYGBqh6
