### PR TITLE
feat(server): grow the production M2-L runner fleet to 10 hosts

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -1035,12 +1035,12 @@ macosFleet:
     name: tuist-runner-cache
     cidr: 172.16.0.0/22
 
-# Customer-runner Mac mini fleet. 9 M2-L hosts at one guest each plus
-# 2 M4-XL hosts at two = 13 concurrent customer runs.
+# Customer-runner Mac mini fleet. 10 M2-L hosts at one guest each plus
+# 2 M4-XL hosts at two = 14 concurrent customer runs.
 #
 # Sized against measured demand, not host count. macOS job concurrency
 # over the 7 days to 2026-08-25 ran p50 3 / p95 5 / p99 6 with a peak of
-# 8, so 13 keeps burst headroom above the observed peak. Trimming the
+# 8, so 14 keeps burst headroom above the observed peak. Trimming the
 # M2-L group to match the peak more tightly saves nothing: a host
 # released from this fleet is parked back in `tuist-pool-` and keeps
 # billing under Apple's 24h floor either way, so the only thing a
@@ -1069,7 +1069,7 @@ runnersFleet:
   # no nodeDrainTimeout, so an evicted Pod is not waited on: retire while
   # the target hosts hold no owned (job-running) runner Pod, or a
   # customer job dies with the node.
-  hostCount: 9
+  hostCount: 10
   # Pre-ordered pool. Operator orders M2-L hosts in the Scaleway
   # console with names starting with `tuist-pool-` ahead of
   # bringing this block live (Mac mini lead times can stretch
@@ -1285,13 +1285,13 @@ runnersFleet:
       # min(cpu, memory) quotient for a shape and caps every pool sharing
       # it at that sum (2 today, both on M4-XL). It has to be derived
       # there rather than written here because the byte budget cannot see
-      # it: 186368 / 28672 reads as 6, pooling memory from M2-L hosts
+      # it: 200704 / 28672 reads as 7, pooling memory from M2-L hosts
       # that cannot seat one of these Pods at all.
       #
       # Set it to the M4-XL host count regardless, as the per-pool bound
       # it is: no single Xcode version should be able to take the whole
       # shape. It moves with `machineGroups[m4].hostCount`, not with the
-      # 13-slot totals the `xcodeOverrides` below use.
+      # 14-slot totals the `xcodeOverrides` below use.
       #
       # Cold: no warm floor. A 12 vCPU Pod parks a whole M4-XL, and idle
       # it would halve the fleet's dual-guest capacity to keep one
@@ -1308,19 +1308,19 @@ runnersFleet:
   # fleet allocator, which apportions the fleet's GUEST-slot budget
   # across all macOS pools using the three-tier (floor / load /
   # headroom) policy. `minWarmPoolFloor` is the always-on warm
-  # guarantee; `maxReplicas: 13` lets either pool absorb the whole
+  # guarantee; `maxReplicas: 14` lets either pool absorb the whole
   # fleet under skewed demand and the allocator caps the joint sum
   # so the pools don't double-book.
   #
   # The budget is slots, not minis: the allocator divides the fleet's
-  # advertised memory by this shape's 14336 MB, so the 9 M2-L hosts are
-  # 9 slots and the 2 M4-XL hosts are 2 each, for 13. These ceilings must
+  # advertised memory by this shape's 14336 MB, so the 10 M2-L hosts are
+  # 10 slots and the 2 M4-XL hosts are 2 each, for 14. These ceilings must
   # move with that number — the allocator never exceeds a pool's
   # maxReplicas, so leaving them behind would let an M4 boot but keep
   # every pool clamped below the capacity it adds, and its second guest
   # would sit idle.
   #
-  # Floors sum to 1 of the 13-slot budget; the remaining 12 slots are
+  # Floors sum to 1 of the 14-slot budget; the remaining 13 slots are
   # dynamically apportioned by queue depth across the pools. Older
   # Xcodes sit cold (floor 0) so an unused runner doesn't tie up a host.
   #
@@ -1340,32 +1340,32 @@ runnersFleet:
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 13
+        maxReplicas: 14
     "26.6":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 1
-        maxReplicas: 13
+        maxReplicas: 14
     "26.5":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 13
+        maxReplicas: 14
     "26.4.1":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 13
+        maxReplicas: 14
     "26.3":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 13
+        maxReplicas: 14
     "26.0.1":
       autoscaling:
         enabled: true
         minWarmPoolFloor: 0
-        maxReplicas: 13
+        maxReplicas: 14
   # Resolved at deploy time from the latest `runner-image@` git tag.
   runnerImageSemver: ""
   pools: []
@@ -1384,7 +1384,7 @@ runnersFleet:
 # comfortably taking jobs.
 #
 # Shares the `tuist-pool-` host pool with macosFleet (2) and
-# runnersFleet (9), so this fleet adds 2 to the pool-demand
+# runnersFleet (10), so this fleet adds 2 to the pool-demand
 # total. The operator's pre-order job for production already
 # tracks the macos + runners side; bump it by 2 ahead of the
 # `helm upgrade` that applies this replica count.

