### PR TITLE
fix(server): move the Faro collector off the path the server Ingress still owns

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -3897,20 +3897,22 @@ entries and never becomes a metric.
 
 **How the data gets here.** The Grafana Faro Web SDK is an npm dependency
 bundled into the server's own JavaScript, so there is no third-party script and
-no extra request origin. It posts to `https://tuist.dev/-/faro`, which the
-`tuist` chart routes at the `faro.receiver` on the `alloy-receiver` collector
-through an ExternalName Service (`server.faro` in `infra/helm/tuist`). Alloy
-forwards to Grafana Cloud Loki.
+no extra request origin. It posts to `https://tuist.dev/-/faro/collect`, which
+the `tuist` chart routes at the `faro.receiver` on the `alloy-receiver`
+collector through an ExternalName Service (`server.faro` in
+`infra/helm/tuist`). Alloy forwards to Grafana Cloud Loki.
 
 **The collector path is rewritten, and that is the fragile part.** Alloy's
 `faro.receiver` serves POST on `/collect` and nothing else, so a dedicated
-Ingress rewrites `/-/faro` to `/collect` before it reaches the receiver. It is a
-separate Ingress object from the server's on purpose: `rewrite-target` is a
-per-Ingress annotation, so putting the path on the main Ingress would rewrite
-`/` as well and take the whole site down. The first deploy of this pipeline
-shipped without the rewrite and every payload got a 404 from Alloy's router,
-which is why the triage below starts by reading the body of that 404 rather
-than only its status.
+Ingress rewrites `/-/faro/collect` to `/collect` before it reaches the receiver.
+It is a separate Ingress object from the server's on purpose: `rewrite-target`
+is a per-Ingress annotation, so putting the path on the main Ingress would
+rewrite `/` as well and take the whole site down. ingress-nginx denies an
+Ingress whose host and path another Ingress already defines, so the collector
+path must be one no other Ingress on `tuist.dev` lists. The first deploy of
+this pipeline shipped without the rewrite and every payload got a 404 from
+Alloy's router, which is why the triage below starts by reading the body of
+that 404 rather than only its status.
 
 Keeping the collector on a path of the site rather than its own hostname is
 deliberate: it makes the request same-origin, so there is no CORS preflight and
@@ -4056,7 +4058,7 @@ Triage follows the payload:
 1. **Browser** — view source on tuist.dev and check `globalThis.analytics` has a
    `collector_url`. Empty means `TUIST_FARO_COLLECTOR_URL` is unset, i.e.
    `server.faro.collectorUrl` is empty in the chart.
-2. **Ingress** — `curl -sX POST https://tuist.dev/-/faro -H 'Content-Type: application/json' -d '{}'`
+2. **Ingress** — `curl -sX POST https://tuist.dev/-/faro/collect -H 'Content-Type: application/json' -d '{}'`
    should not 404. **Read the body, not just the status**, because the two 404s
    mean opposite things: a plain-text `404 page not found` is Go's, so the
    request reached Alloy and only the path is wrong (the rewrite Ingress is

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -1635,8 +1635,9 @@ k8s-monitoring:
 
         // Browser real user monitoring for tuist.dev. The Grafana Faro Web SDK
         // bundled into the server's JavaScript posts here through the tuist.dev
-        // Ingress (server.faro in the tuist chart routes /-/faro at this port
-        // via an ExternalName Service), so the request stays same-origin.
+        // Ingress (server.faro in the tuist chart routes /-/faro/collect at
+        // this port via an ExternalName Service), so the request stays
+        // same-origin.
         //
         // Web vitals arrive as `kind=measurement` entries whose logfmt line
         // carries one field per vital (lcp, cls, inp, fcp, ttfb). The LCP alert

--- a/infra/helm/tuist/templates/server-faro-ingress.yaml
+++ b/infra/helm/tuist/templates/server-faro-ingress.yaml
@@ -7,7 +7,9 @@ Ingress rather than another path on it: applied there it would rewrite "/" too
 and take the whole site down.
 
 ingress-nginx merges rules for a host across Ingress objects, so this adds the
-collector path to the same host the server Ingress already serves.
+collector path to the same host the server Ingress already serves. It also
+denies an Ingress whose host and path another Ingress already defines, so
+collectorUrl must differ from every path the server Ingress lists.
 */}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -247,7 +247,7 @@ server:
   # and no separate domain for content blockers to filter, which would skew the
   # web-vital percentiles the LCP alerts read.
   faro:
