### PR TITLE
fix(infra): lift the containerd image-store quota from Linux runner boxes

### DIFF
--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -717,15 +717,27 @@ Every install these kinds start lays down a redundant root plus a **separate XFS
 join a box where it cannot (`dataProjectQuotaScript` in
 `controllers/linux/linux_cloudinit.go`).
 
-The image store gets a reserved project of its own (`containerdQuotaScript`,
-project 100). It is the only consumer of `/data` that is not a tenant, and a
-per-volume quota is a ceiling rather than a reservation, so a tenant inside its
-own ceiling can still be denied space something else took first. Nothing else
-bounds it: the kubelet's image GC triggers on the FILESYSTEM being nearly full,
-so it only reclaims once the box is already squeezing tenants. The ceiling is
-deliberately generous, because containerd hitting it means failed pulls that
-image GC cannot resolve, and unlike the `/data` mount setup a failure to apply
-it does not fail the join.
+On a **cache box** the image store gets a reserved project of its own
+(`containerdQuotaScript`, project 100). It is the only consumer of `/data` that
+is not a tenant, and a per-volume quota is a ceiling rather than a reservation,
+so a tenant inside its own ceiling can still be denied space something else took
+first. Nothing else bounds it: the kubelet's image GC triggers on the FILESYSTEM
+being nearly full, so it only reclaims once the box is already squeezing
+tenants. The ceiling is deliberately generous, because containerd hitting it
+means failed pulls that image GC cannot resolve, and unlike the `/data` mount
+setup a failure to apply it does not fail the join.
+
+**Only cache boxes get it** (`hostsKuraCacheVolumes`, keyed off the
+`tuist.dev/kura-cache` taint). A runner box has no tenant volumes on `/data`, so
+the quota protects nothing there while still being reachable: under `kata-qemu`
+the runner container's writable layer is a host overlayfs snapshot inside the
+image store, so ordinary CI writes land against project 100. XFS reports a blown
+project quota as ENOSPC, and image GC keys on the filesystem's free space, which
+on an 828 GiB `/data` never trips. A runner box that hit the ceiling therefore
+failed every job it accepted, permanently, on a disk that was 94% free. Absence
+of the taint means no quota: quota-ing a box with no tenants buys nothing and
+costs an unclearable ceiling, while skipping one that has tenants only returns
+it to the defence-in-depth it had before the quota existed.
 
 The chain it exists to close: a Kura cache PV is a local-path *directory* on
 `/data`, a directory has no size, so the pod's `ephemeral-storage` request is

--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -739,6 +739,18 @@ of the taint means no quota: quota-ing a box with no tenants buys nothing and
 costs an unclearable ceiling, while skipping one that has tenants only returns
 it to the defence-in-depth it had before the quota existed.
 
+Gating the self-join alone reaches no live box (see "strategy: OnDelete"
+above), so `reconcileLinuxContainerdQuotaDrift` (`containerd_quota_drift.go`)
+lifts the limit in place from any Ready non-cache box and stamps
+`tuist.dev/containerd-quota-lifted` on the Node. The quota is XFS metadata with
+no Kubernetes-visible observable, so like the kubelet-config hash the stamp IS
+the observable, written only on the lift script's exit status. The lift is one
+`xfs_quota limit -p bhard=0` plus dropping the `/etc/projects` line: no restart
+of anything, effective in the kernel immediately, so a box mid-ENOSPC recovers
+without a drain. `ContainerdQuotaLifted=False/ContainerdQuotaPresent` on the
+Machine is the loud state before the lift, `ContainerdQuotaLiftFailed` after a
+failed one.
+
 The chain it exists to close: a Kura cache PV is a local-path *directory* on
 `/data`, a directory has no size, so the pod's `ephemeral-storage` request is
 scheduler admission at placement time and nothing bounds what one account

