### PR TITLE
fix(infra): release a bare-metal box whose reinstall is already running

### DIFF
--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -31,8 +31,8 @@ detail the Apple Silicon kind.
 | `ScalewayAppleSiliconMachine` | One Mac mini. Has the Scaleway server type, zone, OS, per-host pod CIDR, fleet name (ties Machines on the same fleet to one shared SSH key), and kubelet version. SSH and bootstrap material are operator-managed — no Secret refs in the spec. |
 | `ScalewayAppleSiliconMachineTemplate` | Template MachineDeployments / MachineSets clone from. |
 | `ScalewayElasticMetalMachine` (+ `…Template`) | One Scaleway Elastic Metal server (Linux bare metal): offer type, zone, OS, PN id, node taints, `fleetName`. SSH self-join (no user-data channel); local-NVMe (`scw-local-nvme`) cache. Reinstall-on-release. |
-| `DediboxMachine` (+ `…Template`) | One Scaleway Dedibox bare-metal server (eu-central): adopts a pre-prepped box by tag, `fleetName`. Left installed on release. |
-| `OVHDedicatedMachine` (+ `…Template`) | One OVHcloud US bare-metal server (the us-east / us-west / ap-southeast cache regions and the Gravelines runner pool): adopts a pre-prepped box by displayName prefix, `fleetName`, `nodeTaints`. Left installed on release. |
+| `DediboxMachine` (+ `…Template`) | One Scaleway Dedibox bare-metal server (eu-central): adopts a pre-prepped box by tag, `fleetName`. Reinstall-on-release. |
+| `OVHDedicatedMachine` (+ `…Template`) | One OVHcloud US bare-metal server (the us-east / us-west / ap-southeast cache regions and the Gravelines runner pool): adopts a pre-prepped box by displayName prefix, `fleetName`, `nodeTaints`. Reinstall-on-release. |
 | `TuistCluster` | Cluster-level stub (CAPI core requires it for the parent Cluster to validate). Sets `Status.Ready=true` once it exists. Shared by all machine kinds. |
 
 API group: `infrastructure.cluster.x-k8s.io/v1alpha1`. Short names:
@@ -694,6 +694,21 @@ Release (`reconcileDelete`) drops the Node + identity + TOFU pin and **reinstall
 the box back into the pool**. It stays a monthly contract (release is not a contract
 termination), but the reinstall wipes the OS to a clean, claimable state — any
 node-local volume is lost and the host key rotates, so the next claim re-TOFUs it.
+
+**A reinstall already in flight is a completed release, not a failure.** All three
+kinds reach the provider before dropping the finalizer, so a controller restart
+between a successful install call and the finalizer patch — or two Machines on one
+box — has the release ask for a second wipe of a box already being wiped. Every
+provider rejects that for the whole ~30 minute install, and retrying on it holds
+the Machine in `Deleting`: the MachineDeployment stays a replica above spec and a
+`helm upgrade --atomic` rollback waiting on that count runs out its step ceiling
+(2026-09-03, 13 minutes on `ns3048220`). Each kind therefore reads the box's own
+install state and releases when a wipe is already running — OVH gates on
+`Client::BadRequest::TaskAlreadyExists` plus an install-function task in the task
+list, Dedibox and Elastic Metal on the install status the API reports, since
+neither names the collision. A failure that is not that retries on a bounded
+interval rather than controller-runtime's default backoff, which doubles to a
+1000s cap and idles the Machine long after the provider frees the box.
 
 ### Disk layout, and why it is an install-time decision
 

