### PR TITLE
fix(swifterpm,cli): preserve root symbolic links when flattening

### DIFF
--- a/swifterpm/Sources/swifterpm/FileSystemSupport.swift
+++ b/swifterpm/Sources/swifterpm/FileSystemSupport.swift
@@ -145,13 +145,27 @@ extension FileSystem {
         }
         try await move(from: nested.absolutePath, to: temp.absolutePath, options: [])
         for entry in try await contentsOfDirectory(at: temp) {
-            try await move(
-                from: entry.absolutePath,
-                to: url.appendingPathComponent(entry.lastPathComponent).absolutePath,
-                options: []
-            )
+            let destination = url.appendingPathComponent(entry.lastPathComponent)
+            if isSymlink(entry) {
+                try moveSymbolicLink(from: entry, to: destination)
+            } else {
+                try await move(from: entry.absolutePath, to: destination.absolutePath, options: [])
+            }
         }
         try await remove(temp.absolutePath)
+    }
+
+    private func moveSymbolicLink(from source: URL, to destination: URL) throws {
+        let result = source.path.withCString { sourcePath in
+            destination.path.withCString { destinationPath in
+                rename(sourcePath, destinationPath)
+            }
+        }
+        guard result == 0 else {
+            let errorCode = errno
+            let message = String(cString: strerror(errorCode))
+            throw ToolError.message("failed to move symbolic link from \(source.path) to \(destination.path): \(message)")
+        }
     }
 
     /// Materialise `source` at `destination`, removing any existing item first. By default,

--- a/swifterpm/Tests/swifterpmTests/FileSystemSupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/FileSystemSupportTests.swift
@@ -117,6 +117,27 @@ struct FileSystemSupportTests {
     }
 
     @Test
+    func flattenSingleDirectoryPreservesRootSymbolicLinks() async throws {
+        try await withTemporaryDirectory { root in
+            let packageRoot = root.appendingPathComponent("package-1.0.0")
+            let agents = packageRoot.appendingPathComponent("AGENTS.md")
+            let claude = packageRoot.appendingPathComponent("CLAUDE.md")
+            try await fileSystem.atomicWrite("instructions", to: agents)
+            try await fileSystem.atomicWrite("// package manifest", to: packageRoot.appendingPathComponent("Package.swift"))
+            try await fileSystem.createSymbolicLink(
+                from: claude.absolutePath,
+                to: try RelativePath(validating: "AGENTS.md")
+            )
+
+            try await fileSystem.flattenSingleDirectory(root)
+
+            let flattenedLink = root.appendingPathComponent("CLAUDE.md")
+            #expect(fileSystem.isSymlink(flattenedLink))
+            #expect(try await fileSystem.exists(flattenedLink.absolutePath))
+        }
+    }
+
+    @Test
     func flattenSingleDirectoryPreservesPackageSourcesAtRoot() async throws {
         try await withTemporaryDirectory { root in
             let packageManifest = root.appendingPathComponent("Package.swift")


### PR DESCRIPTION
## What changed

- Added regression coverage for a registry source archive with a package-root `CLAUDE.md -> AGENTS.md` symbolic link.
- Flattening now renames symbolic links directly instead of resolving their targets before moving them.

## Why

Registry packages may include root-level symbolic links. Tuist should preserve those links while normalizing the archive wrapper directory.

## Root cause

Flattening moves entries individually. When a link target is moved first, its relative symbolic link is temporarily unresolved. The generic move operation checks the resolved source path and rejects that link even though the link itself still exists.

## Approach

The flattening path now uses a direct rename for symbolic links. Rename moves the link object without resolving its target, so it is safe regardless of directory enumeration order. Regular files and directories continue to use the existing filesystem move operation.

## Impact

Registry-based dependency installation succeeds for packages whose archive wrapper contains root-level relative symbolic links.

## Validation

- `swift test --replace-scm-with-registry --filter FileSystemSupportTests/flattenSingleDirectoryPreservesRootSymbolicLinks`
- `swift test --replace-scm-with-registry`