--- a/infra/cluster-api-provider-tuist/controllers/linux/containerd_quota_drift.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/containerd_quota_drift.go
@@ -56,13 +56,18 @@ const (
 // The guards match containerdQuotaScript exactly. Where any of them fail the
 // self-join applied no quota, so there is nothing to lift and the script exits
 // 0, which lets the controller stamp the Node and stop dialling.
+//
+// The script arrives over SSH as the install user, so a per-line sudo prefix
+// does not cover shell redirections: the open happens before sudo runs. Both
+// writes here are redirections, the lock fd on a root-owned file the bootstrap
+// created and the rewrite of /etc/projects, so the privileged half runs as one
+// root shell fed by a heredoc. The read-only guards stay outside it; findmnt
+// needs no privilege and a box with nothing to lift never escalates at all.
 func renderContainerdQuotaLiftScript(opts linuxCloudInitOptions) string {
 	sudo, _ := escalation(opts.BootstrapUser)
 	return fmt.Sprintf(`#!/usr/bin/env bash
 set -euxo pipefail
 data=/data
-dir=/data/containerd
-projid=%[2]d
 
 mountpoint -q "$data" || exit 0
 [ "$(findmnt -no SOURCE "$data")" != "$(findmnt -no SOURCE /)" ] || exit 0
@@ -72,19 +77,26 @@ case ",$(findmnt -no OPTIONS "$data")," in
   *) exit 0 ;;
 esac
 
+%[1]sbash -s <<'TUIST_ROOT'
+set -euxo pipefail
+data=/data
+dir=/data/containerd
+projid=%[2]d
+
 exec 9>/var/lock/tuist-kura-quota.lock
-%[1]sflock 9
+flock 9
 
 # bhard=0 is how xfs_quota removes a limit; the project keeps accounting, which
 # is harmless and leaves usage readable if anyone asks.
-%[1]sxfs_quota -x -c "limit -p bhard=0 $projid" "$data"
+xfs_quota -x -c "limit -p bhard=0 $projid" "$data"
 # Drop the /etc/projects entry so the usage exporter, should it ever run here,
 # does not report a ceiling this box no longer has.
 if [ -f /etc/projects ]; then
-  %[1]sgrep -v ":$dir$" /etc/projects > /tmp/projects.tuist || true
-  %[1]scat /tmp/projects.tuist > /etc/projects
-  %[1]srm -f /tmp/projects.tuist
+  grep -v ":$dir$" /etc/projects > /tmp/projects.tuist || true
+  cat /tmp/projects.tuist > /etc/projects
+  rm -f /tmp/projects.tuist
 fi
+TUIST_ROOT
 `, sudo, containerdProjectID)
 }
 

--- a/infra/cluster-api-provider-tuist/controllers/linux/containerd_quota_drift.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/containerd_quota_drift.go
@@ -1,0 +1,186 @@
+package linux
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/tuist/tuist/infra/cluster-api-provider-tuist/internal/credentials"
+	bootstrap "github.com/tuist/tuist/infra/macos-host-bootstrap"
+)
+
+// containerdQuotaLiftedAnnotation records, on the Node, that the image-store
+// project quota has been lifted from a box that never needed it. The quota is
+// XFS on-disk metadata with no Kubernetes-visible observable, so like the
+// kubelet-config hash this is stamped by the controller only once the lift has
+// exited 0, and the check keys convergence on it.
+const containerdQuotaLiftedAnnotation = "tuist.dev/containerd-quota-lifted"
+
+// ContainerdQuotaLiftedCondition reports whether a box with no cache volumes
+// still carries the image-store ceiling its self-join applied.
+//
+// The self-join is rendered once and the fleet MachineDeployments use
+// strategy: OnDelete, so gating the quota on the cache taint at bootstrap
+// reaches zero live machines. A runner box that already has the quota keeps
+// failing every job once its containers' writable layers fill the 64 GiB
+// project, on a disk that is otherwise empty, until something lifts it.
+const ContainerdQuotaLiftedCondition clusterv1.ConditionType = "ContainerdQuotaLifted"
+
+const (
+	// ContainerdQuotaPresentReason is set before any lift is attempted, so a
+	// box the operator cannot reach is visibly still capped rather than
+	// silently retried.
+	ContainerdQuotaPresentReason = "ContainerdQuotaPresent"
+
+	// ContainerdQuotaLiftFailedReason is set when the in-place lift could not
+	// complete: the box is unreachable, or xfs_quota refused.
+	ContainerdQuotaLiftFailedReason = "ContainerdQuotaLiftFailed"
+)
+
+// renderContainerdQuotaLiftScript renders the idempotent script the repair
+// pipes over SSH to a Ready non-cache box.
+//
+// Strictly additive: it changes one quota limit and one line of /etc/projects.
+// No apt, no containerd restart, no kubelet, no /data remount, so it needs no
+// drain and disturbs no running job. Lifting a project limit takes effect in
+// the kernel immediately; writes that were failing with ENOSPC succeed on the
+// next attempt without any process restarting.
+//
+// The guards match containerdQuotaScript exactly. Where any of them fail the
+// self-join applied no quota, so there is nothing to lift and the script exits
+// 0, which lets the controller stamp the Node and stop dialling.
+func renderContainerdQuotaLiftScript(opts linuxCloudInitOptions) string {
+	sudo, _ := escalation(opts.BootstrapUser)
+	return fmt.Sprintf(`#!/usr/bin/env bash
+set -euxo pipefail
+data=/data
+dir=/data/containerd
+projid=%[2]d
+
+mountpoint -q "$data" || exit 0
+[ "$(findmnt -no SOURCE "$data")" != "$(findmnt -no SOURCE /)" ] || exit 0
+[ "$(findmnt -no FSTYPE "$data")" = xfs ] || exit 0
+case ",$(findmnt -no OPTIONS "$data")," in
+  *,prjquota,*|*,pquota,*) ;;
+  *) exit 0 ;;
+esac
+
+exec 9>/var/lock/tuist-kura-quota.lock
+%[1]sflock 9
+
+# bhard=0 is how xfs_quota removes a limit; the project keeps accounting, which
+# is harmless and leaves usage readable if anyone asks.
+%[1]sxfs_quota -x -c "limit -p bhard=0 $projid" "$data"
+# Drop the /etc/projects entry so the usage exporter, should it ever run here,
+# does not report a ceiling this box no longer has.
+if [ -f /etc/projects ]; then
+  %[1]sgrep -v ":$dir$" /etc/projects > /tmp/projects.tuist || true
+  %[1]scat /tmp/projects.tuist > /etc/projects
+  %[1]srm -f /tmp/projects.tuist
+fi
+`, sudo, containerdProjectID)
+}
+
+// stampContainerdQuotaLifted records the lift on the Node so the check is a
+// map lookup from then on.
+func stampContainerdQuotaLifted(ctx context.Context, c client.Client, node *corev1.Node) error {
+	helper, err := patch.NewHelper(node, c)
+	if err != nil {
+		return err
+	}
+	if node.Annotations == nil {
+		node.Annotations = map[string]string{}
+	}
+	node.Annotations[containerdQuotaLiftedAnnotation] = "true"
+	return helper.Patch(ctx, node)
+}
+
+// reconcileLinuxContainerdQuotaDrift lifts the image-store quota, in place,
+// from a Ready box whose spec says no cache volumes land on it.
+//
+// On a cache box (kura-cache taint) this deletes any stale condition and
+// returns. On a stamped node it is one map lookup. Otherwise it marks the
+// machine visibly capped, dials the box, lifts the limit, and stamps the Node
+// only on the script's exit status.
+//
+// Returns requeue=true when it did work or deferred, false when there was
+// nothing to do.
+func reconcileLinuxContainerdQuotaDrift(
+	ctx context.Context,
+	c client.Client,
+	cm *credentials.Manager,
+	machine conditions.Setter,
+	machineName, fleet string,
+	opts linuxCloudInitOptions,
+	node *corev1.Node,
+) (requeue bool, err error) {
+	logger := log.FromContext(ctx)
+
+	if hostsKuraCacheVolumes(opts.Taints) {
+		conditions.Delete(machine, ContainerdQuotaLiftedCondition)
+		return false, nil
+	}
+	if node.Annotations[containerdQuotaLiftedAnnotation] == "true" {
+		conditions.MarkTrue(machine, ContainerdQuotaLiftedCondition)
+		return false, nil
+	}
+
+	conditions.MarkFalse(machine, ContainerdQuotaLiftedCondition, ContainerdQuotaPresentReason,
+		clusterv1.ConditionSeverityError,
+		"box hosts no cache volumes but its image store may still carry the %d GiB project quota, which fails every job once runner writable layers fill it; lifting in place",
+		containerdQuotaBytes/(1024*1024*1024))
+
+	host := nodeInternalIP(node)
+	if host == "" {
+		logger.Info("deferring containerd quota lift until the node reports an InternalIP", "node", node.Name)
+		return true, nil
+	}
+
+	privateKey, err := cm.EnsureFleetSSHKey(ctx, fleet)
+	if err != nil {
+		return false, fmt.Errorf("fleet ssh key for containerd quota lift: %w", err)
+	}
+	known := ""
+	if creds, fpErr := cm.GetMachineBootstrap(ctx, machineName); fpErr != nil {
+		return false, fmt.Errorf("read host fingerprint for containerd quota lift: %w", fpErr)
+	} else if creds != nil {
+		known = creds.HostFingerprint
+	}
+	hostKey := bootstrap.NewHostKeyState(known)
+
+	sshErr := bootstrapOverSSH(ctx, opts.BootstrapUser, host, privateKey, renderContainerdQuotaLiftScript(opts), hostKey)
+	if observed := hostKey.Observed(); observed != "" && observed != known {
+		if perr := cm.SetMachineHostFingerprint(ctx, machineName, observed); perr != nil {
+			logger.Error(perr, "persist host fingerprint after containerd quota lift; will retry", "node", node.Name)
+		}
+	}
+	if sshErr != nil {
+		conditions.MarkFalse(machine, ContainerdQuotaLiftedCondition, ContainerdQuotaLiftFailedReason,
+			clusterv1.ConditionSeverityError,
+			"could not lift the image-store quota on %s, so the box still fails jobs once the project fills: %v", host, sshErr)
+		return false, fmt.Errorf("lift containerd quota over ssh on %s: %w", host, sshErr)
+	}
+	if stampErr := stampContainerdQuotaLifted(ctx, c, node); stampErr != nil {
+		return false, fmt.Errorf("stamp containerd quota lift: %w", stampErr)
+	}
+
+	conditions.MarkTrue(machine, ContainerdQuotaLiftedCondition)
+	logger.Info("lifted the image-store quota from a box that hosts no cache volumes",
+		"node", node.Name, "host", host, "taints", strings.Join(taintKeys(opts.Taints), ","))
+	return true, nil
+}
+
+func taintKeys(taints []corev1.Taint) []string {
+	keys := make([]string, 0, len(taints))
+	for _, taint := range taints {
+		keys = append(keys, taint.Key)
+	}
+	return keys
+}

