### PR TITLE
fix(infra): run the container smoke job's steps under bash

### DIFF
--- a/.github/workflows/linux-runners-staging-smoke.yml
+++ b/.github/workflows/linux-runners-staging-smoke.yml
@@ -96,6 +96,14 @@ jobs:
     # is the JS action that exercises the externals + actions trees.
     permissions:
       contents: read
+    # Inside a job container the default shell is `sh -e {0}`, and
+    # ubuntu:22.04's /bin/sh is dash, which rejects the `set -euo
+    # pipefail` every step below opens with ("Illegal option -o
+    # pipefail", exit 2). Without this the job dies on its first step
+    # and never reaches the checkout it exists to exercise.
+    defaults:
+      run:
+        shell: bash
     container:
       image: ubuntu:22.04
     steps:
@@ -117,6 +125,11 @@ jobs:
       - name: Checkout landed in the workspace
         run: |
           set -euo pipefail
+          # The action's own bundle under _actions is what came back
+          # empty when the sidecar mounted the work directory at the
+          # wrong path; assert it before the workspace it produced.
+          test -f /__w/_actions/actions/checkout/v4/dist/index.js \
+            || { echo "ERROR: checkout bundle missing from the actions tree"; exit 1; }
           test -f "$GITHUB_WORKSPACE/README.md"
           echo "Workspace: $GITHUB_WORKSPACE"
 


### PR DESCRIPTION
## What

Adds a bash default shell to the `container-smoke` job in `.github/workflows/linux-runners-staging-smoke.yml`, and strengthens the post-checkout assertion to check the action bundle itself.

```yaml
defaults:
  run:
    shell: bash
```

The `smoke` job is deliberately left alone: it runs directly on the runner, where the default shell is already bash.

## Why

`container-smoke` was added in https://github.com/tuist/tuist/pull/12769 to guard the `jobs.<id>.container` regression fixed there. As written it could never catch that regression, because it failed before reaching the step that does the guarding.

Root cause: inside a `jobs.<id>.container` job, GitHub Actions' default shell is `sh -e {0}`, not `bash -e {0}` as it is for steps running directly on the runner. `ubuntu:22.04`'s `/bin/sh` is dash, and every `run:` step in the job opens with `set -euo pipefail`, which dash rejects:

```
/__w/_temp/<id>.sh: 1: set: Illegal option -o pipefail
##[error]Process completed with exit code 2.
```

So the job died on its very first step, "Step script is reachable inside the container", and never reached `actions/checkout@v4` — the JS action that exercises the externals and `_actions` trees, which is the entire point of the job.

Confirmed empirically: an identical workflow run on a production `tuist-linux-large` runner failed exactly this way (https://github.com/tuist/tuist/actions/runs/33810573080), and the steps ran once a bash shell was added.

## Why this fix over the alternatives

- **`defaults.run.shell: bash`** (chosen): one job-level key, keeps the steps as written, and `ubuntu:22.04` already ships bash so the image is unchanged.
- **Dropping `-o pipefail` from each step**: would make the steps dash-compatible but silently weakens the assertions, and the next step someone adds reintroduces the failure.
- **Switching the image to one whose `/bin/sh` is bash**: changes what the smoke test actually covers, for no benefit.

## Additional change

The post-checkout step now asserts `/__w/_actions/actions/checkout/v4/dist/index.js` exists before checking the workspace it produced. That exact missing file was the customer-reported symptom of the original regression, so asserting it directly makes the guard match the failure it is meant to catch, rather than inferring it from a checkout side effect.

## Impact

Developer-facing only; this is a manually dispatched staging smoke test and does not run on push. Before this change the workflow's container coverage was inert — it reported a failure on every run regardless of whether the regression it guards was present.

## Validation

- Parsed the workflow YAML and confirmed `defaults.run.shell` resolves to `bash` on `container-smoke` only, with `smoke` unchanged and all five steps intact.
- Swept the repo's other job containers (`cli.yml`, `cli-build-publish.yml`, all `swift:6.2`). They are also dash-based images, but none of their steps use `set -o pipefail`, so none are affected and none were touched.

The end-to-end confirmation is a `workflow_dispatch` run against staging, which needs the `tuist-staging-linux` profile and has not been run from this branch.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
