### PR TITLE
fix(server): name the frame an xcactivitylog parser crash trapped on

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -34,8 +34,14 @@ COPY server/native/xcactivitylog_nif/Sources/ Sources/
 COPY server/native/xcactivitylog_nif/Tests/ Tests/
 COPY server/native/xcactivitylog_nif/.swiftpm/ .swiftpm/
 
+# The backtracer is the only thing that turns a Swift trap into a named frame:
+# optimized Swift emits a bare trap instruction, so without it a crash reaches
+# Tuist.Processor.XCActivityLogParser as an exit status and an empty string. The
+# static build is taken because the runner carries only the Swift shared
+# libraries, not a toolchain.
 RUN swift build -c release --replace-scm-with-registry --product xcactivitylog-parser && \
     cp .build/release/xcactivitylog-parser /nif/xcactivitylog-parser && \
+    cp /usr/libexec/swift/linux/swift-backtrace-static /nif/swift-backtrace && \
     mkdir -p /nif/swift-libs && \
     cp -a /usr/lib/swift/linux/lib*.so* /nif/swift-libs/
 
@@ -169,17 +175,20 @@ RUN mix release
 
 # ========================================
 # Stage: Release with parser
-# Places the Swift parser executable under the release's tuist app priv dir,
-# where Tuist.Processor.XCActivityLogParser looks it up at runtime.
+# Places the Swift parser executable and the backtracer it crashes through under
+# the release's tuist app priv dir, where Tuist.Processor.XCActivityLogParser
+# looks both up at runtime.
 # ========================================
 FROM builder AS release-with-parser
 
 COPY --from=swift-builder /nif/xcactivitylog-parser /tmp/nif/xcactivitylog-parser
+COPY --from=swift-builder /nif/swift-backtrace /tmp/nif/swift-backtrace
 
 RUN TUIST_REL_DIR=$(ls -d /app/_build/${MIX_ENV}/rel/tuist/lib/tuist-*) && \
     mkdir -p "$TUIST_REL_DIR/priv/native" && \
-    cp /tmp/nif/xcactivitylog-parser "$TUIST_REL_DIR/priv/native/" && \
-    chmod +x "$TUIST_REL_DIR/priv/native/xcactivitylog-parser"
+    cp /tmp/nif/xcactivitylog-parser /tmp/nif/swift-backtrace "$TUIST_REL_DIR/priv/native/" && \
+    chmod +x "$TUIST_REL_DIR/priv/native/xcactivitylog-parser" \
+             "$TUIST_REL_DIR/priv/native/swift-backtrace"
 
 # ========================================
 # Stage: Common runtime

--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -75,6 +75,12 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
       {:error, :object_not_found} when attempt <= @not_visible_snoozes ->
         {:snooze, @not_visible_snooze_seconds}
 
+      {:error, {:parser_crashed, status, output} = reason} ->
+        Logger.error("Build processing failed permanently for build #{build_id}: #{inspect(reason)}")
+        report_parser_crash(build_id, project_id, storage_key, status, output)
+        mark_failed_build_processing(build_id, project_id, account_id, build_metadata)
+        {:discard, reason}
+
       {:error, reason} ->
         if attempt >= max_attempts do
           Logger.error("Build processing failed permanently for build #{build_id}: #{inspect(reason)}")
@@ -138,6 +144,23 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
 
     {:ok, _build} = Builds.create_build(attrs)
     :ok
+  end
+
+  # Oban emits `[:oban, :job, :stop]` for an explicit discard and
+  # `[:oban, :job, :exception]` only for a failure, so discarding drops the
+  # report that retrying to exhaustion used to produce. `output` carries the
+  # Swift backtrace, which is what says where the parser trapped.
+  defp report_parser_crash(build_id, project_id, storage_key, status, output) do
+    Sentry.capture_message("The xcactivitylog parser crashed",
+      level: :error,
+      extra: %{
+        build_id: build_id,
+        project_id: project_id,
+        storage_key: storage_key,
+        exit_status: status,
+        parser_output: output
+      }
+    )
   end
 
   defp mark_failed_build_processing(build_id, project_id, account_id, build_metadata) do