--- a/infra/cluster-api-provider-tuist/controllers/linux/containerd_quota_drift_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/containerd_quota_drift_test.go
@@ -21,7 +21,6 @@ func TestRenderContainerdQuotaLiftScript(t *testing.T) {
 		`[ "$(findmnt -no FSTYPE "$data")" = xfs ] || exit 0`,
 		"*,prjquota,*|*,pquota,*) ;;",
 		`grep -v ":$dir$" /etc/projects`,
-		"sudo xfs_quota",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("expected %q in the lift script, got:\n%s", want, script)
@@ -31,6 +30,61 @@ func TestRenderContainerdQuotaLiftScript(t *testing.T) {
 		if strings.Contains(script, forbidden) {
 			t.Fatalf("lift script must not contain %q (not additive), got:\n%s", forbidden, script)
 		}
+	}
+}
+
+// The script runs over SSH as the install user, and a per-line sudo does not
+// cover a shell redirection: the open happens as that user before sudo runs.
+// The lock fd reopens a root-owned file the bootstrap created, and /etc/projects
+// is root-owned, so either would fail the script before the Node is stamped and
+// the repair would retry forever. Every write therefore has to sit inside one
+// root shell, and nothing inside that shell may carry its own sudo, since the
+// heredoc is already root.
+func TestContainerdQuotaLiftWritesRunInARootShell(t *testing.T) {
+	script := renderContainerdQuotaLiftScript(linuxCloudInitOptions{BootstrapUser: "ubuntu"})
+
+	const opener = "sudo bash -s <<'TUIST_ROOT'\n"
+	open := strings.Index(script, opener)
+	if open < 0 {
+		t.Fatalf("expected the privileged block to open a root shell, got:\n%s", script)
+	}
+	bodyStart := open + len(opener)
+	closeIdx := strings.Index(script[bodyStart:], "\nTUIST_ROOT\n")
+	if closeIdx < 0 {
+		t.Fatalf("expected the root heredoc to be terminated, got:\n%s", script)
+	}
+	// guards is everything before the escalation; root is the heredoc body
+	// alone, excluding the opener line that carries the one legitimate sudo.
+	guards, root := script[:open], script[bodyStart:bodyStart+closeIdx]
+
+	for _, write := range []string{"exec 9>", "> /etc/projects", "> /tmp/projects.tuist", "xfs_quota", "flock"} {
+		if strings.Contains(guards, write) {
+			t.Fatalf("%q runs outside the root shell, where the redirection opens as the install user:\n%s", write, script)
+		}
+		if !strings.Contains(root, write) {
+			t.Fatalf("expected %q inside the root shell, got:\n%s", write, script)
+		}
+	}
+	if strings.Contains(root, "sudo") {
+		t.Fatalf("root shell must not re-escalate, got:\n%s", root)
+	}
+	if !strings.Contains(guards, "findmnt") {
+		t.Fatalf("read-only guards should run before escalating, got:\n%s", guards)
+	}
+	if !strings.Contains(root, "set -euxo pipefail") {
+		t.Fatalf("a failure inside the root shell must propagate to the outer exit status, got:\n%s", root)
+	}
+}
+
+// Root on the box (no BootstrapUser) needs no sudo, and the block must still be
+// a heredoc-fed shell so the two renderings differ only by the prefix.
+func TestContainerdQuotaLiftScriptAsRoot(t *testing.T) {
+	script := renderContainerdQuotaLiftScript(linuxCloudInitOptions{})
+	if strings.Contains(script, "sudo") {
+		t.Fatalf("expected no sudo when bootstrapping as root, got:\n%s", script)
+	}
+	if !strings.Contains(script, "\nbash -s <<'TUIST_ROOT'\n") {
+		t.Fatalf("expected the same heredoc shape without a prefix, got:\n%s", script)
 	}
 }
 

