### PR TITLE
fix(infra): reclaim canary Kura instances on a one-day window

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -191,6 +191,30 @@ server:
       # traffic-driven placement is observable rather than collapsing onto a
       # single funded region.
       value: ca-east,eu-central
+    - name: TUIST_KURA_INACTIVE_DAYS
+      # Every account this environment provisions comes from an acceptance
+      # test run, and a test account never builds again. On the production
+      # 90-day default none of them are ever reclaimed, so each cascade run
+      # leaves its instances behind and the namespace grows without bound:
+      # kura went from 5 pods to 61 in six hours on 2026-09-03, saturating
+      # local-path storage and adding ~9.7k active series. A one-day window
+      # with no tracking grace reclaims a run's accounts by the next day,
+      # matching staging.
+      #
+      # The `tuist` account above takes cache demand on every cascade run, so
+      # it stays live through the working week and cold-returns after a quiet
+      # weekend, which is the same path staging exercises.
+      value: "1"
+    - name: TUIST_KURA_PRESSURE_INACTIVE_DAYS
+      value: "1"
+    - name: TUIST_KURA_DEMAND_TRACKING_GRACE_DAYS
+      value: "0"
+    - name: TUIST_KURA_ARCHIVAL_SWEEP_CRON
+      # The production default is @daily, which would leave an instance
+      # eligible for up to another day against the one-day window above.
+      # Hourly closes that to an hour; staging's */5 buys nothing here, where
+      # nobody is watching a single instance through its cycle.
+      value: "0 * * * *"
     # Wave 0 (canary) of a progressive Kura runtime rollout (spec #79).
     # This environment's rollouts run expedited, so the value only shapes
     # interim-paced ordering here; kept aligned with production.


### PR DESCRIPTION
## What changed

Canary gets the Kura lifecycle window overrides staging already carries: a one-day inactivity window, a zero-day demand-tracking grace, and an hourly archival sweep instead of the daily default.

## Why

#12761 provisions an account's Kura instance when its first project is created. On canary, every account that creates a project comes from an acceptance-test run, and a test account never builds again.

`TUIST_KURA_INACTIVE_DAYS` and `TUIST_KURA_DEMAND_TRACKING_GRACE_DAYS` are currently set only in `values-managed-staging.yaml`. Canary has no override, so it inherits the production defaults of a 90-day window plus a 7-day grace, and nothing reclaims those instances. Each cascade run leaves its accounts behind permanently.

On 2026-09-03 the `kura` namespace on canary went from a flat 5 pods to 61 in about six hours, starting at 10:20 UTC. The first cascade run of the day was 10:27 UTC. Production moved 45 to 52 in the same window and staging stayed flat at 21, which is the shape you would expect: production is real accounts behaving as designed, staging already reclaims, canary accumulates.

That is also what tripped `Anomaly: Metrics Usage (Medium sensitivity)` (uid `ffntarv51sxz4b`). The namespace went from 444 to 10,123 active series. At the metered rate of 8.00 USD per 1,000 series per month, verified against `grafanacloud_org_metrics_overage` on three separate days, that is roughly 77 USD/month acquired in six hours, and it does not stop: while pods can still schedule it adds about 78 USD/day of monthly run-rate, and about 15 USD/day once they can only go Pending.

The bill is the smaller problem. Canary is already out of schedulable local-path storage, with 21 pods and 19 PVCs Pending, and canary sits on the production deploy cascade's critical path.

## Why this fix

The 90-day window is right for production, where a quiet account is a customer who may come back and a cold return costs them a wait. It is wrong only for disposable accounts, which is exactly the distinction staging already draws with these variables. Reusing them keeps one mechanism rather than adding a canary-specific admission rule.

The alternative considered was tightening the seed path itself. Its only gate is `Capacity.under_pressure?`, which is documented to return false whenever either side cannot be read so that pressure archival never runs uninformed. That is correct for its original caller and wrong as an admission gate, where failing open means seed anyway. Changing it would alter production provisioning to fix a canary configuration gap, so it is left alone here and noted below.

A middle option, a three-day window that survives a quiet weekend, was rejected: at the observed creation rate it still lands well above canary's roughly 40-pod schedulable ceiling, so it would not actually bound the namespace.

The `tuist` account pinned by `TUIST_KURA_CANARY_ACCOUNT_HANDLES` takes cache demand on every cascade run, so it stays live through the working week and cold-returns after a quiet weekend. That is the same path staging exercises today.

The sweep is hourly rather than staging's `*/5`. Against a one-day window the daily default would leave an instance eligible for up to another day; hourly closes that, and the tighter cadence buys nothing here where nobody is watching a single instance through its cycle.

## Impact

Canary reclaims each cascade run's Kura instances the following day instead of holding them for 90. No production or staging behaviour changes. Existing canary instances are reclaimed by the sweep once this deploys, which should return the namespace to roughly its previous 5 pods and drop about 9.7k active series.

## Validation

- `helm lint` against this values file parses it; the one reported error is a pre-existing template issue in `templates/dedibox-fleet.yaml`, unrelated to this change and present without it.
- Confirmed all four variables parse to `server.extraEnv` alongside the existing `TUIST_KURA_*` entries, with string values.
- Attribution measured rather than assumed: per-cluster `kube_pod_info` counts isolated the growth to `kura` on canary, `count({cluster="tuist-canary",namespace="kura"})` gave the 444 to 10,123 series step, and `kube_pod_owner` confirmed the pods are per-account 2-replica StatefulSets.

## Open question for review

Today's 28 accounts cannot be cleanly split between this seed path and the first-cache-request path that #12781 newly exercises on canary, without reading the canary account rows. Both landed today. The window override bounds the namespace either way, but if the real rate is materially above roughly 20 accounts/day then even a one-day window sits above canary's schedulable ceiling and the seed path needs a genuine admission gate as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
