### PR TITLE
fix(infra): clear finalizer-pinned runner pods instead of retrying forever

### DIFF
--- a/infra/runners-controller/controllers/provisioning.go
+++ b/infra/runners-controller/controllers/provisioning.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	tuistv1 "github.com/tuist/tuist/infra/runners-controller/api/v1alpha1"
@@ -367,6 +368,17 @@ func linuxProvisioningStartedAt(pod *corev1.Pod) (time.Time, bool) {
 		}
 	}
 	return time.Time{}, false
+}
+
+// nodeMissing reports whether the Pod's node is gone from the API. A Pod that
+// never scheduled has no node to have owned anything on it. Only a definitive
+// NotFound counts: a transient API error proves nothing, and treating it as
+// "gone" would strip a finalizer whose owner is alive and mid-cleanup.
+func (r *RunnerPoolReconciler) nodeMissing(ctx context.Context, nodeName string) bool {
+	if nodeName == "" {
+		return true
+	}
+	return apierrors.IsNotFound(r.Get(ctx, client.ObjectKey{Name: nodeName}, &corev1.Node{}))
 }
 
 func (r *RunnerPoolReconciler) nodeConditionSummary(ctx context.Context, nodeName string) string {

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -320,12 +320,35 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 
 		if terminationTimedOut(p, r.now()) {
+			// A force delete cannot bypass a finalizer: the Delete succeeds as
+			// a no-op on an already-deleting Pod and the object stays, so
+			// retrying every reconcile spins forever and inflates the counter.
+			// A finalizer this controller does not own may also still be doing
+			// real work — tart-kubelet tears the guest VM down under
+			// tart-kubelet.tuist.dev/vm-cleanup — so leave it to its owner
+			// while that owner can still run.
+			//
+			// Unless the node is gone. Then the cleanup can never run and
+			// never needs to: the VM went with the host, and the finalizer is
+			// pinning an object whose only effect now is to keep this branch
+			// firing. One such Pod sat deleting for nine days.
+			nodeGone := r.nodeMissing(ctx, p.Spec.NodeName)
+			if len(p.Finalizers) > 0 && !nodeGone {
+				logger.V(1).Info("stuck terminating runner pod is finalizer-pinned; leaving it to its owner",
+					"pod", p.Name,
+					"node", p.Spec.NodeName,
+					"finalizers", p.Finalizers,
+					"deletingFor", r.now().Sub(p.DeletionTimestamp.Time).String(),
+				)
+				continue
+			}
 			nodeConditions := r.nodeConditionSummary(ctx, p.Spec.NodeName)
 			logger.Info("force reap runner pod kubelet did not finish terminating",
 				"pod", p.Name,
 				"node", p.Spec.NodeName,
 				"deletingFor", r.now().Sub(p.DeletionTimestamp.Time).String(),
 				"nodeConditions", nodeConditions,
+				"clearingFinalizers", p.Finalizers,
 			)
 			if r.Recorder != nil {
 				r.Recorder.Eventf(p, corev1.EventTypeWarning, "RunnerPodTerminationStuck",
@@ -333,7 +356,7 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					r.now().Sub(p.DeletionTimestamp.Time).Truncate(time.Second), p.Spec.NodeName, nodeConditions)
 			}
 			metrics.RecordStuckTermination(pool.Name)
-			if err := r.forceReapRunner(ctx, p); err != nil {
+			if err := r.forceReapRunner(ctx, p, nodeGone); err != nil {
 				logger.Error(err, "force reap stuck terminating runner pod; will retry", "pod", p.Name)
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
@@ -732,9 +755,24 @@ func (r *RunnerPoolReconciler) reapRunner(ctx context.Context, pod *corev1.Pod) 
 // alternative is capacity reserved forever for a VM doing no work — but it is
 // why the caller logs the node and raises an Event: a node that produces these
 // repeatedly wants draining, not another force delete.
-func (r *RunnerPoolReconciler) forceReapRunner(ctx context.Context, pod *corev1.Pod) error {
+//
+// `clearFinalizers` additionally strips the Pod's finalizers. Reserve it for a
+// Pod whose node is gone: a finalizer whose owner still exists may be doing
+// real cleanup, and removing it out from under them leaks whatever it was
+// releasing.
+func (r *RunnerPoolReconciler) forceReapRunner(ctx context.Context, pod *corev1.Pod, clearFinalizers bool) error {
 	r.reportStopped(ctx, pod)
 
+	// Grace period 0 does not bypass a finalizer; only removing it does. The
+	// caller decides when that is safe, which is when the finalizer's owner is
+	// gone with its node and can never run again.
+	if clearFinalizers && len(pod.Finalizers) > 0 {
+		patched := pod.DeepCopy()
+		patched.Finalizers = nil
+		if err := r.Patch(ctx, patched, client.MergeFrom(pod)); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("clear finalizers on pod %s: %w", pod.Name, err)
+		}
+	}
 	if err := r.Delete(ctx, pod, client.GracePeriodSeconds(0)); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("force delete pod %s: %w", pod.Name, err)
 	}

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -1749,14 +1749,19 @@ func TestIdleReplicasExcludesDarwinPodWithStaleHeartbeat(t *testing.T) {
 // with its containers still running. Nothing else in the controller can see it
 // (isAlive excludes a deleting Pod), so it holds its node's CPU and memory
 // against the scheduler indefinitely while the pool reads as having a gap.
-func TestReconcileForceReapsPodKubeletNeverFinishedTerminating(t *testing.T) {
+//
+// This one is pinned by a finalizer whose owning node is gone, which a force
+// delete alone cannot clear: grace period 0 does not bypass a finalizer, so the
+// Delete succeeds as a no-op and the object stays. Observed in production as a
+// Pod deleting for nine days while the reap retried six times a minute.
+func TestReconcileForceReapsFinalizerPinnedPodWhoseNodeIsGone(t *testing.T) {
 	now := time.Unix(10_000, 0)
 	scheme := mustScheme(t)
 	pool := newLinuxKataPool("linux", 1, 4)
 	node := readyLinuxRunnerNode("runner-node", pool.Spec.FleetSelector)
 	pod := linuxPod("linux-runner-zombie", pool.Name, nil)
-	pod.Spec.NodeName = node.Name
-	pod.Finalizers = []string{"tuist.dev/test-hold"}
+	pod.Spec.NodeName = "node-that-no-longer-exists"
+	pod.Finalizers = []string{"tart-kubelet.tuist.dev/vm-cleanup"}
 	deletion := metav1.NewTime(now.Add(-4 * time.Hour))
 	pod.DeletionTimestamp = &deletion
 	pod.DeletionGracePeriodSeconds = ptr.To[int64](30)
@@ -1790,6 +1795,51 @@ func TestReconcileForceReapsPodKubeletNeverFinishedTerminating(t *testing.T) {
 		}
 	default:
 		t.Fatal("expected RunnerPodTerminationStuck event")
+	}
+}
+
+// A finalizer whose owner still exists may be doing real cleanup (tart-kubelet
+// tears the guest VM down under tart-kubelet.tuist.dev/vm-cleanup). Stripping it
+// would leak whatever it was releasing, and force-deleting around it cannot work
+// anyway, so the Pod is left alone rather than retried every reconcile.
+func TestReconcileLeavesFinalizerPinnedPodOnLiveNodeAlone(t *testing.T) {
+	now := time.Unix(10_000, 0)
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux", 1, 4)
+	node := readyLinuxRunnerNode("runner-node", pool.Spec.FleetSelector)
+	pod := linuxPod("linux-runner-pinned", pool.Name, nil)
+	pod.Spec.NodeName = node.Name
+	pod.Finalizers = []string{"tart-kubelet.tuist.dev/vm-cleanup"}
+	deletion := metav1.NewTime(now.Add(-4 * time.Hour))
+	pod.DeletionTimestamp = &deletion
+	pod.DeletionGracePeriodSeconds = ptr.To[int64](30)
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: pod.Name, Namespace: pod.Namespace}}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool, node, pod, sa).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		Build()
+	recorder := record.NewFakeRecorder(2)
+	r := &RunnerPoolReconciler{
+		Client:      c,
+		Scheme:      scheme,
+		DispatchURL: "http://dispatch",
+		DindImage:   "docker:dind",
+		Now:         func() time.Time { return now },
+		Recorder:    recorder,
+	}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: nn(pool.Namespace, pool.Name)}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if err := c.Get(context.Background(), nn(sa.Namespace, sa.Name), &corev1.ServiceAccount{}); err != nil {
+		t.Fatalf("finalizer-pinned Pod on a live node was reaped: %v", err)
+	}
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected event for a Pod left to its finalizer owner: %q", event)
+	default:
 	}
 }
 