--- a/infra/cluster-api-provider-tuist/controllers/linux/containerd_quota_drift_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/containerd_quota_drift_test.go
@@ -1,0 +1,124 @@
+package linux
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+)
+
+// The lift is additive and instantaneous: one xfs_quota call and one line of
+// /etc/projects. Anything that restarts a daemon or touches the kubelet would
+// disturb a live job, and nothing about removing a limit needs it.
+func TestRenderContainerdQuotaLiftScript(t *testing.T) {
+	script := renderContainerdQuotaLiftScript(linuxCloudInitOptions{BootstrapUser: "ubuntu"})
+
+	for _, want := range []string{
+		"limit -p bhard=0 $projid",
+		"projid=100",
+		`[ "$(findmnt -no FSTYPE "$data")" = xfs ] || exit 0`,
+		"*,prjquota,*|*,pquota,*) ;;",
+		`grep -v ":$dir$" /etc/projects`,
+		"sudo xfs_quota",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("expected %q in the lift script, got:\n%s", want, script)
+		}
+	}
+	for _, forbidden := range []string{"systemctl", "apt-get", "kubelet", "umount", "bhard=$bytes"} {
+		if strings.Contains(script, forbidden) {
+			t.Fatalf("lift script must not contain %q (not additive), got:\n%s", forbidden, script)
+		}
+	}
+}
+
+// A cache box keeps its quota: the taint is the whole reason it exists there.
+// The check must not dial, so the harness leaves no InternalIP and the test
+// asserts it returned before deferring on one.
+func TestContainerdQuotaLeftInPlaceOnCacheBoxes(t *testing.T) {
+	h := newKataHarness(t, false, nil)
+	h.machine.Spec.NodeTaints = cacheFleetTaints()
+
+	requeue, err := reconcileLinuxContainerdQuotaDrift(context.Background(), h.client, h.r.CredentialsManager,
+		h.machine, h.machine.Name, h.machine.Spec.FleetName, h.r.hostOptions(h.machine), h.liveNode())
+	if err != nil || requeue {
+		t.Fatalf("expected a no-op on a cache box, got requeue=%v err=%v", requeue, err)
+	}
+	if cond := conditions.Get(h.machine, ContainerdQuotaLiftedCondition); cond != nil {
+		t.Fatalf("expected no %s condition on a cache box, got %v", ContainerdQuotaLiftedCondition, cond)
+	}
+	if got := h.liveNode().Annotations[containerdQuotaLiftedAnnotation]; got != "" {
+		t.Fatalf("cache box was stamped %q", got)
+	}
+}
+
+// A runner box that the self-join already capped is visibly capped before any
+// repair is attempted, so an unreachable box reads as a fault, not as pending.
+func TestContainerdQuotaPresentIsSurfacedBeforeTheLift(t *testing.T) {
+	h := newKataHarness(t, true, nil)
+	h.machine.Spec.NodeTaints = []corev1.Taint{{Key: "tuist.dev/runner-tier", Value: "bare-metal", Effect: corev1.TaintEffectNoSchedule}}
+
+	requeue, err := reconcileLinuxContainerdQuotaDrift(context.Background(), h.client, h.r.CredentialsManager,
+		h.machine, h.machine.Name, h.machine.Spec.FleetName, h.r.hostOptions(h.machine), h.liveNode())
+	if err != nil || !requeue {
+		t.Fatalf("expected a deferral without an InternalIP, got requeue=%v err=%v", requeue, err)
+	}
+	cond := conditions.Get(h.machine, ContainerdQuotaLiftedCondition)
+	if cond == nil || cond.Status != corev1.ConditionFalse || cond.Reason != ContainerdQuotaPresentReason {
+		t.Fatalf("expected %s=False/%s before the lift, got %v", ContainerdQuotaLiftedCondition, ContainerdQuotaPresentReason, cond)
+	}
+	if got := h.liveNode().Annotations[containerdQuotaLiftedAnnotation]; got != "" {
+		t.Fatalf("node was stamped %q without a lift", got)
+	}
+}
+
+// The Node is stamped only on the script's exit status. A failed dial must
+// leave it unstamped so the next reconcile tries again, and must name the
+// failure on the Machine.
+func TestContainerdQuotaLiftFailureNeverStampsTheNode(t *testing.T) {
+	h := newKataHarness(t, true, nil)
+	h.machine.Spec.NodeTaints = []corev1.Taint{{Key: "tuist.dev/runner-tier", Value: "bare-metal", Effect: corev1.TaintEffectNoSchedule}}
+	h.node.Status.Addresses = []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "127.0.0.1"}}
+	if err := h.client.Status().Update(context.Background(), h.node); err != nil {
+		t.Fatal(err)
+	}
+
+	requeue, err := reconcileLinuxContainerdQuotaDrift(context.Background(), h.client, h.r.CredentialsManager,
+		h.machine, h.machine.Name, h.machine.Spec.FleetName, h.r.hostOptions(h.machine), h.liveNode())
+	if err == nil {
+		t.Fatalf("expected the lift to fail against an unreachable host, got requeue=%v", requeue)
+	}
+	if got := h.liveNode().Annotations[containerdQuotaLiftedAnnotation]; got != "" {
+		t.Fatalf("node was stamped %q despite a failed lift", got)
+	}
+	cond := conditions.Get(h.machine, ContainerdQuotaLiftedCondition)
+	if cond == nil || cond.Status != corev1.ConditionFalse || cond.Reason != ContainerdQuotaLiftFailedReason {
+		t.Fatalf("expected %s=False/%s after a failed lift, got %v", ContainerdQuotaLiftedCondition, ContainerdQuotaLiftFailedReason, cond)
+	}
+}
+
+// Once stamped the check is a map lookup and never dials again, even with an
+// address that would otherwise be tried.
+func TestContainerdQuotaLiftNoOpWhenStamped(t *testing.T) {
+	h := newKataHarness(t, true, nil)
+	h.machine.Spec.NodeTaints = []corev1.Taint{{Key: "tuist.dev/runner-tier", Value: "bare-metal", Effect: corev1.TaintEffectNoSchedule}}
+	h.node.Status.Addresses = []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "127.0.0.1"}}
+	if err := h.client.Status().Update(context.Background(), h.node); err != nil {
+		t.Fatal(err)
+	}
+	if err := stampContainerdQuotaLifted(context.Background(), h.client, h.liveNode()); err != nil {
+		t.Fatal(err)
+	}
+
+	requeue, err := reconcileLinuxContainerdQuotaDrift(context.Background(), h.client, h.r.CredentialsManager,
+		h.machine, h.machine.Name, h.machine.Spec.FleetName, h.r.hostOptions(h.machine), h.liveNode())
+	if err != nil || requeue {
+		t.Fatalf("expected a no-op on a stamped node, got requeue=%v err=%v", requeue, err)
+	}
+	cond := conditions.Get(h.machine, ContainerdQuotaLiftedCondition)
+	if cond == nil || cond.Status != corev1.ConditionTrue {
+		t.Fatalf("expected %s=True on a stamped node, got %v", ContainerdQuotaLiftedCondition, cond)
+	}
+}

