### PR TITLE
fix(infra): count a Kura region's empty nodes towards its capacity

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -50,28 +50,61 @@ an unmatched label value is silently ignored.
 
 ## Recording rules for Kura regions
 
-No `kura_*` request, memory, disk or egress series carries a `region` label,
-and `kube_node_labels` keeps only the `kubernetes.io/*` labels, so a node has
-no region either. The only carriers are `kura_node_geo_info` and
-`kura_node_info`, which exist once per Kura pod. Every region-scoped rule in
-this document therefore joins through them, and two recording rules make that
-join once so the rules stay readable and the join has one place to change.
+No `kura_*` request, memory, disk or egress series carries a `region` label.
+The only carriers are `kura_node_geo_info` and `kura_node_info`, which exist
+once per Kura cache pod. Every region-scoped rule in this document therefore
+joins through them, and four recording rules make that join once so the rules
+stay readable and the join has one place to change.
+
+A node reaches its region through its CAPI pool, which is what a KuraInstance's
+`nodeSelector` pins (`Tuist.Kura.Regions` `node_pool`, one pool per region).
+`kube_node_labels` carries it as `label_node_cluster_x_k8s_io_pool`, which the
+chart allow-lists (`telemetryServices.kube-state-metrics.metricLabelsAllowlist`
+in `infra/helm/k8s-monitoring/values.yaml`; kube-state-metrics exposes no node
+label that is not allow-listed). Going through the pool is what lets a node
+that hosts no cache pod count towards its region: one cache pod anywhere in the
+pool names the region, and every node of that pool inherits it.
 
 Create them under **Alerting → Recording rules**, folder `Alerts`, group
-`Kura region joins`, evaluated every minute.
+`Kura region joins`, evaluated every minute. Rules in a group evaluate in
+order, so keep the order below: `kura:pool_region` reads the two rules above
+it and `kura:node_region` reads them both.
 
 ```promql
-# kura:pod_region — one series per Kura pod, carrying its region
+# kura:pod_region
+# One series per Kura cache pod, carrying its region.
 max by (cluster, pod, region) (kura_node_geo_info)
 ```
 
 ```promql
-# kura:node_region — one series per node that hosts at least one Kura pod
-max by (cluster, node, region) (
-  kube_pod_info{namespace="kura"}
-  * on (cluster, pod) group_left(region) max by (cluster, pod, region) (kura_node_geo_info)
+# kura:node_pool
+# One series per node that carries a CAPI pool label.
+max by (cluster, node, pool) (
+  label_replace(
+    kube_node_labels{label_node_cluster_x_k8s_io_pool!=""},
+    "pool", "$1", "label_node_cluster_x_k8s_io_pool", "(.*)")
 )
 ```
+
+```promql
+# kura:pool_region
+# One series per pool that Kura serves a region from.
+max by (cluster, pool, region) (
+  (kube_pod_info{namespace="kura"} * on (cluster, pod) group_left(region) kura:pod_region)
+  * on (cluster, node) group_left(pool) kura:node_pool
+)
+```
+
+```promql
+# kura:node_region
+# One series per node of a pool that Kura serves a region from.
+max by (cluster, node, region) (
+  kura:node_pool * on (cluster, pool) group_left(region) kura:pool_region
+)
+```
+
+`kura:node_region` keeps the `(cluster, node, region)` shape it had when it was
+derived from cache pods alone, so every rule that joins through it is unchanged.
 
 Usage, for a per-pod and a per-node series respectively:
 
@@ -95,17 +128,21 @@ are about customer capacity.
 
 Two limits to keep in mind:
 