--- a/infra/cluster-api-provider-tuist/controllers/linux/dedibox_release_reinstall_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/dedibox_release_reinstall_test.go
@@ -1,0 +1,153 @@
+package linux
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-tuist/api/v1alpha1"
+	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/credentials"
+	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/dedibox"
+)
+
+const (
+	dediboxReleaseServerID = 75839
+	dediboxReleaseZone     = "fr-par-1"
+	dediboxReleaseFleet    = "tuist-kura-dedibox"
+)
+
+// dediboxAPI serves the Dedibox endpoints the release reinstall walks, with the
+// install POST and the install status wired per test. Reached through the
+// client's own DEDIBOX_API_URL override rather than an injected transport.
+type dediboxAPI struct {
+	installStatus string
+	installCode   int
+	installPosted bool
+}
+
+func (d *dediboxAPI) client(t *testing.T) *dedibox.Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		write := func(code int, body any) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(code)
+			_ = json.NewEncoder(w).Encode(body)
+		}
+		switch {
+		case strings.HasSuffix(req.URL.Path, "/ssh-keys"):
+			write(http.StatusOK, map[string]any{"ssh_keys": []map[string]string{{"id": "key-1", "public_key": "any"}}})
+		case strings.HasSuffix(req.URL.Path, "/os"):
+			write(http.StatusOK, map[string]any{"os": []map[string]any{
+				{"id": 42, "name": "Ubuntu", "version": "24.04 LTS", "allow_ssh_keys": true, "requires_user": true},
+			}})
+		case strings.HasSuffix(req.URL.Path, "/install") && req.Method == http.MethodPost:
+			d.installPosted = true
+			write(d.installCode, map[string]string{"message": "install already in progress"})
+		case strings.HasSuffix(req.URL.Path, "/install"):
+			write(http.StatusOK, map[string]any{"status": d.installStatus})
+		default:
+			write(http.StatusNotFound, map[string]string{"message": "unmapped " + req.URL.Path})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("DEDIBOX_SCW_SECRET_KEY", "test")
+	t.Setenv("DEDIBOX_SCW_PROJECT_ID", "proj")
+	t.Setenv("DEDIBOX_API_URL", server.URL)
+	c, err := dedibox.NewClientFromEnv()
+	if err != nil {
+		t.Fatalf("dedibox client: %v", err)
+	}
+	return c
+}
+
+func releasingDediboxMachine() *infrav1.DediboxMachine {
+	machine := &infrav1.DediboxMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "tuist",
+			Name:       "tuist-kura-dedibox-abc12-xyz34",
+			Finalizers: []string{DediboxMachineFinalizer},
+		},
+	}
+	machine.Spec.FleetName = dediboxReleaseFleet
+	machine.Status.ServerID = dediboxReleaseServerID
+	machine.Status.Zone = dediboxReleaseZone
+	return machine
+}
+
+func newDediboxReleaseReconciler(t *testing.T, api *dediboxAPI) (*DediboxMachineReconciler, *infrav1.DediboxMachine, *record.FakeRecorder) {
+	t.Helper()
+	scheme := releaseScheme(t)
+	machine := releasingDediboxMachine()
+	secret := fleetSSHKeySecret(t, machine.Namespace, dediboxReleaseFleet)
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(machine, secret).Build()
+	recorder := record.NewFakeRecorder(10)
+	return &DediboxMachineReconciler{
+		Client:             cl,
+		Scheme:             scheme,
+		DediboxClient:      api.client(t),
+		Recorder:           recorder,
+		CredentialsManager: &credentials.Manager{Client: cl, Namespace: machine.Namespace},
+	}, machine, recorder
+}
+
+// The Dedibox release holds the finalizer until the reinstall completes, so a
+// rejected install POST is not a slow release — it is a Machine that never
+// leaves Deleting at all. Dedibox reports no error class for "an install is
+// already queued", so the box's own install status is the readable signal, and
+// an install already running is the state the release is trying to reach.
+func TestDediboxReleaseAdoptsAnInstallAlreadyInFlight(t *testing.T) {
+	api := &dediboxAPI{installCode: http.StatusBadRequest, installStatus: "installing"}
+	r, machine, recorder := newDediboxReleaseReconciler(t, api)
+
+	result, done, err := r.reconcileReleaseReinstall(context.Background(), machine)
+	if err != nil {
+		t.Fatalf("reconcileReleaseReinstall: %v", err)
+	}
+	if done {
+		t.Fatal("release reported done while the install is still running")
+	}
+	if result.RequeueAfter != dediboxInstallPollInterval {
+		t.Fatalf("RequeueAfter = %s, want the install poll interval %s", result.RequeueAfter, dediboxInstallPollInterval)
+	}
+	if machine.Annotations[dediboxReleaseReinstallStartedAnnotation] != "true" {
+		t.Fatal("the in-flight install was not adopted, so the release retries the POST forever")
+	}
+	if machine.Annotations[dediboxReleaseReinstallObservedAnnotation] != "true" {
+		t.Fatal("an install seen running is the in-progress observation the completion gate needs")
+	}
+	if events := drainRecorder(recorder); !strings.Contains(events, "ReleasedToPool") {
+		t.Fatalf("events = %q, want a ReleasedToPool event recording the in-flight install", events)
+	}
+}
+
+// A rejected POST on a box with no install running still has to retry, bounded,
+// with the finalizer kept.
+func TestDediboxReleaseRetriesBoundedWhenNoInstallIsRunning(t *testing.T) {
+	api := &dediboxAPI{installCode: http.StatusInternalServerError, installStatus: "installed"}
+	r, machine, recorder := newDediboxReleaseReconciler(t, api)
+
+	result, done, err := r.reconcileReleaseReinstall(context.Background(), machine)
+	if err != nil {
+		t.Fatalf("reconcileReleaseReinstall returned %v; an error makes controller-runtime ignore RequeueAfter", err)
+	}
+	if done {
+		t.Fatal("release reported done on a box that was never reinstalled")
+	}
+	if result.RequeueAfter <= 0 || result.RequeueAfter > dediboxInstallPollInterval {
+		t.Fatalf("RequeueAfter = %s, want a bounded retry of at most %s", result.RequeueAfter, dediboxInstallPollInterval)
+	}
+	if machine.Annotations[dediboxReleaseReinstallStartedAnnotation] == "true" {
+		t.Fatal("marked the reinstall started even though no install is running on the box")
+	}
+	if events := drainRecorder(recorder); !strings.Contains(events, "ReleaseReinstallFailed") {
+		t.Fatalf("events = %q, want a ReleaseReinstallFailed event", events)
+	}
+}

