### PR TITLE
fix(infra): scale the Linux provisioning ceiling with the fleet

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1231,7 +1231,8 @@ after 85 days of uptime. Kubelet reports that per Pod, not as a node
 condition, so the node stayed `Ready` with no Memory/Disk/PID pressure
 and, being the emptiest node in the fleet, the scheduler preferred it.
 Every Pod it accepted sat in `Init:0/4` holding a slot in the
-fleet-wide provisioning ceiling (`maxConcurrentPerFleetSelector: 4`)
+provisioning ceiling — a single fleet-wide 4 at the time, since replaced
+by a per-node budget (`maxConcurrentPerNode`) that a cordon shrinks —
 until the 5-minute start timeout reaped it, and the replacement landed
 on the same node. The ceiling stayed saturated by Pods that could never
 run, so every sibling shape was refused admission with
@@ -1380,16 +1381,16 @@ creation, not waiting on capacity.
 On 2026-09-02 `linux-4vcpu-16gb`, with every Linux shape allowed
 `maxReplicas: 120`, was targeted at 67 replicas on a fleet that seats
 24 of that shape. The excess sat Pending on `Insufficient memory`,
-and because the provisioning admission budgets Pending Pods fleet-wide
-(`maxConcurrentPerFleetSelector`, default 4), those four dead Pods held
-the whole budget and every sibling shape was refused with
-`reason="fleet_cap"`. `linux-2vcpu-8gb` sat at zero Pods for over an
+and because the provisioning admission budgets Pending Pods across the
+shared fleet (then a flat 4, now `maxConcurrentPerNode` times the healthy
+node count), those four dead Pods held the whole budget and every sibling
+shape was refused with `reason="fleet_cap"`. `linux-2vcpu-8gb` sat at zero Pods for over an
 hour with 143 `tuist-linux` jobs queued, one of them the production
 cascade's own first job, so nothing could deploy. The 300-second
 unschedulable reap did not help: the hog recreated each Pod the moment
 it was released.
 
-It fired again on 2026-09-03 with no hog at all, so check the other two
+It fired again on 2026-09-03 with no hog at all, so check the other
 causes before reaching for `maxReplicas`. First, look for Pods stuck
 `Terminating`: a Kata sandbox whose shim never tears the VM down keeps
 its node's CPU and memory reserved while being invisible to the
@@ -1410,6 +1411,14 @@ filled the ceiling between them while the starved pool reported
 starved pool now measures against the whole ceiling and its siblings
 measure against the ceiling minus what it is owed; if you see a pool
 blocked with its share unused, that reservation is not working.