-- A node is attributable to a region only once it hosts a Kura pod. A freshly
-  added, still empty node is invisible to every region rollup until the first
-  placement lands on it. The fix is upstream: allow-list a `tuist.dev/region`
-  node label into `kube_node_labels` and read it here instead.
+- A region is attributable only once it runs a cache pod somewhere in its pool.
+  A region whose boxes are provisioned ahead of its first tenant, or whose
+  instances have all been archived, has no row until the first placement lands.
+  An empty node in a pool that runs a cache pod on another node does count, so
+  a node added to a live region contributes its capacity immediately.
 - Grafana Cloud Adaptive Metrics can aggregate a label away without the series
   disappearing. It has already done so for `tuist_kura_capacity_reserved_gibibytes`
   and `tuist_kura_capacity_allocatable_gibibytes` (`cluster`, `region` and
   `pod` are gone; only a fleet-wide sum is queryable), which is why no rule
   below reads them. A rule that selects on `region` then **errors** rather than
   returning nothing, so set **Error** to **Alerting** on the region rules and
-  check the Adaptive Metrics recommendations before trusting a new one.
+  check the Adaptive Metrics recommendations before trusting a new one. The
+  same applies to `label_node_cluster_x_k8s_io_pool` on `kube_node_labels`:
+  if it is aggregated away, `kura:node_pool` empties and every region rollup
+  goes with it.
 
 ## Critical alerts
 
@@ -831,25 +868,29 @@ of the older ones too.
 ```promql
 label_replace(sum by (cluster, region) (
   floor((max by (cluster, node) (kube_node_status_capacity{resource="tuist_dev_memory_ceiling_mib"})
-         - sum by (cluster, node) (kube_pod_container_resource_requests{resource="tuist_dev_memory_ceiling_mib"})) / (2 * 4096))
+         - (sum by (cluster, node) (kube_pod_container_resource_requests{resource="tuist_dev_memory_ceiling_mib"})
+            or max by (cluster, node) (kube_node_status_capacity{resource="tuist_dev_memory_ceiling_mib"}) * 0)) / (2 * 4096))
   * on (cluster, node) group_left(region) kura:node_region{cluster="tuist-production"}
 ), "constraint", "ceiling", "", "")
 or
 label_replace(sum by (cluster, region) (
   floor((max by (cluster, node) (kube_node_status_allocatable{resource="memory"})
-         - sum by (cluster, node) (kube_pod_container_resource_requests{resource="memory"})) / 1048576 / (2 * 1024))
+         - (sum by (cluster, node) (kube_pod_container_resource_requests{resource="memory"})
+            or max by (cluster, node) (kube_node_status_allocatable{resource="memory"}) * 0)) / 1048576 / (2 * 1024))
   * on (cluster, node) group_left(region) kura:node_region{cluster="tuist-production"}
 ), "constraint", "memory", "", "")
 or
 label_replace(sum by (cluster, region) (
   floor((max by (cluster, node) (kube_node_status_allocatable{resource="ephemeral_storage"})
-         - sum by (cluster, node) (kube_pod_container_resource_requests{resource="ephemeral_storage"})) / (2 * 50 * 1073741824))
+         - (sum by (cluster, node) (kube_pod_container_resource_requests{resource="ephemeral_storage"})
+            or max by (cluster, node) (kube_node_status_allocatable{resource="ephemeral_storage"}) * 0)) / (2 * 50 * 1073741824))
   * on (cluster, node) group_left(region) kura:node_region{cluster="tuist-production"}
 ), "constraint", "disk", "", "")
 or
 label_replace(sum by (cluster, region) (
   floor((max by (cluster, node) (kube_node_status_capacity{resource="tuist_dev_egress_mbps"})
-         - sum by (cluster, node) (kube_pod_container_resource_requests{resource="tuist_dev_egress_mbps"})) / (2 * 25))
+         - (sum by (cluster, node) (kube_pod_container_resource_requests{resource="tuist_dev_egress_mbps"})
+            or max by (cluster, node) (kube_node_status_capacity{resource="tuist_dev_egress_mbps"}) * 0)) / (2 * 25))
   * on (cluster, node) group_left(region) kura:node_region{cluster="tuist-production"}
 ), "constraint", "egress", "", "")
 ```
