### PR TITLE
feat(infra): expose Bazel event origin

### DIFF
--- a/infra/helm/tuist/templates/server-bazel-events-ingress.yaml
+++ b/infra/helm/tuist/templates/server-bazel-events-ingress.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.server.enabled .Values.server.bazelEvents.enabled }}
+{{- $serviceName := include "tuist.componentName" (dict "root" . "component" "server") }}
+{{- $ingress := .Values.server.bazelEvents }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tuist.componentName" (dict "root" . "component" "server-bazel-events") }}
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  {{- with $ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- if $ingress.tlsSecretName }}
+  tls:
+    - hosts:
+        - {{ required "server.bazelEvents.host is required when its ingress is enabled" $ingress.host | quote }}
+      secretName: {{ $ingress.tlsSecretName | quote }}
+  {{- end }}
+  rules:
+    - host: {{ required "server.bazelEvents.host is required when its ingress is enabled" $ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  name: http
+{{- end }}

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -123,6 +123,11 @@ server:
       nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 
+  bazelEvents:
+    enabled: true
+    host: build-canary.tuist.dev
+    tlsSecretName: tuist-tls-cloudflare-origin
+
   # Request sized so a surge pod (chart-default maxSurge: 1) co-schedules
   # alongside the live pod on the 2-worker canary nodepool. Steady-state
   # working set is ~700 MiB; the 2 GiB limit absorbs that under load.

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -261,6 +261,11 @@ server:
       nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 
+  bazelEvents:
+    enabled: true
+    host: build.tuist.dev
+    tlsSecretName: tuist-tls-cloudflare-origin
+
   # Full prod resource envelope — sized against the ccx23 worker.
   resources:
     requests:

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -250,6 +250,11 @@ server:
       nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 
+  bazelEvents:
+    enabled: true
+    host: build-staging.tuist.dev
+    tlsSecretName: tuist-tls-cloudflare-origin
+
   autoscaling:
     enabled: false
 

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -423,6 +423,19 @@ server:
     type: ClusterIP
     port: 80
     targetPort: 8080
+  # Dedicated HTTP origin for Bazel build events. Bazel Build Event Service
+  # traffic terminates at Kura, which forwards normalized events only to the
+  # authenticated server webhook exposed by this ingress.
+  bazelEvents:
+    enabled: false
+    className: nginx
+    host: ""
+    tlsSecretName: ""
+    annotations:
+      external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+      nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+      nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
   resources: {}
   extraEnv: []
   # Additional env from Secrets or ConfigMaps. List of objects with


### PR DESCRIPTION
## What changed

Adds an optional `bazelEvents` ingress to the Tuist Helm chart. Managed staging, canary, and production deployments enable it at their respective `build` hostnames and route the build origin to the existing server HTTP service.

## Why

Bazel build-event traffic needs an independently addressable origin without exposing a second server protocol listener.

## Approach

Bazel's [Build Event Service](https://bazel.build/remote/bep) remains on Kura, which forwards normalized events to Tuist. The dedicated hostname is the routing boundary, so the ingress forwards all paths to the server. Only Kura's Bazel-event callback is configured to use that origin today. The ingress is disabled by default for self-hosted deployments and uses the same Cloudflare proxy intent, request-body limit, request-buffering behavior, and response-header buffer size as the main server ingress.

## Impact

Managed environments gain `build.tuist.dev`, `build-staging.tuist.dev`, and `build-canary.tuist.dev` for Bazel event traffic. No extra container port, Kubernetes Service port, or server listener is introduced.

## Validation

- Rendered the chart for self-hosted and staging value combinations.
- Confirmed the build hostname routes `/` to the server service.
- Ran `helm lint` successfully for the self-hosted value set.
- Ran `git diff --check`.

### How to test locally

```sh
helm template tuist infra/helm/tuist \
  -f infra/helm/tuist/values-self-hosted-ci.yaml \
  --set server.bazelEvents.enabled=true \
  --set server.bazelEvents.host=build.example.test \
  --set server.bazelEvents.tlsSecretName=build-tls
```
