### PR TITLE
fix(server): unbreak the server test suite on main

### DIFF
--- a/server/test/tuist_web/controllers/api/cache_controller_test.exs
+++ b/server/test/tuist_web/controllers/api/cache_controller_test.exs
@@ -205,6 +205,9 @@ defmodule TuistWeb.API.CacheControllerTest do
       # The stand-in answer stops being right the moment the account's own
       # instance starts serving, so it must not be held for the usual interval.
       stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+      stub(Tuist.Environment, :dev?, fn -> false end)
+      stub(Tuist.Environment, :test?, fn -> false end)
+      stub(Tuist.Environment, :kura_available_region_ids, fn -> ["us-east", "eu-central"] end)
       stub(Tuist.Environment, :cache_endpoints, fn -> ["https://default.tuist.dev"] end)
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)

--- a/server/test/tuist_web/live/overview_live_test.exs
+++ b/server/test/tuist_web/live/overview_live_test.exs
@@ -297,8 +297,8 @@ defmodule TuistWeb.OverviewLiveTest do
 
       assert has_element?(lv, "#bazel-action-cache-hit-rate", "50.0%")
       assert has_element?(lv, "#bazel-action-cache-lookups", "2")
-      assert has_element?(lv, "#bazel-cache-downloads", "6.0 KB")
-      assert has_element?(lv, "#bazel-cache-uploads", "3.0 KB")
+      assert has_element?(lv, "#bazel-cache-downloads", "6.1 KB")
+      assert has_element?(lv, "#bazel-cache-uploads", "3.1 KB")
       assert has_element?(lv, "[data-part=bazel-latest-observation]", "Latest observation:")
     end
   end


### PR DESCRIPTION
## What changed

Two test files. No production code.

- `test/tuist_web/controllers/api/cache_controller_test.exs`: the provisioning test now stubs `Environment.dev?`, `Environment.test?`, and `Environment.kura_available_region_ids`, matching what https://github.com/tuist/tuist/pull/12798 already did for every other caller of `AccountPolicies.resolve/1`.
- `test/tuist_web/live/overview_live_test.exs`: the Bazel cache totals now expect `6.1 KB` and `3.1 KB` instead of `6.0 KB` and `3.0 KB`.

## Why

Both tests are red on `main` and have been since this morning, so every open pull request inherits the failure. `Test` and `Test (oldest supported ClickHouse)` have failed on the last several `main` runs.

**`TuistWeb.API.CacheControllerTest`**, red since https://github.com/tuist/tuist/pull/12798. That change made `AccountPolicies.resolve/1` refuse a service region the deployment does not serve, rather than resolving into one nothing will ever provision. `Kura.Regions.available/0` returns only the local controller region under `dev?` or `test?`, so in the test environment a fresh Air account is now refused, `Demand.instance_expected?/1` returns false, and `GET /api/cache/endpoints` answers with the full `max-age=3600` instead of the 30 seconds the stand-in answer is meant to carry. #12798 added the three stubs to `accounts_test.exs`, `demand_test.exs`, `account_policies_test.exs`, and `backfill_cache_demand_worker_test.exs`, but this controller test reaches the same code path and was missed.

The production behaviour is what #12798 intended, so the test moves rather than the code.

**`TuistWeb.OverviewLiveTest`**, red since https://github.com/tuist/tuist/pull/12782 introduced it. The fixture records 4096 and 2048 bytes of hits and 2048 and 1024 bytes of writes, and the assertions divide those by 1024. `Tuist.Utilities.ByteFormatter.format_bytes/1` is decimal, as it is for every other byte figure in the dashboard, so 6144 renders as `6.1 KB` and 3072 as `3.1 KB`. Only the expectations were wrong.

## Impact

`main` goes green again, and open pull requests stop inheriting two failures that have nothing to do with them.

## Validation

Both suites run locally against Postgres and ClickHouse, red before green:

- On unmodified `main`: `Result: 56/58 passed`, failing exactly the two tests CI reports.
- With this change: `Result: 58 passed`.
- `mix format --check-formatted` passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