--- a/infra/cluster-api-provider-tuist/controllers/linux/dediboxmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/dediboxmachine_controller.go
@@ -413,14 +413,28 @@ func (r *DediboxMachineReconciler) reconcileReleaseReinstall(ctx context.Context
 
 	serverID := uint64(machine.Status.ServerID)
 	if machine.Annotations[dediboxReleaseReinstallStartedAnnotation] != "true" {
-		if err := r.reinstallToPool(ctx, machine); err != nil {
-			r.event(machine, "ReleaseReinstallFailed", "reinstall on release: %v (will retry)", err)
-			return ctrl.Result{}, false, err
+		err := r.reinstallToPool(ctx, machine)
+		switch {
+		case err == nil:
+			r.event(machine, "ReleasedToPool", "Reinstalling Dedibox server %d to a clean, claimable state", machine.Status.ServerID)
+			logger.Info("started Dedibox reinstall on release", "id", machine.Status.ServerID)
+		case r.dediboxInstallAlreadyInFlight(ctx, machine):
+			// An install already running IS the state this release is driving the
+			// box to, so adopt it rather than retrying a POST Dedibox will keep
+			// rejecting for the whole install. Seeing it running also satisfies
+			// the observation the completion gate below waits for, so a `done`
+			// read later belongs to this install and not to the one that put the
+			// box into service.
+			machine.Annotations[dediboxReleaseReinstallObservedAnnotation] = "true"
+			r.event(machine, "ReleasedToPool", "Dedibox server %d is already being reinstalled; releasing without queueing a second install", machine.Status.ServerID)
+			logger.Info("release found a Dedibox install already in flight", "id", machine.Status.ServerID)
+		default:
+			r.event(machine, "ReleaseReinstallFailed", "reinstall on release: %v (retrying in %s)", err, dediboxInstallPollInterval)
+			logger.Error(err, "reinstall Dedibox box on release", "id", machine.Status.ServerID)
+			return ctrl.Result{RequeueAfter: dediboxInstallPollInterval}, false, nil
 		}
 		machine.Annotations[dediboxReleaseReinstallStartedAnnotation] = "true"
 		machine.Status.Phase = "Reinstalling"
-		r.event(machine, "ReleasedToPool", "Reinstalling Dedibox server %d to a clean, claimable state", machine.Status.ServerID)
-		logger.Info("started Dedibox reinstall on release", "id", machine.Status.ServerID)
 		return ctrl.Result{RequeueAfter: dediboxInstallPollInterval}, false, nil
 	}
 
@@ -447,6 +461,34 @@ func (r *DediboxMachineReconciler) reconcileReleaseReinstall(ctx context.Context
 	r.event(machine, "ReleasedToPool", "Reinstalled Dedibox server %d to a clean, claimable state", machine.Status.ServerID)
 	logger.Info("Dedibox release reinstall completed", "id", machine.Status.ServerID)
 	return ctrl.Result{}, true, nil
+}
+
+// dediboxInstallAlreadyInFlight reports whether the box already has an install
+// running, which makes a rejected release reinstall a completed release rather
+// than a failure to retry.
+//
+// Unlike OVH, whose API names the collision (Client::BadRequest::TaskAlreadyExists
+// with the queued task's type), Dedibox answers a rejected install with a bare
+// HTTP status and a free-form message, so there is no error class worth keying
+// on. The box's own install status is the readable signal, and it is the same
+// one the poll below already trusts to decide the release is finished.
+//
+// A box is only adopted once its install reports done, so an install running at
+// release time was started after adoption: by this Machine before a restart lost
+// the finalizer patch, or by a sibling that claimed the same box. What it cannot
+// confirm is that the running install carries this fleet's key and OS — Dedibox
+// exposes a status, not the install's parameters — so an operator reinstalling a
+// held box out of band is accepted too. That already breaks the Machine, and it
+// leaves a box that fails to self-join on its next claim rather than one that
+// joins wrong.
+func (r *DediboxMachineReconciler) dediboxInstallAlreadyInFlight(ctx context.Context, machine *infrav1.DediboxMachine) bool {
+	state, err := r.DediboxClient.InstallState(ctx, machine.Status.Zone, uint64(machine.Status.ServerID))
+	if err != nil {
+		log.FromContext(ctx).Error(err, "read Dedibox install state to classify a rejected release reinstall",
+			"id", machine.Status.ServerID)
+		return false
+	}
+	return state == dedibox.InstallRunning
 }
 
 // reinstallToPool wipes the adopted box back to a clean Ubuntu install with the

--- a/infra/cluster-api-provider-tuist/controllers/linux/ovh_release_reinstall_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/ovh_release_reinstall_test.go
@@ -1,0 +1,265 @@
+package linux
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	goovh "github.com/ovh/go-ovh/ovh"
+	"golang.org/x/crypto/ssh"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	infrav1 "github.com/tuist/tuist/infra/cluster-api-provider-tuist/api/v1alpha1"
+	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/credentials"
+	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/ovh"
+)
+
+const (
+	releaseService = "ns3048220.ip-51-255-75.eu"
+	releaseFleet   = "tuist-kura-ovh"
+)
+
+// fakeOVHReinstallAPI stands in for go-ovh's *ovh.Client: GETs are served from a canned
+// URL map and the reinstall POST returns whatever the test wired.
+type fakeOVHReinstallAPI struct {
+	get       map[string]any
+	postErr   map[string]error
+	postPaths []string
+}
+
+func (f *fakeOVHReinstallAPI) GetWithContext(_ context.Context, url string, res any) error {
+	v, ok := f.get[url]
+	if !ok {
+		return &goovh.APIError{Code: 404, Message: "not found: " + url}
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, res)
+}
+
+func (f *fakeOVHReinstallAPI) PostWithContext(_ context.Context, url string, _, _ any) error {
+	f.postPaths = append(f.postPaths, url)
+	return f.postErr[url]
+}
+
+func (f *fakeOVHReinstallAPI) PutWithContext(_ context.Context, _ string, _, _ any) error { return nil }
+func (f *fakeOVHReinstallAPI) DeleteWithContext(_ context.Context, _ string, _ any) error { return nil }
+
+// installableServer is the GET surface StartInstall needs before it POSTs: the
+// compatible templates and the disk groups the storage layout is planned from.
+func installableServer() map[string]any {
+	return map[string]any{
+		"/dedicated/server/" + releaseService + "/install/compatibleTemplates": map[string][]string{
+			"ovh":      {"ubuntu2404-server_64"},
+			"personal": {},
+		},
+		"/dedicated/server/" + releaseService + "/specifications/hardware": map[string]any{
+			"diskGroups": []map[string]any{{
+				"diskGroupId":   1,
+				"numberOfDisks": 2,
+				"diskSize":      map[string]any{"unit": "Go", "value": 960},
+				"diskType":      "SSD",
+			}},
+		},
+	}
+}
+
+// taskAlreadyExists is the 400 OVH returns for a second reinstall on a server
+// that already has one queued, verbatim from the 2026-09-03 production wedge.
+func taskAlreadyExists() error {
+	return &goovh.APIError{
+		Code:  400,
+		Class: "Client::BadRequest::TaskAlreadyExists",
+		Message: "Task 563254948 of type reinstallServer with status todo is already running on server " +
+			releaseService,
+	}
+}
+
+func releaseScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, rbacv1.AddToScheme, infrav1.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return scheme
+}
+
+// fleetSSHKeySecret pre-seeds the fleet key EnsureFleetSSHKey reads, so the
+// release path never reaches the Scaleway registration generateSSHKey does.
+func fleetSSHKeySecret(t *testing.T, namespace, fleet string) *corev1.Secret {
+	t.Helper()
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := ssh.MarshalPrivateKey(privKey, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sshPub, err := ssh.NewPublicKey(pubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   namespace,
+			Name:        fleet + "-ssh",
+			Annotations: map[string]string{"scaleway.tuist.dev/ssh-key-id": "key-1"},
+		},
+		Data: map[string][]byte{
+			"id_ed25519":     pem.EncodeToMemory(block),
+			"id_ed25519.pub": ssh.MarshalAuthorizedKey(sshPub),
+		},
+	}
+}
+
+func releasingMachine() *infrav1.OVHDedicatedMachine {
+	machine := &infrav1.OVHDedicatedMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "tuist",
+			Name:       "tuist-kura-ovh-abc12-xyz34",
+			Finalizers: []string{OVHDedicatedMachineFinalizer},
+		},
+	}
+	machine.Spec.FleetName = releaseFleet
+	machine.Status.ServiceName = releaseService
+	return machine
+}
+
+func newReleaseReconciler(t *testing.T, api *fakeOVHReinstallAPI) (*OVHDedicatedMachineReconciler, *infrav1.OVHDedicatedMachine, *record.FakeRecorder) {
+	t.Helper()
+	scheme := releaseScheme(t)
+	machine := releasingMachine()
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(machine, fleetSSHKeySecret(t, machine.Namespace, releaseFleet)).
+		Build()
+	recorder := record.NewFakeRecorder(10)
+	return &OVHDedicatedMachineReconciler{
+		Client:             cl,
+		Scheme:             scheme,
+		OVHClient:          &ovh.Client{API: api},
+		Recorder:           recorder,
+		CredentialsManager: &credentials.Manager{Client: cl, Namespace: machine.Namespace},
+	}, machine, recorder
+}
+
+func drainRecorder(recorder *record.FakeRecorder) string {
+	var events []string
+	for {
+		select {
+		case e := <-recorder.Events:
+			events = append(events, e)
+		default:
+			return strings.Join(events, "\n")
+		}
+	}
+}
+
+// A release that finds OVH already reinstalling the box must drop the finalizer
+// rather than retry. reinstallToPool's postcondition is "this box is being
+// returned to a clean, claimable state", and an in-flight reinstallServer task
+// already meets it — but OVH keeps rejecting the second POST with
+// TaskAlreadyExists for the whole ~30 min install, so retrying holds the Machine
+// in Deleting. In production (2026-09-03) that pinned a MachineDeployment one
+// replica above spec for 13 minutes and timed out a helm --atomic rollback.
+func TestOVHReconcileDeleteReleasesWhenReinstallAlreadyInFlight(t *testing.T) {
+	get := installableServer()
+	get["/dedicated/server/"+releaseService+"/task"] = []int64{563254948}
+	get["/dedicated/server/"+releaseService+"/task/563254948"] = map[string]any{
+		"function": "reinstallServer",
+		"status":   "todo",
+	}
+	api := &fakeOVHReinstallAPI{
+		get:     get,
+		postErr: map[string]error{"/dedicated/server/" + releaseService + "/reinstall": taskAlreadyExists()},
+	}
+	r, machine, recorder := newReleaseReconciler(t, api)
+
+	result, err := r.reconcileDelete(context.Background(), machine)
+	if err != nil {
+		t.Fatalf("reconcileDelete: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("reconcileDelete requeued after %s; an in-flight reinstall needs no retry", result.RequeueAfter)
+	}
+	if controllerutil.ContainsFinalizer(machine, OVHDedicatedMachineFinalizer) {
+		t.Fatal("finalizer kept: the Machine wedges in Deleting until the in-flight reinstall finishes")
+	}
+	if events := drainRecorder(recorder); !strings.Contains(events, "ReleasedToPool") {
+		t.Fatalf("events = %q, want a ReleasedToPool event recording the in-flight reinstall", events)
+	}
+}
+
+// TaskAlreadyExists only stands in for a completed release when the queued task
+// is an install. Any other task type (a reboot, a hardware intervention) leaves
+// the box in whatever state the Machine left it, so the reinstall still has to
+// be issued.
+func TestOVHReconcileDeleteRetriesWhenInFlightTaskIsNotAnInstall(t *testing.T) {
+	get := installableServer()
+	get["/dedicated/server/"+releaseService+"/task"] = []int64{563254948}
+	get["/dedicated/server/"+releaseService+"/task/563254948"] = map[string]any{
+		"function": "hardReboot",
+		"status":   "doing",
+	}
+	api := &fakeOVHReinstallAPI{
+		get:     get,
+		postErr: map[string]error{"/dedicated/server/" + releaseService + "/reinstall": taskAlreadyExists()},
+	}
+	r, machine, _ := newReleaseReconciler(t, api)
+
+	result, err := r.reconcileDelete(context.Background(), machine)
+	if err == nil && result.RequeueAfter == 0 {
+		t.Fatal("reconcileDelete neither errored nor requeued; a non-install task is no release guarantee")
+	}
+	if !controllerutil.ContainsFinalizer(machine, OVHDedicatedMachineFinalizer) {
+		t.Fatal("finalizer dropped on a box that was never reinstalled")
+	}
+}
+
+// Every other reinstall failure still retries, and bounded: controller-runtime's
+// default backoff had already stretched to ~6 minutes during the production
+// wedge and doubles to a 1000s cap, so a Machine idles long after OVH frees the
+// server.
+func TestOVHReconcileDeleteRetriesBoundedOnReinstallFailure(t *testing.T) {
+	api := &fakeOVHReinstallAPI{
+		get: installableServer(),
+		postErr: map[string]error{
+			"/dedicated/server/" + releaseService + "/reinstall": &goovh.APIError{
+				Code:    500,
+				Class:   "Server::InternalServerError",
+				Message: "internal server error",
+			},
+		},
+	}
+	r, machine, recorder := newReleaseReconciler(t, api)
+
+	result, err := r.reconcileDelete(context.Background(), machine)
+	if !controllerutil.ContainsFinalizer(machine, OVHDedicatedMachineFinalizer) {
+		t.Fatal("finalizer dropped on a box that was never reinstalled")
+	}
+	if err != nil {
+		t.Fatalf("reconcileDelete returned %v; an error makes controller-runtime ignore RequeueAfter and fall back to unbounded backoff", err)
+	}
+	if result.RequeueAfter <= 0 || result.RequeueAfter > ovhReleaseRetryInterval {
+		t.Fatalf("RequeueAfter = %s, want a bounded retry of at most %s", result.RequeueAfter, ovhReleaseRetryInterval)
+	}
+	if events := drainRecorder(recorder); !strings.Contains(events, "ReleaseReinstallFailed") {
+		t.Fatalf("events = %q, want a ReleaseReinstallFailed event", events)
+	}
+}

--- a/infra/cluster-api-provider-tuist/controllers/linux/ovhdedicatedmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/ovhdedicatedmachine_controller.go
@@ -56,6 +56,15 @@ const (
 
 	// ovhSSHTimeout caps the per-attempt SSH dial + bootstrap run.
 	ovhSSHTimeout = 5 * time.Minute
+
+	// ovhReleaseRetryInterval bounds how long a failed release reinstall waits
+	// before retrying. Returning the error instead would hand the retry to
+	// controller-runtime's default backoff, which doubles to a 1000s cap: during
+	// the 2026-09-03 wedge it had already stretched to ~6 minutes and was heading
+	// for ~17, so the Machine would have idled in Deleting long after OVH freed
+	// the server. The reinstall POST is the only OVH call on this path, so
+	// retrying it every minute costs nothing worth backing off from.
+	ovhReleaseRetryInterval = 60 * time.Second
 )
 
 // OVHDedicatedMachineReconciler reconciles an OVHDedicatedMachine: it adopts a
@@ -455,17 +464,68 @@ func (r *OVHDedicatedMachineReconciler) reconcileDelete(ctx context.Context, mac
 	// (Ubuntu + fleet key + ubuntu login) finishes after the Machine is gone,
 	// leaving a box the next claim self-joins.
 	if machine.Status.ServiceName != "" {
-		if err := r.reinstallToPool(ctx, machine); err != nil {
-			r.event(machine, "ReleaseReinstallFailed", "reinstall on release: %v (will retry)", err)
-			return ctrl.Result{}, err
+		err := r.reinstallToPool(ctx, machine)
+		switch {
+		case err == nil:
+			r.event(machine, "ReleasedToPool", "Reinstalling OVH server %s to a clean, claimable state", machine.Status.ServiceName)
+			logger.Info("reinstalling OVH box on release", "service", machine.Status.ServiceName)
+		case r.reinstallAlreadyInFlight(ctx, machine, err):
+			r.event(machine, "ReleasedToPool", "OVH server %s is already being reinstalled; releasing without queueing a second install", machine.Status.ServiceName)
+			logger.Info("release found an OVH reinstall already in flight", "service", machine.Status.ServiceName)
+		default:
+			r.event(machine, "ReleaseReinstallFailed", "reinstall on release: %v (retrying in %s)", err, ovhReleaseRetryInterval)
+			logger.Error(err, "reinstall OVH box on release", "service", machine.Status.ServiceName)
+			return ctrl.Result{RequeueAfter: ovhReleaseRetryInterval}, nil
 		}
-		r.event(machine, "ReleasedToPool", "Reinstalling OVH server %s to a clean, claimable state", machine.Status.ServiceName)
-		logger.Info("reinstalling OVH box on release", "service", machine.Status.ServiceName)
 	}
 	shared.ForgetEgressMetrics(machine.Name)
 	forgetKataRuntimeMetric(machine.Name)
 	controllerutil.RemoveFinalizer(machine, OVHDedicatedMachineFinalizer)
 	return ctrl.Result{}, nil
+}
+
+// reinstallAlreadyInFlight reports whether a failed release reinstall can be
+// accepted as done because OVH is already reinstalling the box.
+//
+// OVH rejects a reinstall on a server that already has one queued with
+// Client::BadRequest::TaskAlreadyExists, and keeps rejecting it for the ~30
+// minutes the queued install runs. Treating that as retryable holds the
+// finalizer for the whole window: the Machine sits in Deleting, its
+// MachineDeployment stays a replica above spec, and a `helm upgrade --atomic`
+// rollback waiting on that replica count runs out its step ceiling. Two
+// Machines double-claimed one box on 2026-09-03 (fixed in #12779) and the loser
+// wedged for 13 minutes that way; a controller restart between a successful
+// POST and the finalizer patch reaches the same state with one Machine.
+//
+// reinstallToPool's postcondition is "this box is being returned to a clean,
+// claimable state", and an install already in flight meets it, so the release
+// drops the finalizer instead of queueing a second wipe of the same box.
+//
+// The task type is checked rather than assumed: TaskAlreadyExists says only that
+// SOME task is queued, and a reboot or a hardware intervention leaves the box in
+// whatever state the Machine left it. InstallState reads the task list and
+// reports Running only when the newest install-function task is unfinished.
+//
+// What is NOT verified is that the queued install carries this fleet's SSH key
+// and OS template. OVH's task resource exposes a function and a status, not the
+// install parameters, so the only in-band signal is the type. Requiring a
+// sibling Machine to vouch for the parameters would reject the single-Machine
+// restart case above — the more likely trigger, and the one this exists to
+// unwedge. The residual risk is an operator reinstalling, out of band, a box a
+// live Machine still holds: that already breaks the Machine, and its blast
+// radius is a box that fails to self-join on its next claim rather than one that
+// joins wrong.
+func (r *OVHDedicatedMachineReconciler) reinstallAlreadyInFlight(ctx context.Context, machine *infrav1.OVHDedicatedMachine, err error) bool {
+	if !ovh.IsTaskAlreadyExists(err) {
+		return false
+	}
+	state, stateErr := r.OVHClient.InstallState(ctx, machine.Status.ServiceName)
+	if stateErr != nil {
+		log.FromContext(ctx).Error(stateErr, "read OVH task list to classify a rejected release reinstall",
+			"service", machine.Status.ServiceName)
+		return false
+	}
+	return state == ovh.InstallRunning
 }
 
 // reinstallToPool wipes the adopted box back to a clean Ubuntu install with the

--- a/infra/cluster-api-provider-tuist/controllers/linux/scalewayelasticmetalmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/scalewayelasticmetalmachine_controller.go
@@ -56,6 +56,12 @@ const (
 	// and the reconcile retries on the normal cadence.
 	elasticMetalSSHTimeout = 5 * time.Minute
 
+	// elasticMetalReleaseRetryInterval bounds how long a failed release reinstall
+	// waits before retrying. Returning the error would hand the retry to
+	// controller-runtime's default backoff, which doubles to a 1000s cap and
+	// leaves a Machine idling in Deleting long after Scaleway frees the server.
+	elasticMetalReleaseRetryInterval = 60 * time.Second
+
 	// pnIPv4Label is the node label dispatch reads as the Private-Network
 	// address of the runner-cache node. kubelet can't self-set tuist.dev/*
 	// labels under NodeRestriction, so the controller patches it.
@@ -498,10 +504,14 @@ func (r *ScalewayElasticMetalMachineReconciler) reconcileDelete(ctx context.Cont
 			if keyErr != nil {
 				return ctrl.Result{}, fmt.Errorf("read fleet ssh key for release: %w", keyErr)
 			}
+			// ReinstallServer already reads a server that is absent or mid-install
+			// as released, so this only fires on a failure that has to be retried.
 			if relErr := r.ScalewayClient.ReinstallServer(ctx, zone, machine.Status.ServerID,
 				firstNonEmpty(machine.Spec.OS, r.DefaultOS), nonEmpty(sshKeyID)); relErr != nil {
-				r.event(machine, "ReleaseFailed", "release (reinstall) Elastic Metal server %s: %v (will retry)", machine.Status.ServerID, relErr)
-				return ctrl.Result{}, relErr
+				r.event(machine, "ReleaseFailed", "release (reinstall) Elastic Metal server %s: %v (retrying in %s)",
+					machine.Status.ServerID, relErr, elasticMetalReleaseRetryInterval)
+				log.FromContext(ctx).Error(relErr, "reinstall Elastic Metal box on release", "id", machine.Status.ServerID)
+				return ctrl.Result{RequeueAfter: elasticMetalReleaseRetryInterval}, nil
 			}
 		}
 	}

--- a/infra/cluster-api-provider-tuist/internal/ovh/client.go
+++ b/infra/cluster-api-provider-tuist/internal/ovh/client.go
@@ -655,6 +655,31 @@ func mapTaskStatus(status string) InstallState {
 	}
 }
 
+// taskAlreadyExistsClass is the OVHcloud error class returned when the requested
+// task is already queued on the server. The class is a typed field on the API
+// error, so callers key on it rather than on the human-readable message (which
+// carries the task id, type and hostname and is not a stable contract).
+const taskAlreadyExistsClass = "Client::BadRequest::TaskAlreadyExists"
+
+// IsTaskAlreadyExists reports whether err is OVH's rejection of a task it
+// already has queued on the server, e.g. a second reinstall issued while the
+// first is still running:
+//
+//	OVHcloud API error (status code 400): Client::BadRequest::TaskAlreadyExists:
+//	"Task 563254948 of type reinstallServer with status todo is already running
+//	on server ns3048220.ip-51-255-75.eu"
+//
+// It says only that SOME task is in flight, not which; the message names the
+// type but the task list (InstallState) is the readable answer, so callers that
+// care about the type ask there.
+func IsTaskAlreadyExists(err error) bool {
+	var apiErr *ovh.APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.Class == taskAlreadyExistsClass
+	}
+	return false
+}
+
 // IsNotFound reports whether err is an OVH 404, so callers can treat an absent
 // server/task as gone rather than a hard error.
 func IsNotFound(err error) bool {

--- a/infra/cluster-api-provider-tuist/internal/ovh/client_test.go
+++ b/infra/cluster-api-provider-tuist/internal/ovh/client_test.go
@@ -3,6 +3,8 @@ package ovh
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/ovh/go-ovh/ovh"
@@ -550,5 +552,24 @@ func TestPublicEgressRejectsAnOutOfRangeValue(t *testing.T) {
 				t.Fatalf("Mbps = %d, want 0", got.Mbps)
 			}
 		})
