### PR TITLE
fix(cli): make build insights post-action failures diagnosable and non-fatal

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -15,7 +15,7 @@ func inspectBuildPostAction(target: TargetReference) -> ExecutionAction {
         scriptText: """
         eval "$($HOME/.local/bin/mise activate -C $SRCROOT bash --shims)"
 
-        tuist inspect build
+        tuist inspect build || echo "warning: tuist inspect build failed, build insights were not uploaded"
         """,
         target: target
     )
@@ -27,7 +27,7 @@ func inspectTestPostAction(target: TargetReference) -> ExecutionAction {
         scriptText: """
         eval "$($HOME/.local/bin/mise activate -C $SRCROOT bash --shims)"
 
-        tuist inspect test
+        tuist inspect test || echo "warning: tuist inspect test failed, test insights were not uploaded"
         """,
         target: target
     )

--- a/cli/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/cli/Sources/TuistAutomation/XcodeBuild/XcodeBuildController.swift
@@ -319,23 +319,37 @@ public struct XcodeBuildController: XcodeBuildControlling {
 
     public func run(arguments: [String]) async throws {
         let logger = Logger.current
-        
-        func format(_ bytes: [UInt8]) -> String {
-            let string = String(decoding: bytes, as: Unicode.UTF8.self)
-            if Environment.current.isVerbose == true {
-                return string
+
+        func emit(_ line: String, isError: Bool) {
+            if isError {
+                logger.error("\(line)")
             } else {
-                return self.format(string)
+                logger.info("\(line)")
             }
         }
-        
+
         func log(_ bytes: [UInt8], isError: Bool = false) {
-            let lines = format(bytes).split(separator: "\n")
-            for line in lines where !line.isEmpty {
-                if isError {
-                    logger.error("\(line)")
-                } else {
-                    logger.info("\(line)")
+            let string = String(decoding: bytes, as: Unicode.UTF8.self)
+
+            for line in string.split(separator: "\n") {
+                let line = String(line)
+                guard !line.isEmpty else { continue }
+
+                if Environment.current.isVerbose == true {
+                    emit(line, isError: isError)
+                    continue
+                }
+
+                // The formatter discards lines it doesn't recognize, and that includes everything
+                // script phases and scheme actions write. They go to the session log so that a
+                // failing script can be diagnosed from it.
+                guard let formattedLine = formatter.format(line) else {
+                    logger.debug("\(line)")
+                    continue
+                }
+
+                for formattedLine in formattedLine.split(separator: "\n") where !formattedLine.isEmpty {
+                    emit(String(formattedLine), isError: isError)
                 }
             }
         }
@@ -393,17 +407,5 @@ public struct XcodeBuildController: XcodeBuildControlling {
             timeoutTask.cancel()
             return result
         }.value
-    }
-
-    // MARK: - Helpers
-
-    fileprivate func format(_ multiLineText: String) -> String {
-        multiLineText.split(separator: "\n").map {
-            let line = String($0)
-            let formattedLine = formatter.format(line)
-
-            return formattedLine ?? ""
-        }
-        .joined(separator: "\n")
     }
 }

--- a/cli/Sources/TuistGenerator/Utils/BuildInsightsActionMapper.swift
+++ b/cli/Sources/TuistGenerator/Utils/BuildInsightsActionMapper.swift
@@ -26,10 +26,14 @@ struct BuildInsightsActionMapper: BuildInsightsActionMapping {
               let currentExecutablePath = Environment.current.currentExecutablePath() else { return buildAction }
 
         var buildAction = buildAction
+        let warning = "warning: tuist inspect build failed, build insights were not uploaded"
+        // A post-action that exits with a non-zero status fails the build.
+        let scriptText = "\(currentExecutablePath.pathString) inspect build || echo \"\(warning)\""
+
         buildAction.postActions.append(
             ExecutionAction(
                 title: "Push build insights",
-                scriptText: "\(currentExecutablePath.pathString) inspect build",
+                scriptText: scriptText,
                 target: target,
                 shellPath: nil
             )

--- a/cli/Sources/TuistGenerator/Utils/TestInsightsActionMapper.swift
+++ b/cli/Sources/TuistGenerator/Utils/TestInsightsActionMapper.swift
@@ -25,10 +25,14 @@ struct TestInsightsActionMapper: TestInsightsActionMapping {
               !testInsightsDisabled,
               let currentExecutablePath = Environment.current.currentExecutablePath() else { return testAction }
 
+        let warning = "warning: tuist inspect test failed, test insights were not uploaded"
+        // A post-action that exits with a non-zero status fails the build.
+        let scriptText = "\(currentExecutablePath.pathString) inspect test || echo \"\(warning)\""
+
         testAction.postActions.append(
             ExecutionAction(
                 title: "Push test insights",
-                scriptText: "\(currentExecutablePath.pathString) inspect test",
+                scriptText: scriptText,
                 target: target,
                 shellPath: nil
             )

--- a/cli/Sources/TuistInspectCommand/Services/InspectBuildCommandService.swift
+++ b/cli/Sources/TuistInspectCommand/Services/InspectBuildCommandService.swift
@@ -61,6 +61,25 @@
             path: String?,
             derivedDataPath: String? = nil
         ) async throws {
+            // Inside a build this command runs as a scheme post-action, where a non-zero exit
+            // status fails the build it is reporting on. Build insights are not worth that, so
+            // failures are reported as a warning instead.
+            guard Environment.current.workspacePath != nil else {
+                try await inspect(path: path, derivedDataPath: derivedDataPath)
+                return
+            }
+            do {
+                try await inspect(path: path, derivedDataPath: derivedDataPath)
+            } catch {
+                Logger.current
+                    .warning("warning: build insights were not uploaded. \(error.localizedDescription)")
+            }
+        }
+
+        private func inspect(
+            path: String?,
+            derivedDataPath: String?
+        ) async throws {
             let referenceDate = dateService.now()
             guard let executablePath = Bundle.main.executablePath else {
                 throw InspectBuildCommandServiceError.executablePathMissing

--- a/cli/Sources/TuistInspectCommand/Services/InspectTestCommandService.swift
+++ b/cli/Sources/TuistInspectCommand/Services/InspectTestCommandService.swift
@@ -70,6 +70,37 @@
             resultBundlePath: String? = nil,
             mode: TestProcessingMode? = nil
         ) async throws {
+            // Inside a build this command runs as a scheme post-action, where a non-zero exit
+            // status fails the test action it is reporting on. Test insights are not worth that,
+            // so failures are reported as a warning instead.
+            guard Environment.current.workspacePath != nil else {
+                try await inspect(
+                    path: path,
+                    derivedDataPath: derivedDataPath,
+                    resultBundlePath: resultBundlePath,
+                    mode: mode
+                )
+                return
+            }
+            do {
+                try await inspect(
+                    path: path,
+                    derivedDataPath: derivedDataPath,
+                    resultBundlePath: resultBundlePath,
+                    mode: mode
+                )
+            } catch {
+                Logger.current
+                    .warning("warning: test insights were not uploaded. \(error.localizedDescription)")
+            }
+        }
+
+        private func inspect(
+            path: String?,
+            derivedDataPath: String?,
+            resultBundlePath: String?,
+            mode: TestProcessingMode?
+        ) async throws {
             if Environment.current.variables["TUIST_INSPECT_TEST_WAIT"] != "YES",
                Environment.current.workspacePath != nil
             {

--- a/cli/Tests/TuistAutomationAcceptanceTests/XcodeBuild/XcodeBuildControllerTests.swift
+++ b/cli/Tests/TuistAutomationAcceptanceTests/XcodeBuild/XcodeBuildControllerTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import Path
 import Testing
 import TuistCore
+import TuistLoggerTesting
+import TuistLogging
 import TuistSupport
 
 @testable import TuistAutomation
@@ -31,5 +33,34 @@ struct XcodeBuildControllerTests {
 
         // Then
         #expect(version != nil)
+    }
+
+    @Test(.withMockedLogger()) func run_keeps_unformattable_output_in_the_session_log() async throws {
+        // Given
+        let projectPath = SwiftTestingHelper.fixturePath(
+            path: try RelativePath(validating: "Frameworks/Frameworks.xcodeproj")
+        )
+        let subject = XcodeBuildController()
+        Logger.testingLogHandler.logLevel = .debug
+
+        // When
+        try await subject.run(
+            arguments: [
+                "build",
+                "-project", projectPath.pathString,
+                "-scheme", "iOS",
+                "-destination", "generic/platform=iOS Simulator",
+                "CODE_SIGNING_ALLOWED=NO",
+                "CODE_SIGNING_REQUIRED=NO",
+                "CODE_SIGN_IDENTITY=",
+            ]
+        )
+
+        // Then
+        // xcodebuild opens every invocation with this header and xcbeautify has no rule for it, so
+        // it stands in for the script phase output that used to be discarded.
+        let logs = Logger.testingLogHandler.collected
+        #expect(logs[.debug, default: []].contains { $0.hasPrefix("Command line invocation:") })
+        #expect(!logs[.info, default: []].contains { $0.hasPrefix("Command line invocation:") })
     }
 }

--- a/cli/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
+++ b/cli/Tests/TuistAutomationTests/XcodeBuild/XcodeBuildControllerTests.swift
@@ -7,14 +7,21 @@ import Testing
 import TSCBasic
 import TuistCore
 import TuistEnvironment
+import TuistLoggerTesting
+import TuistLogging
 import TuistSupport
 
 @testable import TuistAutomation
 @testable import TuistTesting
 
 final class MockFormatter: Formatting {
+    var formatStub: ((String) -> String?)?
+
     func format(_ line: String) -> String? {
-        line
+        if let formatStub {
+            return formatStub(line)
+        }
+        return line
     }
 }
 
@@ -27,6 +34,31 @@ struct XcodeBuildControllerTests {
         subject = XcodeBuildController(
             formatter: formatter,
             commandRunner: commandRunner
+        )
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment(), .withMockedLogger())
+    func run_logs_unformattable_output_at_debug() async throws {
+        // Given
+        formatter.formatStub = { line in
+            line.hasPrefix("note:") ? line : nil
+        }
+        commandRunner.defaultCaptureStubs = (
+            stderror: nil,
+            stdout: "note: recognized line\nwarning: could not send build insights to Tuist\n",
+            exitstatus: 0
+        )
+
+        Logger.testingLogHandler.logLevel = .debug
+
+        // When
+        try await subject.run(arguments: ["build"])
+
+        // Then
+        let logs = Logger.testingLogHandler.collected
+        #expect(logs[.info, default: []] == ["note: recognized line"])
+        #expect(
+            logs[.debug, default: []].contains("warning: could not send build insights to Tuist")
         )
     }
 

--- a/cli/Tests/TuistGeneratorTests/Utils/BuildInsightsActionMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Utils/BuildInsightsActionMapperTests.swift
@@ -90,4 +90,39 @@ struct BuildInsightsActionMapperTests {
             got == expectedBuildAction
         )
     }
+
+    @Test(.withMockedEnvironment()) func map_generates_a_script_that_cannot_fail_the_build() async throws {
+        // Given
+        let mockEnvironment = try #require(Environment.mocked)
+        mockEnvironment.currentExecutablePathStub = "/nonexistent/tuist"
+
+        let buildAction: BuildAction = .test()
+
+        // When
+        let got = try await subject.map(
+            buildAction,
+            target: nil,
+            buildInsightsDisabled: false
+        )
+
+        // Then
+        let scriptText = try #require(got.postActions.first?.scriptText)
+        let result = try runThroughShell(scriptText)
+        #expect(result.exitCode == 0)
+        #expect(result.standardOutput.contains("warning: tuist inspect build failed"))
+    }
+}
+
+func runThroughShell(_ scriptText: String) throws -> (exitCode: Int32, standardOutput: String) {
+    // Xcode runs an execution action with no explicit shellPath through /bin/sh.
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/sh")
+    process.arguments = ["-c", scriptText]
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = pipe
+    try process.run()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    return (process.terminationStatus, String(decoding: data, as: UTF8.self))
 }

--- a/cli/Tests/TuistGeneratorTests/Utils/BuildInsightsActionMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Utils/BuildInsightsActionMapperTests.swift
@@ -49,7 +49,7 @@ struct BuildInsightsActionMapperTests {
             postActions: [
                 ExecutionAction(
                     title: "Push build insights",
-                    scriptText: "/mise/tuist inspect build",
+                    scriptText: "/mise/tuist inspect build || echo \"warning: tuist inspect build failed, build insights were not uploaded\"",
                     target: nil,
                     shellPath: nil
                 ),
@@ -79,7 +79,7 @@ struct BuildInsightsActionMapperTests {
             postActions: [
                 ExecutionAction(
                     title: "Push build insights",
-                    scriptText: "/mise/tuist inspect build",
+                    scriptText: "/mise/tuist inspect build || echo \"warning: tuist inspect build failed, build insights were not uploaded\"",
                     target: TargetReference(projectPath: "/tmp/project", name: "TargetA"),
                     shellPath: nil
                 ),

--- a/cli/Tests/TuistGeneratorTests/Utils/TestInsightsActionMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Utils/TestInsightsActionMapperTests.swift
@@ -62,7 +62,7 @@ struct TestInsightsActionMapperTests {
             postActions: [
                 ExecutionAction(
                     title: "Push test insights",
-                    scriptText: "/mise/tuist inspect test",
+                    scriptText: "/mise/tuist inspect test || echo \"warning: tuist inspect test failed, test insights were not uploaded\"",
                     target: target,
                     shellPath: nil
                 ),

--- a/cli/Tests/TuistGeneratorTests/Utils/TestInsightsActionMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Utils/TestInsightsActionMapperTests.swift
@@ -72,4 +72,25 @@ struct TestInsightsActionMapperTests {
             got == expectedTestAction
         )
     }
+
+    @Test(.withMockedEnvironment()) func map_generates_a_script_that_cannot_fail_the_test_action() async throws {
+        // Given
+        let mockEnvironment = try #require(Environment.mocked)
+        mockEnvironment.currentExecutablePathStub = "/nonexistent/tuist"
+
+        let testAction: TestAction = .test()
+
+        // When
+        let got = try await subject.map(
+            testAction,
+            target: nil,
+            testInsightsDisabled: false
+        )
+
+        // Then
+        let scriptText = try #require(got?.postActions.first?.scriptText)
+        let result = try runThroughShell(scriptText)
+        #expect(result.exitCode == 0)
+        #expect(result.standardOutput.contains("warning: tuist inspect test failed"))
+    }
 }

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectBuildCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectBuildCommandServiceTests.swift
@@ -8,6 +8,8 @@ import TuistCore
 import TuistEnvironment
 import TuistEnvironmentTesting
 import TuistLoader
+import TuistLoggerTesting
+import TuistLogging
 import TuistProcess
 import TuistServer
 import TuistSupport
@@ -157,6 +159,44 @@ struct InspectBuildCommandServiceTests {
             .called(1)
     }
 
+    @Test(.withMockedEnvironment(), .withMockedLogger())
+    func does_not_fail_the_build_when_running_as_a_post_action() async throws {
+        // Given
+        let mockedEnvironment = try #require(Environment.mocked)
+        mockedEnvironment.variables = [:]
+        mockedEnvironment.workspacePath = "/tmp/path"
+
+        given(backgroundProcessRunner)
+            .runInBackground(.any, environment: .any)
+            .willThrow(TestError("Failed spawning the background process"))
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then
+        #expect(
+            Logger.testingLogHandler.collected[.warning, default: []]
+                .contains { $0.contains("build insights were not uploaded") }
+        )
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func fails_when_not_running_as_a_post_action() async throws {
+        // Given
+        let mockedEnvironment = try #require(Environment.mocked)
+        mockedEnvironment.variables = [:]
+        mockedEnvironment.workspacePath = nil
+
+        given(xcodeProjectOrWorkspacePathLocator)
+            .locate(from: .any)
+            .willThrow(TestError("Could not locate the project"))
+
+        // When / Then
+        await #expect(throws: TestError.self) {
+            try await subject.run(path: nil)
+        }
+    }
+
     @Test(.withMockedEnvironment())
     func when_should_not_wait() async throws {
         // Given
@@ -288,7 +328,7 @@ struct InspectBuildCommandServiceTests {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let projectPath = temporaryDirectory.appending(component: "App.xcodeproj")
         let mockedEnvironment = try #require(Environment.mocked)
-        mockedEnvironment.workspacePath = projectPath
+        mockedEnvironment.workspacePath = nil
 
         given(xcodeProjectOrWorkspacePathLocator)
             .locate(from: .any)
@@ -309,6 +349,37 @@ struct InspectBuildCommandServiceTests {
         ) {
             try await subject.run(path: nil)
         }
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment(), .withMockedLogger())
+    func when_no_logs_exist_and_running_as_a_post_action() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let projectPath = temporaryDirectory.appending(component: "App.xcodeproj")
+        let mockedEnvironment = try #require(Environment.mocked)
+        mockedEnvironment.workspacePath = projectPath
+
+        given(xcodeProjectOrWorkspacePathLocator)
+            .locate(from: .any)
+            .willReturn(projectPath)
+
+        let derivedDataPath = temporaryDirectory.appending(component: "derived-data")
+        given(derivedDataLocator)
+            .locate(for: .any)
+            .willReturn(derivedDataPath)
+        given(xcActivityLogController).mostRecentActivityLogFile(
+            projectDerivedDataDirectory: .value(derivedDataPath),
+            filter: .any
+        ).willReturn(nil)
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then
+        #expect(
+            Logger.testingLogHandler.collected[.warning, default: []]
+                .contains { $0.contains("build insights were not uploaded") }
+        )
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment())

--- a/cli/Tests/TuistKitTests/Services/Inspect/InspectTestCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Inspect/InspectTestCommandServiceTests.swift
@@ -7,6 +7,8 @@ import TuistConfigLoader
 import TuistCore
 import TuistEnvironment
 import TuistLoader
+import TuistLoggerTesting
+import TuistLogging
 import TuistProcess
 import TuistServer
 import TuistSupport
@@ -368,6 +370,28 @@ struct InspectTestCommandServiceTests {
                 skipTestIdentifiers: .any
             )
             .called(1)
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedLogger())
+    func does_not_fail_the_test_action_when_running_as_a_post_action() async throws {
+        // Given
+        let mockedEnvironment = try #require(Environment.mocked)
+        mockedEnvironment.variables = [:]
+        mockedEnvironment.workspacePath = "/tmp/path"
+        mockedEnvironment.currentExecutablePathStub = "/usr/bin/tuist"
+
+        given(backgroundProcessRunner)
+            .runInBackground(.any, environment: .any)
+            .willThrow(TestError("Failed spawning the background process"))
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then
+        #expect(
+            Logger.testingLogHandler.collected[.warning, default: []]
+                .contains { $0.contains("test insights were not uploaded") }
+        )
     }
 
     @Test(.withMockedEnvironment())

--- a/server/priv/docs/en/guides/features/build-insights/generated-projects.md
+++ b/server/priv/docs/en/guides/features/build-insights/generated-projects.md
@@ -31,7 +31,7 @@ let project = Project(
                     .executionAction(
                         title: "Inspect Build",
                         scriptText: """
-                        $HOME/.local/bin/mise x -C $SRCROOT -- tuist inspect build || echo "warning: tuist inspect build failed, build insights were not uploaded"
+                        $HOME/.local/bin/mise x -C $SRCROOT -- tuist inspect build
                         """,
                         target: "MyApp"
                     )
@@ -44,10 +44,6 @@ let project = Project(
 )
 ```
 
-> [!IMPORTANT]
-> Append `|| echo "warning: ..."` to the command as shown above. Without it, a post-action that
-> exits with a non-zero status fails the whole build.
-
 If you are not using Mise, you need to ensure `tuist` is available in the scheme's environment since Xcode post-actions don't inherit your shell's `PATH`. For [Homebrew](https://brew.sh/) installations:
 
 ```swift
@@ -58,7 +54,7 @@ buildAction: .buildAction(
             title: "Inspect Build",
             scriptText: """
             export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-            tuist inspect build || echo "warning: tuist inspect build failed, build insights were not uploaded"
+            tuist inspect build
             """,
             target: "MyApp"
         )

--- a/server/priv/docs/en/guides/features/build-insights/generated-projects.md
+++ b/server/priv/docs/en/guides/features/build-insights/generated-projects.md
@@ -31,7 +31,7 @@ let project = Project(
                     .executionAction(
                         title: "Inspect Build",
                         scriptText: """
-                        $HOME/.local/bin/mise x -C $SRCROOT -- tuist inspect build
+                        $HOME/.local/bin/mise x -C $SRCROOT -- tuist inspect build || echo "warning: tuist inspect build failed, build insights were not uploaded"
                         """,
                         target: "MyApp"
                     )
@@ -44,6 +44,10 @@ let project = Project(
 )
 ```
 
+> [!IMPORTANT]
+> Append `|| echo "warning: ..."` to the command as shown above. Without it, a post-action that
+> exits with a non-zero status fails the whole build.
+
 If you are not using Mise, you need to ensure `tuist` is available in the scheme's environment since Xcode post-actions don't inherit your shell's `PATH`. For [Homebrew](https://brew.sh/) installations:
 
 ```swift
@@ -54,7 +58,7 @@ buildAction: .buildAction(
             title: "Inspect Build",
             scriptText: """
             export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-            tuist inspect build
+            tuist inspect build || echo "warning: tuist inspect build failed, build insights were not uploaded"
             """,
             target: "MyApp"
         )
@@ -72,6 +76,17 @@ For Xcodebuild-driven CI you need to:
 - Add `-resultBundlePath` to your `xcodebuild` command.
 
 Without `-resultBundlePath`, required activity logs and result bundles are not generated and `tuist inspect build` cannot analyze the build.
+
+`tuist xcodebuild` uploads the build run itself, on both successful and failed builds, so you do not
+need `tuist inspect build` as a separate CI step. Keep the scheme post-action for local Xcode builds,
+which `tuist xcodebuild` does not cover.
+
+### Inspect build environment variables {#inspect-build-environment-variables}
+
+| Variable | Description |
+|----------|-------------|
+| `TUIST_INSPECT_BUILD_WAIT` | Set to `YES` to upload before the command exits. Any other value, including `NO`, uploads in a detached background process. |
+| `TUIST_INSPECT_BUILD_TIMEOUT` | Seconds to wait for Xcode to finish writing the build's activity log. Defaults to `10`. This is not a network timeout. |
 
 ## Machine metrics {#machine-metrics}
 

--- a/server/priv/docs/en/guides/features/build-insights/xcode.md
+++ b/server/priv/docs/en/guides/features/build-insights/xcode.md
@@ -37,8 +37,12 @@ For [Mise](https://mise.jdx.dev/), activate `tuist` in the post-action environme
 ```sh
 # -C ensures that Mise loads the configuration from the Mise configuration
 # file in the project's root directory.
-$HOME/.local/bin/mise x -C $SRCROOT -- tuist inspect build
+$HOME/.local/bin/mise x -C $SRCROOT -- tuist inspect build || echo "warning: tuist inspect build failed, build insights were not uploaded"
 ```
+
+> [!IMPORTANT]
+> Append `|| echo "warning: ..."` to the command as shown above. Without it, a post-action that
+> exits with a non-zero status fails the whole build.
 
 > [!TIP]
 > **Mise path resolution**
@@ -49,7 +53,7 @@ For [Homebrew](https://brew.sh/), add the Homebrew paths to the post-action envi
 
 ```sh
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-tuist inspect build
+tuist inspect build || echo "warning: tuist inspect build failed, build insights were not uploaded"
 ```
 
 Once logged in, local builds are tracked and available from the Tuist dashboard:

--- a/server/priv/docs/en/guides/features/build-insights/xcode.md
+++ b/server/priv/docs/en/guides/features/build-insights/xcode.md
@@ -37,12 +37,8 @@ For [Mise](https://mise.jdx.dev/), activate `tuist` in the post-action environme
 ```sh
 # -C ensures that Mise loads the configuration from the Mise configuration
 # file in the project's root directory.
-$HOME/.local/bin/mise x -C $SRCROOT -- tuist inspect build || echo "warning: tuist inspect build failed, build insights were not uploaded"
+$HOME/.local/bin/mise x -C $SRCROOT -- tuist inspect build
 ```
-
-> [!IMPORTANT]
-> Append `|| echo "warning: ..."` to the command as shown above. Without it, a post-action that
-> exits with a non-zero status fails the whole build.
 
 > [!TIP]
 > **Mise path resolution**
@@ -53,7 +49,7 @@ For [Homebrew](https://brew.sh/), add the Homebrew paths to the post-action envi
 
 ```sh
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-tuist inspect build || echo "warning: tuist inspect build failed, build insights were not uploaded"
+tuist inspect build
 ```
 
 Once logged in, local builds are tracked and available from the Tuist dashboard:


### PR DESCRIPTION
## What changed

Four fixes to the build insights post-action path, all prompted by a support investigation where a scheme post-action running `tuist inspect build` failed a CI build and the reason was unrecoverable from any artifact we collect.

1. **`tuist xcodebuild` no longer discards unrecognized xcodebuild output.** It goes to the session log at debug level. Console output is unchanged.
2. **`inspect build` and `inspect test` no longer exit non-zero when they run as a post-action.** They already know they are inside a build, because Xcode sets `WORKSPACE_PATH`, so failures are reported as a warning there. Outside a build both still throw.
3. **The post-action we generate additionally guards against its own binary having moved**, which is the one failure the command cannot catch because it never runs.
4. **Docs**: the CI section says `tuist xcodebuild` already uploads the build run, and `TUIST_INSPECT_BUILD_WAIT` / `TUIST_INSPECT_BUILD_TIMEOUT` are documented. The post-action snippets stay a bare invocation.

## Why

A build failed with nothing but this:

```
** TEST BUILD FAILED **
The following build commands failed:
	Run custom shell script '<insights post-action>'
	Building workspace ... for testing with scheme ...
(3 failures)
```

No reason, anywhere. The script's own stdout and stderr never appeared in the console, and they were not in the session log either, which is the artifact we ask users to send us. Everything else about the run was healthy: the build itself succeeded, and the build insights for that exact build were uploaded twice over, once by `tuist xcodebuild` and once by a separate `tuist inspect build` step, every request returning 200 in a few seconds. Two weeks were spent looking for a server-side timeout that did not exist, because the one piece of evidence that would have ended it in a minute was being thrown away.

### Root cause of the missing output

`Formatter` builds its `XCBeautifier` with `preserveUnbeautifiedLines: false`, and `XcodeBuildController` mapped every `nil` from the formatter to `""`, which the subsequent `where !line.isEmpty` filter dropped. xcbeautify has no rule for the plain text a script phase writes, so script phase and scheme action output was discarded in full. Plain `xcodebuild` shows it; running through us hid it.

Console noise is presumably why the flag is off, so this keeps the console identical and routes the dropped lines to the session log instead. That is the right destination anyway: it is what we ask for in support threads.

### Why the post-action should not be able to fail a build

Insights are telemetry. A telemetry upload breaking the build it measures is the wrong trade in every case.

The first version of this branch solved it by appending `|| echo "warning: ..."` to the documented snippet, which put the burden on every user writing a post-action by hand. That was wrong: the command can tell it is running inside a build from `WORKSPACE_PATH`, so it can decline to exit non-zero on its own. It now does, and the documented snippets go back to a bare invocation.

One failure survives that, and only for the post-action we generate: it embeds an absolute path to the current executable at generation time, so a version bump that moves the binary leaves generated schemes pointing at a path that no longer exists. The shell exits 127 before tuist runs, and no error handling inside the command can catch it. That one keeps a shell guard, which users never see or write.

### Why the docs changed

The post-action snippets are unchanged now that the command handles its own failures. The generated-projects page tells you to add the post-action to custom schemes, and further down tells you to drive CI through `tuist xcodebuild`. It never says the second makes the first redundant, so following the page end to end gives you two uploads of the same build on every CI run. `tuist xcodebuild` uploads the build run itself on both successful and failed builds, so the post-action's job is local Xcode builds, which the wrapper never sees. Worth being explicit, because "delete the post-action" is the wrong conclusion to reach on your own: it is the only thing covering local builds.

The two environment variables were also undocumented and both easy to set backwards. Only the exact string `YES` makes `TUIST_INSPECT_BUILD_WAIT` synchronous, so `NO` and `YES` are not opposites, and `TUIST_INSPECT_BUILD_TIMEOUT` bounds the wait for Xcode to finish writing the activity log rather than any network call, which is how it gets mistaken for evidence of a server-side timeout.

## Impact

Users driving xcodebuild through us get script phase failures they can actually diagnose. Generated schemes stop being able to fail a build over telemetry. Anyone following the docs stops paying for a duplicate upload per build.

The duplicate upload itself is untouched here; the server keys the build on the activity log UUID and `get_or_create_build` is idempotent, so it costs bandwidth and CI seconds but produces no duplicate rows.

## Validation

Every new test was confirmed red on the previous behaviour and green after, by reverting the production change alone and rebuilding.

| Test | Level | Red before |
|---|---|---|
| `run_keeps_unformattable_output_in_the_session_log` (TuistAutomationAcceptanceTests) | E2E, real `xcodebuild` build of the Frameworks fixture | yes |
| `run_logs_unformattable_output_at_debug` (TuistAutomationTests) | Unit, stubbed formatter | yes |
| `does_not_fail_the_build_when_running_as_a_post_action` | Unit, throwing background runner | yes |
| `does_not_fail_the_test_action_when_running_as_a_post_action` | Unit, throwing background runner | yes |
| `when_no_logs_exist_and_running_as_a_post_action` | Unit, no activity log after the timeout | yes |
| `map_generates_a_script_that_cannot_fail_the_build` | Behavioural, runs the generated script through `/bin/sh` | yes, shell exits 127 |
| `map_generates_a_script_that_cannot_fail_the_test_action` | Behavioural, same | yes, shell exits 127 |

The two mapper tests replace what was previously only a string-equality assertion on the generated `scriptText`, which restated the implementation instead of checking that the post-action can no longer break a build.

`when_no_logs_exist` pinned the old throwing behaviour with a workspace path set, so it is split: the original assertion covers the non-post-action case, and the new test covers the post-action case. `fails_when_not_running_as_a_post_action` pins that errors still propagate outside a build.

The acceptance test is the end-to-end one: a real `xcodebuild` build driven through `XcodeBuildController.run`, asserting that xcodebuild's own `Command line invocation:` header, which xcbeautify has no rule for, lands in the session log at debug and stays out of the console stream.

Suite runs:

- `TuistAutomationAcceptanceTests`, full suite: 39 tests in 34 suites passed (706s).
- `TuistKitTests/InspectBuildCommandServiceTests`, `TuistKitTests/InspectTestCommandServiceTests`, `TuistGeneratorTests/BuildInsightsActionMapperTests`, `TuistGeneratorTests/TestInsightsActionMapperTests`, `TuistAutomationTests/XcodeBuildControllerTests`: all passed.
- `mise run lint --fix`: no changes, formatting stable.

Not covered by an automated test: the docs changes, and a stale generated scheme pointing at a relocated tuist binary (the mapper tests simulate it with a nonexistent path rather than performing a real version bump).

## Left out deliberately

Two follow-ups, both worth doing, neither belonging here:

- **Suppressing the redundant in-build upload.** `XcodeBuildController.run` already assembles an explicit environment for the xcodebuild child in order to inject `NSUnbufferedIO`, so a marker set there would propagate into script phases and let the in-build hook no-op when a parent invocation already owns the build run. That is the correct general answer, and much better than asking users to branch on `XPC_SERVICE_NAME`, which answers "am I in Xcode.app" when the real question is "has this build already been uploaded". It needs `XcodeBuildBuildCommandService` to upload on failure first, which it currently does not (only the test service does), otherwise suppressing the post-action would lose insights for failed non-test builds.
- **The ±10s activity log window** in `InspectBuildCommandService.mostRecentActivityLogPath`. A detached `inspect build` rejects any activity log whose `timeStoppedRecording` is more than 10 seconds from its own start, so a project whose post-build phase runs longer than that silently loses insights and then fails with `mostRecentActivityLogNotFound` once the timeout expires. Fixing it means picking new semantics for stale-log protection rather than widening a constant, so it deserves its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