--- a/server/lib/tuist/processor/xcactivitylog_parser.ex
+++ b/server/lib/tuist/processor/xcactivitylog_parser.ex
@@ -7,13 +7,17 @@ defmodule Tuist.Processor.XCActivityLogParser do
   trap — an out-of-range integer conversion on a malformed log, say — and there
   is no way to catch that from the calling code. In-process, that killed the
   BEAM and every job the pod had in flight; out of process it costs the one job
-  and comes back as `{:error, {:parser_crashed, status, output}}`.
+  and comes back as `{:error, {:parser_crashed, status, output}}`, with `output`
+  carrying the Swift backtrace that names the frame that trapped.
 
   Build the executable with: `cd server/native/xcactivitylog_nif && ./build.sh`
-  (the server Dockerfile does this as part of the image build).
+  (the server Dockerfile does this as part of the image build). The Dockerfile
+  additionally ships the Swift backtracer beside it; `build.sh` does not,
+  because the helper is Linux-only.
   """
 
   @executable "xcactivitylog-parser"
+  @backtracer "swift-backtrace"
 
   # Below `ProcessBuildWorker`'s 5 minute wall-time limit so a wedged parse
   # returns a structured error before Oban kills the job.
@@ -59,7 +63,8 @@ defmodule Tuist.Processor.XCActivityLogParser do
     case MuonTrap.cmd(executable, arguments,
            timeout: @timeout,
            delay_to_sigkill: @delay_to_sigkill,
-           stderr_to_stdout: true
+           stderr_to_stdout: true,
+           env: backtracer_env()
          ) do
       {_output, 0} ->
         :ok
@@ -76,6 +81,26 @@ defmodule Tuist.Processor.XCActivityLogParser do
 
       {output, _status} ->
         {:error, String.trim(output)}
+    end
+  end
+
+  # Optimized Swift compiles an out-of-range integer conversion to a bare trap
+  # instruction, so the crash carries no message and `output` arrives empty —
+  # which leaves nothing to tell one trap site from another. The runtime's
+  # backtracer would print the crashing frame, but it looks for its helper in
+  # the toolchain layout that the runtime image does not carry, so the shipped
+  # copy has to be named outright. Registers and the image list are suppressed
+  # to keep the frames small enough to travel in the error tuple.
+  defp backtracer_env do
+    path = Path.join([:code.priv_dir(:tuist), "native", @backtracer])
+
+    if File.exists?(path) do
+      [
+        {"SWIFT_BACKTRACE",
+         "enable=yes,interactive=no,color=no,registers=none,images=none,threads=crashed,swift-backtrace=#{path}"}
+      ]
+    else
+      []
     end
   end
 

--- a/server/test/tuist/builds/workers/process_build_worker_test.exs
+++ b/server/test/tuist/builds/workers/process_build_worker_test.exs
@@ -196,6 +196,60 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
                ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 3, 3))
     end
 
+    # A Swift trap is deterministic on the same archive, so the remaining
+    # attempts would only repeat the download and the parse to reach the same
+    # discard.
+    test "discards a parser crash on the first attempt instead of retrying", %{
+      account: account,
+      project: project,
+      build: build
+    } do
+      expect(Tuist.Storage, :download_to_file, fn _, _, _ -> {:ok, :done} end)
+
+      expect(BuildProcessor, :process_build, fn _path, _ ->
+        {:error, {:parser_crashed, 132, "Program crashed: Illegal instruction"}}
+      end)
+
+      expect(Builds, :create_build, fn attrs ->
+        assert attrs.status == "failed_processing"
+        {:ok, %{id: build.id}}
+      end)
+
+      stub(Sentry, :capture_message, fn _, _ -> {:ok, "id"} end)
+
+      assert {:discard, {:parser_crashed, 132, _}} =
+               ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 1, 5))
+    end
+
+    # Oban emits `[:oban, :job, :stop]` for an explicit discard, not
+    # `[:oban, :job, :exception]`, so discarding drops the report that
+    # retrying to exhaustion used to produce.
+    test "reports a parser crash with the output that names the trap", %{
+      account: account,
+      project: project,
+      build: build
+    } do
+      expect(Tuist.Storage, :download_to_file, fn _, _, _ -> {:ok, :done} end)
+
+      expect(BuildProcessor, :process_build, fn _path, _ ->
+        {:error, {:parser_crashed, 132, "0 XCActivityLogParser.ActivityParser.parse + 9"}}
+      end)
+
+      stub(Builds, :create_build, fn _ -> {:ok, %{id: build.id}} end)
+
+      expect(Sentry, :capture_message, fn message, options ->
+        assert message =~ "parser crashed"
+        assert options[:extra].exit_status == 132
+        assert options[:extra].parser_output =~ "ActivityParser.parse"
+        assert options[:extra].storage_key == @storage_key
+        assert options[:extra].build_id == build.id
+        {:ok, "id"}
+      end)
+
+      assert {:discard, _} =
+               ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 1, 5))
+    end
+
     test "snoozes while the uploaded archive is not visible yet", %{
       account: account,
       project: project,

--- a/server/test/tuist/processor/xcactivitylog_parser_test.exs
+++ b/server/test/tuist/processor/xcactivitylog_parser_test.exs
@@ -5,12 +5,19 @@ defmodule Tuist.Processor.XCActivityLogParserTest do
   alias Tuist.Processor.XCActivityLogParser
 
   @executable_path Path.join([:code.priv_dir(:tuist), "native", "xcactivitylog-parser"])
+  @backtracer_path Path.join([:code.priv_dir(:tuist), "native", "swift-backtrace"])
 
   defp install_parser(script) do
     File.mkdir_p!(Path.dirname(@executable_path))
     File.write!(@executable_path, "#!/bin/sh\n" <> script)
     File.chmod!(@executable_path, 0o755)
     on_exit(fn -> File.rm(@executable_path) end)
+  end
+
+  defp install_backtracer do
+    File.mkdir_p!(Path.dirname(@backtracer_path))
+    File.write!(@backtracer_path, "")
+    on_exit(fn -> File.rm(@backtracer_path) end)
   end
 
   defp parse do
@@ -42,6 +49,28 @@ defmodule Tuist.Processor.XCActivityLogParserTest do
     install_parser(~S|kill -s ILL $$|)
 
     assert {:error, {:parser_crashed, 132, _output}} = parse()
+  end
+
+  # An optimized Swift trap prints nothing on its own, so without the backtracer
+  # a crash arrives as `{:parser_crashed, 132, ""}` and there is no way to tell
+  # which conversion fired.
+  test "points the Swift backtracer at the copy shipped beside the parser" do
+    install_backtracer()
+    install_parser(~S|printf '{"backtrace":"%s"}' "$SWIFT_BACKTRACE" > "$4"|)
+
+    assert {:ok, %{"backtrace" => backtrace}} = parse()
+    assert backtrace =~ "enable=yes"
+    assert backtrace =~ "swift-backtrace=#{@backtracer_path}"
+  end
+
+  # macOS builds ship no backtracer: naming a path that does not exist makes the
+  # Swift runtime print a "unable to locate swift-backtrace" line over whatever
+  # the parser reported.
+  test "leaves SWIFT_BACKTRACE unset when no backtracer ships with the parser" do
+    File.rm(@backtracer_path)
+    install_parser(~S|printf '{"backtrace":"%s"}' "$SWIFT_BACKTRACE" > "$4"|)
+
+    assert {:ok, %{"backtrace" => ""}} = parse()
   end
 
   test "leaves no output file behind" do


### PR DESCRIPTION
## What

Two changes to how an `xcactivitylog` parser crash is diagnosed and handled:

1. Ship the Swift backtracer beside the parser in the runtime image and point the parser process at it, so a trap reports the frame it died on.
2. Discard a parser crash on the first attempt instead of retrying it five times, and report it explicitly so discarding does not lose the Sentry event.

## Why

The build processor reports parser crashes as:

```
Oban.PerformError: Tuist.Builds.Workers.ProcessBuildWorker failed with {:error, {:parser_crashed, 132, ""}}
```

Exit 132 is 128 + 4 = SIGILL, which on Linux x86_64 is how a Swift runtime trap surfaces. The empty string is the entire diagnostic. That is the problem: optimized Swift compiles an out-of-range integer conversion to a bare trap instruction that prints nothing, so there is no way to tell which trap fired.

This matters because the remaining trap sites are upstream in XCLogParser 0.2.49 `ActivityParser.swift`, where `parseAsInt` returns `UInt64` and the caller narrows it with `Int8(...)` / `Int(...)`. There are 13 such conversions. Clamping them from our side is not viable (the `Int8` sites need values under 128, and clamping `sectionType` would turn a token-stream desync into corrupt data), so the fix has to be upstream, and an upstream fix needs to know which conversion it is.

### Root cause of the blindness

`server/Dockerfile` copies only `/usr/lib/swift/linux/lib*.so*` into the `debian:bookworm-slim` runner. The Swift runtime shells out to a separate backtracer helper, `/usr/libexec/swift/linux/swift-backtrace`, which was never copied, so the runtime silently gives up on every crash.

Measured in a container built the way the runner is (slim + those libs, `Int8(UInt64(300))` in a `-O` binary):

| setup | result |
| --- | --- |
| runner-shaped image, default env | `status=132 output=[]` — the production signature exactly |
| the same binary in `swift:6.2-bookworm` | full symbolicated backtrace, **by default** |
| runner-shaped + `SWIFT_BACKTRACE=enable=yes` | `swift runtime: unable to locate swift-backtrace; disabling backtracing.` |
| this PR | 12 lines, 287 bytes, naming the crashing frame |

So we were not opted out of diagnostics; we had deleted the helper.

The runtime resolves the helper against a toolchain layout the image does not have. Putting it at `/usr/libexec/swift/linux/` does not work, and neither does placing it as a sibling of the relocated libdir. Naming it explicitly through `swift-backtrace=<path>` is what actually works, which is why the env var carries an absolute path rather than relying on discovery.

`registers=none,images=none,threads=crashed` keeps the output at ~12 lines so it fits in the error tuple and the Sentry payload. `MuonTrap.cmd(stderr_to_stdout: true)` already returns the child's stderr, so no other plumbing changes.

### Why the retry also had to go

`{:parser_crashed, _, _}` is deterministic: the same archive traps on every attempt. `ProcessBuildWorker` sent it down the generic `{:error, reason}` branch, so Oban retried it five times, each attempt re-downloading the archive and re-running a parse with a four minute timeout, to reach the same discard. That is why four builds produced twenty Sentry events. `XCActivityLogParser`'s own `@moduledoc` already said a crash is "not a transient failure worth retrying"; the worker just did not honour it.

Discarding naively would have silenced the alert, which is the trap worth calling out: Oban emits `[:oban, :job, :stop]` for an explicit `{:discard, reason}` and `[:oban, :job, :exception]` only for a failure, and `TuistCommon.ObanTelemetry` hooks the exception event. The report is therefore made explicitly in the worker, with the backtrace attached, so the signal survives and gets better rather than disappearing.

## Context

The crash class itself is not new. It has been killing processor pods since early August; #12625 closed one trap site of the class but not the rest. #12790 moved the parse out of process, which is why it now arrives as a catchable error instead of taking the BEAM down with every job in flight, and why stuck-`processing` builds went from 5-28/day to 0. This PR is about the next step: turning the contained crash into something actionable.

There is now also a deterministic reproduction. One project's builds parse fine on CLI `4.207.0-canary.10` (3/3) and trap on `4.207.0-canary.13` (9/9), on the same Xcode. The only CLI changes in that window are two graph mappers and a CAS log default, and the graph mappers change what gets built and therefore the shape of the log. That gives a poison input on demand, which combined with the backtrace should be enough to write the upstream fix.

## Impact

- A parser crash now names its frame in Sentry instead of reporting an empty string.
- A crashing build costs one download and one parse instead of five, and produces one Sentry event instead of five.
- Builds that cannot be parsed still land as `failed_processing`, unchanged.
- The runner image grows by ~10 MB (the static backtracer).

## Validation

- `mix test test/tuist/processor/xcactivitylog_parser_test.exs` — 7 passed.
- `mix test test/tuist/builds/workers/process_build_worker_test.exs` — 21 passed.
- Both new test groups confirmed red first. Without the env var the backtracer test fails with `left: ""`, which is the production symptom; without the worker clause both discard tests fail with `{:error, ...}`, which is the retry path.
- `mix credo` on both changed modules: no issues.
- The two Dockerfile shell fragments were run verbatim in `swift:6.2-bookworm` and produce the expected `priv/native` layout. `swift-backtrace-static` is confirmed present in the pinned image.
- The backtracer behaviour in the table above was measured end to end in runner-shaped containers, not inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
