### PR TITLE
fix(cli): keep the derived data path stable across cached rebuilds

### DIFF
--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEECanaryAcceptanceTests.swift
@@ -110,17 +110,22 @@ struct TuistCacheEECanaryAcceptanceTests {
                     "CODE_SIGNING_REQUIRED=NO",
                     "CODE_SIGNING_ALLOWED=NO",
                 ]
-                let coldDerivedDataPath = temporaryDirectory.appending(component: "cold")
+                // Every build writes to this same derived data path: the absolute path of a
+                // compilation's outputs is part of its cache key, so a rebuild that writes
+                // elsewhere cannot hit what this one publishes.
+                let derivedDataPath = temporaryDirectory.appending(component: "derived-data")
+                let buildArguments = baseArguments + ["-derivedDataPath", derivedDataPath.pathString]
                 try await TuistTest.run(
                     XcodeBuildBuildCommand.self,
-                    baseArguments + ["-derivedDataPath", coldDerivedDataPath.pathString]
+                    buildArguments + casArguments(in: temporaryDirectory, name: "cold")
                 )
                 TuistTest.expectLogs("cacheable tasks (0%)")
                 resetUI()
 
                 try await expectFullyCachedRebuild(
-                    arguments: baseArguments,
-                    derivedDataParentDirectory: temporaryDirectory,
+                    arguments: buildArguments,
+                    derivedDataPath: derivedDataPath,
+                    casParentDirectory: temporaryDirectory,
                     fileSystem: fileSystem
                 )
             }
@@ -251,8 +256,9 @@ struct TuistCacheEECanaryAcceptanceTests {
     /// polls the same backend instead of asserting on the first attempt.
     private func expectFullyCachedRebuild(
         arguments: [String],
-        derivedDataParentDirectory: AbsolutePath,
-        fileSystem _: FileSysteming,
+        derivedDataPath: AbsolutePath,
+        casParentDirectory: AbsolutePath,
+        fileSystem: FileSysteming,
         sourceLocation: SourceLocation = #_sourceLocation
     ) async throws {
         let clock = ContinuousClock()
@@ -260,18 +266,15 @@ struct TuistCacheEECanaryAcceptanceTests {
         var attempt = 0
 
         while true {
-            // A fresh directory rather than deleting the previous one: the running
-            // proxy keeps its store and spool under the derived data path, so a
-            // wholesale remove races its writes and throws on a spool file that the
-            // walk enumerated and the proxy has since rotated away. A new directory
-            // is also a colder local CAS than a deleted one, which is what makes a
-            // hit here evidence of the remote.
             attempt += 1
-            let derivedDataPath =
-                derivedDataParentDirectory.appending(component: "warm-\(attempt)")
+            // Removing derived data is what forces the rebuild, and recreating it at the
+            // same path is what keeps the outputs, and with them the cache keys, equal to
+            // the ones the cold build published. The local CAS is elsewhere, so this
+            // neither warms the rebuild nor races the proxy's spool.
+            try await fileSystem.remove(derivedDataPath)
             try await TuistTest.run(
                 XcodeBuildBuildCommand.self,
-                arguments + ["-derivedDataPath", derivedDataPath.pathString]
+                arguments + casArguments(in: casParentDirectory, name: "warm-\(attempt)")
             )
 
             if Logger.testingLogHandler.collected[.warning, >=].contains("cacheable tasks (100%)") {
@@ -285,6 +288,17 @@ struct TuistCacheEECanaryAcceptanceTests {
 
             resetUI()
         }
+    }
+
+    /// Puts the local CAS in a caller-owned directory outside derived data.
+    ///
+    /// The CAS path is not part of a compilation's cache key, so a fresh directory per build
+    /// leaves the keys untouched while emptying the local store: what a build hits then came
+    /// from the remote. Keeping it out of derived data also keeps the proxy's write-ahead
+    /// spool, which lives at `<cas path>/tuist-spool`, clear of what the rebuild loop removes.
+    private func casArguments(in parentDirectory: AbsolutePath, name: String) -> [String] {
+        let casPath = parentDirectory.appending(component: "cas-\(name)")
+        return ["COMPILATION_CACHE_CAS_PATH=\(casPath.pathString)"]
     }
 
     private func selectiveTestingHash(


### PR DESCRIPTION
## What changed

`TuistCacheEECanaryAcceptanceTests.generated_project_with_caching_enabled` now runs the cold build and every warm rebuild against a single derived data path, and rotates the local CAS instead: each build gets its own `COMPILATION_CACHE_CAS_PATH` outside derived data. The rebuild loop goes back to removing derived data between attempts.

## Why

The production cascade has been red at `Acceptance Tests` on this test since the kura-lane rewrite landed. The test fails on `cacheable tasks (100%)`, and the failure is deterministic rather than flaky: every attempt in [run 33790690213](https://github.com/tuist/tuist/actions/runs/33790690213/job/100784858782) reported exactly `112 hits / 124 cacheable tasks (90%)`, for 28 attempts across the full 180 s deadline.

### Root cause

The 12 misses are all `(in target 'App' from project 'App')`, and they are the target's Swift compile tasks; the 112 hits are clang PCM builds. Each missing key appears exactly once in the whole job log, across 30 builds, so the keys churn per build rather than failing to resolve.

They churn because the rebuild loop gave every attempt its own derived data path (`cold`, `warm-1`, `warm-2`, ...), and the absolute path of a compilation's outputs is part of its cache key. Clang PCM keys survive the move, Swift compile keys do not, which puts a hard 90% ceiling on the hit rate. The loop was written that way to avoid removing derived data underneath the running proxy, whose write-ahead spool lives at `<cas path>/tuist-spool` and, with the CAS defaulting into derived data, sat inside the directory being removed.

### Why this fix

Measured on Xcode 26.5 (17F42), the same version CI runs:

- changing only the output path changes the compile cache key;
- changing only `-cas-path` leaves it identical.

So the CAS path is the right thing to rotate. A fresh CAS per build empties the local store without touching a single cache key, which keeps a hit evidence of the remote, and moving the CAS out of derived data takes the proxy's spool with it, so removing derived data no longer races the proxy. That removes the reason the loop stopped reusing one path.

Verified against `examples/xcode/xcode_app`, driving xcodebuild directly:

| build | derived data | CAS | result |
| --- | --- | --- | --- |
| cold | `dd1` | `cas1` | `0 hits / 120 (0%)` |
| removed, rebuilt | `dd1` | `cas1` | `120 hits / 120 (100%)` |
| removed, rebuilt | `dd1` | fresh `cas2` | `0 hits / 120 (0%)` |
| rebuilt elsewhere | `dd2` | `cas1` | `112 hits / 120 (93%)` |

The last row reproduces the CI signature (all PCMs hit, every Swift task misses); the second is the shape this change restores. The third confirms `COMPILATION_CACHE_CAS_PATH` really relocates the store, so a fresh CAS is genuinely cold, and no `CompilationCache` directory is left under derived data.

## Impact

The compilation cache over the kura lane is asserted end to end again instead of at a ceiling it can never clear, and the production cascade stops being blocked here. Note that `Kura canary rollout gate` failed independently in the same run (timed out waiting for the 0.33.1 rollout); this change does not address that.

## Validation

- Measured key composition with `swiftc -Rcache-compile-job` on Xcode 26.5, varying one path at a time.
- Reproduced the ceiling and the fix with xcodebuild, as tabulated above.
- `swiftformat --lint` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)