+	}
+}
+
+func TestIsTaskAlreadyExists(t *testing.T) {
+	// The message shape OVH returned when a second release reinstall raced the
+	// first on ns3048220 (2026-09-03); the class is what is matched on.
+	inFlight := &ovh.APIError{
+		Code:    400,
+		Class:   "Client::BadRequest::TaskAlreadyExists",
+		Message: "Task 563254948 of type reinstallServer with status todo is already running on server ns3048220.ip-51-255-75.eu",
+	}
+	if !IsTaskAlreadyExists(fmt.Errorf("start reinstall on srv: %w", inFlight)) {
+		t.Fatal("IsTaskAlreadyExists = false for a wrapped TaskAlreadyExists; the release would retry until the queued install finishes")
+	}
+	if IsTaskAlreadyExists(&ovh.APIError{Code: 400, Class: "Client::BadRequest", Message: "only 1 single SSH key can be provided"}) {
+		t.Fatal("IsTaskAlreadyExists = true for an unrelated 400")
+	}
+	if IsTaskAlreadyExists(errors.New("dial tcp: connection refused")) {
+		t.Fatal("IsTaskAlreadyExists = true for a non-API error")
 	}
 }

--- a/infra/cluster-api-provider-tuist/internal/scaleway/baremetal_client.go
+++ b/infra/cluster-api-provider-tuist/internal/scaleway/baremetal_client.go
@@ -192,8 +192,14 @@ func (c *BaremetalClient) PartitioningSchemaFor(ctx context.Context, zone scw.Zo
 // reinstalling its OS — the Elastic Metal analog of the macOS ReleaseToPool.
 // Used on Machine delete to RETURN the pre-ordered box to the pool rather than
 // terminate it (the operator owns the pool's lifecycle). The sshKeyIDs re-author
-// the fleet key so the reinstalled box is bootstrappable on its next claim. An
-// absent server (deleted out of band) is treated as already released.
+// the fleet key so the reinstalled box is bootstrappable on its next claim.
+//
+// Two states already satisfy the postcondition and are reported as released
+// rather than acted on: an absent server (deleted out of band), and one Scaleway
+// is already installing. The second is what a controller restart between a
+// successful install and the finalizer patch leaves behind; issuing a second
+// install there is rejected, and the caller retries on any error, so it would
+// hold the Machine in Deleting for the whole install.
 func (c *BaremetalClient) ReinstallServer(ctx context.Context, zone scw.Zone, serverID, osLabel string, sshKeyIDs []string) error {
 	server, err := c.GetServer(ctx, zone, serverID)
 	if err != nil {
@@ -201,6 +207,9 @@ func (c *BaremetalClient) ReinstallServer(ctx context.Context, zone scw.Zone, se
 			return nil
 		}
 		return err
+	}
+	if ServerInstalling(server) {
+		return nil
 	}
 	osID, err := c.resolveOS(ctx, zone, server.OfferID, osLabel)
 	if err != nil {
@@ -316,6 +325,20 @@ func ServerInstalled(server *baremetal.Server) bool {
 		return false
 	}
 	return server.Install != nil && server.Install.Status == baremetal.ServerInstallStatusCompleted
+}
+
+// ServerInstalling reports whether an OS install is queued or already running on
+// the server — the state that makes a further install both unnecessary and
+// rejected.
+func ServerInstalling(server *baremetal.Server) bool {
+	if server.Install == nil {
+		return false
+	}
+	switch server.Install.Status {
+	case baremetal.ServerInstallStatusToInstall, baremetal.ServerInstallStatusInstalling:
+		return true
+	}
+	return false
 }
 
 // ServerInstallFailed reports a terminal install/order failure (out of stock,

--- a/infra/cluster-api-provider-tuist/internal/scaleway/baremetal_client_test.go
+++ b/infra/cluster-api-provider-tuist/internal/scaleway/baremetal_client_test.go
@@ -179,3 +179,57 @@ func TestPartitioningSchemaForFailsClosedOnValidationError(t *testing.T) {
 		t.Fatalf("a rejected schema still reached the install: %+v", api.installReq)
 	}
 }
+
+// A release reinstall issued against a box Scaleway is already installing must
+// read as done, not as a failure. The Elastic Metal delete path retries on any
+// error and only then drops the finalizer, so a controller restart between a
+// successful InstallServer and the finalizer patch would otherwise hold the
+// Machine in Deleting for the whole install: the MachineDeployment stays a
+// replica above spec and a `helm upgrade --atomic` rollback waiting on that
+// count runs out its step ceiling. An install already in flight is the
+// postcondition the reinstall exists to reach, the same reasoning that already
+// treats an absent server as released.
+func TestReinstallServerAcceptsAnInstallAlreadyInFlight(t *testing.T) {
+	for _, status := range []baremetal.ServerInstallStatus{
+		baremetal.ServerInstallStatusToInstall,
+		baremetal.ServerInstallStatusInstalling,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			api := &fakeBaremetalAPI{
+				getServer: &baremetal.Server{
+					ID: "srv", Name: "kura-1", OfferID: "offer",
+					Install: &baremetal.ServerInstall{Status: status},
+				},
+				osList: []*baremetal.OS{{ID: "os", Name: "Ubuntu", Version: "24.04 LTS"}},
+			}
+			c := &BaremetalClient{Baremetal: api}
+
+			if err := c.ReinstallServer(context.Background(), scw.ZoneFrPar1, "srv", "ubuntu_24.04", []string{"key"}); err != nil {
+				t.Fatalf("ReinstallServer: %v", err)
+			}
+			if api.installReq != nil {
+				t.Fatal("queued a second install on a box already installing")
+			}
+		})
+	}
+}
+
+// A finished install is not an in-flight one: the box is back in whatever state
+// the Machine left it, so the release still has to wipe it.
+func TestReinstallServerInstallsOverACompletedInstall(t *testing.T) {
+	api := &fakeBaremetalAPI{
+		getServer: &baremetal.Server{
+			ID: "srv", Name: "kura-1", OfferID: "offer",
+			Install: &baremetal.ServerInstall{Status: baremetal.ServerInstallStatusCompleted},
+		},
+		osList: []*baremetal.OS{{ID: "os", Name: "Ubuntu", Version: "24.04 LTS"}},
+	}
+	c := &BaremetalClient{Baremetal: api}
+
+	if err := c.ReinstallServer(context.Background(), scw.ZoneFrPar1, "srv", "ubuntu_24.04", []string{"key"}); err != nil {
+		t.Fatalf("ReinstallServer: %v", err)
+	}
+	if api.installReq == nil {
+		t.Fatal("a box whose last install completed was left uninstalled on release")
+	}
+}


