### PR TITLE
fix(infra): reap sandboxes kubelet never terminates and reserve their fleet slot

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1389,6 +1389,28 @@ cascade's own first job, so nothing could deploy. The 300-second
 unschedulable reap did not help: the hog recreated each Pod the moment
 it was released.
 
+It fired again on 2026-09-03 with no hog at all, so check the other two
+causes before reaching for `maxReplicas`. First, look for Pods stuck
+`Terminating`: a Kata sandbox whose shim never tears the VM down keeps
+its node's CPU and memory reserved while being invisible to the
+controller, and nine of them held two of the four Linux nodes at 94%
+for four hours. Every shape was then unschedulable for want of real
+capacity, which is what filled the admission budget.
+
+```bash
+kubectl get pods -n tuist-runners --no-headers | grep Terminating
+```
+
+Second, the budget itself could be held by siblings each inside their
+own share. Before the fleet ceiling reserved slots for starved pools,
+`poolCap` bounded each pool's own Pending count but nothing held a slot
+open underneath it, so three siblings holding 1, 1 and 2 of four slots
+filled the ceiling between them while the starved pool reported
+`pendingForPool: 0, poolCap: 4, gap: 19` and was still refused. A
+starved pool now measures against the whole ceiling and its siblings
+measure against the ceiling minus what it is owed; if you see a pool
+blocked with its share unused, that reservation is not working.
+
 ```promql
 (
   max by (cluster, env, fleet) (tuist_runners_queue_length{env="production", fleet=~"tuist-tuist-runner-pool-linux-.*"})

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -310,6 +310,35 @@ independent workqueues:
   moment a starved sibling gets its slot, within one
   `startTimeoutSeconds`.
 
+  The share has to be taken out of the ceiling siblings are measured
+  against, not just out of their own Pending counts. Bounding each pool
+  individually leaves nothing holding a slot open: several pools each
+  comfortably inside their own share still fill the ceiling between them,
+  and the fleet check refuses the starved pool before its reserved share
+  is ever read. On 2026-09-03 `linux-4vcpu-16gb` sat at zero Pods with
+  `pendingForPool: 0, poolCap: 4, gap: 19` — its whole share unused and
+  still blocked — while three siblings held 1, 1 and 2 of the four slots.
+  So a pool that is itself owed a slot measures against the full ceiling
+  (`fleetCap == cap`) and every other pool measures against the ceiling
+  minus the slots its starved siblings are owed, floored at one so a fleet
+  where everything is starved still makes progress one Pod at a time.
+
+  A Pod deleting for longer than its grace period plus five minutes is
+  force-deleted with a warning event. A Kata sandbox whose shim never
+  tears the VM down leaves the Pod Terminating with its containers still
+  `running`, and nothing else in the controller can see it: `isAlive`
+  excludes a deleting Pod, so it is neither a replica nor a provisioning
+  Pod, the pool reads as having a gap, the node reads as full, and the
+  two facts never meet. On 2026-09-03 two of four Linux runner nodes were
+  held this way for four hours, 94% reserved by Pods doing no work. The
+  ordinary reap cannot clear it — a plain `Delete` is a no-op on a Pod
+  that already carries a deletionTimestamp — so the object is dropped
+  outright. The sandbox can outlive the object, leaving the node
+  oversubscribed against what the scheduler believes, which is why the
+  reap logs the node and raises an Event: a node producing these
+  repeatedly wants draining, not another force delete. Watch
+  `tuist_runners_pool_stuck_terminations_total`.
+
   Pod creates are visible to the cached client asynchronously. The
   reconciler therefore keeps a 30-second in-process reservation for each
   successful create and counts it until the cache observes the Pod. This
@@ -404,7 +433,12 @@ independent workqueues:
   `tuist_runners_pool_admission_blocked_total{pool,reason}`,
   `tuist_runners_fleet_ready_nodes{fleet_selector,operating_system}`,
   `tuist_runners_fleet_filtered_nodes{fleet_selector,operating_system,reason}`,
-  and `tuist_runners_pool_pod_start_timeouts_total{pool,reason}`.
+  `tuist_runners_pool_pod_start_timeouts_total{pool,reason}`,
+  and `tuist_runners_pool_stuck_terminations_total{pool}`. The last one
+  counts Pods force-deleted because kubelet never finished terminating
+  them; it is distinct from the start-timeout counter because that means
+  a sandbox failed to come up, while this means one failed to go down and
+  may still be holding its node.
 
   Alongside it, `tuist_runners_pool_oldest_pending_pod_age_seconds{pool}`
   is how long the pool's oldest un-`Running` Pod has been waiting (0 when

--- a/infra/runners-controller/controllers/provisioning.go
+++ b/infra/runners-controller/controllers/provisioning.go
@@ -19,6 +19,10 @@ const (
 	creationReservationLifetime   = 30 * time.Second
 	pollerNotStartedTimeoutReason = "poller_not_started"
 	unschedulableTimeoutReason    = "unschedulable"
+
+	// terminationStuckSlack is how long past its grace period a deleting Pod
+	// may linger before the controller stops waiting for kubelet.
+	terminationStuckSlack = 5 * time.Minute
 )
 
 type creationReservation struct {
@@ -82,6 +86,7 @@ type provisioningAdmission struct {
 	pendingForPool  int
 	pendingForFleet int
 	cap             int
+	fleetCap        int
 	poolCap         int
 	healthyNodes    int
 	blockedReason   string
@@ -202,19 +207,49 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 	// together, and that still holds); what changes is who may top the count
 	// back up after a reap. A hog at its share cannot recreate the Pod the
 	// timeout released, so the slot goes to the sibling that had none.
+	//
+	// Bounding each pool's own Pending count is not enough on its own,
+	// because the shared ceiling is what actually refuses the creation and
+	// nothing holds a slot open under it. Several pools each comfortably
+	// inside their own share still fill the ceiling between them, and the
+	// starved pool is then refused by the fleet check before its reserved
+	// share is ever consulted: measured live at cap 4 with the starved shape
+	// reporting `pendingForPool: 0, poolCap: 4, gap: 19` and still blocked,
+	// while three siblings held 1, 1 and 2 of the four slots.
+	//
+	// So the reservation has to come out of the ceiling the *siblings* are
+	// measured against. A pool that is itself starved keeps the full ceiling
+	// and can take the slot they were held back from.
+	needsSlot := make(map[string]bool, len(poolNames))
 	siblingsNeedingSlot := 0
 	for i := range pools.Items {
-		sibling := &pools.Items[i]
-		if _, ok := poolNames[sibling.Name]; !ok || sibling.Name == pool.Name {
+		candidate := &pools.Items[i]
+		if _, ok := poolNames[candidate.Name]; !ok {
 			continue
 		}
-		if int(sibling.Spec.Replicas) > aliveByPool[sibling.Name] && pendingByPool[sibling.Name] == 0 {
+		starved := int(candidate.Spec.Replicas) > aliveByPool[candidate.Name] &&
+			pendingByPool[candidate.Name] == 0
+		needsSlot[candidate.Name] = starved
+		if starved && candidate.Name != pool.Name {
 			siblingsNeedingSlot++
 		}
 	}
 	poolCap := capN - siblingsNeedingSlot
 	if poolCap < 1 {
 		poolCap = 1
+	}
+
+	// A starved pool is owed a slot, so it measures itself against the whole
+	// ceiling; every other pool measures itself against the ceiling minus the
+	// slots its starved siblings are owed. The floor of 1 keeps the fleet
+	// making progress when more pools are starved than there are slots: the
+	// first Pod to start frees the count for the next one.
+	fleetCap := capN
+	if !needsSlot[pool.Name] {
+		fleetCap = capN - siblingsNeedingSlot
+		if fleetCap < 1 {
+			fleetCap = 1
+		}
 	}
 
 	var nodes corev1.NodeList
@@ -231,6 +266,7 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 		pendingForPool:  pendingForPool,
 		pendingForFleet: pendingForFleet,
 		cap:             capN,
+		fleetCap:        fleetCap,
 		poolCap:         poolCap,
 		healthyNodes:    healthyNodes,
 	}
@@ -238,7 +274,7 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 		admission.blockedReason = "no_healthy_node"
 		return admission, nil
 	}
-	if pendingForFleet >= capN {
+	if pendingForFleet >= fleetCap {
 		admission.blockedReason = "fleet_cap"
 		return admission, nil
 	}
@@ -246,7 +282,7 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 		admission.blockedReason = "pool_share"
 		return admission, nil
 	}
-	admission.available = capN - pendingForFleet
+	admission.available = fleetCap - pendingForFleet
 	if share := poolCap - pendingForPool; share < admission.available {
 		admission.available = share
 	}
@@ -288,6 +324,33 @@ func unschedulableTimedOut(pod *corev1.Pod, pool *tuistv1.RunnerPool, now time.T
 	}
 	rejectedAt, ok := unschedulableSince(pod)
 	return ok && now.Sub(rejectedAt) >= time.Duration(timeoutSeconds)*time.Second
+}
+
+// terminationTimedOut is true once a Pod has been deleting for longer than the
+// grace period kubelet was given, plus a margin. A kata-qemu sandbox whose shim
+// never tears the VM down leaves the Pod in Terminating with its containers
+// still reporting `running`: kubelet stops making progress, nothing retries the
+// kill, and the Pod keeps its node's CPU and memory reserved against the
+// scheduler indefinitely.
+//
+// Nothing else in this controller can see it. isAlive excludes a deleting Pod,
+// so it is neither a replica nor a provisioning Pod: the pool reads as having a
+// gap, the node reads as full, and the two facts never meet. Two of four Linux
+// runner nodes were held this way for four hours, 94% reserved by Pods doing no
+// work, while every shape on the fleet queued behind the shortfall.
+//
+// The margin is deliberately generous. A sandbox that is merely slow to stop is
+// still making progress and will finish on its own; one still present a full
+// grace period and five minutes later is not shutting down, it is stuck.
+func terminationTimedOut(pod *corev1.Pod, now time.Time) bool {
+	if pod.DeletionTimestamp.IsZero() {
+		return false
+	}
+	grace := time.Duration(0)
+	if pod.DeletionGracePeriodSeconds != nil {
+		grace = time.Duration(*pod.DeletionGracePeriodSeconds) * time.Second
+	}
+	return !now.Before(pod.DeletionTimestamp.Time.Add(grace).Add(terminationStuckSlack))
 }
 
 // linuxProvisioningStartedAt uses the scheduler's transition timestamp rather

--- a/infra/runners-controller/controllers/provisioning_test.go
+++ b/infra/runners-controller/controllers/provisioning_test.go
@@ -9,6 +9,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	tuistv1 "github.com/tuist/tuist/infra/runners-controller/api/v1alpha1"
 )
 
 func TestCreationReservationStoreReleasesObservedPod(t *testing.T) {
@@ -183,7 +185,11 @@ func TestProvisioningAdmissionHogCannotRecreateAfterReapWhileSiblingStarves(t *t
 	if err != nil {
 		t.Fatalf("provisioningAdmission(hog): %v", err)
 	}
-	if hogAdmission.poolCap != 3 || hogAdmission.blockedReason != "pool_share" || hogAdmission.available != 0 {
+	// The reservation now comes out of the ceiling the hog is measured against,
+	// so the fleet check is what withholds the slot and it reports `fleet_cap`
+	// rather than `pool_share`. The outcome is the one this test is about: the
+	// hog gets nothing and the starved sibling gets the freed slot.
+	if hogAdmission.poolCap != 3 || hogAdmission.fleetCap != 3 || hogAdmission.available != 0 {
 		t.Fatalf("hog admission = %+v, want share 3 (cap 4 minus one starved sibling) and no availability", hogAdmission)
 	}
 
@@ -250,5 +256,144 @@ func unschedulableRunnerPod(name, poolName string, rejectedAt time.Time) *corev1
 		Reason:             corev1.PodReasonUnschedulable,
 		LastTransitionTime: metav1.NewTime(rejectedAt),
 	}}
+	return pod
+}
+
+// The live regression: the share bounded each pool's own Pending count, but
+// nothing held a slot open under the shared ceiling. Three siblings each well
+// inside their own share filled the ceiling between them, and the starved pool
+// was refused by the fleet check before its reserved share was ever consulted.
+// Measured in production at cap 4 with the starved shape reporting
+// `pendingForPool: 0, poolCap: 4, gap: 19` and still blocked.
+func TestProvisioningAdmissionHoldsFleetSlotForStarvedSibling(t *testing.T) {
+	scheme := mustScheme(t)
+	starved := newLinuxKataPool("linux-starved", 19, 4)
+	hogs := []*tuistv1.RunnerPool{
+		newLinuxKataPool("linux-hog-a", 33, 4),
+		newLinuxKataPool("linux-hog-b", 8, 4),
+		newLinuxKataPool("linux-hog-c", 8, 4),
+	}
+	objs := []client.Object{starved, readyLinuxRunnerNode("runner-node", starved.Spec.FleetSelector)}
+	for _, hog := range hogs {
+		objs = append(objs, hog)
+		objs = append(objs, unschedulableRunnerPod(hog.Name+"-runner-1", hog.Name, time.Unix(1000, 0)))
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	// Three of the four slots are held, one per sibling, so no sibling is over
+	// its own share of three. The last slot is the starved pool's.
+	for _, hog := range hogs {
+		admission, err := r.provisioningAdmission(context.Background(), hog)
+		if err != nil {
+			t.Fatalf("provisioningAdmission(%s): %v", hog.Name, err)
+		}
+		if admission.blockedReason != "fleet_cap" || admission.available != 0 {
+			t.Fatalf("%s admission = %+v, want the last slot withheld for the starved sibling", hog.Name, admission)
+		}
+	}
+
+	admission, err := r.provisioningAdmission(context.Background(), starved)
+	if err != nil {
+		t.Fatalf("provisioningAdmission(starved): %v", err)
+	}
+	if admission.blockedReason != "" || admission.available != 1 {
+		t.Fatalf("starved admission = %+v, want the reserved slot", admission)
+	}
+}
+
+// The reservation must not deadlock a fleet where every pool is starved: the
+// ceiling a sibling measures itself against floors at one, so the first Pod to
+// start frees the count for the next.
+func TestProvisioningAdmissionFleetCeilingFloorsAtOneWhenAllSiblingsStarve(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux-a", 8, 2)
+	objs := []client.Object{pool, readyLinuxRunnerNode("runner-node", pool.Spec.FleetSelector)}
+	for _, name := range []string{"linux-b", "linux-c", "linux-d"} {
+		objs = append(objs, newLinuxKataPool(name, 8, 2))
+	}
+	// The pool under test is provisioning, so it is not itself owed a slot and
+	// measures against the reduced ceiling; its three starved siblings would
+	// take it below zero without the floor.
+	objs = append(objs, unschedulableRunnerPod("linux-a-runner-1", pool.Name, time.Unix(1000, 0)))
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	admission, err := r.provisioningAdmission(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.fleetCap != 1 {
+		t.Fatalf("fleetCap = %d, want a ceiling floored at one", admission.fleetCap)
+	}
+	if admission.blockedReason != "fleet_cap" {
+		t.Fatalf("admission = %+v, want the in-flight Pod to hold the floored ceiling", admission)
+	}
+}
+
+// A pool that is itself owed a slot measures against the whole ceiling; only
+// its siblings are held back. Without this the reservation would cancel itself
+// out whenever more than one pool was starved.
+func TestProvisioningAdmissionStarvedPoolKeepsFullFleetCeiling(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux-a", 8, 4)
+	sibling := newLinuxKataPool("linux-b", 8, 4)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		pool, sibling, readyLinuxRunnerNode("runner-node", pool.Spec.FleetSelector),
+	).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	admission, err := r.provisioningAdmission(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.fleetCap != admission.cap {
+		t.Fatalf("fleetCap = %d, cap = %d, want a starved pool to keep the whole ceiling", admission.fleetCap, admission.cap)
+	}
+}
+
+func TestTerminationTimedOutIgnoresPodThatIsNotDeleting(t *testing.T) {
+	pod := newRunnerPod("runner-a", "img", corev1.PodRunning, "linux-a")
+	if terminationTimedOut(pod, time.Unix(10000, 0)) {
+		t.Fatal("termination reap fired on a Pod with no deletionTimestamp")
+	}
+}
+
+// A sandbox that is merely slow to stop is still making progress. The reap
+// waits out the grace period kubelet was given plus the slack before deciding
+// the shim is stuck.
+func TestTerminationTimedOutWaitsGracePeriodPlusSlack(t *testing.T) {
+	deletedAt := time.Unix(1000, 0)
+	pod := terminatingRunnerPod("runner-a", "linux-a", deletedAt, 30)
+	deadline := deletedAt.Add(30 * time.Second).Add(terminationStuckSlack)
+
+	if terminationTimedOut(pod, deadline.Add(-time.Second)) {
+		t.Fatal("termination reap fired before the grace period and slack elapsed")
+	}
+	if !terminationTimedOut(pod, deadline) {
+		t.Fatal("termination reap did not fire after the grace period and slack elapsed")
+	}
+}
+
+// A Pod deleted with no grace period still gets the slack: kubelet needs a
+// moment to tear the sandbox down even when it was told not to wait.
+func TestTerminationTimedOutAppliesSlackWithoutGracePeriod(t *testing.T) {
+	deletedAt := time.Unix(1000, 0)
+	pod := terminatingRunnerPod("runner-a", "linux-a", deletedAt, 0)
+	pod.DeletionGracePeriodSeconds = nil
+
+	if terminationTimedOut(pod, deletedAt.Add(terminationStuckSlack-time.Second)) {
+		t.Fatal("termination reap fired inside the slack")
+	}
+	if !terminationTimedOut(pod, deletedAt.Add(terminationStuckSlack)) {
+		t.Fatal("termination reap did not fire after the slack")
+	}
+}
+
+func terminatingRunnerPod(name, poolName string, deletedAt time.Time, graceSeconds int64) *corev1.Pod {
+	pod := newRunnerPod(name, "img", corev1.PodRunning, poolName)
+	deletion := metav1.NewTime(deletedAt)
+	pod.DeletionTimestamp = &deletion
+	pod.DeletionGracePeriodSeconds = &graceSeconds
 	return pod
 }

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -319,6 +319,29 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			continue
 		}
 
+		if terminationTimedOut(p, r.now()) {
+			nodeConditions := r.nodeConditionSummary(ctx, p.Spec.NodeName)
+			logger.Info("force reap runner pod kubelet did not finish terminating",
+				"pod", p.Name,
+				"node", p.Spec.NodeName,
+				"deletingFor", r.now().Sub(p.DeletionTimestamp.Time).String(),
+				"nodeConditions", nodeConditions,
+			)
+			if r.Recorder != nil {
+				r.Recorder.Eventf(p, corev1.EventTypeWarning, "RunnerPodTerminationStuck",
+					"Pod has been terminating for %s without kubelet completing it; dropping the object to release node %s. The sandbox may still be running there; node conditions: %s",
+					r.now().Sub(p.DeletionTimestamp.Time).Truncate(time.Second), p.Spec.NodeName, nodeConditions)
+			}
+			metrics.RecordStuckTermination(pool.Name)
+			if err := r.forceReapRunner(ctx, p); err != nil {
+				logger.Error(err, "force reap stuck terminating runner pod; will retry", "pod", p.Name)
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			}
+			phaseReplicas.remove(p)
+			reaped++
+			continue
+		}
+
 		if unschedulableTimedOut(p, pool, r.now()) {
 			rejectedAt, _ := unschedulableSince(p)
 			logger.Info("reap runner pod the scheduler could not place",
@@ -497,6 +520,7 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					"pendingForPool", admission.pendingForPool,
 					"pendingForFleet", admission.pendingForFleet,
 					"cap", admission.cap,
+					"fleetCap", admission.fleetCap,
 					"poolCap", admission.poolCap,
 					"healthyNodes", admission.healthyNodes,
 				)
@@ -684,6 +708,35 @@ func (r *RunnerPoolReconciler) reapRunner(ctx context.Context, pod *corev1.Pod) 
 
 	if err := r.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("delete pod %s: %w", pod.Name, err)
+	}
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pod.Namespace,
+			Name:      pod.Name,
+		},
+	}
+	if err := r.Delete(ctx, sa); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete sa %s: %w", pod.Name, err)
+	}
+	return nil
+}
+
+// forceReapRunner drops a Pod the kubelet will not finish terminating. The
+// ordinary reap issues a plain Delete, which is a no-op on a Pod that already
+// carries a deletionTimestamp, so dropping the object is the only way to hand
+// its node's CPU and memory back to the scheduler.
+//
+// The sandbox can outlive the object: a force delete does not reach the stuck
+// shim, so the QEMU process may keep running and the node is then oversubscribed
+// against what the scheduler believes. That is still the better trade — the
+// alternative is capacity reserved forever for a VM doing no work — but it is
+// why the caller logs the node and raises an Event: a node that produces these
+// repeatedly wants draining, not another force delete.
+func (r *RunnerPoolReconciler) forceReapRunner(ctx context.Context, pod *corev1.Pod) error {
+	r.reportStopped(ctx, pod)
+
+	if err := r.Delete(ctx, pod, client.GracePeriodSeconds(0)); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("force delete pod %s: %w", pod.Name, err)
 	}
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1741,5 +1742,90 @@ func TestIdleReplicasExcludesDarwinPodWithStaleHeartbeat(t *testing.T) {
 
 	if got := idleReplicasGauge(t, poolName); got != 2 {
 		t.Fatalf("idle replicas = %v, want 2 (the wedged Pod is not capacity; the silent one still is)", got)
+	}
+}
+
+// A kata sandbox whose shim never tears the VM down leaves the Pod deleting
+// with its containers still running. Nothing else in the controller can see it
+// (isAlive excludes a deleting Pod), so it holds its node's CPU and memory
+// against the scheduler indefinitely while the pool reads as having a gap.
+func TestReconcileForceReapsPodKubeletNeverFinishedTerminating(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux", 1, 4)
+	node := readyLinuxRunnerNode("runner-node", pool.Spec.FleetSelector)
+	pod := linuxPod("linux-runner-zombie", pool.Name, nil)
+	pod.Spec.NodeName = node.Name
+	pod.Finalizers = []string{"tuist.dev/test-hold"}
+	deletion := metav1.NewTime(now.Add(-4 * time.Hour))
+	pod.DeletionTimestamp = &deletion
+	pod.DeletionGracePeriodSeconds = ptr.To[int64](30)
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace}}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, node, pod, sa).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+	recorder := record.NewFakeRecorder(2)
+	r := &RunnerPoolReconciler{
+		Client:      c,
+		Scheme:      scheme,
+		DispatchURL: "http://dispatch",
+		DindImage:   "docker:dind",
+		Now:         func() time.Time { return now },
+		Recorder:    recorder,
+	}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if err := c.Get(context.Background(), nn(sa.Namespace, sa.Name), &corev1.ServiceAccount{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("stuck Pod's ServiceAccount get error = %v, want NotFound", err)
+	}
+	select {
+	case event := <-recorder.Events:
+		if !strings.Contains(event, "RunnerPodTerminationStuck") {
+			t.Fatalf("event = %q, want RunnerPodTerminationStuck", event)
+		}
+	default:
+		t.Fatal("expected RunnerPodTerminationStuck event")
+	}
+}
+
+// A Pod that is merely shutting down is still making progress; force-deleting
+// it would cut a graceful drain short.
+func TestReconcileLeavesRecentlyDeletedPodAlone(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux", 1, 4)
+	node := readyLinuxRunnerNode("runner-node", pool.Spec.FleetSelector)
+	pod := linuxPod("linux-runner-draining", pool.Name, nil)
+	pod.Spec.NodeName = node.Name
+	pod.Finalizers = []string{"tuist.dev/test-hold"}
+	deletion := metav1.NewTime(now.Add(-time.Minute))
+	pod.DeletionTimestamp = &deletion
+	pod.DeletionGracePeriodSeconds = ptr.To[int64](30)
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace}}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, node, pod, sa).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+	r := &RunnerPoolReconciler{
+		Client:      c,
+		Scheme:      scheme,
+		DispatchURL: "http://dispatch",
+		DindImage:   "docker:dind",
+		Now:         func() time.Time { return now },
+		Recorder:    record.NewFakeRecorder(2),
+	}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if err := c.Get(context.Background(), nn(sa.Namespace, sa.Name), &corev1.ServiceAccount{}); err != nil {
+		t.Fatalf("draining Pod's ServiceAccount was reaped early: %v", err)
 	}
 }

--- a/infra/runners-controller/internal/metrics/metrics.go
+++ b/infra/runners-controller/internal/metrics/metrics.go
@@ -187,10 +187,15 @@ var (
 		Name: "tuist_runners_pool_pod_start_timeouts_total",
 		Help: "Bound Linux runner Pods reaped after failing to start their dispatch poller within the configured timeout.",
 	}, []string{poolLabel, reasonLabel})
+
+	stuckTerminationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "tuist_runners_pool_stuck_terminations_total",
+		Help: "Runner Pods force-deleted after kubelet did not finish terminating them within the grace period. A non-zero rate means sandboxes are leaking on their nodes.",
+	}, []string{poolLabel})
 )
 
 func init() {
-	ctrlmetrics.Registry.MustRegister(target, allocated, warmDeficitReplicas, minWarmFloor, rollingPods, stalePods, rollCap, phaseReplicas, oldestPendingPodAge, claimedJobs, occupiedRunners, queuedJobs, idleReplicas, pendingProvisioningPods, admissionBlockedTotal, fleetReadyNodes, fleetFilteredNodes, podStartTimeoutsTotal)
+	ctrlmetrics.Registry.MustRegister(target, allocated, warmDeficitReplicas, minWarmFloor, rollingPods, stalePods, rollCap, phaseReplicas, oldestPendingPodAge, claimedJobs, occupiedRunners, queuedJobs, idleReplicas, pendingProvisioningPods, admissionBlockedTotal, fleetReadyNodes, fleetFilteredNodes, podStartTimeoutsTotal, stuckTerminationsTotal)
 }
 
 // RecordAllocation publishes one pool's allocation outcome for this
@@ -248,6 +253,14 @@ func RecordFleetNodes(fleetSelector, operatingSystem string, ready int, filtered
 
 func RecordPodStartTimeout(pool, reason string) {
 	podStartTimeoutsTotal.WithLabelValues(pool, reason).Inc()
+}
+
+// RecordStuckTermination counts a Pod the controller force-deleted because
+// kubelet never finished terminating it. Distinct from the start-timeout
+// counter on purpose: that one means a sandbox failed to come up, this one
+// means one failed to go down and may still be holding its node.
+func RecordStuckTermination(pool string) {
+	stuckTerminationsTotal.WithLabelValues(pool).Inc()
 }
 
 // RecordRoll publishes a pool's Pod-template rollout progress for this


### PR DESCRIPTION
## What changed

Two independent defects in the runners controller, both surfaced by the same incident.

**1. Sandboxes kubelet never finishes terminating are now force-deleted.**

A Kata sandbox whose shim never tears the VM down leaves the Pod in `Terminating` with its containers still reporting `running`. Nothing in the controller could see it: `isAlive` excludes a deleting Pod, so it is neither a replica nor a provisioning Pod. The pool reads as having a gap, the node reads as full, and the two facts never meet.

A Pod deleting for longer than its grace period plus five minutes is now dropped outright, with a warning Event, the node name, and its conditions logged. The ordinary reap cannot do this: a plain `Delete` is a no-op on a Pod that already carries a deletionTimestamp.

**2. The provisioning share is now taken out of the ceiling siblings are measured against.**

#12794 shrank a pool's own share (`poolCap`) by one per starved sibling, but the shared ceiling is what actually refuses the creation and nothing held a slot open underneath it. Several pools each comfortably inside their own share still filled the ceiling between them, and the starved pool was refused by the fleet check before its reserved share was ever read.

A pool that is itself owed a slot now measures against the whole ceiling; every other pool measures against the ceiling minus what its starved siblings are owed, floored at one so a fleet where everything is starved still makes progress one Pod at a time.

## Why

`Release Server (amd64)` on the production cascade sat `queued` for 45 minutes. `tuist_runners_queue_withheld` was 0, so it was not the account concurrency cap.

Nine Pods had been stuck `Terminating` for two to four hours, with `deletionGracePeriodSeconds: 30`, no finalizers, and the `runner` container still `running`. Both affected nodes were `Ready`, kubelet heartbeating, no Memory/Disk/PID pressure. Two of the four Linux runner nodes were entirely zombie, 4/4 and 5/5 Pods, holding 29000m + 90 GiB and 29250m + 92.5 GiB, 94% of each box, doing no work.

With no seat anywhere, the 16 vCPU shapes went `Unschedulable` on `Insufficient cpu, Insufficient memory`, sat until the 300 s reap, and were recreated immediately, pinning `pendingForFleet` at the cap. Every sibling was admitted 0.

Force-deleting the zombies took the fleet from 94-98% reserved to 38-64%, and the deploy job stayed queued anyway:

```
pool=linux-4vcpu-16gb   reason=fleet_cap  pendingForPool=0  poolCap=4  gap=19
pool=linux-2vcpu-8gb    reason=fleet_cap  pendingForPool=2  poolCap=3  gap=33
pool=linux-16vcpu-32gb  reason=fleet_cap  pendingForPool=1  poolCap=3  gap=1
```

The starved pool had its entire reserved share unused and was still refused. That is the second defect, and it is why capacity alone did not clear it.

## Why this shape of fix

The obvious alternative for the first defect is to let the existing reap handle deleting Pods. It cannot: `Delete` on a Pod that is already deleting does nothing, so the object has to be dropped. That has a real cost, which the code and the runbook both state rather than hide. A force delete does not reach the stuck shim, so the QEMU process can outlive the object and leave the node oversubscribed against what the scheduler believes. It is still the better trade than capacity reserved forever for a VM doing no work, and it is why the reap logs the node and raises an Event: a node producing these repeatedly wants draining, not another force delete.

For the second, the alternative was to let a starved pool exceed the fleet ceiling. That would break the burst guarantee the ceiling exists for, which is that at most `cap` sandboxes start together. Reserving the slot by holding siblings back instead keeps the guarantee exactly as it was; only who may claim the last slots changes.

## Impact

No configuration changes. The fleet stops losing capacity to leaked sandboxes without an operator noticing, and a pool with queued work and no Pods gets the next freed slot by construction rather than by winning a reconcile race against a sibling with a larger gap.

New metric `tuist_runners_pool_stuck_terminations_total{pool}`, deliberately separate from the start-timeout counter: that one means a sandbox failed to come up, this one means one failed to go down and may still be holding its node. A non-zero rate is the leading indicator for this incident class.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test ./...` green across all packages.
- Both new admission tests were confirmed red against the previous behaviour before the fix. `TestProvisioningAdmissionHoldsFleetSlotForStarvedSibling` reproduced the production reading exactly, with the hog reporting `available: 1` where the starved sibling was owed the slot.
- The reconcile-level force-reap test was confirmed red with the new branch disabled.
- `TestProvisioningAdmissionHogCannotRecreateAfterReapWhileSiblingStarves` now reports `fleet_cap` instead of `pool_share`. Same outcome, and the assertion was updated with a note: the fleet ceiling is what withholds the slot now.
- The `Runner pool starved` alert added by #12794 fired correctly during the incident (active 15:51:50, "25 dispatchable queued job(s) and zero Pods") and named the right pool. Its runbook pointed only at the `maxReplicas` lever, which was not the cause here, so it now covers stuck terminations and the share defect too.

Verified live against production while diagnosing; the controller change itself is not yet deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
