### PR TITLE
fix(server): rewrite the Faro collector path to /collect so vitals reach Loki

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -3882,6 +3882,16 @@ no extra request origin. It posts to `https://tuist.dev/-/faro`, which the
 through an ExternalName Service (`server.faro` in `infra/helm/tuist`). Alloy
 forwards to Grafana Cloud Loki.
 
+**The collector path is rewritten, and that is the fragile part.** Alloy's
+`faro.receiver` serves POST on `/collect` and nothing else, so a dedicated
+Ingress rewrites `/-/faro` to `/collect` before it reaches the receiver. It is a
+separate Ingress object from the server's on purpose: `rewrite-target` is a
+per-Ingress annotation, so putting the path on the main Ingress would rewrite
+`/` as well and take the whole site down. The first deploy of this pipeline
+shipped without the rewrite and every payload got a 404 from Alloy's router,
+which is why the triage below starts by reading the body of that 404 rather
+than only its status.
+
 Keeping the collector on a path of the site rather than its own hostname is
 deliberate: it makes the request same-origin, so there is no CORS preflight and
 no Content Security Policy change, and no separate domain for content blockers
@@ -3902,12 +3912,20 @@ Because `| logfmt` promotes every field to a label, each query needs an explicit
 `by (app_environment)` or `sum by (...)`. Without it a range aggregation returns
 one series per unique field combination, which is per-session.
 
+**`app_environment` is `prod`, not `production`.** The value comes from
+`Tuist.Environment.env()` and is the same spelling Sentry uses; `production` is
+the k8s and Grafana Cloud label layer, a different thing. Every rule here
+originally filtered `production` and therefore matched nothing — and because the
+percentile rules are No Data: OK, that read as a healthy, fast site rather than
+a broken pipeline. If a rule in this group ever goes quiet, re-run its query
+with the environment filter removed before believing the silence.
+
 ```logql
 quantile_over_time(0.95,
   {service_name="tuist-web", kind="measurement"}
     | logfmt
     | type="web-vitals"
-    | app_environment="production"
+    | app_environment="prod"
     | lcp!=""
     | unwrap lcp [6h]
 ) by (app_environment) / 1000
@@ -3993,7 +4011,7 @@ sum(count_over_time(
   {service_name="tuist-web", kind="measurement"}
     | logfmt
     | type="web-vitals"
-    | app_environment="production"
+    | app_environment="prod"
     | lcp!="" [2h]
 )) < 1
 ```
@@ -4018,9 +4036,13 @@ Triage follows the payload:
 1. **Browser** — view source on tuist.dev and check `globalThis.analytics` has a
    `collector_url`. Empty means `TUIST_FARO_COLLECTOR_URL` is unset, i.e.
    `server.faro.collectorUrl` is empty in the chart.
-2. **Ingress** — `curl -i https://tuist.dev/-/faro` should not 404. A 404 means
-   `server.faro.receiverHost` is empty so the ExternalName Service and its
-   ingress path were not rendered.
+2. **Ingress** — `curl -sX POST https://tuist.dev/-/faro -H 'Content-Type: application/json' -d '{}'`
+   should not 404. **Read the body, not just the status**, because the two 404s
+   mean opposite things: a plain-text `404 page not found` is Go's, so the
+   request reached Alloy and only the path is wrong (the rewrite Ingress is
+   missing or its annotation was dropped), whereas the server's HTML error page
+   means the request never left Phoenix and `server.faro.receiverHost` is empty,
+   so neither the ExternalName Service nor the Faro Ingress was rendered.
 3. **Alloy** — `faro_receiver_measurements_total` on the `alloy-receiver`
    collector counts what it ingested. Rising there but absent in Loki is a
    forwarding problem, not a browser one.

