### PR TITLE
fix(server): clear the Trivy findings blocking the Security and Docker build jobs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,25 +2,18 @@
 # Revisit whenever the scan turns red: drop entries whose fixed package has
 # landed in the Debian suite the runner image tracks (bookworm-security).
 
-# High-severity Chromium vulnerabilities fixed upstream in 151.0.7922.169.
-# Debian fixed them for bookworm in 151.0.7922.169-1~deb12u1 (DLA-4749-1), but
-# bookworm-security still publishes 151.0.7922.137-1~deb12u1, so `apt-get
-# upgrade` in server/Dockerfile has no patched package to install. Only trixie
-# and unstable carry the fixed build today, and pulling Chromium from either
-# onto bookworm would replace hundreds of core packages including glibc.
+# High-severity Chromium vulnerabilities fixed upstream in 152.0.7977.75.
+# Debian carries that build in unstable only (152.0.7977.75-1); bookworm-security
+# still publishes 151.0.7922.173-1~deb12u1, which the security tracker marks
+# vulnerable to all three, so `apt-get upgrade` in server/Dockerfile has no
+# patched package to install. Pulling Chromium from unstable onto bookworm would
+# replace hundreds of core packages including glibc.
 # Chromium is present solely to render Open Graph images. It renders markup the
 # server builds from fixed templates, with only length-validated text
 # interpolated in, and never navigates to a remote page, so the crafted-page
-# vector every one of these CVEs requires is not reachable. Drop these entries
-# once bookworm-security publishes 151.0.7922.169-1~deb12u1.
-CVE-2026-76033
-CVE-2026-76036
-CVE-2026-76037
-CVE-2026-76038
-CVE-2026-76039
-CVE-2026-76040
-CVE-2026-76041
-CVE-2026-76043
-CVE-2026-76044
-CVE-2026-76045
-CVE-2026-76047
+# vector CVE-2026-84349 and CVE-2026-84351 require is not reachable, and the
+# Omnibox that CVE-2026-84357 targets does not exist in that headless run.
+# Drop these entries once bookworm-security publishes 152.0.7977.75-1~deb12u1.
+CVE-2026-84349
+CVE-2026-84351
+CVE-2026-84357

--- a/server/package.json
+++ b/server/package.json
@@ -34,6 +34,7 @@
       "form-data": "4.0.6",
       "@opentelemetry/core": "2.8.0",
       "ts-deepmerge": "8.0.0",
+      "fflate": "0.4.9",
       "nanoid@^3.0.0": "3.3.18",
       "nanoid@^5.0.0": "5.1.16"
     },

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   defu: 6.1.5
   dompurify: 3.4.13
   fast-uri: 3.1.7
+  fflate: 0.4.9
   flatted: 3.4.2
   follow-redirects: 1.16.0
   form-data: 4.0.6
@@ -47,6 +48,7 @@ time:
   dompurify@3.4.13: 2026-08-03T14:16:00.210Z
   echarts@6.1.0: 2026-05-19T17:52:11.076Z
   fast-uri@3.1.7: 2026-09-02T11:06:41.962Z
+  fflate@0.4.9: 2026-07-20T16:20:26.758Z
   form-data@4.0.6: 2026-06-12T17:37:53.689Z
   hasown@2.0.4: 2026-05-28T18:11:39.940Z
   https-proxy-agent@5.0.1: 2022-04-14T18:42:00.761Z
@@ -864,8 +866,8 @@ packages:
   fast-uri@3.1.7:
     resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
-  fflate@0.4.8:
-    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
@@ -2680,7 +2682,7 @@ snapshots:
 
   fast-uri@3.1.7: {}
 
-  fflate@0.4.8: {}
+  fflate@0.4.9: {}
 
   flatted@3.4.2: {}
 
@@ -3362,7 +3364,7 @@ snapshots:
       '@posthog/types': 1.363.2
       core-js: 3.49.0
       dompurify: 3.4.13