### PR DESCRIPTION
A Machine's release reinstalls its bare-metal box back to a clean, claimable state as the last step before dropping the finalizer, and every error on that step was treated as retryable. When the provider already has a reinstall queued on the box it rejects the second one for the whole ~30 minute install, so the retry never succeeds and the Machine sits in `Deleting` / `WaitingForInfrastructureDeletion` for the duration.

OVH returns:

```
OVHcloud API error (status code 400): Client::BadRequest::TaskAlreadyExists:
"Task 563254948 of type reinstallServer with status todo is already running on
server ns3048220.ip-51-255-75.eu"
```

### How it happened in production (2026-09-03)

Two Machines shared one box because of the concurrent-adopt double-claim fixed in https://github.com/tuist/tuist/pull/12779 (`6sdk4` and `g7jgl` both on `ns3048220`). When the MachineDeployment scaled down, both released and both tried to reinstall that box. `6sdk4` won; `g7jgl` wedged from 08:34:08Z to 08:47:35Z.

Consequences beyond the 13 minute delay:

- The MachineDeployment stayed one replica above spec for the whole window, so `helm upgrade --atomic`'s rollback wait could not complete and the workflow's 70m step ceiling killed it, leaving the release in `pending-rollback`.
- The box was reinstalled twice back to back, so it was the last of three to return to the pool.