--- a/infra/helm/tuist/templates/server-faro-ingress.yaml
+++ b/infra/helm/tuist/templates/server-faro-ingress.yaml
@@ -1,0 +1,42 @@
+{{- if and .Values.server.enabled .Values.server.ingress.enabled .Values.server.faro.receiverHost (hasPrefix "/" .Values.server.faro.collectorUrl) }}
+{{- /*
+Alloy's faro.receiver serves POST on /collect and nothing else, so the collector
+path has to be rewritten before it reaches the receiver. rewrite-target is a
+per-Ingress annotation, which is why this is a separate object from the server
+Ingress rather than another path on it: applied there it would rewrite "/" too
+and take the whole site down.
+
+ingress-nginx merges rules for a host across Ingress objects, so this adds the
+collector path to the same host the server Ingress already serves.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "faro") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: faro
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /collect
+spec:
+  {{- with .Values.server.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.server.ingress.tlsSecretName }}
+  tls:
+    - hosts:
+        - {{ .Values.server.ingress.host | quote }}
+      secretName: {{ .Values.server.ingress.tlsSecretName | quote }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.server.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.server.faro.collectorUrl | quote }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "tuist.componentName" (dict "root" . "component" "faro-receiver") }}
+                port:
+                  number: {{ .Values.server.faro.receiverPort }}
+{{- end }}

--- a/infra/helm/tuist/templates/server-ingress.yaml
+++ b/infra/helm/tuist/templates/server-ingress.yaml
@@ -29,15 +29,6 @@ spec:
           {{- with .Values.server.ingress.extraPaths }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- if and .Values.server.faro.receiverHost (hasPrefix "/" .Values.server.faro.collectorUrl) }}
-          - path: {{ .Values.server.faro.collectorUrl | quote }}
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "tuist.componentName" (dict "root" . "component" "faro-receiver") }}
-                port:
-                  number: {{ .Values.server.faro.receiverPort }}
-          {{- end }}
           - path: /
             pathType: Prefix
             backend:

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -445,8 +445,11 @@ server:
   faro:
     collectorUrl: ""
     # In-cluster address of the Faro receiver. Setting it renders an
-    # ExternalName Service and routes collectorUrl's path at it from the server
-    # Ingress, which is what keeps the collector same-origin with the site.
+    # ExternalName Service plus a dedicated Ingress that routes collectorUrl's
+    # path at it, which is what keeps the collector same-origin with the site.
+    # That Ingress rewrites to /collect, the only path Alloy's faro.receiver
+    # serves, so collectorUrl can be any path that does not collide with a
+    # route the server itself answers.
     receiverHost: ""
     receiverPort: 12347
   # Refuse a new Kura instance before it can use the region's reserved storage


### PR DESCRIPTION
Follow-up to #12816. The Faro pipeline deployed but collects nothing: every payload the browser sends gets a 404, Loki holds zero web vitals, and all six LCP rules sit at No Data — which they treat as OK. A fast site and a dead collector look identical.

Two independent faults, both found by checking production rather than CI.

### The path

Alloy's `faro.receiver` [serves POST on `/collect`](https://github.com/grafana/alloy/blob/main/internal/component/faro/receiver/server.go) and nothing else; its router 404s everything else. The ingress forwarded `/-/faro` verbatim, so the request arrived and was rejected.

Confirmed from the response rather than guessed:

```
HTTP/2 404
content-type: text/plain; charset=utf-8
content-length: 19
x-content-type-options: nosniff

404 page not found
```

That is Go's `http.NotFound`, not Phoenix's HTML error page — so Cloudflare, nginx, the ExternalName Service and Alloy were all working and only the path was wrong.

The fix rewrites `/-/faro` to `/collect` from a **separate** Ingress object. `rewrite-target` is a per-Ingress annotation, so adding it to the server Ingress would rewrite `/` as well and take the whole site down. ingress-nginx merges rules for a host across objects, so a second Ingress adds the path without touching the first.

Pointing the SDK at `/collect` directly would have avoided the rewrite entirely, but `/collect` is Google Analytics' endpoint path and sits on content-blocker lists. Staying off those lists is the whole reason the collector is same-origin, so that shortcut would have traded one silent-data-loss bug for another.

### The environment spelling

The app emits `app_environment="prod"` — from `Tuist.Environment.env()`, the same value Sentry uses. The rules filtered `"production"`, which is the k8s and Grafana Cloud label spelling, a different layer. That filter matched nothing, and with `No Data: OK` it read as a healthy site.

Fixed in all eleven queries across the six rules in Grafana, and in `alerts.md`. This one would have outlived the path fix silently, since it fails the same way whether or not data is arriving.

### On the guard rule that should have caught this

This is exactly what the paused "browser vitals telemetry missing" rule exists for, and it was paused, so nothing alerted. That was the right call at the time — nothing had ever posted to the stream, so leaving it active would have fired continuously from creation — but it does mean the first real failure went unannounced.

Its description now names both faults as the first things to check, and the ingress triage step says to **read the body** of a 404 rather than only its status, because a Go 404 and a Phoenix 404 point at opposite halves of the chain.

### Validation

- Both Ingress objects render, with the rewrite scoped to the collector path and the server Ingress carrying no rewrite annotation.
- All 11 rule queries verified via the provisioning API to filter `prod`, with zero stale `production` filters remaining.

### After this deploys

1. `curl -sX POST https://tuist.dev/-/faro -H 'Content-Type: application/json' -d '{}'` should stop returning `404 page not found`.
2. Confirm measurements land: `{service_name="tuist-web", kind="measurement"}` in Explore.
3. **Unpause "Web - browser vitals telemetry missing"** — until then the five percentile rules are unguarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