-    collectorUrl: /-/faro
+    collectorUrl: /-/faro/collect
     receiverHost: k8s-monitoring-alloy-receiver.observability.svc.cluster.local
     receiverPort: 12347
 

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -443,8 +443,10 @@ server:
     # ExternalName Service plus a dedicated Ingress that routes collectorUrl's
     # path at it, which is what keeps the collector same-origin with the site.
     # That Ingress rewrites to /collect, the only path Alloy's faro.receiver
-    # serves, so collectorUrl can be any path that does not collide with a
-    # route the server itself answers.
+    # serves. ingress-nginx rejects an Ingress that claims a host and path
+    # another Ingress already defines, so collectorUrl has to be a path no
+    # other Ingress on the host lists, and it cannot be moved onto or off the
+    # server Ingress in the same upgrade that renders it here.
     receiverHost: ""
     receiverPort: 12347
   # Refuse a new Kura instance before it can use the region's reserved storage


### PR DESCRIPTION
## What changed

`server.faro.collectorUrl` in production moves from `/-/faro` to `/-/faro/collect`, so the dedicated Faro Ingress no longer claims a path the server Ingress still owns. The chart comments and the LCP runbook in `infra/helm/k8s-monitoring/alerts.md` are updated to match.

## Why

The production deploy ([run 33804831185](https://github.com/tuist/tuist/actions/runs/33804831185/job/100823276626)) fails at `helm upgrade`:

```
Error: UPGRADE FAILED: release tuist failed, and has been rolled back due to
rollback-on-failure being set: failed to create resource: admission webhook
"validate.nginx.ingress.kubernetes.io" denied the request: host "tuist.dev" and
path "/-/faro" is already defined in ingress tuist/tuist-tuist-server
```

## Root cause

https://github.com/tuist/tuist/pull/12831 moved the Faro collector path off the server Ingress and onto a new `tuist-tuist-faro` Ingress, so it could carry a `rewrite-target` without rewriting `/` as well. That moves a host/path pair between two Ingress objects, and ingress-nginx denies an Ingress whose host and path another Ingress already defines.

Helm applies same-kind resources in template-path order, so `server-faro-ingress.yaml` is created before `server-ingress.yaml` is patched to drop the path. At that instant both objects claim `tuist.dev` + `/-/faro`, and the webhook rejects the create. The release rolls back to the pre-change revision, which restores `/-/faro` on the server Ingress, so the conflict is permanent rather than something a retry clears. Production has failed this way on every attempt since revision 572.

## Why this fix over the alternatives

Giving the collector a path nothing else claims removes the overlap instead of racing it. The new Ingress serves `/-/faro/collect`, and the same upgrade drops `/-/faro` from the server Ingress, so there is no instant where two objects claim the same pair.

It also makes a rollback safe, which the previous shape was not: rolling back re-adds `/-/faro` to the server Ingress while the Faro Ingress is still live, deadlocking in the same way in the other direction.

Renaming the template so it sorts after `server-ingress.yaml` would also unblock the deploy, but it leans on Helm's undocumented within-kind ordering and leaves the two objects one rename away from colliding again. The path is now documented in `values.yaml` and in the template as one that cannot overlap another Ingress on the host.

## Impact

Production only. `server.faro.receiverHost` is set nowhere else, so canary and staging render neither the ExternalName Service nor the Faro Ingress and are unaffected.

Browsers pick the collector URL up from `TUIST_FARO_COLLECTOR_URL` at render time, so nothing is pinned to the old path. `/-/faro` was never actually working: it reached Alloy's router unrewritten and got a 404, which is the bug https://github.com/tuist/tuist/pull/12831 set out to fix.

## Validation

`helm template` against `values-managed-common.yaml` + `values-managed-production.yaml`:

- `tuist-tuist-faro` renders `nginx.ingress.kubernetes.io/rewrite-target: /collect` on `tuist.dev` `/-/faro/collect` to `tuist-tuist-faro-receiver:12347`
- `tuist-tuist-server` lists only `/`, no faro path
- `TUIST_FARO_COLLECTOR_URL` renders as `/-/faro/collect`

`helm lint` fails identically at `HEAD` on `templates/dedibox-fleet.yaml`, a pre-existing parser quirk unrelated to this change; `helm template`, which is what the deploy runs, renders clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)