### PR DESCRIPTION
## What changed

The stuck-termination reap added in #12819 could not clear a Pod held by a finalizer. `client.GracePeriodSeconds(0)` does not bypass one, so the `Delete` succeeded as a no-op, the object stayed, and the branch fired again on the next reconcile.

Now the reap strips the Pod's finalizers, but only when its node is gone. A finalizer whose owner still exists is left alone and the Pod is skipped rather than retried, so the loop terminates in both directions.

## Why

Observed in production immediately after #12819 rolled out. The one Pod it found was a nine-day-old macOS zombie:

```
finalizers:                  ['tart-kubelet.tuist.dev/vm-cleanup']
deletionGracePeriodSeconds:  0
nodeName:                    tuist-tuist-runners-fleet-mndbc-2t7nk   (node not found)
```

The reap logged `force reap runner pod kubelet did not finish terminating` six times a minute against it, forever. Two consequences: the Pod was never cleared, and because the no-op `Delete` returns success, every pass counted as a reap and incremented `tuist_runners_pool_stuck_terminations_total`. That counter was added in #12819 as the leading indicator for leaked sandboxes; an unbounded climb from a single stuck object makes it useless for the job it exists to do.

Worth noting the original fix was not wrong for the case that caused the incident. The nine Linux zombies that held two of four nodes had no finalizers, which is why a plain force delete cleared them by hand and why the reap handles them correctly. This is the other variant.