-      fflate: 0.4.8
+      fflate: 0.4.9
       preact: 10.29.0
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.2.0


### PR DESCRIPTION
Two Trivy jobs on the Server workflow are red on `main` ([run 33804824941](https://github.com/tuist/tuist/actions/runs/33804824941)). They look like one failure because they share a tool, but they are unrelated scans with unrelated causes, and each needed its own fix.

### Security job: fflate

[The Security job](https://github.com/tuist/tuist/actions/runs/33804824941/job/100812680819) fails on `fflate` 0.4.8, CVE-2026-45820, a denial of service via crafted ZIP archives. It reaches us transitively through `posthog-js`, which declares `fflate: ^0.4.8`. The finding is only MEDIUM, but `trivy fs` in `mise/tasks/security.sh` runs without a `--severity` filter, so MEDIUM is enough to fail the job.

Fixed by pinning a pnpm override to 0.4.9 and regenerating the lockfile with `aube install --lockfile-only`. 0.4.9 is the lowest fixed release and sits inside the range `posthog-js` asks for, so the lockfile change is confined to that one package rather than dragging `posthog-js` onto a new major of its own dependency.

### Docker build job: Chromium

[The Docker build job](https://github.com/tuist/tuist/actions/runs/33804824941/job/100812680577) fails on the image scan instead, with 9 HIGH findings: three Chromium CVEs across `chromium`, `chromium-common` and `chromium-sandbox`.

Root cause is a single upstream move. bookworm-security advanced Chromium from 151.0.7922.137 to 151.0.7922.173, and that one bump did two things at once: it fixed all eleven CVEs `.trivyignore` was carrying, and it exposed three newer ones (CVE-2026-84349, CVE-2026-84351, CVE-2026-84357) that 151.0.7922.173 is itself vulnerable to.

There is nothing to upgrade. `server/Dockerfile` installs `chromium` unpinned and already runs `apt-get upgrade` behind `APT_CACHE_BUST`, so it installs whatever bookworm-security publishes. Debian carries the fixed build, 152.0.7977.75, in unstable only. Pulling Chromium from unstable onto bookworm would replace hundreds of core packages including glibc, which is not a trade worth making for this. So the ignore file is the correct lever, as it was the last time this batch rotated.

The eleven stale entries are dropped and the three new ones added, with the reason the file requires. Chromium is installed solely to render Open Graph images: it renders markup the server builds from fixed templates with only length-validated text interpolated in, runs headless, and never navigates to a remote page. The crafted-page vector CVE-2026-84349 and CVE-2026-84351 require is therefore not reachable, and the Omnibox that CVE-2026-84357 targets does not exist in that run.

Worth knowing for the next reviewer: this batch rotates wholesale every few weeks rather than accumulating, so expect the same shape of change again, not a growing ignore list.

### Impact

CI only. No runtime or product behaviour changes. The `fflate` bump is a patch release of a transitive dependency of the analytics client.

### How to test locally

Run the Security job's exact scan from `server/`:

```
trivy fs --exit-code 1 --skip-files "mix.exs,mix.lock" --skip-dirs "priv/static,node_modules,deps,_build" ./
```

It reports 0 vulnerabilities and exits 0 on this branch, against 1 MEDIUM on `main`.

The image scan needs the full release build, so it was not run locally. It was verified by argument against the archive itself rather than the security tracker, whose top table can show a pending upload rather than an installable one:

```
curl -sfL https://deb.debian.org/debian-security/dists/bookworm-security/main/binary-amd64/Packages.xz | xz -dc | grep -A1 '^Package: chromium$'
```

That confirms the newest installable Chromium is 151.0.7922.173-1~deb12u1, so no patched package exists to install. Every one of the eleven dropped CVEs was checked against the Debian security tracker and is fixed at or below the version the image actually installs, so none of them can fire again; each of the three added ones is still marked vulnerable at that version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