+
+Third, the ceiling itself may have shrunk. It is
+`maxConcurrentPerNode` times the fleet's healthy node count, published
+as `tuist_runners_fleet_provisioning_ceiling`, so nodes leaving the
+fleet — cordoned, NotReady, or under memory/disk/PID pressure — lower it
+with no configuration change. A ceiling well below `4 * <node count>`
+with `reason="fleet_cap"` on every pool is a node problem, and
+`tuist_runners_fleet_filtered_nodes` says which reason took them out.
 
 ```promql
 (

--- a/infra/helm/tuist/crds/tuist.dev_runnerpools.yaml
+++ b/infra/helm/tuist/crds/tuist.dev_runnerpools.yaml
@@ -136,15 +136,24 @@ spec:
                     one mismatched pool cannot weaken the fleet safety limit.
                     Ignored for macOS pools.
                   properties:
-                    maxConcurrentPerFleetSelector:
+                    maxConcurrentPerNode:
                       type: integer
                       default: 4
                       minimum: 1
                       description: |
-                        Maximum Linux runner Pods across the shared fleet that
+                        Maximum Linux runner Pods per healthy fleet node that
                         may be waiting for their dispatch poller to start.
-                        Excess replica demand remains uncreated and is retried
-                        as existing sandboxes become ready.
+                        The controller multiplies it by the fleet's healthy
+                        node count to get the shared ceiling, so adding
+                        machines raises start throughput. Excess replica
+                        demand remains uncreated and is retried as existing
+                        sandboxes become ready.
+
+                        Replaces `maxConcurrentPerFleetSelector`, which was a
+                        single fleet-wide integer and so did not scale with
+                        the fleet. Structural-schema pruning drops the old
+                        field from any CR that still carries it, and the
+                        controller ignores it.
                     startTimeoutSeconds:
                       type: integer
                       default: 300

--- a/infra/helm/tuist/templates/runner-pool.yaml
+++ b/infra/helm/tuist/templates/runner-pool.yaml
@@ -371,7 +371,7 @@ spec:
   runtimeClass: {{ $runtimeClass | quote }}
   {{- end }}
   provisioning:
-    maxConcurrentPerFleetSelector: {{ dig "maxConcurrentPerFleetSelector" 4 $provisioning }}
+    maxConcurrentPerNode: {{ dig "maxConcurrentPerNode" 4 $provisioning }}
     startTimeoutSeconds: {{ dig "startTimeoutSeconds" 300 $provisioning }}
   {{- if $autoscaling }}
   autoscaling:
@@ -458,7 +458,7 @@ spec:
   runtimeClass: {{ $shapeRuntimeClass | quote }}
   {{- end }}
   provisioning:
-    maxConcurrentPerFleetSelector: {{ dig "maxConcurrentPerFleetSelector" 4 $provisioning }}
+    maxConcurrentPerNode: {{ dig "maxConcurrentPerNode" 4 $provisioning }}
     startTimeoutSeconds: {{ dig "startTimeoutSeconds" 300 $provisioning }}
   autoscaling:
     enabled: {{ dig "enabled" true $autoscaling }}

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -2209,12 +2209,15 @@ runnersFleetLinux:
   # runner container. 0 disables it.
   idleTimeoutSeconds: 300
   # Linux Kata sandbox admission is shared across every pool using this
-  # fleet selector. Keeping only four sandboxes in the pre-poller start
-  # phase prevents a queue spike from asking both bare-metal kubelets to
-  # boot dozens of virtual machines at once. Per-pool / per-shape values
-  # override these defaults; the controller enforces the lowest sibling maximum.
+  # fleet selector. The budget is per node and the controller multiplies
+  # it by the fleet's healthy node count: what a start burst threatens is
+  # one kubelet and one Kata runtime, so the limit belongs per host, and
+  # expressing it fleet-wide meant adding machines raised capacity without
+  # raising start throughput. A cordoned or NotReady node takes its share
+  # of the budget with it. Per-pool / per-shape values override these
+  # defaults; the controller enforces the lowest sibling maximum.
   provisioning:
-    maxConcurrentPerFleetSelector: 4
+    maxConcurrentPerNode: 4
     # Starts after the scheduler binds the Pod to a node. 0 disables.
     startTimeoutSeconds: 300
   # Value of the `node.cluster.x-k8s.io/pool=` label CAPI's
@@ -2255,7 +2258,7 @@ runnersFleetLinux:
     #   # the privileged sidecar off the bare-metal host kernel.
     #   runtimeClass: kata-qemu
     #   provisioning:
-    #     maxConcurrentPerFleetSelector: 4
+    #     maxConcurrentPerNode: 4
     #     startTimeoutSeconds: 300
     #   autoscaling:
     #     enabled: true

--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -281,10 +281,40 @@ independent workqueues:
   gap, `RunnerPoolReconciler` counts every alive, unclaimed Pod whose
   dispatch poller has not started across sibling pools sharing
   the same operating system and `FleetSelector`. It creates only up to
-  `spec.provisioning.maxConcurrentPerFleetSelector` (default 4), using
-  the lowest sibling value so one mismatched pool cannot weaken the
-  fleet boundary. Excess demand remains a replica gap and is retried
-  every five seconds. macOS pools skip this gate.
+  the fleet ceiling, `spec.provisioning.maxConcurrentPerNode` (default
+  4) times the fleet's healthy node count, using the lowest sibling
+  per-node value so one mismatched pool cannot weaken the fleet
+  boundary. Excess demand remains a replica gap and is retried every
+  five seconds. macOS pools skip this gate.
+
+  The budget is per node because what it protects is per node: each host
+  runs its own kubelet and its own Kata runtime, and a simultaneous
+  sandbox-start burst overwhelms one of them, not the fleet. Expressed
+  fleet-wide it did the opposite of its job — adding hardware raised
+  capacity without raising start throughput, so the fleet could be
+  simultaneously idle and refusing work. Measured on 2026-09-03: 62 jobs
+  queued across the Linux pools, one node at 0% CPU and 0% memory and
+  two more near half, every pool refused with `reason="fleet_cap"`, and
+  raising the ceiling by hand filled the idle machines inside one
+  reconcile tick (`linux-4vcpu-16gb` went from 1 Pod to 18).
+
+  The node count is `summarizeFleetNodes`, so it already excludes
+  cordoned, NotReady and pressured nodes. That is deliberate and it is
+  what makes the documented remedy below — cordon a host that accepts
+  sandboxes it cannot start — take that host's share of the start budget
+  away with it, instead of leaving the ceiling inflated by a node
+  contributing nothing.
+
+  The field replaces `maxConcurrentPerFleetSelector`, which was a single
+  fleet-wide integer. Nothing reads the old name: structural-schema
+  pruning drops it from any CR that still carries it, including the
+  value patched onto production by hand during the 2026-09-03 incident.
+  The CRD lives in `crds/`, which helm does not touch on upgrade, so the
+  schema has to be re-applied out of band as usual — and until it is,
+  `maxConcurrentPerNode` is pruned on the way in and the accessor's
+  default (4 per node) applies, which is the intended behaviour anyway.
+  A stale schema therefore degrades to the right answer rather than to
+  the old one.
 
   The count deliberately includes Pods with no node. An unbound Pod is
   one the scheduler may bind at any moment, and nothing re-checks
@@ -294,6 +324,36 @@ independent workqueues:
   Scheduling gates do not help here either: a gate can be removed but
   never re-added, so a Pod that turns out to be unschedulable after
   ungating is back to holding a slot with no way to reclaim it.
+
+  A ceiling that scales with the fleet bounds how many sandboxes are
+  coming up across it, but not how many land on one host — this
+  controller does not place Pods, and steering them was tried and
+  dropped (see the per-node circuit breaker below). What it can bound is
+  how many are handed to the scheduler at once, and the Pods with no
+  node yet that the scheduler has *not* rejected are exactly the set
+  that can arrive on one kubelet together: kube-scheduler prefers the
+  least-allocated node, which on a fleet with an idle host means all of
+  them. So that set is capped at one node's budget, refused with
+  `reason="placement_burst"`. It costs nothing in steady state — those
+  Pods bind within a second or two, well inside the five-second tick —
+  and it makes a batch of creations converge on the ceiling over a few
+  ticks rather than landing as one burst.
+
+  So `placement_burst` on `tuist_runners_pool_admission_blocked_total` is
+  what a healthy ramp looks like, not a fault: a pool with a gap of 19
+  reports it on every tick until the gap closes. A *sustained* one with a
+  queue behind it means the Pods are not binding, which is the
+  unschedulable reap's territory. The same counter reports whichever term
+  actually capped the tick, not only outright refusals — that is what
+  `limitedBy` is for. Attributing a ramp to the ceiling would leave
+  `fleet_cap` meaning nothing.
+
+  A Pod the scheduler has already refused is excluded from that set,
+  though it still holds its slot in the ceiling. It is not about to
+  arrive anywhere; it binds one at a time as capacity frees. Counting it
+  would rebuild the 2026-09-02 starvation on the new gate, with a shape
+  no node can seat parking its Pods for a whole start timeout while
+  every sibling is refused behind them.
 
   The ceiling is shared, so it is also divided. A pool's own share
   (`poolCap`) is the fleet ceiling minus one for every sibling pool that
@@ -388,6 +448,14 @@ independent workqueues:
   of that particular fault — any node that accepts Pods it cannot start
   reproduces it.
 
+  A per-node ceiling softens this without removing it. The dead Pods now
+  hold one node's budget rather than the whole fleet's, so siblings keep
+  creating on the healthy hosts instead of stopping dead; and cordoning
+  the broken node, still the remedy, now also removes its contribution
+  to the ceiling rather than leaving phantom budget behind. What has not
+  changed is that the replacement Pod keeps landing on the broken node,
+  so its share of the budget stays burnt until an operator intervenes.
+
   A per-node circuit breaker was built and then deliberately dropped:
   counting `poller_not_started` timeouts per node and steering new Pods
   away with a required `kubernetes.io/hostname NotIn` affinity. It works,
@@ -433,8 +501,14 @@ independent workqueues:
   `tuist_runners_pool_admission_blocked_total{pool,reason}`,
   `tuist_runners_fleet_ready_nodes{fleet_selector,operating_system}`,
   `tuist_runners_fleet_filtered_nodes{fleet_selector,operating_system,reason}`,
+  `tuist_runners_fleet_provisioning_ceiling{fleet_selector,operating_system}`,
   `tuist_runners_pool_pod_start_timeouts_total{pool,reason}`,
-  and `tuist_runners_pool_stuck_terminations_total{pool}`. The last one
+  and `tuist_runners_pool_stuck_terminations_total{pool}`. The ceiling is
+  the derived budget the admission gate measures against, so it moves
+  with the healthy node count on its own: a drop with no chart change
+  means nodes left the fleet, and comparing it against the summed
+  pending-provisioning gauges says how much of the budget is in use. The
+  last one
   counts Pods force-deleted because kubelet never finished terminating
   them; it is distinct from the start-timeout counter because that means
   a sandbox failed to come up, while this means one failed to go down and

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types.go
@@ -102,9 +102,10 @@ type RunnerPoolSpec struct {
 
 	// Provisioning bounds how many Linux Kata sandboxes may be starting at
 	// once across pools that share this pool's FleetSelector, and how long a
-	// bound Pod may take to start its dispatch poller. The controller uses the
-	// lowest maxConcurrentPerFleetSelector configured by sibling pools so a
-	// mismatched pool cannot weaken the shared safety boundary.
+	// bound Pod may take to start its dispatch poller. The bound is
+	// maxConcurrentPerNode times the fleet's healthy node count, using the
+	// lowest per-node value configured by sibling pools so a mismatched pool
+	// cannot weaken the shared safety boundary.
 	//
 	// Linux only. macOS runner Pods use the Tart host lifecycle and do not
 	// participate in this admission gate.
@@ -220,22 +221,24 @@ type RunnerPoolAutoscaling struct {
 }
 
 const (
-	defaultMaxConcurrentProvisioningPerFleetSelector int32 = 4
-	defaultProvisioningStartTimeoutSeconds           int32 = 300
+	defaultMaxConcurrentProvisioningPerNode int32 = 4
+	defaultProvisioningStartTimeoutSeconds  int32 = 300
 )
 
 // RunnerPoolProvisioning carries the Linux Kata sandbox admission knobs.
 // Pointer fields preserve a deliberate zero for startTimeoutSeconds while
 // allowing the custom-resource defaults to distinguish an omitted value.
 type RunnerPoolProvisioning struct {
-	// MaxConcurrentPerFleetSelector is the maximum number of Linux runner
-	// Pods that may be waiting for their dispatch poller to start across all
-	// sibling pools sharing the same operating system and FleetSelector. The lowest sibling value is
-	// authoritative for the shared fleet. Default 4.
+	// MaxConcurrentPerNode is the maximum number of Linux runner Pods that
+	// may be waiting for their dispatch poller to start per healthy fleet
+	// node, across all sibling pools sharing the same operating system and
+	// FleetSelector. The controller multiplies it by the node count to get
+	// the shared fleet ceiling, and uses the lowest sibling value so one
+	// mismatched pool cannot weaken the fleet boundary. Default 4.
 	// +kubebuilder:default=4
 	// +kubebuilder:validation:Minimum=1
 	// +optional
-	MaxConcurrentPerFleetSelector *int32 `json:"maxConcurrentPerFleetSelector,omitempty"`
+	MaxConcurrentPerNode *int32 `json:"maxConcurrentPerNode,omitempty"`
 
 	// StartTimeoutSeconds bounds how long a Linux runner Pod that has been
 	// assigned to a node may wait for its dispatch poller to start. Timed-out
@@ -247,14 +250,14 @@ type RunnerPoolProvisioning struct {
 	StartTimeoutSeconds *int32 `json:"startTimeoutSeconds,omitempty"`
 }
 
-func (p *RunnerPoolProvisioning) MaxConcurrentPerFleetSelectorOrDefault() int32 {
+func (p *RunnerPoolProvisioning) MaxConcurrentPerNodeOrDefault() int32 {
 	// The custom-resource schema rejects 0. Keep the non-positive fallback
 	// defensive for typed test clients and clusters whose schema has not yet
 	// been upgraded; unlike StartTimeoutSeconds, zero never disables this cap.
-	if p == nil || p.MaxConcurrentPerFleetSelector == nil || *p.MaxConcurrentPerFleetSelector <= 0 {
-		return defaultMaxConcurrentProvisioningPerFleetSelector
+	if p == nil || p.MaxConcurrentPerNode == nil || *p.MaxConcurrentPerNode <= 0 {
+		return defaultMaxConcurrentProvisioningPerNode
 	}
-	return *p.MaxConcurrentPerFleetSelector
+	return *p.MaxConcurrentPerNode
 }
 
 func (p *RunnerPoolProvisioning) StartTimeoutSecondsOrDefault() int32 {

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types_test.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types_test.go
@@ -119,27 +119,27 @@ func TestAutoscalingOrDefaultAccessors(t *testing.T) {
 
 func TestProvisioningOrDefaultAccessors(t *testing.T) {
 	unset := &RunnerPoolProvisioning{}
-	if got := unset.MaxConcurrentPerFleetSelectorOrDefault(); got != 4 {
-		t.Errorf("unset MaxConcurrentPerFleetSelector = %d, want 4", got)
+	if got := unset.MaxConcurrentPerNodeOrDefault(); got != 4 {
+		t.Errorf("unset MaxConcurrentPerNode = %d, want 4", got)
 	}
 	if got := unset.StartTimeoutSecondsOrDefault(); got != 300 {
 		t.Errorf("unset StartTimeoutSeconds = %d, want 300", got)
 	}
 
 	configured := &RunnerPoolProvisioning{
-		MaxConcurrentPerFleetSelector: ptr.To[int32](2),
-		StartTimeoutSeconds:           ptr.To[int32](0),
+		MaxConcurrentPerNode: ptr.To[int32](2),
+		StartTimeoutSeconds:  ptr.To[int32](0),
 	}
-	if got := configured.MaxConcurrentPerFleetSelectorOrDefault(); got != 2 {
-		t.Errorf("configured MaxConcurrentPerFleetSelector = %d, want 2", got)
+	if got := configured.MaxConcurrentPerNodeOrDefault(); got != 2 {
+		t.Errorf("configured MaxConcurrentPerNode = %d, want 2", got)
 	}
 	if got := configured.StartTimeoutSecondsOrDefault(); got != 0 {
 		t.Errorf("explicit-zero StartTimeoutSeconds = %d, want 0", got)
 	}
 
 	var nilProvisioning *RunnerPoolProvisioning
-	if got := nilProvisioning.MaxConcurrentPerFleetSelectorOrDefault(); got != 4 {
-		t.Errorf("nil MaxConcurrentPerFleetSelector = %d, want 4", got)
+	if got := nilProvisioning.MaxConcurrentPerNodeOrDefault(); got != 4 {
+		t.Errorf("nil MaxConcurrentPerNode = %d, want 4", got)
 	}
 }
 

--- a/infra/runners-controller/api/v1alpha1/zz_generated.deepcopy.go
+++ b/infra/runners-controller/api/v1alpha1/zz_generated.deepcopy.go
@@ -93,8 +93,8 @@ func (in *RunnerPoolSpec) DeepCopyInto(out *RunnerPoolSpec) {
 
 func (in *RunnerPoolProvisioning) DeepCopyInto(out *RunnerPoolProvisioning) {
 	*out = *in
-	if in.MaxConcurrentPerFleetSelector != nil {
-		in, out := &in.MaxConcurrentPerFleetSelector, &out.MaxConcurrentPerFleetSelector
+	if in.MaxConcurrentPerNode != nil {
+		in, out := &in.MaxConcurrentPerNode, &out.MaxConcurrentPerNode
 		*out = new(int32)
 		**out = **in
 	}

--- a/infra/runners-controller/controllers/provisioning.go
+++ b/infra/runners-controller/controllers/provisioning.go
@@ -83,14 +83,21 @@ func (s *creationReservationStore) reconcile(
 }
 
 type provisioningAdmission struct {
-	available       int
-	pendingForPool  int
-	pendingForFleet int
-	cap             int
-	fleetCap        int
-	poolCap         int
-	healthyNodes    int
-	blockedReason   string
+	available         int
+	pendingForPool    int
+	pendingForFleet   int
+	awaitingPlacement int
+	perNode           int
+	cap               int
+	fleetCap          int
+	poolCap           int
+	healthyNodes      int
+	blockedReason     string
+	// limitedBy names the term that capped a non-zero `available`. The
+	// admission metric reports a reason whenever a replica gap survives the
+	// tick, and a gap larger than the slots on offer is the ordinary way to
+	// ramp, so without this it would attribute every ramp to the ceiling.
+	limitedBy string
 }
 
 func isLinuxKataPool(pool *tuistv1.RunnerPool) bool {
@@ -125,6 +132,21 @@ func unschedulableSince(pod *corev1.Pod) (time.Time, bool) {
 	return time.Time{}, false
 }
 
+// awaitingPlacement is a provisioning Pod the scheduler is about to bind: it
+// has no node yet and has not been rejected. These are the only Pods that can
+// arrive on one kubelet together, so they are what the burst gate counts. A
+// Pod the scheduler has already refused is not in this set — it binds one at a
+// time as capacity frees up, and counting it would let a shape no node can
+// seat block creation fleet-wide for a whole start timeout, which is the
+// starvation the per-pool share exists to prevent.
+func awaitingPlacement(pod *corev1.Pod) bool {
+	if pod.Spec.NodeName != "" {
+		return false
+	}
+	_, rejected := unschedulableSince(pod)
+	return !rejected
+}
+
 func (r *RunnerPoolReconciler) provisioningAdmission(
 	ctx context.Context,
 	pool *tuistv1.RunnerPool,
@@ -135,15 +157,15 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 	}
 
 	poolNames := map[string]struct{}{pool.Name: {}}
-	capN := int(pool.Spec.Provisioning.MaxConcurrentPerFleetSelectorOrDefault())
+	perNode := int(pool.Spec.Provisioning.MaxConcurrentPerNodeOrDefault())
 	for i := range pools.Items {
 		sibling := &pools.Items[i]
 		if !isLinuxKataPool(sibling) || sibling.Spec.FleetSelector != pool.Spec.FleetSelector {
 			continue
 		}
 		poolNames[sibling.Name] = struct{}{}
-		if siblingCap := int(sibling.Spec.Provisioning.MaxConcurrentPerFleetSelectorOrDefault()); siblingCap < capN {
-			capN = siblingCap
+		if siblingPerNode := int(sibling.Spec.Provisioning.MaxConcurrentPerNodeOrDefault()); siblingPerNode < perNode {
+			perNode = siblingPerNode
 		}
 	}
 
@@ -155,15 +177,16 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 		return provisioningAdmission{}, fmt.Errorf("list fleet runner pods: %w", err)
 	}
 
-	// Every provisioning Pod counts, bound or not. An unbound Pod is one
-	// the scheduler may bind at any moment, with no further admission
-	// check in between, so excluding it would let a backlog accumulate and
-	// then start together the instant capacity returns — exactly the
-	// simultaneous-sandbox-start burst this ceiling exists to prevent.
-	// Pods that can never bind are released by unschedulableTimedOut
-	// rather than by being discounted here.
+	// Every provisioning Pod counts against the ceiling, bound or not. An
+	// unbound Pod is one the scheduler may bind at any moment, with no
+	// further admission check in between, so excluding it would let a
+	// backlog accumulate and then start together the instant capacity
+	// returns — exactly the simultaneous-sandbox-start burst this ceiling
+	// exists to prevent. Pods that can never bind are released by
+	// unschedulableTimedOut rather than by being discounted here.
 	observed := make(map[string]struct{}, len(pods.Items))
 	pendingForFleet := 0
+	placing := 0
 	pendingByPool := make(map[string]int, len(poolNames))
 	aliveByPool := make(map[string]int, len(poolNames))
 	for i := range pods.Items {
@@ -181,6 +204,9 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 		}
 		pendingForFleet++
 		pendingByPool[owner]++
+		if awaitingPlacement(pod) {
+			placing++
+		}
 	}
 
 	reserved, reservedByPool := r.creationReservations.reconcile(
@@ -190,6 +216,11 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 		r.now(),
 	)
 	pendingForFleet += reserved
+	// A reservation is a Pod created moments ago, so it has no node yet and
+	// the scheduler has not refused it: it is awaiting placement by
+	// definition, and counting it is what makes the burst gate hold across
+	// sibling pools inside the informer-cache window.
+	placing += reserved
 	for name, count := range reservedByPool {
 		pendingByPool[name] += count
 	}
@@ -235,23 +266,6 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 			siblingsNeedingSlot++
 		}
 	}
-	poolCap := capN - siblingsNeedingSlot
-	if poolCap < 1 {
-		poolCap = 1
-	}
-
-	// A starved pool is owed a slot, so it measures itself against the whole
-	// ceiling; every other pool measures itself against the ceiling minus the
-	// slots its starved siblings are owed. The floor of 1 keeps the fleet
-	// making progress when more pools are starved than there are slots: the
-	// first Pod to start frees the count for the next one.
-	fleetCap := capN
-	if !needsSlot[pool.Name] {
-		fleetCap = capN - siblingsNeedingSlot
-		if fleetCap < 1 {
-			fleetCap = 1
-		}
-	}
 
 	var nodes corev1.NodeList
 	if err := r.List(ctx, &nodes, client.MatchingLabels{
@@ -263,13 +277,49 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 	metrics.RecordFleetNodes(pool.Spec.FleetSelector, pool.Spec.OS, healthyNodes, filtered)
 	metrics.RecordPendingProvisioningPods(pool.Name, pendingForPool)
 
+	// The ceiling is per-node arithmetic, not a constant. What it protects is
+	// one kubelet and one Kata runtime being asked to bring up too many
+	// microVMs at once; that risk is per host, so the budget has to be too,
+	// and a fleet-wide constant makes added hardware raise capacity without
+	// raising start throughput. Measured on 2026-09-03: 62 jobs queued across
+	// the Linux pools with one node at 0% CPU and 0% memory and two more near
+	// half, every pool refused with `fleet_cap`.
+	//
+	// summarizeFleetNodes already excludes cordoned, NotReady and pressured
+	// nodes, so a node taken out of service takes its share of the start
+	// budget with it — the remedy for a host that accepts sandboxes it cannot
+	// start stays a cordon, and now it also stops that host inflating the
+	// ceiling.
+	ceiling := perNode * healthyNodes
+	metrics.RecordFleetProvisioningCeiling(pool.Spec.FleetSelector, pool.Spec.OS, ceiling)
+
+	poolCap := ceiling - siblingsNeedingSlot
+	if poolCap < 1 {
+		poolCap = 1
+	}
+
+	// A starved pool is owed a slot, so it measures itself against the whole
+	// ceiling; every other pool measures itself against the ceiling minus the
+	// slots its starved siblings are owed. The floor of 1 keeps the fleet
+	// making progress when more pools are starved than there are slots: the
+	// first Pod to start frees the count for the next one.
+	fleetCap := ceiling
+	if !needsSlot[pool.Name] {
+		fleetCap = ceiling - siblingsNeedingSlot
+		if fleetCap < 1 {
+			fleetCap = 1
+		}
+	}
+
 	admission := provisioningAdmission{
-		pendingForPool:  pendingForPool,
-		pendingForFleet: pendingForFleet,
-		cap:             capN,
-		fleetCap:        fleetCap,
-		poolCap:         poolCap,
-		healthyNodes:    healthyNodes,
+		pendingForPool:    pendingForPool,
+		pendingForFleet:   pendingForFleet,
+		awaitingPlacement: placing,
+		perNode:           perNode,
+		cap:               ceiling,
+		fleetCap:          fleetCap,
+		poolCap:           poolCap,
+		healthyNodes:      healthyNodes,
 	}
 	if healthyNodes == 0 {
 		admission.blockedReason = "no_healthy_node"
@@ -283,9 +333,30 @@ func (r *RunnerPoolReconciler) provisioningAdmission(
 		admission.blockedReason = "pool_share"
 		return admission, nil
 	}
+	// The ceiling bounds how many sandboxes are coming up across the fleet;
+	// it does not bound how many land on one host, because the controller
+	// does not place Pods and steering them was tried and dropped (see the
+	// per-node circuit breaker in AGENTS.md). What it can bound is how many
+	// are handed to the scheduler at once, and a batch with no nodes yet is
+	// exactly the batch that can arrive on one kubelet together — the
+	// scheduler prefers the least-allocated node, which on a fleet with an
+	// idle host means all of them. Capping the in-flight unplaced set at one
+	// node's budget makes the worst case one node's worth, and costs nothing
+	// in steady state: those Pods bind within a second or two, so the gate
+	// clears long before the next five-second tick.
+	if placing >= perNode {
+		admission.blockedReason = "placement_burst"
+		return admission, nil
+	}
 	admission.available = fleetCap - pendingForFleet
+	admission.limitedBy = "fleet_cap"
 	if share := poolCap - pendingForPool; share < admission.available {
 		admission.available = share
+		admission.limitedBy = "pool_share"
+	}
+	if burst := perNode - placing; burst < admission.available {
+		admission.available = burst
+		admission.limitedBy = "placement_burst"
 	}
 	return admission, nil
 }

--- a/infra/runners-controller/controllers/provisioning_test.go
+++ b/infra/runners-controller/controllers/provisioning_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -350,6 +351,227 @@ func TestProvisioningAdmissionStarvedPoolKeepsFullFleetCeiling(t *testing.T) {
 	if admission.fleetCap != admission.cap {
 		t.Fatalf("fleetCap = %d, cap = %d, want a starved pool to keep the whole ceiling", admission.fleetCap, admission.cap)
 	}
+}
+
+// The ceiling is per-node arithmetic, so hardware raises start throughput.
+// Under the fleet-wide constant this pool was refused at four in flight no
+// matter how many machines stood idle: measured on 2026-09-03 with 62 jobs
+// queued, one node at 0% CPU and 0% memory, and every pool on `fleet_cap`.
+func TestProvisioningAdmissionCeilingScalesWithHealthyNodes(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux-a", 20, 4)
+	objs := []client.Object{pool}
+	for _, name := range []string{"node-a", "node-b", "node-c"} {
+		objs = append(objs, readyLinuxRunnerNode(name, pool.Spec.FleetSelector))
+	}
+	for i, node := range []string{"node-a", "node-a", "node-b", "node-b", "node-c"} {
+		objs = append(objs, boundRunnerPod(fmt.Sprintf("linux-a-runner-%d", i), pool.Name, node))
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	admission, err := r.provisioningAdmission(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.cap != 12 {
+		t.Fatalf("cap = %d, want the per-node budget times three healthy nodes", admission.cap)
+	}
+	if admission.blockedReason != "" || admission.available != 4 {
+		t.Fatalf("admission = %+v, want a full node's worth of creations, not a fleet-wide four", admission)
+	}
+}
+
+// Scaling the ceiling with the fleet must not stop it being a ceiling.
+func TestProvisioningAdmissionBlocksWhenTheDerivedCeilingIsFull(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux-a", 20, 2)
+	objs := []client.Object{pool}
+	for _, name := range []string{"node-a", "node-b", "node-c"} {
+		objs = append(objs, readyLinuxRunnerNode(name, pool.Spec.FleetSelector))
+	}
+	for i, node := range []string{"node-a", "node-a", "node-b", "node-b", "node-c", "node-c"} {
+		objs = append(objs, boundRunnerPod(fmt.Sprintf("linux-a-runner-%d", i), pool.Name, node))
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	admission, err := r.provisioningAdmission(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.cap != 6 || admission.blockedReason != "fleet_cap" || admission.available != 0 {
+		t.Fatalf("admission = %+v, want the six-slot ceiling held by six in-flight Pods", admission)
+	}
+}
+
+// A node that cannot take Pods must not lend the fleet start budget. This is
+// what makes the documented remedy for a host that accepts sandboxes it cannot
+// start — cordon it — shrink the ceiling rather than leave it inflated.
+func TestProvisioningAdmissionCeilingExcludesUnusableNodes(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux-a", 20, 4)
+	cordoned := readyLinuxRunnerNode("node-cordoned", pool.Spec.FleetSelector)
+	cordoned.Spec.Unschedulable = true
+	notReady := readyLinuxRunnerNode("node-down", pool.Spec.FleetSelector)
+	notReady.Status.Conditions = []corev1.NodeCondition{{
+		Type:   corev1.NodeReady,
+		Status: corev1.ConditionFalse,
+	}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		pool, readyLinuxRunnerNode("node-a", pool.Spec.FleetSelector), cordoned, notReady,
+	).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	admission, err := r.provisioningAdmission(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.healthyNodes != 1 || admission.cap != 4 {
+		t.Fatalf("admission = %+v, want only the one usable node to contribute budget", admission)
+	}
+}
+
+// The ceiling bounds sandboxes coming up across the fleet; it cannot bound how
+// many land on one host, because the controller does not place Pods. What it
+// bounds instead is how many are handed to the scheduler at once — the batch
+// that can arrive on one kubelet together, since the scheduler prefers the
+// least-allocated node and an idle host attracts all of them.
+func TestProvisioningAdmissionLimitsSimultaneousPlacement(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux-a", 40, 4)
+	objs := []client.Object{pool}
+	for _, name := range []string{"node-a", "node-b", "node-c"} {
+		objs = append(objs, readyLinuxRunnerNode(name, pool.Spec.FleetSelector))
+	}
+	for i := 0; i < 4; i++ {
+		objs = append(objs, newRunnerPod(fmt.Sprintf("linux-a-runner-%d", i), "img", corev1.PodPending, pool.Name))
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	admission, err := r.provisioningAdmission(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.awaitingPlacement != 4 {
+		t.Fatalf("awaitingPlacement = %d, want the four unbound Pods", admission.awaitingPlacement)
+	}
+	if admission.blockedReason != "placement_burst" || admission.available != 0 {
+		t.Fatalf("admission = %+v, want the twelve-slot ceiling still gated at one node's worth of placements", admission)
+	}
+}
+
+// A Pod the scheduler has already refused is not about to arrive anywhere, so
+// it must not hold the burst gate. Counting it would rebuild the 2026-09-02
+// starvation on the new gate: a shape no node can seat parks its Pods for a
+// whole start timeout and every sibling is refused creation behind them.
+func TestProvisioningAdmissionPlacementBurstIgnoresRejectedPods(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux-a", 40, 4)
+	objs := []client.Object{pool}
+	for _, name := range []string{"node-a", "node-b", "node-c"} {
+		objs = append(objs, readyLinuxRunnerNode(name, pool.Spec.FleetSelector))
+	}
+	for i := 0; i < 4; i++ {
+		objs = append(objs, unschedulableRunnerPod(fmt.Sprintf("linux-a-runner-%d", i), pool.Name, time.Unix(1000, 0)))
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	admission, err := r.provisioningAdmission(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.awaitingPlacement != 0 {
+		t.Fatalf("awaitingPlacement = %d, want rejected Pods left out of the burst gate", admission.awaitingPlacement)
+	}
+	if admission.blockedReason != "" || admission.available != 4 {
+		t.Fatalf("admission = %+v, want creations to continue under the parked Pods", admission)
+	}
+}
+
+// The admission metric reports a reason whenever a replica gap survives the
+// tick, including the ordinary case of a gap larger than the slots on offer.
+// With three terms able to cap creations, attributing all of them to the
+// ceiling would make `reason="fleet_cap"` mean nothing.
+func TestProvisioningAdmissionNamesTheTermThatCappedCreations(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newLinuxKataPool("linux-a", 40, 4)
+	objs := []client.Object{pool}
+	for _, name := range []string{"node-a", "node-b", "node-c"} {
+		objs = append(objs, readyLinuxRunnerNode(name, pool.Spec.FleetSelector))
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	admission, err := r.provisioningAdmission(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.available != 4 || admission.limitedBy != "placement_burst" {
+		t.Fatalf("admission = %+v, want a ramp attributed to the burst gate, not the ceiling", admission)
+	}
+
+	// Nine of the twelve slots in flight: now the ceiling is what binds.
+	for i, node := range []string{"node-a", "node-a", "node-a", "node-b", "node-b", "node-b", "node-c", "node-c", "node-c"} {
+		objs = append(objs, boundRunnerPod(fmt.Sprintf("linux-a-runner-%d", i), pool.Name, node))
+	}
+	c = fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r = &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	admission, err = r.provisioningAdmission(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("provisioningAdmission: %v", err)
+	}
+	if admission.available != 3 || admission.limitedBy != "fleet_cap" {
+		t.Fatalf("admission = %+v, want the remaining ceiling attributed to fleet_cap", admission)
+	}
+}
+
+// The fair-share reservation from the fleet-slot fix has to keep working
+// against a ceiling that is now derived rather than configured.
+func TestProvisioningAdmissionHoldsFleetSlotForStarvedSiblingOnMultiNodeFleet(t *testing.T) {
+	scheme := mustScheme(t)
+	starved := newLinuxKataPool("linux-starved", 19, 2)
+	hog := newLinuxKataPool("linux-hog", 33, 2)
+	objs := []client.Object{starved, hog}
+	for _, name := range []string{"node-a", "node-b"} {
+		objs = append(objs, readyLinuxRunnerNode(name, starved.Spec.FleetSelector))
+	}
+	// Four of the ceiling's four slots, so only the reservation can free one.
+	for i, node := range []string{"node-a", "node-a", "node-b", "node-b"} {
+		objs = append(objs, boundRunnerPod(fmt.Sprintf("linux-hog-runner-%d", i), hog.Name, node))
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme}
+
+	hogAdmission, err := r.provisioningAdmission(context.Background(), hog)
+	if err != nil {
+		t.Fatalf("provisioningAdmission(hog): %v", err)
+	}
+	if hogAdmission.cap != 4 || hogAdmission.fleetCap != 3 || hogAdmission.available != 0 {
+		t.Fatalf("hog admission = %+v, want a derived ceiling of 4 with one slot withheld", hogAdmission)
+	}
+
+	starvedAdmission, err := r.provisioningAdmission(context.Background(), starved)
+	if err != nil {
+		t.Fatalf("provisioningAdmission(starved): %v", err)
+	}
+	if starvedAdmission.fleetCap != starvedAdmission.cap {
+		t.Fatalf("starved admission = %+v, want the whole derived ceiling", starvedAdmission)
+	}
+}
+
+func boundRunnerPod(name, poolName, nodeName string) *corev1.Pod {
+	pod := newRunnerPod(name, "img", corev1.PodPending, poolName)
+	pod.Spec.NodeName = nodeName
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:               corev1.PodScheduled,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(time.Unix(1000, 0)),
+	}}
+	return pod
 }
 
 func TestTerminationTimedOutIgnoresPodThatIsNotDeleting(t *testing.T) {

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -533,6 +533,9 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			if admissionBlocked {
 				reason := admission.blockedReason
 				if reason == "" {
+					reason = admission.limitedBy
+				}
+				if reason == "" {
 					reason = "fleet_cap"
 				}
 				metrics.RecordAdmissionBlocked(pool.Name, reason)
@@ -542,6 +545,8 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					"creating", createLimit,
 					"pendingForPool", admission.pendingForPool,
 					"pendingForFleet", admission.pendingForFleet,
+					"awaitingPlacement", admission.awaitingPlacement,
+					"perNode", admission.perNode,
 					"cap", admission.cap,
 					"fleetCap", admission.fleetCap,
 					"poolCap", admission.poolCap,

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -59,13 +59,13 @@ func newPool(name, image string, replicas int32) *tuistv1.RunnerPool {
 	}
 }
 
-func newLinuxKataPool(name string, replicas, maxProvisioning int32) *tuistv1.RunnerPool {
+func newLinuxKataPool(name string, replicas, maxProvisioningPerNode int32) *tuistv1.RunnerPool {
 	pool := newPool(name, "ghcr.io/tuist/tuist-linux-runner:test", replicas)
 	pool.Spec.OS = "linux"
 	pool.Spec.RuntimeClass = "kata-qemu"
 	pool.Spec.Provisioning = &tuistv1.RunnerPoolProvisioning{
-		MaxConcurrentPerFleetSelector: ptr.To(maxProvisioning),
-		StartTimeoutSeconds:           ptr.To[int32](300),
+		MaxConcurrentPerNode: ptr.To(maxProvisioningPerNode),
+		StartTimeoutSeconds:  ptr.To[int32](300),
 	}
 	return pool
 }

--- a/infra/runners-controller/internal/metrics/metrics.go
+++ b/infra/runners-controller/internal/metrics/metrics.go
@@ -183,6 +183,11 @@ var (
 		Help: "Runner-fleet nodes excluded from capacity or provisioning admission, grouped by reason.",
 	}, []string{fleetSelectorLabel, operatingSystemLabel, reasonLabel})
 
+	fleetProvisioningCeiling = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tuist_runners_fleet_provisioning_ceiling",
+		Help: "Concurrent Linux Kata sandbox starts a runner fleet allows: the per-node budget times its healthy node count. Compare with the sum of tuist_runners_pool_pending_provisioning_pods to see how much of the ceiling is in use.",
+	}, []string{fleetSelectorLabel, operatingSystemLabel})
+
 	podStartTimeoutsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "tuist_runners_pool_pod_start_timeouts_total",
 		Help: "Bound Linux runner Pods reaped after failing to start their dispatch poller within the configured timeout.",
@@ -195,7 +200,7 @@ var (
 )
 
 func init() {
-	ctrlmetrics.Registry.MustRegister(target, allocated, warmDeficitReplicas, minWarmFloor, rollingPods, stalePods, rollCap, phaseReplicas, oldestPendingPodAge, claimedJobs, occupiedRunners, queuedJobs, idleReplicas, pendingProvisioningPods, admissionBlockedTotal, fleetReadyNodes, fleetFilteredNodes, podStartTimeoutsTotal, stuckTerminationsTotal)
+	ctrlmetrics.Registry.MustRegister(target, allocated, warmDeficitReplicas, minWarmFloor, rollingPods, stalePods, rollCap, phaseReplicas, oldestPendingPodAge, claimedJobs, occupiedRunners, queuedJobs, idleReplicas, pendingProvisioningPods, admissionBlockedTotal, fleetReadyNodes, fleetFilteredNodes, fleetProvisioningCeiling, podStartTimeoutsTotal, stuckTerminationsTotal)
 }
 
 // RecordAllocation publishes one pool's allocation outcome for this
@@ -249,6 +254,16 @@ func RecordFleetNodes(fleetSelector, operatingSystem string, ready int, filtered
 	for _, reason := range fleetNodeFilterReasons {
 		fleetFilteredNodes.WithLabelValues(fleetSelector, operatingSystem, reason).Set(float64(filtered[reason]))
 	}
+}
+
+// RecordFleetProvisioningCeiling publishes the fleet's derived concurrent-start
+// budget. It moves with the healthy node count, so a drop without a
+// configuration change means nodes left the fleet.
+func RecordFleetProvisioningCeiling(fleetSelector, operatingSystem string, ceiling int) {
+	if ceiling < 0 {
+		ceiling = 0
+	}
+	fleetProvisioningCeiling.WithLabelValues(fleetSelector, operatingSystem).Set(float64(ceiling))
 }
 
 func RecordPodStartTimeout(pool, reason string) {


### PR DESCRIPTION
## What changed

The Linux Kata provisioning ceiling was `spec.provisioning.maxConcurrentPerFleetSelector` (default 4): a single fleet-wide integer capping how many sandboxes may boot at once across every RunnerPool sharing a `fleetSelector`, enforced in `provisioningAdmission` in `infra/runners-controller/controllers/provisioning.go`.

It is now `spec.provisioning.maxConcurrentPerNode` (default 4) times the fleet's healthy node count.

## Why

The old ceiling ignored node count, so adding hardware raised capacity without raising start throughput.

Measured in production on 2026-09-03: 62 jobs queued across the Linux pools while one node sat at 0% CPU and 0% memory and two more were near half, roughly two and a half idle machines, and every pool was refused with `reason="fleet_cap"`. Raising the cap to 12 by hand absorbed the idle capacity within one reconcile tick (`linux-4vcpu-16gb` went from 1 Pod to 18), which confirms the ceiling and not capacity was binding.

### Root cause

The ceiling exists to stop a simultaneous-sandbox-start burst overwhelming kubelet and the Kata runtime. That risk is per host: each node runs its own kubelet and its own Kata runtime, and a burst overwhelms one of them, not the fleet. The bug is that the guarantee was expressed per fleet while the thing it protects is per node, which is why it both under-protected a busy host and throttled an idle one.

Deriving the budget per node is therefore the safer statement as well as the higher-throughput one, not a trade between them.

## Why this shape over the obvious alternatives

**Per-node budget rather than a bigger constant.** A constant tuned for today's fleet is wrong again on the next hardware change, and says nothing about what a single kubelet is being asked to do.

**Node count from `summarizeFleetNodes`, which already excludes cordoned, NotReady and pressured nodes.** This was deliberate rather than incidental: the documented remedy for a host that accepts sandboxes it cannot start is a manual cordon, and previously a cordoned node kept contributing phantom budget to the ceiling. Now it takes its share with it.

**A per-node ceiling alone would have been a regression, so there is a second gate.** A larger ceiling bounds how many sandboxes are coming up across the fleet but not how many land on one host. kube-scheduler prefers the least-allocated node, so on a fleet with an idle machine a 16-Pod batch lands mostly on that one, which is the burst the ceiling exists to prevent. I did not reuse `nodeSeatsForShape` or otherwise steer placement: this controller does not place Pods, and steering them was already tried and deliberately dropped (the per-node circuit breaker documented in `AGENTS.md`). What the controller can bound is how many Pods are handed to the scheduler at once. Provisioning Pods with no node that the scheduler has not rejected are exactly the set that can arrive on one kubelet together, so that set is capped at one node's budget, refused with `reason="placement_burst"`. It costs nothing in steady state because those Pods bind within a second or two, well inside the five-second tick.

**Pods the scheduler has already refused are excluded from that gate**, while still holding their slot in the ceiling. Counting them would have rebuilt the 2026-09-02 starvation on the new gate: a shape no node can seat parks its Pods for a whole start timeout and every sibling is refused behind them. There is a test for exactly this.

**The fair-share reservation from #12819 is untouched in shape.** A starved sibling is still owed a slot out of the ceiling its siblings measure against. `TestProvisioningAdmissionHoldsFleetSlotForStarvedSibling` and its neighbours pass unmodified, because they build single-node fleets where the derived ceiling equals the old constant, which is also the cleanest evidence the change is behaviour-preserving at fleet size 1. A multi-node version of the reservation test was added.

**`maxConcurrentPerFleetSelector` is replaced, not kept as an optional clamp.** Keeping it would have been a trap. The CRD lives in `crds/`, which helm does not touch on upgrade, and its old schema defaults that field to 4, so on any cluster whose schema had not been re-applied the clamp would have silently pinned the fleet at 4 forever. As replaced, a stale schema prunes `maxConcurrentPerNode` on the way in and the accessor default (4 per node) applies, which is the intended behaviour anyway, so a stale schema degrades to the right answer rather than the old one. The value patched onto production by hand during the incident is pruned the same way and is now inert.

## Also fixed

The admission metric's attribution. `tuist_runners_pool_admission_blocked_total` reports a reason whenever a replica gap survives the tick, and a gap larger than the slots on offer is the ordinary way to ramp. With three terms now able to cap creations, the old `reason == "" -> "fleet_cap"` fallback would have labelled every ramp a ceiling refusal. `limitedBy` now names the term that actually capped the tick.

## Impact

- Linux runner pools absorb a queue spike across the whole fleet instead of four sandboxes at a time, so idle nodes stop sitting idle behind a full queue.
- Cordoning a bad node now also shrinks the ceiling, so the manual remedy is no longer partially defeated.
- New metric `tuist_runners_fleet_provisioning_ceiling{fleet_selector,operating_system}` publishes the derived budget. A drop with no chart change means nodes left the fleet.
- New blocked/limited reason `placement_burst`. It is what a healthy ramp looks like, not a fault; only a sustained one with a queue behind it is a signal. Documented in `AGENTS.md` and in the runner alert runbook.
- **Deploy note:** the CRD needs the usual out-of-band re-apply (`kubectl apply -f infra/helm/tuist/crds/tuist.dev_runnerpools.yaml`) for `maxConcurrentPerNode` to take effect. Until then the controller falls back to its default of 4 per node, which is the intended value, so ordering is not load-bearing.
- Coordinates with the sibling task restoring chart ownership of the hand-patched production value: that field no longer exists, so the chart-ownership work should target `maxConcurrentPerNode` instead.

## How to test locally

```bash
cd infra/runners-controller && go test ./... && go vet ./... && gofmt -l .
```

16 provisioning-admission tests, 7 of them new:

- ceiling scales with healthy node count, and still blocks when the derived ceiling is full
- cordoned and NotReady nodes contribute no budget
- the placement burst gate holds, and ignores Pods the scheduler already rejected
- the fair-share reservation still holds a slot on a multi-node fleet
- the admission metric names the term that capped creations

Chart render:

```bash
helm lint infra/helm/tuist --set server.license.key=dummy
```

```bash
helm template t infra/helm/tuist --set runnersFleetLinux.enabled=true --set runnersFleetLinux.name=runners-linux --set runnersFleet.namespace=tuist-runners --set server.license.key=dummy --set runnersFleetLinux.shapeRunnerImage=ghcr.io/tuist/x:1 --set runnersFleetLinux.shapeRuntimeClass=kata-qemu --set 'runnersFleetLinux.shapes[0].vcpus=4' --set 'runnersFleetLinux.shapes[0].memoryGb=16' --show-only templates/runner-pool.yaml
```

renders `provisioning.maxConcurrentPerNode: 4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