## Why this shape of fix

The tempting version is to strip finalizers whenever the reap fires. That is wrong: `tart-kubelet.tuist.dev/vm-cleanup` is how tart-kubelet tears the guest VM down, and removing it while its owner is alive would orphan a running VM on a Mac host — the same leak this reap exists to prevent, caused by the reap.

Gating on node existence is what makes it safe. Once the node is gone the cleanup can never run and has nothing left to release, because the VM went with the host. `nodeMissing` only treats a definitive `IsNotFound` as gone, so a transient API error does not strip a finalizer whose owner is alive and mid-cleanup.

Leaving a live-node Pod pinned means it can still linger. That is the correct outcome: force-deleting around a working finalizer cannot help, so the Pod belongs to its owner until the owner finishes or the node dies. It is logged at V(1) so it stays discoverable without spamming.

## Impact

Finalizer-pinned Pods on dead nodes are now cleared instead of retried forever. `stuck_terminations_total` counts real reaps again, so a non-zero rate means what it is documented to mean. No configuration changes.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test ./...` green.
- `TestReconcileForceReapsFinalizerPinnedPodWhoseNodeIsGone` covers the reap, including finalizer removal.
- `TestReconcileLeavesFinalizerPinnedPodOnLiveNodeAlone` covers the skip, asserting no Event is raised and the ServiceAccount survives.
- The previous test asserted the reap on a Pod that was finalizer-pinned on a *live* node. That now correctly does nothing, so it was replaced by the two cases above rather than adjusted to keep passing.
- Diagnosed against production with #12819 running: `sha-531f20bb8d86` live, `fleetCap` present in the admission logs, and the reap loop reproducing at 12 attempts per 120 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