@@ -935,14 +976,22 @@ reads as zero. The `constraint` label is what lets the summary say which lever
 to pull; the `or` makes one row per constraint, and a box that advertises no
 ceiling (the kura-fleet pool today) simply has no `ceiling` row.
 
-Measured on 2026-09-02: one production region already cannot place another
-enterprise instance by ceiling and would fire on creation, which is a real
-finding rather than noise; the other regions have room for two or more. By
-native memory every region has room for many, so the ceiling is the binding
-constraint everywhere it is advertised. By disk the tightest production
-regions fit two more instances and the widest five, so the disk row is quiet
-on creation; the staging runner region fits one, which is why the scope is
-production. By egress every governed region fits at least a dozen more.
+Each row subtracts `... or <capacity> * 0` rather than the request sum alone. A
+node running no cache pod has no `kube_pod_container_resource_requests` series
+for that resource at all, and a binary operator drops a node that is missing
+from either side, so without the default an empty node contributes nothing and
+the region reads as the occupied nodes only. That is the same blind spot the
+pool-derived `kura:node_region` closes, and both halves are needed: the join
+puts the node in the region, the default gives it its capacity.
+
+Measured on 2026-09-03, per constraint, as `eu-central` / `us-east` /
+`us-west`: ceiling 6 / 1 / 4, memory 20 / 8 / 10, disk 10 / 3 / 5, egress
+34 / 96 / 58. The ceiling binds first in every region that advertises one, and
+`us-east` is the region to watch. Most of `eu-central`'s ceiling room is a
+second node that carries no cache pod yet, which is the case the pool-derived
+join and the zero default exist to count: read against its occupied node alone
+the region reports 0 and fires. Staging and canary regions are out of scope, so
+a staging runner region past the disk pressure line does not fire.
 
 ### Kura cache box out of memory
 

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -636,6 +636,13 @@ k8s-monitoring:
   telemetryServices:
     kube-state-metrics:
       deploy: true
+      # kube_node_labels carries only the kubernetes.io/* labels by default.
+      # The Kura region recording rules in alerts.md read a node's CAPI pool
+      # from it, which is what a KuraInstance's nodeSelector pins
+      # (Tuist.Kura.Regions node_pool, one pool per region), so that a node
+      # counts towards its region's capacity before a cache pod lands on it.
+      metricLabelsAllowlist:
+        - nodes=[node.cluster.x-k8s.io/pool]
     node-exporter:
       deploy: true
       # Setting tolerations overrides the subchart's broad default


### PR DESCRIPTION
## What changed

`kura:node_region`, the recording rule every Kura region rollup in `alerts.md` joins through, now reaches a node through its **CAPI pool** instead of through the cache pods running on it. Two new recording rules (`kura:node_pool`, `kura:pool_region`) sit between them. The four constraint rows of **Kura - region cannot place another instance** also default an absent request sum to zero.

The chart change allow-lists `node.cluster.x-k8s.io/pool` into `kube_node_labels`, since kube-state-metrics exposes no node label that is not allow-listed.

## Why

The alert fired **critical** for `eu-central` / `ceiling` on `tuist-production`, summary "can place 0 more enterprise instances; add a node". The region could in fact place **six**. Ordering a box off that alert would have been buying capacity that was already racked.

## Root cause

Two independent blind spots, both of which drop a node that runs no cache pod. Either one alone is enough to produce the false reading, which is why fixing only the join left the alert at 0 in testing.

**1. The region join.** `kura:node_region` was built from `kura_node_geo_info`, a series that exists once per Kura **cache** pod. A node was attributable to its region only after a cache pod landed on it. The `kura` namespace DaemonSets (`kura-peer-demux-<region>`, the egress-tree agent) do not emit it.

`eu-central`'s node pool had just been rolled: both dedibox nodes were created within the last ~14 hours, every cache pod rescheduled onto the first one to come up, the second joined minutes later, and nothing rebalances running pods. So one node held 12 replicas at 49152 of 56744 MiB of ceiling (7592 MiB free, 600 MiB short of the 8192 MiB a two-replica enterprise instance needs) while its sibling sat completely empty and invisible.