--- a/infra/runners-controller/controllers/autoscaler_controller_test.go
+++ b/infra/runners-controller/controllers/autoscaler_controller_test.go
@@ -936,15 +936,15 @@ func macosNodeWithResources(name, fleetSelector string, cpu int64, memoryMB int6
 	return node
 }
 
-// The production topology: 9 M2-L (8 CPU / 14336 MB) + 2 M4-XL
-// (12 CPU / 28672 MB). The 6 vCPU shape seats 13, the 12 vCPU shape
+// The production topology: 10 M2-L (8 CPU / 14336 MB) + 2 M4-XL
+// (12 CPU / 28672 MB). The 6 vCPU shape seats 14, the 12 vCPU shape
 // seats 2 — and the second number is the one no fleet-wide division can
-// produce, since 186368 MB / 28672 reads as 6.
+// produce, since 200704 MB / 28672 reads as 7.
 func TestAutoscaler_ShapePlacementCapsCountSeatsPerNode(t *testing.T) {
 	const fleet = "runners-macos"
 
 	objects := []client.Object{}
-	for i := 0; i < 9; i++ {
+	for i := 0; i < 10; i++ {
 		objects = append(objects, macosNodeWithResources(fmt.Sprintf("m2-%d", i), fleet, 8, 14336))
 	}
 	for i := 0; i < 2; i++ {
@@ -968,8 +968,8 @@ func TestAutoscaler_ShapePlacementCapsCountSeatsPerNode(t *testing.T) {
 		t.Fatalf("shapePlacementCaps: %v", err)
 	}
 
-	if got := caps[small.key()]; got != 13 {
-		t.Fatalf("6 vCPU seats = %d, want 13 (9 M2-L at one + 2 M4-XL at two)", got)
+	if got := caps[small.key()]; got != 14 {
+		t.Fatalf("6 vCPU seats = %d, want 14 (10 M2-L at one + 2 M4-XL at two)", got)
 	}
 	if got := caps[large.key()]; got != 2 {
 		t.Fatalf("12 vCPU seats = %d, want 2 (M4-XL only, one guest each)", got)

--- a/infra/runners-controller/controllers/reservation.go
+++ b/infra/runners-controller/controllers/reservation.go
@@ -91,7 +91,7 @@ const (
 	//
 	// Every reservation is capacity withdrawn from the small shapes while
 	// it converges, so this stays at one. On macOS a second concurrent
-	// drain would hold two hosts, up to 4 of the 13-slot production
+	// drain would hold two hosts, up to 4 of the 14-slot production
 	// fleet, to serve two large jobs. On Linux the argument is sharper
 	// still: that fleet is a handful of bare-metal boxes, so a single
 	// reservation is already a large share of it out of circulation.


### PR DESCRIPTION
## What changed

`runnersFleet.hostCount` in the production overlay goes 9 -> 10, and every
`xcodeOverrides[*].maxReplicas` goes 13 -> 14 alongside it. The comments that
carry the fleet arithmetic (the header total, the byte-budget worked example,
the slot budget, the floor split, the builders fleet's pool-demand note) move
with the numbers, as do the two runners-controller comments that describe the
production topology and the test that encodes it.

## Why

A tenth M2-L Mac mini was added to the shared `tuist-pool-` pool, so the fleet
can now claim it. Adoption is SKU-exact and there is no auto-order path: the
controller only claims hosts an operator has already parked, which is what this
raise turns into capacity.

The fleet is now 10 M2-L hosts at one guest each plus 2 M4-XL hosts at two =
14 concurrent customer runs.

## Why maxReplicas moves in the same change

`hostCount` alone would let the host join and stay unusable. The runners
controller's allocator apportions a slot budget (advertised memory divided by
the 6 vCPU shape's 14336 MB) but never exceeds a pool's own `maxReplicas`, so
ceilings left at 13 would clamp every Xcode pool below the capacity the new
host adds. Slots, not minis, are what those ceilings bound, which is why an
M2-L raises them by 1 where an M4-XL raises them by 2.

The 12 vCPU shape's `maxReplicas` deliberately does not move. It tracks the
M4-XL host count as a per-pool bound, not the fleet total, and no M4 host was
added.

## Impact

Customer macOS concurrency ceiling 13 -> 14. Measured demand over the 7 days to
2026-08-25 was p50 3 / p95 5 / p99 6 with a peak of 8, so this is burst
headroom rather than a response to saturation; a host that would otherwise sit
parked in the pool bills the same either way, and the only thing not claiming
it buys is queueing plus a cold boot per queued job.

Nothing here touches staging or canary, both of which run a single M2-L host.

## Validation

- `helm template` of the production overlay the way `helm.yml` renders it
  (`values-managed-common.yaml` + `values-managed-production.yaml` +
  `values-ci.yaml`): the `runners-fleet` MachineDeployment renders
  `replicas: 10`, the `-m4` group stays at 2, the six 6 vCPU macOS RunnerPools
  render `maxReplicas: 14`, and the six 12 vCPU pools stay at 2.
- `go test ./controllers/ -run TestAutoscaler_ShapePlacementCaps` in
  `infra/runners-controller`: the topology test now builds 10 M2-L + 2 M4-XL
  nodes and asserts 14 seats for the 6 vCPU shape and 2 for the 12 vCPU shape.
- `go build ./...` and `go vet ./controllers/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