### What changed

`reinstallToPool`'s postcondition is "this box is being returned to a clean, claimable state". A reinstall already in flight meets it, so the release now drops the finalizer instead of queueing a second wipe of the same box.

**The task type is checked, not assumed.** `TaskAlreadyExists` says only that *some* task is queued, and a reboot or a hardware intervention leaves the box in whatever state the Machine left it. So the rejection only counts as a release when OVH's task list also reports an install-function task still unfinished (`InstallState == InstallRunning`). The error itself is classified on `ovh.APIError`'s typed `Class` field rather than by matching the message, which carries the task id and hostname and is not a contract.

**What is deliberately not verified is that the queued install carries this fleet's SSH key and OS template.** OVH's task resource exposes a function and a status, not the install's parameters, so the type is the only in-band signal. Requiring a sibling Machine to vouch for the parameters was considered and rejected: it would refuse the likelier trigger, which is one Machine retrying after a controller restart between a successful POST and the finalizer patch. That needs no double-claim at all, and the sibling lookup degenerates there because the releasing Machine is itself the only holder of the box — so the check would have preserved the wedge it exists to remove. The residual risk is an operator reinstalling, out of band, a box a live Machine still holds; that already breaks the Machine, and it leaves a box that fails to self-join on its next claim rather than one that joins wrong.