`alerts.md` already documented this limitation and proposed allow-listing a `tuist.dev/region` node label. That label does not exist: the kura-controller sets `tuist.dev/region` on pods and PVCs, never on nodes. The pool label already on every node carries the same information, and `Tuist.Kura.Regions` declares one pool per region, so it needs no new labeling controller.

**2. The subtraction.** Each row computes `capacity - requests` per node. A node running no cache pod has no `kube_pod_container_resource_requests` series for that resource at all (the empty dedibox node had requests for `memory` only, from its DaemonSets, and none for `tuist_dev_memory_ceiling_mib`, `ephemeral_storage` or `tuist_dev_egress_mbps`). A binary operator drops a node missing from either side, so the empty node vanished from the arithmetic even once the join placed it in the region.

## Why this approach

Going through the pool keeps the region's identity where it is already authoritative, the `nodeSelector` the provisioner pins on the KuraInstance, and needs no change to the CAPI provider or the kura-controller. It also keeps `kura:node_region` at its existing `(cluster, node, region)` shape, so the nine rules that join through it are untouched by this PR.

The alternative, hardcoding a pool-to-region map in the recording rule, would drift the moment a region is added.

## Impact

Capacity alerts stop reporting a region as full when it has an unoccupied node. This is the ceiling row today, but the same shape would have hidden real disk and egress headroom on any newly added node.

A residual limit is documented rather than fixed: a region with **no** cache pod anywhere in its pool still has no row, because the pool learns its region from a running pod. `ap-southeast` is in that state today. That is strictly narrower than the previous blind spot, which covered every unoccupied node in every region.

## Validation

The pool label is not in `kube_node_labels` until this deploys, so the rule chain was measured against live production data with the pool simulated from the MachineDeployment prefix, which is one-to-one with the pool. Node attribution came out as intended: `eu-central` gains its second node, every other region is unchanged.

Alert value, before and after, as `eu-central` / `us-east` / `us-west`:

| constraint | before | after |
|---|---|---|
| ceiling | **0** / 1 / 4 | **6** / 1 / 4 |
| memory | 7 / 8 / 10 | 20 / 8 / 10 |
| disk | 2 / 3 / 5 | 10 / 3 / 5 |
| egress | 14 / 96 / 58 | 34 / 96 / 58 |

Only `eu-central` moves, which is the one region holding an empty node.

Cross-checks that the reading is real and not a second artifact:

- The empty node is `Ready`, not unschedulable, and carries the same `tuist.dev/kura-cache=true:NoSchedule` taint as its occupied sibling, with the same 838.5 GiB allocatable disk and 56744 MiB advertised ceiling.
- The per-region `kura-peer-demux-eu-central` DaemonSet runs on **both** dedibox nodes and nowhere else. `peer_demux_controller.go` copies its `NodeSelector` and `Tolerations` verbatim from the region's KuraInstance spec, so where it runs is exactly where a cache instance is schedulable.
- The region is full of reservations, not usage: the entire Kura workload on the occupied node has never exceeded 3790 MiB in 14 days against 28372 MiB allocatable.

`helm template` against `values-production.yaml` renders `--metric-labels-allowlist=nodes=[node.cluster.x-k8s.io/pool]`.

## Deploying

`alerts.md` is the source of record for hand-created Grafana rules, so applying this needs, in order:

1. Deploy the chart so `kube_node_labels` starts carrying `label_node_cluster_x_k8s_io_pool`.
2. Confirm the label survives Grafana Cloud Adaptive Metrics. If it is aggregated away, `kura:node_pool` empties and every region rollup goes with it. `alerts.md` now flags this alongside the existing note for the capacity gauges.
3. Create `kura:node_pool` and `kura:pool_region` in the `Kura region joins` group **before** editing `kura:node_region`, since rules in a group evaluate in order.
4. Update the four constraint rows of the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
