### PR TITLE
fix(kura): bound hyper's HTTP/1.1 write queue to the charged send buffer

### DIFF
--- a/kura/src/app.rs
+++ b/kura/src/app.rs
@@ -50,7 +50,7 @@ const HTTP2_MAX_CONCURRENT_STREAMS: u32 = 128;
 const HTTP2_STREAM_WINDOW_BYTES: u32 = 4 * 1024 * 1024;
 const HTTP2_CONNECTION_WINDOW_BYTES: u32 = 16 * 1024 * 1024;
 const HTTP2_MAX_FRAME_SIZE: u32 = 64 * 1024;
-const HTTP2_MAX_SEND_BUFFER_BYTES: usize = crate::constants::RESPONSE_STREAM_SEND_BUFFER_BYTES;
+const HTTP_MAX_SEND_BUFFER_BYTES: usize = crate::constants::RESPONSE_STREAM_SEND_BUFFER_BYTES;
 const HTTP2_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(30);
 const HTTP2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
 const MEMORY_SAMPLE_INTERVAL: Duration = Duration::from_millis(200);
@@ -520,18 +520,24 @@ async fn cohosted_fallback(request: axum::extract::Request) -> axum::response::R
 // serves both HTTP/1.1 and HTTP/2 (incl. h2c prior-knowledge), so one listener
 // handles cache + gRPC.
 fn configure_http_builder(builder: &mut HttpBuilder<TokioExecutor>) {
+    // `max_buf_size` is what bounds hyper's HTTP/1.1 write queue. Without it
+    // hyper keeps pulling response chunks for a stalled client until it holds
+    // 16 buffers or ~408 KiB, far past the `RESPONSE_STREAM_SEND_BUFFER_BYTES`
+    // every response stream is charged. The public Ingress proxies to kura over
+    // HTTP/1.1, so this is the common cache-serving transport, not an edge case.
     builder
         .http1()
         .keep_alive(true)
         .timer(TokioTimer::new())
-        .header_read_timeout(Some(Duration::from_secs(30)));
+        .header_read_timeout(Some(Duration::from_secs(30)))
+        .max_buf_size(HTTP_MAX_SEND_BUFFER_BYTES);
     builder
         .http2()
         .initial_stream_window_size(Some(HTTP2_STREAM_WINDOW_BYTES))
         .initial_connection_window_size(Some(HTTP2_CONNECTION_WINDOW_BYTES))
         .max_concurrent_streams(Some(HTTP2_MAX_CONCURRENT_STREAMS))
         .max_frame_size(Some(HTTP2_MAX_FRAME_SIZE))
-        .max_send_buf_size(HTTP2_MAX_SEND_BUFFER_BYTES)
+        .max_send_buf_size(HTTP_MAX_SEND_BUFFER_BYTES)
         .keep_alive_interval(Some(HTTP2_KEEP_ALIVE_INTERVAL))
         .keep_alive_timeout(HTTP2_KEEP_ALIVE_TIMEOUT)
         .timer(TokioTimer::new());
@@ -1374,10 +1380,15 @@ async fn wait_for_task_shutdown<T>(
 
 #[cfg(test)]
 mod tests {
+    use std::{pin::Pin, task::Poll};
+
     use tokio::{sync::oneshot, time::timeout};
 
     use super::*;
-    use crate::test_support::test_context;
+    use crate::{
+        constants::{RESPONSE_STREAM_MIN_CHUNK_BYTES, RESPONSE_STREAM_SEND_BUFFER_BYTES},
+        test_support::test_context,
+    };
 
     #[test]
     fn http_builder_accepts_http1_and_http2() {
@@ -1389,6 +1400,127 @@ mod tests {
         // HTTP/2 (h2c REAPI gRPC) on the same socket.
         assert!(builder.is_http1_available());
         assert!(builder.is_http2_available());
+    }
+
+    /// In-memory transport that behaves like the production socket: it reports
+    /// vectored-write support, so hyper's HTTP/1.1 connection picks the same
+    /// queued write strategy it uses for `TcpStream` and TLS streams.
+    struct VectoredDuplex(tokio::io::DuplexStream);
+
+    impl tokio::io::AsyncRead for VectoredDuplex {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.0).poll_read(cx, buf)
+        }
+    }
+
+    impl tokio::io::AsyncWrite for VectoredDuplex {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Pin::new(&mut self.0).poll_write(cx, buf)
+        }
+
+        fn poll_write_vectored(
+            mut self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+            bufs: &[std::io::IoSlice<'_>],
+        ) -> Poll<std::io::Result<usize>> {
+            let Some(buf) = bufs.iter().find(|buf| !buf.is_empty()) else {
+                return Poll::Ready(Ok(0));
+            };
+            Pin::new(&mut self.0).poll_write(cx, buf)
+        }
+
+        fn is_write_vectored(&self) -> bool {
+            true
+        }
+
+        fn poll_flush(
+            mut self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.0).poll_flush(cx)
+        }
+
+        fn poll_shutdown(
+            mut self: Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.0).poll_shutdown(cx)
+        }
+    }
+
+    const STALLED_CLIENT_TRANSPORT_BYTES: usize = 1024;
+
+    /// Bytes hyper pulls from a response body over HTTP/1.1, configured the
+    /// way the production listener is, for a client that never reads. The
+    /// transport holds exactly `STALLED_CLIENT_TRANSPORT_BYTES`, so everything
+    /// past that sits in hyper's own write queue.
+    async fn http1_body_bytes_pulled_for_a_stalled_client() -> usize {
+        use std::{
+            convert::Infallible,
+            sync::atomic::{AtomicUsize, Ordering},
+        };
+        use tokio::io::AsyncWriteExt as _;
+
+        let (mut client, server) = tokio::io::duplex(STALLED_CLIENT_TRANSPORT_BYTES);
+        let pulled = Arc::new(AtomicUsize::new(0));
+        let counted = Arc::clone(&pulled);
+        let service =
+            hyper::service::service_fn(move |_request: hyper::Request<hyper::body::Incoming>| {
+                let counted = Arc::clone(&counted);
+                async move {
+                    let body = futures_util::stream::unfold((), move |()| {
+                        let counted = Arc::clone(&counted);
+                        async move {
+                            counted.fetch_add(RESPONSE_STREAM_MIN_CHUNK_BYTES, Ordering::SeqCst);
+                            let chunk =
+                                bytes::Bytes::from(vec![b'x'; RESPONSE_STREAM_MIN_CHUNK_BYTES]);
+                            Some((Ok::<_, Infallible>(hyper::body::Frame::data(chunk)), ()))
+                        }
+                    });
+                    Ok::<_, Infallible>(hyper::Response::new(http_body_util::StreamBody::new(body)))
+                }
+            });
+        let mut builder = HttpBuilder::new(TokioExecutor::new());
+        configure_http_builder(&mut builder);
+        tokio::spawn(async move {
+            let _ = builder
+                .serve_connection(
+                    hyper_util::rt::TokioIo::new(VectoredDuplex(server)),
+                    service,
+                )
+                .await;
+        });
+        client
+            .write_all(b"GET /artifact HTTP/1.1\r\nHost: kura\r\n\r\n")
+            .await
+            .expect("send request");
+        sleep(Duration::from_millis(500)).await;
+        drop(client);
+        pulled.load(Ordering::SeqCst)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn http1_send_queue_stays_within_the_charged_send_buffer() {
+        let pulled = http1_body_bytes_pulled_for_a_stalled_client().await;
+        let queued = pulled.saturating_sub(STALLED_CLIENT_TRANSPORT_BYTES);
+
+        // Response streams charge `RESPONSE_STREAM_SEND_BUFFER_BYTES` for the
+        // transport buffer plus their live reader chunks; hyper may hold one
+        // more chunk in flight past the cap.
+        let charged = RESPONSE_STREAM_SEND_BUFFER_BYTES + RESPONSE_STREAM_MIN_CHUNK_BYTES * 2;
+        assert!(
+            queued <= charged,
+            "hyper queued {queued} bytes for a stalled HTTP/1.1 client, more than the \
+             {charged} bytes a response stream is charged"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

`configure_http_builder` now sets `http1().max_buf_size(RESPONSE_STREAM_SEND_BUFFER_BYTES)` (64 KiB), the same value the HTTP/2 side already passes as `max_send_buf_size`. A regression test drives `configure_http_builder` over an in-memory transport with a fixed 1 KiB capacity, for a client that sends one GET and never reads, and asserts that the bytes hyper pulls from the response body stay within the 64 KiB transport charge plus the two live reader chunks a stream is accounted for.

## Why

#12795 cut `RESPONSE_STREAM_SEND_BUFFER_BYTES` from 512 KiB to 64 KiB and sized the degraded response pool from `2 × 8 KiB + 64 KiB`, describing 64 KiB as the physical per-stream transport cap. That is true for HTTP/2, where `max_send_buf_size` stops the stream from taking more capacity. It is not true for HTTP/1.1: hyper's h1 dispatcher keeps polling the body while its write queue is under `MAX_BUF_LIST_BUFFERS` (16) buffers and `DEFAULT_MAX_BUFFER_SIZE` (~408 KiB), and kura never set `max_buf_size`. The public kura Ingress uses `backend-protocol: HTTP`, so ingress-nginx talks HTTP/1.1 to kura for the whole HTTP cache path; this is the common serving transport, not an edge case.

## Root cause

The old 512 KiB constant happened to exceed hyper's h1 queue ceiling, so the accounting held by accident. Lowering it to h2's cap without applying the equivalent h1 cap left the h1 queue unbounded relative to the charge. For 8 KiB degraded chunks hyper queues ~120 KiB per stream against a 64 KiB charge, so a saturated degraded pool held about 1.7× its share; for 256 KiB chunks the excess was ~344 KiB per stream.

Measured with a standalone hyper 1.9.0 server using the production builder settings and a non-reading client, bytes queued beyond the kernel socket buffers:

| Chunk | HTTP/1.1 before | HTTP/1.1 after | HTTP/2 |
|---|---:|---:|---:|
| 8 KiB | ~120 KiB | ~64 KiB | ~64 KiB |
| 256 KiB | ~448 KiB | ~192 KiB | ~256 KiB |

## Why this fix

`max_buf_size` is the one hyper h1 knob that bounds the queued strategy (`bufs_cnt < 16 && remaining < max_buf_size`), so it makes h1 match the h2 accounting with no change to the charge formula or the pool partition. Raising the constant back to 512 KiB would have restored the bound but reinstated the memory overcharge #12795 removed.

## Impact

No wire or config change. HTTP/1.1 responses to stalled clients now hold at most 64 KiB plus one chunk in hyper, the amount every response stream is already charged, so the response-budget partition from #12795 is enforced on the transport production actually uses. Fast clients are unaffected: the queue only fills when the socket is already blocked.

## Validation

- `cargo test --lib app::tests::http1_send_queue_stays_within_the_charged_send_buffer`: passes with the fix (three runs); with the `max_buf_size` line removed it fails deterministically with `hyper queued 130048 bytes ... more than the 81920 bytes a response stream is charged`.
- The test transport reports vectored-write support so hyper selects the same queued write strategy it uses for `TcpStream` and TLS streams. A first version over real loopback sockets was dropped because macOS autotunes loopback buffers up to 4 MiB, which made the socket baseline drift between runs.
- `cargo clippy --all-targets` and `cargo fmt --check` clean.

### Cluster check (throwaway k3s cluster, kura built from this branch vs. main)

Deployed both images to the same single-node cluster and pointed 150 HTTP/1.1 clients that send a GET and never read at one kura pod, sampling the kura process's anonymous RSS at idle and 60 s into the stall.

| Scenario | main | this branch |
|---|---:|---:|
| 2 MiB artifact, mmap-served (400 clients, 284 admitted) | +11.9 MiB | +13.2 MiB |
| 608 MiB artifact, owned 256 KiB chunks (150 clients, all admitted) | +76.3 MiB | +75.2 MiB |

No regression, and no measurable difference either: mmap-served responses hand hyper zero-copy slices, and with 256 KiB chunks the first partially written chunk already exceeds both the old 408 KiB and the new 64 KiB threshold, so both builds settle at two live chunks per stream. The degraded 8 KiB-chunk pool, where the unit test shows the 16-buffer queue, could not be exercised: once the response pool and the mmap pool fill (~284 streams here), every degraded admission fails with `degraded_memory_unavailable` because mmap serving reserves transient memory on top of the response-stream reservation for the same bytes, and the request is shed. That is pre-existing behaviour (present at the base commit) and unrelated to this change; it is worth a separate look because it makes the degraded path unreachable exactly when it is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

