### PR TITLE
fix(infra): declare statefulRaidLevel in every Cluster CR

### DIFF
--- a/infra/k8s/clusters/cluster-canary.yaml
+++ b/infra/k8s/clusters/cluster-canary.yaml
@@ -49,6 +49,12 @@ spec:
       # (`tuist-bm-canary-…`).
       - name: bareMetalCluster
         value: canary
+      # Declared in every cluster, including those with no stateful pool. See
+      # the variable's definition in `clusterclass-tuist.yaml`: a defaulted
+      # ClusterClass variable left implicit here makes the post-apply drift
+      # check in `mgmt-cluster-apply.yml` fail permanently.
+      - name: statefulRaidLevel
+        value: 1
       # Insert InternalIP so the apiserver can reach kubelets on nodes with no
       # ExternalIP and an unresolvable Hostname (the Scaleway Elastic Metal kura
       # node + the macOS-PN fleet) for `kubectl logs`/`exec`. Flipping this

--- a/infra/k8s/clusters/cluster-pentest.yaml
+++ b/infra/k8s/clusters/cluster-pentest.yaml
@@ -38,6 +38,12 @@ spec:
         value: /run/systemd/resolve/resolv.conf
       - name: disableControlPlaneKubeletLocalMode
         value: true
+      # Declared in every cluster, including those with no stateful pool. See
+      # the variable's definition in `clusterclass-tuist.yaml`: a defaulted
+      # ClusterClass variable left implicit here makes the post-apply drift
+      # check in `mgmt-cluster-apply.yml` fail permanently.
+      - name: statefulRaidLevel
+        value: 1
     workers:
       machineDeployments:
         # The server, package registry, persistent data services, and platform

--- a/infra/k8s/clusters/cluster-preview.yaml
+++ b/infra/k8s/clusters/cluster-preview.yaml
@@ -50,6 +50,12 @@ spec:
       - name: hcloudSSHKeyName
         value:
           - name: tuist-ops
+      # Declared in every cluster, including those with no stateful pool. See
+      # the variable's definition in `clusterclass-tuist.yaml`: a defaulted
+      # ClusterClass variable left implicit here makes the post-apply drift
+      # check in `mgmt-cluster-apply.yml` fail permanently.
+      - name: statefulRaidLevel
+        value: 1
     workers:
       machineDeployments:
         - class: hcloud-worker

--- a/infra/k8s/clusters/cluster-production.yaml
+++ b/infra/k8s/clusters/cluster-production.yaml
@@ -50,6 +50,12 @@ spec:
       # (`tuist-bm-production-…`).
       - name: bareMetalCluster
         value: production
+      # Declared in every cluster, including those with no stateful pool. See
+      # the variable's definition in `clusterclass-tuist.yaml`: a defaulted
+      # ClusterClass variable left implicit here makes the post-apply drift
+      # check in `mgmt-cluster-apply.yml` fail permanently.
+      - name: statefulRaidLevel
+        value: 1
       # Insert InternalIP so the apiserver can reach kubelets on nodes with no
       # ExternalIP and an unresolvable Hostname (the Scaleway Elastic Metal kura
       # node + the macOS-PN fleet) for `kubectl logs`/`exec`. Flipping this

--- a/infra/k8s/clusters/cluster-staging.yaml
+++ b/infra/k8s/clusters/cluster-staging.yaml
@@ -59,6 +59,12 @@ spec:
       # (`tuist-bm-staging-…`).
       - name: bareMetalCluster
         value: staging
+      # Declared in every cluster, including those with no stateful pool. See
+      # the variable's definition in `clusterclass-tuist.yaml`: a defaulted
+      # ClusterClass variable left implicit here makes the post-apply drift
+      # check in `mgmt-cluster-apply.yml` fail permanently.
+      - name: statefulRaidLevel
+        value: 1
       # Insert InternalIP ahead of Hostname so the apiserver can reach the
       # cross-cloud kura kubelets (Dedibox/Elastic Metal): they report no
       # ExternalIP and an unresolvable Hostname, so the default order lands on