### The sibling kinds

Both share the shape and are fixed the same way, keyed on what each API actually exposes:

- **Dedibox** answers a rejected install with a bare HTTP status and a free-form message, so there is no error class worth keying on. The controller reads the box's install state instead — the same read its release poll already trusts — and adopts a running install, recording it as the in-progress observation the completion gate waits for.
- **Elastic Metal** already fetches the server before installing, so `ReinstallServer` now reports a server Scaleway is installing as released, next to the absent-server case it already treated that way.

### Bounded retry

`reconcileDelete` returned the error with no `RequeueAfter`, which controller-runtime answers with its default exponential backoff (5ms doubling to a 1000s cap). During the wedge the interval had already stretched to ~6 minutes and was heading for ~17, so a Machine can idle long after the provider frees the server. All three kinds now requeue on a fixed 60s interval (Dedibox on its existing install poll interval) and log plus event the failure.

The error is not returned alongside `RequeueAfter`, because controller-runtime ignores `RequeueAfter` when the error is non-nil and falls back to the rate limiter — returning both would have looked like a fix without being one.

### How to test locally

```bash
cd infra/cluster-api-provider-tuist && go build ./... && go vet ./... && go test ./... -count=1
```

Tests were written failing first:

- `TestOVHReconcileDeleteReleasesWhenReinstallAlreadyInFlight` — a fake OVH API returning the verbatim `TaskAlreadyExists` 400 drops the finalizer with no requeue and events `ReleasedToPool`.
- `TestOVHReconcileDeleteRetriesWhenInFlightTaskIsNotAnInstall` — the same 400 with a `hardReboot` task in flight keeps the finalizer. Verified to be a real guard by stubbing the task-type check out and watching it fail.
- `TestOVHReconcileDeleteRetriesBoundedOnReinstallFailure` — an unrelated 500 keeps the finalizer, returns no error, and requeues bounded.
- `TestDediboxReleaseAdoptsAnInstallAlreadyInFlight` / `TestDediboxReleaseRetriesBoundedWhenNoInstallIsRunning` — the same pair for the Dedibox release, driven through the client's own `DEDIBOX_API_URL` override rather than widening its transport for tests.
- `TestReinstallServerAcceptsAnInstallAlreadyInFlight` / `TestReinstallServerInstallsOverACompletedInstall` — Elastic Metal skips the install for `to_install`/`installing` and still installs over a `completed` one.
- `TestIsTaskAlreadyExists` — the class matches through a wrapped error and does not match unrelated 400s or non-API errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