--- a/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit.go
@@ -304,7 +304,7 @@ func instanceTypeOrDefault(t string) string {
 // brings the PN VLAN up first. The leading indent prefix is supplied by the
 // caller so it nests correctly under cloud-init's YAML block or stands alone in
 // a bare script.
-func bootstrapBody(k8sMinor, sudo, sudoE string, writeFile func(producer, path string) string, vlanSetup, kataSetup string) string {
+func bootstrapBody(k8sMinor, sudo, sudoE string, writeFile func(producer, path string) string, vlanSetup, kataSetup, containerdQuota string) string {
 	// Pipe `containerd config default` through sed so the rendered config sets
 	// the CRI registry config_path to /etc/containerd/certs.d. containerd v2
 	// emits an empty `[plugins."io.containerd.grpc.v1.cri".registry]` table, so
@@ -366,13 +366,7 @@ export DEBIAN_FRONTEND=noninteractive
 # mounted filesystem (single-partition Elastic Metal), and the trailing 'true'
 # keeps set -e happy regardless.
 %[2]ssh -c 'mountpoint -q /data && [ "$(findmnt -no SOURCE /data)" != "$(findmnt -no SOURCE /)" ] && { mkdir -p /data/containerd; sed -ri "s#^root = .*#root = \"/data/containerd\"#" /etc/containerd/config.toml; }; true'
-# Bound the image store's share of /data. It is the one consumer on that
-# filesystem that is not a tenant, and nothing else caps it: image GC keys on
-# the FILESYSTEM being 85%% full, so on a box whose tenants are light containerd
-# can grow into the headroom their quotas were written against and starve them
-# below their own ceilings. Tolerated on failure (see containerdQuotaScript).
-%[10]s
-# The kura cache PVCs use a local-path StorageClass that carves each PV as a
+%[10]s# The kura cache PVCs use a local-path StorageClass that carves each PV as a
 # directory under /opt/local-path-provisioner. Bind that onto /data too, so the
 # cache volumes land on the big disk rather than the ~20G root: without it two
 # co-located replicas (replicas>=2 on a single box) fill the root and the second
@@ -391,7 +385,7 @@ curl -fsSL https://pkgs.k8s.io/core:/stable:/%[1]s/deb/Release.key | %[2]sgpg --
 %[2]ssystemctl daemon-reload
 %[2]ssystemctl enable --now kubelet`,
 		k8sMinor, sudo, sudoE, containerdConfig, aptSource, mirrorHosts, vlanSetup, hardeningSysctl, watchdogDropIn,
-		containerdQuotaSetup(sudo, writeFile), kataSetup)
+		containerdQuota, kataSetup)
 }
 
 // vlanBringUp renders the PN-VLAN setup prepended to the bootstrap body when a
@@ -532,7 +526,7 @@ func renderLinuxCloudInitWithOptions(opts linuxCloudInitOptions) string {
 	sudo, sudoE := escalation(opts.BootstrapUser)
 	writeFile := writeFileFunc(sudo)
 	vlanSetup := vlanBringUp(sudo, opts.PrivateNetworkVLAN)
-	body := indent(bootstrapBody(opts.K8sMinor, sudo, sudoE, writeFile, vlanSetup, kataSetup(sudo, sudoE, opts.KataRuntime)), "      ")
+	body := indent(bootstrapBody(opts.K8sMinor, sudo, sudoE, writeFile, vlanSetup, kataSetup(sudo, sudoE, opts.KataRuntime), containerdQuotaSetup(sudo, writeFile, hostsKuraCacheVolumes(opts.Taints))), "      ")
 
 	// Optional cluster-CA write_files entry: written so the kubelet's
 	// clientCAFile can verify the apiserver's client cert (see
@@ -597,7 +591,7 @@ func renderLinuxBootstrapScript(opts linuxCloudInitOptions) string {
 	sudo, sudoE := escalation(opts.BootstrapUser)
 	writeFile := writeFileFunc(sudo)
 	vlanSetup := vlanBringUp(sudo, opts.PrivateNetworkVLAN)
-	body := bootstrapBody(opts.K8sMinor, sudo, sudoE, writeFile, vlanSetup, kataSetup(sudo, sudoE, opts.KataRuntime))
+	body := bootstrapBody(opts.K8sMinor, sudo, sudoE, writeFile, vlanSetup, kataSetup(sudo, sudoE, opts.KataRuntime), containerdQuotaSetup(sudo, writeFile, hostsKuraCacheVolumes(opts.Taints)))
 
 	heredoc := func(path, content string) string {
 		// `<<'EOF'` keeps the body literal (no shell expansion of $ or `).
@@ -721,6 +715,31 @@ if ! has_project_quota; then
 fi
 `
 
+// kuraCacheTaintKey marks a box as a Kura cache region. Every cache fleet
+// template hardcodes it (ovh-fleet.yaml, ovh-fleets.yaml's default,
+// dedibox-fleet.yaml); a pool that is not a cache region overrides nodeTaints
+// with its own, which is already what keeps it out of the cache-only surfaces
+// keyed off that map. Reusing it here keeps one source of truth for "is this a
+// cache box" rather than adding a second that can drift from the taint.
+const kuraCacheTaintKey = "tuist.dev/kura-cache"
+
+// hostsKuraCacheVolumes reports whether tenant cache volumes land on this box's
+// /data, which is the only thing the image-store quota exists to protect.
+//
+// Absence of the taint means no quota. The two ways to be wrong here are
+// asymmetric: quota-ing a box that has no tenants buys nothing and costs a hard
+// ENOSPC ceiling that no GC can clear (image GC keys on the filesystem, which is
+// nowhere near full), while skipping a box that does have tenants only returns
+// it to the defence-in-depth it had before the quota existed.
+func hostsKuraCacheVolumes(taints []corev1.Taint) bool {
+	for _, taint := range taints {
+		if taint.Key == kuraCacheTaintKey {
+			return true
+		}
+	}
+	return false
+}
+
 // containerdProjectID is the reserved XFS project for the image store. Volume
 // projects are hashed into [1000, 16000999] by the provisioner hook, so a small
 // fixed id below that range cannot collide with one.
@@ -801,11 +820,20 @@ xfs_quota -x -c "limit -p bhard=$bytes $projid" "$data"
 // after the image store has been relocated onto /data (the directory has to
 // exist to carry a project) and after apt has installed xfsprogs, which is why
 // it lives in bootstrapBody rather than beside the /data mount setup.
-func containerdQuotaSetup(sudo string, writeFile func(producer, path string) string) string {
+func containerdQuotaSetup(sudo string, writeFile func(producer, path string) string, cacheVolumes bool) string {
+	if !cacheVolumes {
+		return ""
+	}
 	return strings.Join([]string{
+		"# Bound the image store's share of /data. It is the one consumer on that",
+		"# filesystem that is not a tenant, and nothing else caps it: image GC keys on",
+		"# the FILESYSTEM being 85% full, so on a box whose tenants are light containerd",
+		"# can grow into the headroom their quotas were written against and starve them",
+		"# below their own ceilings. Tolerated on failure (see containerdQuotaScript).",
 		writeFile("printf '%s' "+shellSingleQuote(containerdQuotaScript), containerdQuotaPath),
 		sudo + "chmod 0755 " + containerdQuotaPath,
 		sudo + "bash " + containerdQuotaPath + " || echo 'tuist: could not bound the containerd image store; continuing' >&2",
+		"",
 	}, "\n")
 }
 

--- a/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit_test.go
@@ -361,6 +361,36 @@ func TestBootstrapInstallsXFSTools(t *testing.T) {
 	}
 }
 
+// cacheFleetTaints is what every cache fleet template stamps on its boxes, and
+// what tells the self-join that tenant volumes will land on this /data.
+func cacheFleetTaints() []corev1.Taint {
+	return []corev1.Taint{{Key: kuraCacheTaintKey, Value: "true", Effect: corev1.TaintEffectNoSchedule}}
+}
+
+// A runner box has no tenant volumes on /data, so the image-store quota bounds
+// nothing there and only adds a ceiling that nothing can clear: XFS reports a
+// blown project quota as ENOSPC, and the kubelet's image GC keys on the
+// FILESYSTEM's free space, which on an 828 GiB /data is nowhere near a
+// threshold. A runner Pod's whole writable layer lives in that store, so the
+// quota is reached by ordinary CI and the box then fails every job it accepts
+// until it is drained.
+func TestContainerdQuotaSkippedOnFleetsWithoutCacheVolumes(t *testing.T) {
+	script := renderLinuxBootstrapScript(linuxCloudInitOptions{
+		NodeName: "runner-1", KubeconfigYAML: "kubeconfig\n", K8sMinor: "v1.34",
+		BootstrapUser: "ubuntu", InstanceType: "ovh", KataRuntime: true,
+		Taints: []corev1.Taint{{Key: "tuist.dev/runner-tier", Value: "bare-metal", Effect: corev1.TaintEffectNoSchedule}},
+	})
+
+	if strings.Contains(script, containerdQuotaPath) {
+		t.Fatalf("expected no image-store quota on a fleet with no cache volumes, got:\n%s", script)
+	}
+	// The relocation itself must stay: the image store still belongs on the big
+	// disk rather than the ~20G root, quota or not.
+	if !strings.Contains(script, "mkdir -p /data/containerd") {
+		t.Fatalf("expected the image-store relocation to survive, got:\n%s", script)
+	}
+}
+
 // The image store is the one consumer of /data that is not a tenant, and it is
 // otherwise unbounded: the kubelet's image GC triggers on the FILESYSTEM being
 // nearly full, so on a box whose tenants are light containerd can grow into the
@@ -371,7 +401,7 @@ func TestBootstrapInstallsXFSTools(t *testing.T) {
 func TestBootstrapBoundsContainerdImageStoreAfterItsPrerequisites(t *testing.T) {
 	script := renderLinuxBootstrapScript(linuxCloudInitOptions{
 		NodeName: "kura-1", KubeconfigYAML: "kubeconfig\n", K8sMinor: "v1.34",
-		BootstrapUser: "ubuntu", InstanceType: "ovh",
+		BootstrapUser: "ubuntu", InstanceType: "ovh", Taints: cacheFleetTaints(),
 	})
 
 	quotaIdx := strings.Index(script, "bash "+containerdQuotaPath)
@@ -393,7 +423,7 @@ func TestBootstrapBoundsContainerdImageStoreAfterItsPrerequisites(t *testing.T) 
 // join. Every tenant on the box is bounded either way; what is lost is defence
 // in depth on the shared pool, which is the state the box was in before.
 func TestContainerdQuotaDoesNotFailTheJoin(t *testing.T) {
-	script := renderLinuxBootstrapScript(linuxCloudInitOptions{NodeName: "n", K8sMinor: "v1.34"})
+	script := renderLinuxBootstrapScript(linuxCloudInitOptions{NodeName: "n", K8sMinor: "v1.34", Taints: cacheFleetTaints()})
 	line := "bash " + containerdQuotaPath + " || echo"
 	if !strings.Contains(script, line) {
 		t.Fatalf("expected the containerd quota step to be tolerated, got:\n%s", script)

--- a/infra/cluster-api-provider-tuist/controllers/linux/ovhdedicatedmachine_controller.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/ovhdedicatedmachine_controller.go
@@ -364,6 +364,12 @@ func (r *OVHDedicatedMachineReconciler) reconcileNormal(ctx context.Context, mac
 			} else if requeue {
 				return ctrl.Result{RequeueAfter: 20 * time.Second}, nil
 			}
+			if requeue, quotaErr := reconcileLinuxContainerdQuotaDrift(ctx, r.Client, r.CredentialsManager, machine, machine.Name, fleet, r.hostOptions(machine), node); quotaErr != nil {
+				logger.Error(quotaErr, "containerd quota lift failed; will retry")
+				return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+			} else if requeue {
+				return ctrl.Result{RequeueAfter: 20 * time.Second}, nil
+			}
 		}
 		return ctrl.Result{RequeueAfter: KubeletConfigDriftResyncInterval}, nil
 	}


### PR DESCRIPTION
## What changed

The 64 GiB XFS project quota on containerd's image store (project 100) is no longer applied to boxes that host no Kura cache volumes, and a drift reconcile lifts it in place from the ones that already carry it.

- `containerdQuotaSetup` is gated on `hostsKuraCacheVolumes`, keyed off the `tuist.dev/kura-cache` taint every cache fleet template stamps.
- `reconcileLinuxContainerdQuotaDrift` runs on the OVH machine controller's Ready path, next to the kata drift reconcile. On a non-cache box it SSHes in, runs `xfs_quota -x -c "limit -p bhard=0 100" /data`, drops the `/etc/projects` line, and stamps `tuist.dev/containerd-quota-lifted` on the Node. Cache boxes are untouched.
- The Machine carries `ContainerdQuotaLifted=False` with reason `ContainerdQuotaPresent` before the lift and `ContainerdQuotaLiftFailed` after a failed one, so an unreachable box stays loud instead of being retried silently.

The lift changes one quota limit and one line of `/etc/projects`. No apt, no containerd restart, no kubelet, no remount, so a box currently mid-ENOSPC recovers on its next write with no drain and no disruption to running jobs.

## Why

Linux CI has been failing with `No space left on device` on a disk that is 94% free. The quota, not the filesystem, is what fills. XFS surfaces a blown project quota as ENOSPC, and the kubelet's image GC keys on the filesystem's available bytes, so on an 828 GiB `/data` nothing ever reclaims: a box that reaches the ceiling fails every job it accepts until something intervenes. Once containerd cannot even `mkdir` its own sandbox state, every new pod on that node fails `FailedCreatePodSandBox` and the existing ones cannot be killed either.

Project 100 exists so the image store cannot crowd out Kura tenant cache volumes that share `/data`. Runner boxes host no tenant volumes. They inherited the quota purely by sharing the OVH self-join path, so on them it defends nothing and only adds a cliff at 8% of the disk.

## Why this, and not the alternatives already tried

Two other fixes shipped first, and today shows they are not sufficient on their own.

- **Fix the composition.** [#12769](https://github.com/tuist/tuist/pull/12769) moved the job workspace onto the `work` emptyDir at `/home/runner/work`. That landed and is deployed (runners-controller 0.22.1 at 07:33 UTC, 0.22.2 at 10:12 UTC), and emptyDirs live under `/data/kubelet`, which is outside project 100, so the workspace genuinely left the quota. The quota filled anyway: `Test (oldest supported ClickHouse)` on main died at 13:26 UTC today with the runner worker crashing on its own `_diag` write. What remains on the writable layer, mise toolchains, `$HOME` caches, Hex and npm stores, still overruns 64 GiB across the pods a 31 vCPU box packs. A box that is healthy right now peaks at 67 GiB of `/data` under normal load.
- **Fix the lifecycle.** [#12789](https://github.com/tuist/tuist/pull/12789) reaps pods whose job GitHub already finished. That removes one way a pinned node stays pinned, but nothing about it stops the node from filling in the first place.
- **Raise the number.** The ceiling was bridged by hand to 96 GiB on all four production boxes yesterday. Three of them were reinstalled around 09:30 UTC today, cloud-init re-rendered `bhard=64g`, and the bridge went with them. Both boxes that wedged today are reinstalled ones; the single box that was not reinstalled still carries the bridge, peaks above the cliff at 74 GiB, and has not wedged. A manual host-side ceiling does not survive a reinstall, and a higher number only moves a cliff that tracks concurrency and repo size.

[#12787](https://github.com/tuist/tuist/pull/12787) proposed the gate alone and was closed, on the reasoning that the quota bounds the snapshotter on every box and should stay uniform while composition and lifecycle were fixed. Both of those are now fixed and deployed, and the ceiling is still reached, so the premise no longer holds. The gate alone was also incomplete for a second reason: the bootstrap renders once and the fleet MachineDeployments use `strategy: OnDelete`, so gating at self-join reaches zero live machines. That is what the drift reconcile adds.

## What bounds a box now, when a couple of disk-heavy jobs fill it

Lifting the quota does not leave the image store unbounded. It swaps a ceiling nothing in Kubernetes can see for the filesystem, which is the signal every kubelet reclaim mechanism already keys on.

- **Headroom.** `/data` on a runner box is 828 GiB, 745 GiB of it allocatable ephemeral storage. The ceiling being lifted is 64 GiB, 8% of the disk.
- **First, image GC.** At 85% used the kubelet reclaims unused images. Under the quota this never ran: it keys on the filesystem, and the filesystem was 94% free while project 100 was full.
- **Then, eviction.** `evictionHard` as the self-join renders it is `imagefs.available: 15%`, `nodefs.available: 10%`, plus both inode signals. The kubelet evicts pods ranked by local ephemeral usage, which for a runner pod is its writable layer plus the emptyDirs holding the workspace and the dind storage, so the disk-heavy jobs are exactly what gets picked. The node takes `node.kubernetes.io/disk-pressure` and the pool stops landing new work on it.
- **Then it recovers on its own.** An evicted pod releases its writable layer and its emptyDirs, usage drops back under the threshold, `DiskPressure` clears and the box serves again. No drain, no SSH, no manual `xfs_quota`.

The difference is the blast radius. A blown project quota surfaces as ENOSPC to whoever writes next, which is some innocent job rather than the one that filled the box, and once the project is full containerd cannot create a sandbox or tear one down, so the node can neither start work nor be cleaned up without a human on the host. Filling the real filesystem instead costs the disk-heavy job an eviction and a retry, and leaves the node able to fix itself.

Cache boxes keep the quota for the inverse reason. A tenant's data there lives in a local-path PV, a directory on `/data` that ephemeral-storage accounting does not attribute to the pod, so eviction cannot aim at the account that filled the box and would take down every tenant on it. XFS project quotas are the only real boundary there, which is what `dataProjectQuotaScript` and the per-volume hooks exist for.

## Impact

Runner boxes stop carrying a ceiling that protects nothing on them and that no GC can clear. Cache boxes keep the quota exactly as it is, including the defence-in-depth over the shared pool it was written for. Live runner boxes are lifted without a drain, so the two currently wedged nodes recover as the reconcile reaches them rather than needing a manual `xfs_quota` over SSH.

## Validation

- `go build ./...`, `go vet ./...` and `gofmt -l` clean in `infra/cluster-api-provider-tuist`.
- `go test ./...` passes for the module, including the seven new cases in `containerd_quota_drift_test.go` covering: the rendered script's guards, the privileged writes running in one root shell rather than under a per-line sudo that cannot cover a redirection, the no-op on cache boxes, the visibly capped condition before a lift, no Node stamp after a failed lift, and the map-lookup no-op once stamped. `linux_cloudinit_test.go` gains the case that a fleet without cache volumes renders no quota setup at all.
- Measured on the fleet today: `/data` byte-flat at 70.03 GiB (64 GiB project plus the kubelet root) on the two wedged boxes, against 74.28 GiB peaks with no wedge on the box that still has the manual bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

