### PR TITLE
fix(server): preflight the production helm upgrade with a server-side dry run

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -1241,6 +1241,52 @@ jobs:
           rm -f "$runner_pools_render"
           echo "::endgroup::"
 
+          # Push the rendered release through the API server, admission
+          # webhooks included, without persisting anything. A rejection fails
+          # the deploy here, before the real upgrade has mutated the release,
+          # so the run cannot end in an --atomic rollback. That rollback is
+          # what makes a rejected resource expensive: it reverts every other
+          # resource in the release along with it, including changes applied
+          # outside the release by a hotfix, and it restores the previous
+          # manifest under a database the pre-upgrade migration has already
+          # moved forward.
+          #
+          # Same arguments as the upgrade below, built from the same shell, so
+          # the two cannot drift. Hooks are rendered but not executed, so the
+          # migration Job does not run twice.
+          #
+          # Skipped when the namespace does not exist: a server-side dry run
+          # cannot validate namespaced resources against a namespace that is
+          # not there, and --create-namespace does not create one during a dry
+          # run. That case is a first install, where there is no live release
+          # for a rollback to damage.
+          echo "::group::helm upgrade --dry-run=server (preflight)"
+          if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+            preflight_log="$(mktemp)"
+            if helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
+              --namespace "$NAMESPACE" \
+              "${helm_values_args[@]}" \
+              --set server.image.tag="$IMAGE_TAG" \
+              --set codebaseSearch.image.tag="$CODEBASE_SEARCH_IMAGE_TAG" \
+              --set registry.image.tag="$registry_image_tag" \
+              --set kuraController.image.tag="$KURA_CONTROLLER_IMAGE_TAG" \
+              "${image_sets[@]}" \
+              --dry-run=server >"$preflight_log" 2>&1; then
+              rm -f "$preflight_log"
+              echo "Preflight passed; the API server accepts the rendered release."
+              echo "::endgroup::"
+            else
+              echo "::endgroup::"
+              echo "::error title=Helm preflight failed::The API server rejected the rendered release. Nothing was applied and the live release is untouched."
+              tail -80 "$preflight_log"
+              rm -f "$preflight_log"
+              exit 1
+            fi
+          else
+            echo "Namespace $NAMESPACE does not exist yet; skipping the preflight for this first install."
+            echo "::endgroup::"
+          fi
+
           helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
             --namespace "$NAMESPACE" --create-namespace \
             "${helm_values_args[@]}" \


### PR DESCRIPTION
## What changed

Adds a `helm upgrade --dry-run=server` preflight immediately before the real upgrade in the production deploy job, in the same step and built from the same shell variables.

If the API server rejects the rendered release, the job fails there with the rejection in the log and nothing applied. If it passes, the real upgrade runs exactly as before. `--atomic --timeout 60m --wait` is untouched.

## Why

Tonight's deploy was denied by an admission webhook partway through the apply:

```
admission webhook "validate.nginx.ingress.kubernetes.io" denied the request:
host "tuist.dev" and path "/-/faro" is already defined in ingress tuist/tuist-tuist-server
```

The rejection itself was cheap to fix (#12837). What was expensive was what `--atomic` did next. It rolled the entire release back, which:

- reverted the server Deployment carrying the signup fix that was the whole point of the deploy, so a live incident stayed live
- restored the previous pod template, silently undoing a hotfix that had been applied out of band with `kubectl set env`, because a rollback restores the previous release manifest rather than the current cluster state
- left the stale Ingress path in place, so the next deploy would have hit the identical wall

That last part is the shape of the problem: a rejected resource takes every other resource in the release down with it, and anything applied outside the release disappears without a trace in the deploy log.

Worth naming a second asymmetry this exposes, even though it did not bite tonight: the migration Job is a `pre-install,pre-upgrade` hook, so it runs and commits before the resources that can be rejected. A rollback returns the application manifests to the previous revision but cannot return Postgres with them, so the old image ends up running against a forward-migrated schema.

A server-side dry run sends every rendered manifest through the API server with `dryRun=All`, which invokes validating webhooks without persisting. Tonight's denial would have surfaced with zero changes applied, no rollback, no clobbered hotfix, and the fix would have been the same one-line values change.

## Why in the same step rather than a separate one

The upgrade's arguments come from `helm_values_args` and `image_sets`, bash arrays built earlier in that same step from resolved image tags and per-environment values. A separate step would have to rebuild them, and a preflight that validates different arguments than the upgrade is worse than no preflight. Running both from one shell makes drift impossible.

## Behaviour details

- Hooks are rendered but not executed during a dry run, so the migration Job does not run twice.
- Skipped when the namespace does not exist. A server-side dry run cannot validate namespaced resources against a missing namespace, and `--create-namespace` does not create one during a dry run. That case is a first install, where there is no live release for a rollback to damage.
- On failure the last 80 lines of the preflight output are printed under a workflow error annotation.

## What this does not do

It narrows the class of failures that reach the real upgrade, it does not eliminate rollbacks. Anything that only manifests during rollout still fails the way it does today: image pull failures, failing probes, and pods that cannot be scheduled. That last one is not hypothetical here, since the failed run also had an xcresult-processor pod sitting `Pending` with no node.

Whether `--atomic` should stay for this release is a separate question and deliberately not part of this change.

## Validation

- `bash -n` on the extracted step script passes.
- The workflow YAML parses, and the step still contains both the new `--dry-run=server` invocation and the unchanged `--atomic --timeout 60m --wait`.
- `actionlint` reports nothing new. The only findings on the file are pre-existing `tuist-linux` runner-label warnings that predate this change.
- Not exercised end to end. It runs against the production cluster from the deploy job, so the first real signal is the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
