### PR TITLE
docs(server): correct the registry guidance on resolving source control packages in Xcode

### DIFF
--- a/server/priv/docs/en/guides/features/registry.md
+++ b/server/priv/docs/en/guides/features/registry.md
@@ -32,7 +32,7 @@ let tuist = Tuist(
 With this option, `tuist generate` will automatically create the registry configuration file in your workspace. This eliminates the need to run `tuist registry setup` separately.
 
 > [!TIP]
-> `registryEnabled` also configures the registry for projects that integrate dependencies through Xcode's default Swift Package Manager integration, rather than Tuist's XcodeProj-based integration. To additionally resolve packages that are declared with a source control URL from the registry, follow <.localized_link href="/guides/features/registry/xcode-project#resolving-source-control-packages">Resolving source control packages</.localized_link>.
+> `registryEnabled` also configures the registry for projects that integrate dependencies through Xcode's default Swift Package Manager integration, rather than Tuist's XcodeProj-based integration. It doesn't configure Xcode to resolve packages that are declared with a source control URL from the registry. To do that, run `tuist registry setup` or `tuist registry login` once on each machine, as described in <.localized_link href="/guides/features/registry/xcode-project#resolving-source-control-packages">Resolving source control packages</.localized_link>.
 
 
 ### Option 2: Manual setup {#manual-setup}

--- a/server/priv/docs/en/guides/features/registry.md
+++ b/server/priv/docs/en/guides/features/registry.md
@@ -32,7 +32,7 @@ let tuist = Tuist(
 With this option, `tuist generate` will automatically create the registry configuration file in your workspace. This eliminates the need to run `tuist registry setup` separately.
 
 > [!TIP]
-> `registryEnabled` also configures the registry for projects that integrate dependencies through Xcode's default Swift Package Manager integration, rather than Tuist's XcodeProj-based integration. It doesn't configure Xcode to resolve packages that are declared with a source control URL from the registry. To do that, run `tuist registry setup` or `tuist registry login` once on each machine, as described in <.localized_link href="/guides/features/registry/xcode-project#resolving-source-control-packages">Resolving source control packages</.localized_link>.
+> `registryEnabled` also configures the registry for projects that integrate dependencies through Xcode's default Swift Package Manager integration, rather than Tuist's XcodeProj-based integration. It doesn't configure Xcode to resolve packages that are declared with a source control URL from the registry. To do that, run `tuist registry setup` once on each machine, as described in <.localized_link href="/guides/features/registry/xcode-project#resolving-source-control-packages">Resolving source control packages</.localized_link>.
 
 
 ### Option 2: Manual setup {#manual-setup}

--- a/server/priv/docs/en/guides/features/registry.md
+++ b/server/priv/docs/en/guides/features/registry.md
@@ -32,19 +32,7 @@ let tuist = Tuist(
 With this option, `tuist generate` will automatically create the registry configuration file in your workspace. This eliminates the need to run `tuist registry setup` separately.
 
 > [!TIP]
-> If you want to integrate dependencies through Xcode's default Swift Package Manager integration (rather than Tuist's XcodeProj-based integration), enabling `registryEnabled` in your generated projects will configure them to use the registry automatically:
->
-> ```swift
-> import ProjectDescription
->
-> let tuist = Tuist(
->     project: .tuist(
->         generationOptions: .options(
->             registryEnabled: true
->         )
->     )
-> )
-> ```
+> `registryEnabled` also configures the registry for projects that integrate dependencies through Xcode's default Swift Package Manager integration, rather than Tuist's XcodeProj-based integration. To additionally resolve packages that are declared with a source control URL from the registry, follow <.localized_link href="/guides/features/registry/xcode-project#resolving-source-control-packages">Resolving source control packages</.localized_link>.
 
 
 ### Option 2: Manual setup {#manual-setup}

--- a/server/priv/docs/en/guides/features/registry/generated-project.md
+++ b/server/priv/docs/en/guides/features/registry/generated-project.md
@@ -33,4 +33,4 @@ let project = Project(
 ```
 
 > [!TIP]
-> You don't have to add every package by its registry identifier. `tuist registry setup` and `tuist registry login` also configure Xcode to resolve packages that are declared with a source control URL from the registry, which `registryEnabled` doesn't do on its own. See <.localized_link href="/guides/features/registry/xcode-project#resolving-source-control-packages">Resolving source control packages</.localized_link>.
+> You don't have to add every package by its registry identifier. Running `tuist registry setup` once the project has been generated also configures Xcode to resolve packages that are declared with a source control URL from the registry, which `registryEnabled` doesn't do on its own. See <.localized_link href="/guides/features/registry/xcode-project#resolving-source-control-packages">Resolving source control packages</.localized_link>.

--- a/server/priv/docs/en/guides/features/registry/generated-project.md
+++ b/server/priv/docs/en/guides/features/registry/generated-project.md
@@ -33,4 +33,4 @@ let project = Project(
 ```
 
 > [!TIP]
-> Instead of adding every package by its registry identifier, you can have Xcode resolve packages that are declared with a source control URL from the registry. Follow <.localized_link href="/guides/features/registry/xcode-project#resolving-source-control-packages">Resolving source control packages</.localized_link>.
+> You don't have to add every package by its registry identifier. `tuist registry setup` and `tuist registry login` also configure Xcode to resolve packages that are declared with a source control URL from the registry, which `registryEnabled` doesn't do on its own. See <.localized_link href="/guides/features/registry/xcode-project#resolving-source-control-packages">Resolving source control packages</.localized_link>.

--- a/server/priv/docs/en/guides/features/registry/generated-project.md
+++ b/server/priv/docs/en/guides/features/registry/generated-project.md
@@ -31,3 +31,6 @@ let project = Project(
     ]
 )
 ```
+
+> [!TIP]
+> Instead of adding every package by its registry identifier, you can have Xcode resolve packages that are declared with a source control URL from the registry. Follow <.localized_link href="/guides/features/registry/xcode-project#resolving-source-control-packages">Resolving source control packages</.localized_link>.

--- a/server/priv/docs/en/guides/features/registry/xcode-project.md
+++ b/server/priv/docs/en/guides/features/registry/xcode-project.md
@@ -11,6 +11,15 @@ To add packages using the registry in your Xcode project, use the default Xcode 
 
 ![Adding package dependencies](/images/guides/features/build/registry/registry-add-package.png)
 
-> [!NOTE]
-> Xcode currently doesn't support automatically replacing source control packages with their registry equivalents. You will need to manually remove the source control package and add the registry package to speed up the resolution.
+## Resolving source control packages {#resolving-source-control-packages}
 
+Packages that are declared with a source control URL, such as the transitive dependencies of the packages you add, are resolved from source control by default. `tuist registry setup` and `tuist registry login` configure Xcode to resolve them from the registry instead by writing the following user default:
+
+```bash
+defaults write com.apple.dt.Xcode IDEPackageDependencySCMToRegistryTransformation useRegistryIdentityAndSources
+```
+
+Xcode then resolves a source control package from the registry whenever a registry equivalent exists, and falls back to source control when it doesn't.
+
+> [!NOTE]
+> This is a per-machine Xcode preference and not a project setting, so committing the registry configuration file doesn't share it with the rest of your team. Every developer needs to run `tuist registry setup` or `tuist registry login` once on their machine. The preference then applies to all Xcode projects on that machine.

--- a/server/priv/docs/en/guides/features/registry/xcode-project.md
+++ b/server/priv/docs/en/guides/features/registry/xcode-project.md
@@ -13,7 +13,7 @@ To add packages using the registry in your Xcode project, use the default Xcode 
 
 ## Resolving source control packages {#resolving-source-control-packages}
 
-Packages that are declared with a source control URL, such as the transitive dependencies of the packages you add, are resolved from source control by default. `tuist registry setup` and `tuist registry login` configure Xcode to resolve them from the registry instead by writing the following user default:
+Packages that are declared with a source control URL, such as the transitive dependencies of the packages you add, are resolved from source control by default. `tuist registry setup` configures Xcode to resolve them from the registry instead by writing the following user default:
 
 ```bash
 defaults write com.apple.dt.Xcode IDEPackageDependencySCMToRegistryTransformation useRegistryIdentityAndSources
@@ -22,4 +22,4 @@ defaults write com.apple.dt.Xcode IDEPackageDependencySCMToRegistryTransformatio
 Xcode then resolves a source control package from the registry whenever a registry equivalent exists, and falls back to source control when it doesn't.
 
 > [!NOTE]
-> This is a per-machine Xcode preference and not a project setting, so committing the registry configuration file doesn't share it with the rest of your team. Every developer needs to run `tuist registry setup` or `tuist registry login` once on their machine. The preference then applies to all Xcode projects on that machine.
+> This is a per-machine Xcode preference and not a project setting, so committing the registry configuration file doesn't share it with the rest of your team. Every developer needs to run `tuist registry setup` once on their machine. The preference then applies to all Xcode projects on that machine.


### PR DESCRIPTION
The registry documentation told readers that Xcode cannot resolve source control packages through the registry, and that the only way forward is to remove each package and re-add it by registry identifier, one at a time. That is wrong, and it has been wrong for a while. It came up while answering a customer question about pulling a whole dependency graph through a registry mirror, where the docs led to the opposite of the correct answer.

### What changed

- [xcode-project.md](https://github.com/tuist/tuist/blob/claude/xcode-dependencies-registry-7cfdcf/server/priv/docs/en/guides/features/registry/xcode-project.md) replaces the incorrect note with a "Resolving source control packages" section documenting the Xcode user default that the CLI writes, and the caveat that it is per-machine.
- [registry.md](https://github.com/tuist/tuist/blob/claude/xcode-dependencies-registry-7cfdcf/server/priv/docs/en/guides/features/registry.md) had a tip that repeated verbatim the same code block sitting three lines above it, and claimed `registryEnabled` configures Xcode's default package integration "automatically" without qualification. The tip now states what the option actually covers and links to the new section.
- [generated-project.md](https://github.com/tuist/tuist/blob/claude/xcode-dependencies-registry-7cfdcf/server/priv/docs/en/guides/features/registry/generated-project.md) instructed readers to add every package by registry identifier with no mention of the alternative. It now links to the new section.

Only the English source language is touched.

### Why the docs were wrong

[#7443](https://github.com/tuist/tuist/pull/7443) ("Improve tuist registry output, fix resolving registry transitive dependencies") added [DefaultsController](https://github.com/tuist/tuist/blob/claude/xcode-dependencies-registry-7cfdcf/cli/Sources/TuistSupport/Utils/DefaultsController.swift), which writes:

```
defaults write com.apple.dt.Xcode IDEPackageDependencySCMToRegistryTransformation useRegistryIdentityAndSources
```

That value is Xcode's counterpart of SwiftPM's `--replace-scm-with-registry`: registry identity and sources. With it set, Xcode substitutes source control package references with their registry equivalents during resolution, transitive dependencies included, and falls back to source control where no equivalent exists. `tuist registry login` writes it unconditionally on macOS, and `tuist registry setup` writes it when the target is an `.xcworkspace` or `.xcodeproj`. The docs change in #7443 only covered the command output, so the stale claim survived on the Xcode project page.

### Known gap this change documents rather than fixes

`registryEnabled: true` only generates `registries.json` during `tuist generate`. It does not write the Xcode preference. So the setup path the docs call "recommended" does not on its own give you registry resolution for source control packages, which is why the tip now points at the section instead of implying the option covers everything. Setting the preference during generation when `registryEnabled` is on looks like the right follow-up, and is deliberately out of scope here so this stays a documentation change.

### How to test locally

The change is markdown content in `server/priv/docs/en`, with frontmatter untouched and heading anchors in the same `{#id}` form as the surrounding pages.

```
mise run dev
```

Then open `/guides/features/registry/xcode-project` and check that the new section renders and that the anchor links from `/guides/features/registry` and `/guides/features/registry/generated-project` land on it.

I did not run the server test suite for this. The worktree has no server dependencies installed and `mix test` stops at `deps.get` before compiling, so the verification behind this PR is the code reading above plus reading the rendered markdown, not an executed test run.