--- a/infra/k8s/clusters/clusterclass-tuist.yaml
+++ b/infra/k8s/clusters/clusterclass-tuist.yaml
@@ -419,6 +419,17 @@ spec:
     # the host is claimed: the layout is fixed at install, so changing it
     # afterwards means a reinstall and a replica rebuild from the peer.
     # Do not set 0: caph rewrites RAID 0 to 1 in the installimage wrapper.
+    #
+    # EVERY Cluster CR must declare this explicitly, including the ones with
+    # no stateful pool. A defaulted variable a Cluster does not declare is
+    # appended to the live `spec.topology.variables` by the topology
+    # controller in ALPHABETICAL order, while `kubectl diff` appends it after
+    # the declared ones; the two orders then disagree on every subsequent
+    # run and the post-apply drift check in `mgmt-cluster-apply.yml` can
+    # never converge. That is what turned the merge of #12799 red. The three
+    # older defaulted variables hid the problem by happening to sort after
+    # the declared ones already. Any future variable with a `default` needs
+    # the same treatment in the same change.
     - name: statefulRaidLevel
       required: false
       schema:


### PR DESCRIPTION
Unblocks the mgmt cluster. The merge of #12799 left `mgmt-cluster-apply` red at "Verify converged management state", so the staging ClickHouse host is still unclaimed and no further cluster change can go out until this lands.

### What broke

Every apply step in that run succeeded. Only the post-apply `kubectl diff` failed:

```
Declarative drift remains for infra/k8s/clusters/cluster-canary.yaml
+    - name: statefulRaidLevel
+      value: 1
     - name: workerNodeLabels
     ...
-    - name: statefulRaidLevel
-      value: 1
```

Canary is not special, it is first alphabetically. The same diff exists for all five clusters.

### Root cause

A Cluster CR's live `spec.topology.variables` holds the variables its manifest declares, in manifest order, followed by every ClusterClass variable that carries a `default` and was not declared. The topology controller keeps that second group sorted alphabetically. `kubectl diff` instead renders those defaulted entries appended after the declared ones.

So as soon as a defaulted variable sorts anywhere other than last, the live order and the diff order disagree, and they keep disagreeing on every subsequent run. The check cannot converge on its own, which is why the failure is permanent rather than transient.

The three older defaulted variables (`hcloudWorkerMachinePlacementGroupName`, `workerNodeLabels`, `workerNodeTaints`) all happened to sort after every declared variable, so the ordering never diverged and this has not been hit before. `statefulRaidLevel` sorts between them and exposed it.

### The fix

Declare `statefulRaidLevel` in all five Cluster CRs, which moves it into the section whose order both sides agree on. The value is the default of 1 everywhere, so this changes nothing about what the templates render and rolls no machine.

Production takes 10 in the change that gives it a stateful pool and its four-disk box, not here. Preview and pentest have no stateful pool at all and still declare it, because the drift is a property of the variable having a default, not of the cluster using it.

The rule now lives in the ClusterClass comment next to the variable, since the next variable with a `default` will hit this the same way unless it is declared in the same change.

### Alternative considered

Dropping the `default` from the variable would also fix the ordering, since only defaulted variables get appended. Rejected: the default is what makes the two-disk case correct without every cluster having to know the RAID level of hardware it does not have, and removing it would make the variable required for clusters that never render the template.

### Validation

All six manifests parse, and every Cluster CR reports `statefulRaidLevel = 1`. The real validation is the workflow going green on merge, since that is the thing currently failing. After it does, the expected sequence is the staging `HetznerBareMetalHost` leaving `Available`, caph running installimage for 8 to 15 minutes, and the node joining tainted `tuist.dev/stateful=clickhouse`.

### How to test locally

Not reproducible locally: the check runs `kubectl diff` against the management cluster. Reviewing means confirming the variable is declared in all five Cluster CRs with the value 1, and watching the workflow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
