### PR TITLE
fix(kura): stop charging mapped-file serving against the transient budget

### DIFF
--- a/kura/src/memory/mod.rs
+++ b/kura/src/memory/mod.rs
@@ -656,15 +656,15 @@ impl MemoryController {
             return None;
         }
         let permits = u32::try_from(requested_bytes).ok()?;
+        // Mapped bytes are clean, resident page cache with their own try-only
+        // pool; the transient budget covers unreclaimable anonymous work and is
+        // charged separately by the response-stream admission. Charging the
+        // mapped span there as well exhausted transient once the mmap pool
+        // filled, and the degraded response pool, which needs a small transient
+        // reservation per stream, could then admit nothing.
         let concurrency = self.inner.pools.try_acquire_mmap_serving(permits)?;
-        let transient = self
-            .try_reserve_transient(requested_bytes as u64, AdmissionClass::Foreground)
-            .ok()?;
-        // The caller releases this reservation with the response body. Sampled
-        // container usage does not enter transient admission arithmetic.
         Some(MmapMemoryPermit {
             _concurrency: concurrency,
-            _transient: transient,
         })
     }
 
@@ -1425,7 +1425,9 @@ mod tests {
         let permit = controller
             .try_acquire_mmap_serving(64 * 1024 * 1024)
             .expect("permit should be available");
-        assert_eq!(controller.transient_reserved_bytes(), 64 * 1024 * 1024);
+        // Mapped pages are bounded by the mmap pool alone; they never consume
+        // the transient budget that anonymous response buffers draw from.
+        assert_eq!(controller.transient_reserved_bytes(), 0);
         assert!(
             controller
                 .try_acquire_mmap_serving(65 * 1024 * 1024)
@@ -1436,6 +1438,47 @@ mod tests {
         controller.observe(128 * 1024 * 1024);
         assert_eq!(controller.transient_reserved_bytes(), 0);
         assert!(controller.try_acquire_mmap_serving(1).is_none());
+    }
+
+    #[tokio::test]
+    async fn degraded_reads_stay_admissible_while_mmap_serving_holds_its_pool() {
+        let metrics = Metrics::new("eu-west".into(), "tenant".into());
+        let controller = MemoryController::with_runtime_limit(
+            metrics,
+            4 * 1024 * 1024 * 1024,
+            2_576_351_232,
+            3_650_093_056,
+        );
+        controller.observe(0);
+
+        let mapped = controller
+            .try_acquire_mmap_serving(controller.mmap_serving_pool_bytes())
+            .expect("the whole mmap pool should be available");
+        let mut streams = Vec::new();
+        while let Ok(stream) =
+            controller.try_acquire_response_stream_memory(4 * 1024 * 1024, "http")
+        {
+            streams.push(stream);
+        }
+        assert!(!streams.is_empty());
+
+        // With the fixed and elastic response pools exhausted and the mmap pool
+        // fully lent out, a public read must still find transient headroom for
+        // its degraded reservation instead of being shed.
+        let degraded_stream_bytes =
+            RESPONSE_STREAM_SEND_BUFFER_BYTES + RESPONSE_STREAM_MIN_CHUNK_BYTES * 2;
+        let degraded = match controller
+            .acquire_degraded_response_stream_memory(degraded_stream_bytes, "http")
+            .await
+        {
+            Ok(permit) => permit,
+            Err(error) => panic!("degraded admission failed: {error:?}"),
+        };
+
+        drop(degraded);
+        drop(streams);
+        drop(mapped);
+        assert_eq!(controller.transient_reserved_bytes(), 0);
     }
 
     #[test]

--- a/kura/src/memory/mod.rs
+++ b/kura/src/memory/mod.rs
@@ -1,9 +1,10 @@
+use std::collections::HashMap;
 use std::sync::{
-    Arc,
+    Arc, Mutex as StdMutex,
     atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
 };
 use std::time::Instant;
-use tokio::sync::Notify;
+use tokio::sync::{Notify, OwnedSemaphorePermit};
 use tokio::time::timeout;
 
 use crate::constants::RESPONSE_STREAM_SEND_BUFFER_BYTES;
@@ -21,8 +22,8 @@ pub use cgroup::{
 pub use pressure::MemoryPressure;
 pub use reservation::{
     ForegroundAdmissionTimeout, ForegroundMemoryReservation, MemoryPermit, MmapMemoryPermit,
-    ResponseStreamAdmissionError, ResponseStreamAdmissionPatience, ResponseStreamMemoryPermit,
-    ResponseTransportGuard, TransientMemoryReservation,
+    MmapRegion, ResponseStreamAdmissionError, ResponseStreamAdmissionPatience,
+    ResponseStreamMemoryPermit, ResponseTransportGuard, TransientMemoryReservation,
 };
 
 use pools::MemoryPools;
@@ -66,6 +67,11 @@ fn forced_memory_pressure_for_tests() -> Option<MemoryPressure> {
     parse_forced_memory_pressure(&std::env::var("KURA_TEST_FORCE_MEMORY_PRESSURE").ok()?)
 }
 
+struct MmapRegionEntry {
+    mappings: usize,
+    _permit: OwnedSemaphorePermit,
+}
+
 struct MemoryControllerInner {
     runtime_limit_bytes: u64,
     soft_limit_bytes: u64,
@@ -88,6 +94,8 @@ struct MemoryControllerInner {
     response_stream_notify_without_waiters: AtomicBool,
     state: AtomicU8,
     pressure_changed: Notify,
+    /// Mapped regions currently lent out, each holding its pool permit once.
+    mmap_regions: StdMutex<HashMap<MmapRegion, MmapRegionEntry>>,
     pools: MemoryPools,
     metrics: Metrics,
 }
@@ -209,6 +217,7 @@ impl MemoryController {
                 response_stream_notify_without_waiters: AtomicBool::new(false),
                 state: AtomicU8::new(MemoryPressure::Normal.as_u8()),
                 pressure_changed: Notify::new(),
+                mmap_regions: StdMutex::new(HashMap::new()),
                 pools,
                 metrics,
             }),
@@ -651,21 +660,70 @@ impl MemoryController {
         self.inner.pools.mmap_serving_bytes()
     }
 
-    pub fn try_acquire_mmap_serving(&self, requested_bytes: usize) -> Option<MmapMemoryPermit> {
+    /// Lends `region` out of the mmap pool, charging `requested_bytes` (the
+    /// page-aligned span) once per distinct region rather than once per
+    /// mapping. Mapped bytes are clean, resident page cache with their own
+    /// try-only pool; the transient budget covers unreclaimable anonymous work
+    /// and is charged separately by the response-stream admission. Charging the
+    /// mapped span there as well exhausted transient once the mmap pool filled,
+    /// and the degraded response pool, which needs a small transient
+    /// reservation per stream, could then admit nothing.
+    pub fn try_acquire_mmap_serving(
+        &self,
+        region: MmapRegion,
+        requested_bytes: usize,
+    ) -> Option<MmapMemoryPermit> {
         if requested_bytes == 0 || self.should_reclaim_file_cache() {
             return None;
         }
-        let permits = u32::try_from(requested_bytes).ok()?;
-        // Mapped bytes are clean, resident page cache with their own try-only
-        // pool; the transient budget covers unreclaimable anonymous work and is
-        // charged separately by the response-stream admission. Charging the
-        // mapped span there as well exhausted transient once the mmap pool
-        // filled, and the degraded response pool, which needs a small transient
-        // reservation per stream, could then admit nothing.
-        let concurrency = self.inner.pools.try_acquire_mmap_serving(permits)?;
+        let mut regions = self
+            .inner
+            .mmap_regions
+            .lock()
+            .expect("mmap region lock poisoned");
+        if let Some(entry) = regions.get_mut(&region) {
+            entry.mappings += 1;
+        } else {
+            let permits = u32::try_from(requested_bytes).ok()?;
+            let permit = self.inner.pools.try_acquire_mmap_serving(permits)?;
+            regions.insert(
+                region.clone(),
+                MmapRegionEntry {
+                    mappings: 1,
+                    _permit: permit,
+                },
+            );
+        }
+        drop(regions);
         Some(MmapMemoryPermit {
-            _concurrency: concurrency,
+            controller: self.clone(),
+            region,
         })
+    }
+
+    fn release_mmap_region(&self, region: &MmapRegion) {
+        let mut regions = self
+            .inner
+            .mmap_regions
+            .lock()
+            .expect("mmap region lock poisoned");
+        let Some(entry) = regions.get_mut(region) else {
+            return;
+        };
+        entry.mappings = entry.mappings.saturating_sub(1);
+        if entry.mappings == 0 {
+            regions.remove(region);
+        }
+    }
+
+    /// Distinct mapped regions currently charged to the mmap pool.
+    #[cfg(test)]
+    fn mapped_region_count(&self) -> usize {
+        self.inner
+            .mmap_regions
+            .lock()
+            .expect("mmap region lock poisoned")
+            .len()
     }
 
     pub fn response_streaming_pool_bytes(&self) -> usize {
@@ -972,6 +1030,14 @@ impl MemoryController {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn mmap_region(source: &str, len: usize) -> MmapRegion {
+        MmapRegion {
+            source: Arc::from(source),
+            offset: 0,
+            len: len as u64,
+        }
+    }
     use crate::{
         constants::RESPONSE_STREAM_MIN_CHUNK_BYTES,
         memory::reservation::RESPONSE_STREAM_ADMISSION_TIMEOUT,
@@ -1130,7 +1196,11 @@ mod tests {
             MemoryPressure::Normal
         );
         assert!(controller.should_reclaim_file_cache());
-        assert!(controller.try_acquire_mmap_serving(1).is_none());
+        assert!(
+            controller
+                .try_acquire_mmap_serving(mmap_region("probe", 1), 1)
+                .is_none()
+        );
         assert!(controller.allow_background_admission());
         assert!(controller.allow_segment_refresh());
         assert!(controller.allow_manifest_cache_admission());
@@ -1151,7 +1221,11 @@ mod tests {
             MemoryPressure::Normal
         );
         assert!(!controller.should_reclaim_file_cache());
-        assert!(controller.try_acquire_mmap_serving(1).is_some());
+        assert!(
+            controller
+                .try_acquire_mmap_serving(mmap_region("probe", 1), 1)
+                .is_some()
+        );
         assert!(controller.allow_background_admission());
     }
 
@@ -1423,21 +1497,66 @@ mod tests {
         let controller = MemoryController::new(metrics, 128 * 1024 * 1024, 256 * 1024 * 1024);
 
         let permit = controller
-            .try_acquire_mmap_serving(64 * 1024 * 1024)
+            .try_acquire_mmap_serving(mmap_region("a", 64 * 1024 * 1024), 64 * 1024 * 1024)
             .expect("permit should be available");
         // Mapped pages are bounded by the mmap pool alone; they never consume
         // the transient budget that anonymous response buffers draw from.
         assert_eq!(controller.transient_reserved_bytes(), 0);
         assert!(
             controller
-                .try_acquire_mmap_serving(65 * 1024 * 1024)
+                .try_acquire_mmap_serving(mmap_region("b", 65 * 1024 * 1024), 65 * 1024 * 1024)
                 .is_none()
         );
 
         drop(permit);
         controller.observe(128 * 1024 * 1024);
         assert_eq!(controller.transient_reserved_bytes(), 0);
-        assert!(controller.try_acquire_mmap_serving(1).is_none());
+        assert!(
+            controller
+                .try_acquire_mmap_serving(mmap_region("c", 1), 1)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn mmap_serving_charges_a_region_once_across_concurrent_mappings() {
+        let metrics = Metrics::new("eu-west".into(), "tenant".into());
+        let controller = MemoryController::new(metrics, 128 * 1024 * 1024, 192 * 1024 * 1024);
+        assert_eq!(controller.mmap_serving_pool_bytes(), 64 * 1024 * 1024);
+        let span = 48 * 1024 * 1024;
+
+        // Two responses mapping the same artifact alias the same page-cache
+        // pages, so the pool sees one region, and a second distinct region of
+        // the same size no longer fits.
+        let first = controller
+            .try_acquire_mmap_serving(mmap_region("hot", span), span)
+            .expect("first mapping fits the pool");
+        let second = controller
+            .try_acquire_mmap_serving(mmap_region("hot", span), span)
+            .expect("a concurrent mapping of the same region is free");
+        assert_eq!(controller.mapped_region_count(), 1);
+        assert!(
+            controller
+                .try_acquire_mmap_serving(mmap_region("cold", span), span)
+                .is_none()
+        );
+
+        // The region stays charged until its last mapping drops.
+        drop(first);
+        assert_eq!(controller.mapped_region_count(), 1);
+        assert!(
+            controller
+                .try_acquire_mmap_serving(mmap_region("cold", span), span)
+                .is_none()
+        );
+        drop(second);
+        assert_eq!(controller.mapped_region_count(), 0);
+        let cold = controller
+            .try_acquire_mmap_serving(mmap_region("cold", span), span)
+            .expect("the released region's permits are available again");
+        assert_eq!(controller.mapped_region_count(), 1);
+        drop(cold);
+        assert_eq!(controller.mapped_region_count(), 0);
     }
 
     #[tokio::test]
@@ -1452,7 +1571,10 @@ mod tests {
         controller.observe(0);
 
         let mapped = controller
-            .try_acquire_mmap_serving(controller.mmap_serving_pool_bytes())
+            .try_acquire_mmap_serving(
+                mmap_region("whole-pool", controller.mmap_serving_pool_bytes()),
+                controller.mmap_serving_pool_bytes(),
+            )
             .expect("the whole mmap pool should be available");
         let mut streams = Vec::new();
         while let Ok(stream) =

--- a/kura/src/memory/reservation.rs
+++ b/kura/src/memory/reservation.rs
@@ -47,7 +47,6 @@ impl MemoryPermit {
 
 pub struct MmapMemoryPermit {
     pub(super) _concurrency: OwnedSemaphorePermit,
-    pub(super) _transient: TransientMemoryReservation,
 }
 
 pub struct ResponseStreamMemoryPermit {

--- a/kura/src/memory/reservation.rs
+++ b/kura/src/memory/reservation.rs
@@ -45,8 +45,28 @@ impl MemoryPermit {
     }
 }
 
+/// Identity of a mapped file region. The mmap pool charges each distinct
+/// region once, however many concurrent responses map it: mappings of the same
+/// file pages alias the same page-cache pages, so the physical footprint does
+/// not grow with the number of readers.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct MmapRegion {
+    pub source: Arc<str>,
+    pub offset: u64,
+    pub len: u64,
+}
+
+/// One mapping's share of a region's pool charge. The pool permit is held by
+/// the region entry and released when the last mapping of that region drops.
 pub struct MmapMemoryPermit {
-    pub(super) _concurrency: OwnedSemaphorePermit,
+    pub(super) controller: MemoryController,
+    pub(super) region: MmapRegion,
+}
+
+impl Drop for MmapMemoryPermit {
+    fn drop(&mut self) {
+        self.controller.release_mmap_region(&self.region);
+    }
 }
 
 pub struct ResponseStreamMemoryPermit {

--- a/kura/src/mmap.rs
+++ b/kura/src/mmap.rs
@@ -298,7 +298,14 @@ mod tests {
             192 * 1024 * 1024,
         );
         let permit = memory
-            .try_acquire_mmap_serving(bytes.max(1))
+            .try_acquire_mmap_serving(
+                crate::memory::MmapRegion {
+                    source: std::sync::Arc::from("test"),
+                    offset: 0,
+                    len: bytes.max(1) as u64,
+                },
+                bytes.max(1),
+            )
             .expect("permit should be acquired");
         (memory, permit)
     }

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -50,7 +50,7 @@ use crate::{
         FOREGROUND_FILE_CACHE_DROP_INTERVAL_BYTES, FileCachePolicy, reserve_foreground_staging,
     },
     io::{IoController, PersistentFile},
-    memory::MemoryController,
+    memory::{MemoryController, MmapRegion},
     mmap::{map_file_region, mapped_span_bytes},
     multipart::{error::MultipartError, part::MultipartPart, upload::MultipartUpload},
     replication::{operation::ReplicationOperation, outbox_message::OutboxMessage},
@@ -1997,7 +1997,15 @@ impl Store {
             let Some(requested_bytes) = mapped_span_bytes(offset, manifest.size) else {
                 return Ok(None);
             };
-            let Some(permit) = self.memory.try_acquire_mmap_serving(requested_bytes) else {
+            let region = MmapRegion {
+                source: Arc::from(segment_id.as_str()),
+                offset,
+                len: manifest.size,
+            };
+            let Some(permit) = self
+                .memory
+                .try_acquire_mmap_serving(region, requested_bytes)
+            else {
                 return Ok(None);
             };
             let handle = self.segment_handle(segment_id).await?;
@@ -2016,7 +2024,15 @@ impl Store {
             let Some(requested_bytes) = mapped_span_bytes(0, manifest.size) else {
                 return Ok(None);
             };
-            let Some(permit) = self.memory.try_acquire_mmap_serving(requested_bytes) else {
+            let region = MmapRegion {
+                source: Arc::from(blob_path.as_str()),
+                offset: 0,
+                len: manifest.size,
+            };
+            let Some(permit) = self
+                .memory
+                .try_acquire_mmap_serving(region, requested_bytes)
+            else {
                 return Ok(None);
             };
             let handle = self.blob_handle(blob_path).await?;


### PR DESCRIPTION
## What changed

Two commits.

1. `MemoryController::try_acquire_mmap_serving` no longer takes a transient-memory reservation alongside its mmap-pool permit.
2. The mmap pool is charged once per mapped **region** (segment or blob, offset, length) instead of once per response. `MmapMemoryPermit` now identifies its region; the first mapping of a region takes the pool permits, later concurrent mappings of the same region share them, and the permits are released when the last mapping drops. Mappings of the same file pages alias the same page-cache pages, so this makes the pool bound distinct mapped bytes, which is what the kernel can actually hold. On the throwaway cluster 252 mappings of one 2 MiB artifact had "filled" a 512 MiB pool that physically held 2 MiB, and every later reader was pushed onto the streaming path, which copies chunks into anonymous memory.

`MemoryController::try_acquire_mmap_serving` no longer takes a transient-memory reservation alongside its mmap-pool permit; `MmapMemoryPermit` now carries only the pool permit. The existing mmap test asserts transient stays at zero; one new test fills the mmap pool plus the fixed and elastic response pools and asserts that a degraded response admission still succeeds; another asserts that two concurrent mappings of one region hold one pool charge, a second distinct region of the same size is refused while it is held, and the charge is released only when the last mapping drops.

## Why

Found while load-testing #12827 on a throwaway cluster. Ramping 600 non-reading HTTP/1.1 clients against a 2 MiB artifact on one kura pod: 252 reads were served through mmap and 32 through the streaming reader (284 active), `kura_response_stream_reserved_bytes` sat at 545 MB, and `kura_memory_transient_reserved_bytes` sat at exactly 1 GiB, the whole transient budget. Every further public read then timed out on normal admission (250 ms degradable patience), fell to the degraded path, failed it with `outcome="degraded_memory_unavailable"`, and was shed with 429: 632 sheds out of 600 clients across two runs, zero degraded admissions. The degraded pool exists precisely for the moment the normal pools are full, and it was unreachable at that moment.

## Root cause

An mmap-served read is charged to transient twice: once by the response-stream admission (chunk-sized send buffers, the same charge every stream pays) and once more for the whole mapped span by `try_acquire_mmap_serving`. With a 512 MiB mmap pool that second charge alone consumes half the 1 GiB transient budget, and the elastic response pool is derived on the assumption that transient holds each response charge once (`transient − response − transient/4`). The overlap pushes transient to 100% before the pools that feed the degraded path are exhausted, and the degraded admission needs an 80 KiB transient reservation per stream.

The mapped span charge was added in #12009 when the permit type was introduced. `docs/architecture.md` already describes the intended design: "Mapped-file serving has a separate try-only bound because it covers already-resident reclaimable pages", and the transient budget is documented as the bound on unreclaimable anonymous work. The mmap pool is that separate bound; the transient charge duplicated it.

## Why this fix

Dropping the extra reservation restores the documented single-charge model with no new knob: mapped bytes are bounded once by the mmap pool (still try-only and still refused under file-cache reclaim), and the response-stream admission keeps charging the send buffers. The alternative, carving a dedicated transient slice for degraded streams, would add a third partition and still leave mapped pages counted as anonymous memory.

## Impact

Under a full response pool a node now degrades public reads to the bounded 8 KiB pool instead of shedding them, as designed. Nodes that serve mostly mmap-backed reads gain back up to the mmap pool size (512 MiB on large instances) of transient headroom for uploads, materialization, and degraded streams. No wire, disk, or configuration change.

## Validation

- `cargo test --lib memory::tests::degraded_reads_stay_admissible_while_mmap_serving_holds_its_pool`: passes; with the transient reservation put back it fails with `degraded admission failed: QueueFull`.
- Full kura unit suite: 849 passed, 0 failed; `cargo clippy --all-targets` and `cargo fmt --check` clean.
- Local docker A/B, one standalone node per build (`kura-local:main` from `origin/main`, `kura-local:mmapfix` from this branch), acceleration disabled so reads go through hyper and the admission pools, a 2 MiB artifact, and a sibling container ramping non-reading HTTP/1.1 clients at 4/s against the node's container IP (a host-side client is absorbed by the port-forward proxy and never stalls the node).

  With the production-shaped 1 GiB transient budget, transient reserved on main tracks the response reservations plus exactly 2 MiB per mapped stream (681.6 MB = 539 MB + 68 × 2 MiB at 320 streams); on this branch it equals the response reservations exactly (524.3 MB = 524.3 MB). A single node with 320 clients does not run that budget dry, so the shed behaviour was reproduced with the soft-to-hard gap set to 256 MiB (transient 256 MiB, response pool 128 MiB), 240 clients:

  | | main | this branch |
  |---|---:|---:|
  | transient reserved once 64 streams are mapped | 268,435,456 (100%) | 134,217,728 |
  | streams admitted | 64 | 240 |
  | degraded admissions | 0 | 147 |
  | sheds (429), all `degraded_memory_unavailable` on main | 176 | 0 |

  On main the 64th mapping (64 × 4 MiB) fills transient and every later read times out on normal admission, fails degraded admission for want of 80 KiB, and is shed. On this branch the same node maps 134 streams, fills its response pools, and then admits every remaining read through the degraded pool.

### Does this raise OOM risk?

No. Mapped artifact pages are clean, file-backed page cache from a `MAP_PRIVATE`/`PROT_READ` mapping with no `mlock`, `MAP_POPULATE`, or `MADV_WILLNEED` (`src/mmap.rs`); the kernel reclaims them under the cgroup limit even while mapped. Kura's admission already follows `pressure_bytes`, which counts only memory that can kill the container (anon, unreclaimable kernel charge, shmem, sock, dirty, writeback), the transient budget remains capped at the soft-to-hard gap, and both reclaim arms still deny new mmap grants. This change only stops spending the anonymous budget on reclaimable pages.

Measured on the local nodes with a 1.5 GiB container limit (soft 700 MiB, hard 1300 MiB, transient 600 MiB), 600 stalled HTTP/1.1 clients at 8/s on a 2 MiB artifact:

| | main | this branch |
|---|---:|---:|
| streams admitted | 600 | 600 |
| served via mmap / streaming reader | 36 / 564 | 335 / 488 |
| peak cgroup `memory.current` | 226 MB | 126 MB |
| peak anon | 201 MB | 103 MB |
| `file_mapped` | ≤ 12 MB | ≤ 11 MB |
| `oom_kill` events | 0 | 0 |

The fixed node uses about half the memory for the same load: streams that get an mmap grant hand hyper zero-copy page-cache slices, whereas on main the double charge starves the mmap pool early and pushes those streams onto the streaming reader, which copies every chunk into anonymous memory. `file_mapped` stays around 10 MB with 335 mappings because mappings of the same artifact share physical page-cache pages; the pool's span accounting is an upper bound on distinct pages, not a per-stream cost.

### Same artifact, production-shaped budget, pages kept resident

Local docker nodes with the k05 KuraInstance watermarks (4 GiB limit, transient 1 GiB, mmap pool 512 MiB), a sibling container re-reading the segment every second so the residency gate does not interfere (the OrbStack VM otherwise evicts page cache within seconds, which is why earlier local runs saw few mappings), 320 stalled clients of one 2 MiB artifact at 4/s:

| | main | this branch (both commits) |
|---|---:|---:|
| transient reserved vs response reserved | 1023 MB vs 513 MB (2×) | 604 MB vs 604 MB |
| served via mmap | 271, capped at 256 concurrent (pool = 256 × 2 MiB) | 302, one 2 MiB region charged |
| streams admitted | 269 of 320 | 320 of 320 |
| sheds (429), all `degraded_memory_unavailable` | 51 | 0 |
| peak cgroup `memory.current` / `file_mapped` | 57 MB / 13 MB | 67 MB / 7 MB |

This is the k05 failure reproduced end to end on main: transient fills at exactly the point the mmap pool does, and from then on every public read is shed while the pod is using under 60 MB of real memory.

### Distinct artifacts, production-shaped budget, pages kept resident

Same nodes and budget as above (transient 1 GiB, mmap pool 512 MiB, response pools 322 + 316 MiB), 320 distinct 2 MiB artifacts (640 MiB, more than the pool), 640 stalled clients at 8/s spread across them so each artifact is read by two clients:

| | main | this branch (both commits) |
|---|---:|---:|
| distinct regions mapped when the pool fills | 256 | 256 |
| reads served through mmap | 257 | 512 (the second reader of each mapped artifact shares its region) |
| transient reserved at that point | 1023 MB (pool full and transient full at the same moment) | 561 MB |
| streams admitted | 269 of 640 | 640 of 640 |
| degraded admissions | 12 | 324 |
| sheds (429), all `degraded_memory_unavailable` | 371 | 0 |
| `oom_kill` | 0 | 0 |

On main, filling the 512 MiB mmap pool with distinct regions costs 4 MiB of transient per stream (2 MiB span + 2 MiB response charge), so the 1 GiB transient budget is exhausted exactly when the pool is, and every read after the 269th is shed. On this branch the pool fills at the same 256 distinct regions (the bound on mapped bytes is unchanged), the second reader of each artifact is served from the existing mapping at no pool cost, transient holds only the response charges, and the remaining 384 reads fall through to the streaming reader and the degraded pool as designed. Note that with a sibling container keeping pages resident, the page-cache charge lands on that container's cgroup, so `file_mapped` in kura's cgroup understates the mapped footprint in these resident runs; the earlier tight-limit run without the keeper is the one that exercised kernel reclaim.

### Distinct artifacts under a tight limit

Same 1.5 GiB-limit configuration as the OOM table above, 320 distinct 2 MiB artifacts, 640 stalled clients spread across them: both builds admitted all 640 (528 through the degraded pool), 0 sheds, 0 `oom_kill`. `file_mapped` never exceeded 37 MB on either build and `workingset_refault_file` climbed steadily throughout, i.e. the kernel was reclaiming clean mapped pages under the limit and kura kept serving; mappings are only handed out for pages already resident (`mincore`), so the mapped footprint tracks what the kernel chooses to keep, not the pool size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




