### PR TITLE
fix(infra): measure runner starvation on the pool, not on a recycled Pod

### DIFF
--- a/infra/helm/tuist/crds/tuist.dev_runnerpools.yaml
+++ b/infra/helm/tuist/crds/tuist.dev_runnerpools.yaml
@@ -252,3 +252,7 @@ spec:
                   type: string
                   format: date-time
                   description: Timestamp the controller last observed spec.image change. The server-side dispatch endpoint uses this to stagger HTTP 410 drain responses across a rolling window so the warm pool doesn't drop to zero on every digest-pin bump.
+                unplaceableSince:
+                  type: string
+                  format: date-time
+                  description: Timestamp this pool most recently began holding demand the scheduler could not place, and has held continuously since; absent when the pool is placing everything it wants. The node-reservation state machine reads it to decide when a pool has waited long enough to be worth draining a host for, and which of several starved pools on a fleet goes first. It lives here rather than being derived from Pod ages because the reaper recycles unplaced Pods every startTimeoutSeconds, which would restart a per-Pod clock before a drain could ever converge.

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -1449,19 +1449,31 @@ runnersFleetLinux:
     # Default shape: all `tuist-default` + `linux` default-profile
     # (`tuist-linux`) traffic lands here, so it carries the fleet's warm
     # floor. Sized against RAM, not slots: request == limit == the
-    # advertised shape, so the floor reserves `floor * 8 GiB` on a
-    # ~504 GiB fleet whether or not those Pods ever touch it. At 30 it
-    # reserved 240 GiB and left no 16 GiB hole, so `4vcpu-16gb` could
-    # not place a single Pod while running well under a third of the
-    # fleet's real memory. 12 sits above observed concurrent demand and
-    # leaves the heavier shapes room to schedule. Revisit alongside
-    # decoupling the scheduler request from the shape limit, which is
-    # what would let the floor be a slot count again.
+    # advertised shape, so the floor reserves `floor * 10.5 GiB` (8 GiB
+    # + the kata RuntimeClass's 2.5 GiB podFixed) on the fleet whether or
+    # not those Pods ever touch it. At 30 it reserved 315 GiB and left no
+    # 16 GiB hole, so `4vcpu-16gb` could not place a single Pod while
+    # running well under a third of the fleet's real memory.
+    #
+    # 12 was set against "observed concurrent demand" but measured well
+    # above it. Over the 7 days to 2026-09-04 this pool averaged 2.2
+    # occupied runners against 13.2 idle — 86% idle, with the floor
+    # itself as the reason. On the 4-node OVH RISE-L fleet that is
+    # ~138 GiB of a ~467 GiB fleet held by Pods doing nothing, against a
+    # `16vcpu-32gb` Pod that needs a contiguous 34.5 GiB and spent
+    # 2026-09-04 07:23-08:36 unable to find one.
+    #
+    # 4 still covers the p50 of occupied runners with headroom, and the
+    # jobs behind it are short — this shape's median runtime is under
+    # three minutes, so a cold start on the marginal Pod is a small share
+    # of a small job. Revisit alongside decoupling the scheduler request
+    # from the shape limit, which is what would let the floor be a slot
+    # count again.
     - vcpus: 2
       memoryGb: 8
       default: true
       autoscaling:
-        minWarmPoolFloor: 12
+        minWarmPoolFloor: 4
     - { vcpus: 4, memoryGb: 8 }
     - { vcpus: 4, memoryGb: 16 }
     - { vcpus: 8, memoryGb: 16 }

--- a/infra/runners-controller/api/v1alpha1/runnerpool_types.go
+++ b/infra/runners-controller/api/v1alpha1/runnerpool_types.go
@@ -340,6 +340,23 @@ type RunnerPoolStatus struct {
 	// replicas and survives a restart mid-rollout.
 	// +optional
 	ImageRolledAt metav1.Time `json:"imageRolledAt,omitempty"`
+
+	// UnplaceableSince is when this pool most recently began holding
+	// demand the scheduler could not place, and has held continuously
+	// since. Nil means the pool is placing everything it wants.
+	//
+	// It lives on the pool rather than being derived from Pod ages
+	// because the reaper deletes an unplaced Pod at
+	// `provisioning.startTimeoutSeconds` (300s by default) and the pool
+	// immediately recreates it. A starvation clock read from
+	// `pod.CreationTimestamp` therefore restarts every five minutes and
+	// can never measure a starvation longer than one reap cycle — which
+	// is exactly the window a node reservation needs to converge. The
+	// reservation state machine reads this to decide both when a pool
+	// has waited long enough to be worth draining a host for, and which
+	// of several starved pools on a fleet goes first.
+	// +optional
+	UnplaceableSince *metav1.Time `json:"unplaceableSince,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/infra/runners-controller/controllers/reservation.go
+++ b/infra/runners-controller/controllers/reservation.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -136,11 +137,12 @@ func (r *RunnerPoolReconciler) reconcileReservation(
 
 	value := podtemplate.ReservationValue(pool.Name)
 	held := reservedNode(nodes, value)
-	starved := starvedPod(pods, now)
+	starvedFor := trackStarvation(pool, pods, now)
+	starved := starvedFor >= reservationGrace
 
 	if held != nil {
 		switch {
-		case starved == nil:
+		case starvedFor == 0:
 			logger.Info("releasing node reservation; pool is served", "node", held.Name, "pool", pool.Name)
 			return r.releaseReservation(ctx, held, time.Time{})
 		case reservationAge(held, now) > reservationTimeout:
@@ -153,10 +155,35 @@ func (r *RunnerPoolReconciler) reconcileReservation(
 		}
 	}
 
-	if starved == nil {
+	if !starved {
 		return nil
 	}
 	if reservationCount(nodes) >= maxFleetReservations {
+		return nil
+	}
+
+	// Oldest starvation goes first. Without this the fleet's single
+	// reservation is handed out in reconcile order, and the shapes that
+	// need it least win: a granular shape is starved often and converges
+	// in seconds, so it takes the slot, releases, and takes it again,
+	// while the coarse shape — the only one that genuinely cannot be
+	// served without a drain — waits behind pools that were merely
+	// queued. Production ran exactly that on 2026-09-04: the 16 vCPU
+	// pool waited 07:23 to 08:36 while 2, 4 and 8 vCPU pools cycled
+	// through the slot.
+	//
+	// Ordering on starvation age rather than on shape size keeps the
+	// rule symmetric. The opposite failure is on record too — a big
+	// pool holding the fleet-wide provisioning budget while the default
+	// shape was admitted nothing and the deploy cascade queued behind
+	// it — and a size-ordered rule would have made that one worse.
+	ahead, err := r.longerStarvedPool(ctx, pool, nodes, now)
+	if err != nil {
+		return err
+	}
+	if ahead != "" {
+		logger.V(1).Info("yielding the fleet reservation to a pool starved longer",
+			"pool", pool.Name, "waitingFor", ahead, "starvedFor", starvedFor.String())
 		return nil
 	}
 
@@ -204,32 +231,175 @@ func (r *RunnerPoolReconciler) reconcileReservation(
 	}
 
 	logger.Info("reserving node to fit a starved runner",
-		"node", target.Name, "pool", pool.Name, "pod", starved.Name)
+		"node", target.Name, "pool", pool.Name,
+		"pod", unplacedPodName(pods), "starvedFor", starvedFor.String())
 	return r.reserveNode(ctx, target, value, now)
 }
 
-// starvedPod returns a Pod that has waited past the grace period with no
-// node assigned. Phase is not the test on its own — an unscheduled Pod
-// and a Pod whose VM is still booting are both Pending — so this asks
-// for an empty `spec.nodeName`, which only an unplaced Pod has.
-func starvedPod(pods []corev1.Pod, now time.Time) *corev1.Pod {
-	var oldest *corev1.Pod
+// trackStarvation folds the pool's current placement state into
+// `status.UnplaceableSince` and returns how long it has been starved.
+// Zero means nothing is waiting.
+//
+// The caller mutates the pool in place; the reconciler's existing
+// `Status().Update` at the end of the pass persists it, the same way
+// `ObservedImage`/`ImageRolledAt` are handled.
+//
+// This replaces a per-Pod age test. Measuring starvation on a Pod's own
+// `CreationTimestamp` cannot work while the reaper deletes unplaced Pods
+// at `startTimeoutSeconds` and the pool recreates them: a Pod only
+// counted as starved between the 2-minute grace and the 5-minute reap,
+// so the moment a cohort was reaped together the replacements were all
+// too young, the pool read as "served", and a reservation part-way
+// through draining a host was thrown away. Production, 2026-09-04
+// 08:24:24: a reap and a "pool is served" release in the same second,
+// with the pool going 3 -> 2 -> 1 -> 0 Running across the window.
+func trackStarvation(pool *tuistv1.RunnerPool, pods []corev1.Pod, now time.Time) time.Duration {
+	if !poolUnplaceable(pool, pods) {
+		pool.Status.UnplaceableSince = nil
+		return 0
+	}
+	if pool.Status.UnplaceableSince == nil {
+		// Seed from the oldest Pod still waiting rather than from now.
+		// The stamp is the only durable record of the wait, so a
+		// controller restart — or the first reconcile after this field
+		// was introduced — would otherwise forgive every starvation in
+		// flight and make a Pod that has waited an hour look brand new.
+		start := now
+		if oldest := oldestUnplacedCreation(pods); !oldest.IsZero() && oldest.Before(start) {
+			start = oldest
+		}
+		stamp := metav1.NewTime(start)
+		pool.Status.UnplaceableSince = &stamp
+	}
+	if elapsed := now.Sub(pool.Status.UnplaceableSince.Time); elapsed > 0 {
+		return elapsed
+	}
+	// A starvation that starts this instant has lasted no time, but it
+	// IS a starvation — a flat zero would read as "served" and release
+	// a reservation that is still needed.
+	return time.Nanosecond
+}
+
+// oldestUnplacedCreation is the creation time of the longest-waiting
+// unplaced Pod, or the zero time when nothing is waiting.
+func oldestUnplacedCreation(pods []corev1.Pod) time.Time {
+	var oldest time.Time
 	for i := range pods {
 		pod := &pods[i]
-		if pod.Spec.NodeName != "" || !pod.DeletionTimestamp.IsZero() {
+		if !isAlive(pod) || pod.Spec.NodeName != "" {
 			continue
 		}
-		if pod.Status.Phase != corev1.PodPending {
-			continue
-		}
-		if now.Sub(pod.CreationTimestamp.Time) < reservationGrace {
-			continue
-		}
-		if oldest == nil || pod.CreationTimestamp.Time.Before(oldest.CreationTimestamp.Time) {
-			oldest = pod
+		created := pod.CreationTimestamp.Time
+		if oldest.IsZero() || created.Before(oldest) {
+			oldest = created
 		}
 	}
 	return oldest
+}
+
+// poolUnplaceable reports whether the pool is holding demand it has not
+// placed: an unscheduled Pod, or fewer bound Pods than `spec.replicas`.
+//
+// The second clause is what makes the signal survive the reap. Between
+// the reaper deleting an unplaced Pod and the converge loop recreating
+// it, the pool can momentarily own no unplaced Pod at all while being no
+// better served than it was a second earlier. `spec.replicas` is set by
+// the autoscaler from real demand and is untouched by the reap, so it
+// still reports the gap across that window.
+func poolUnplaceable(pool *tuistv1.RunnerPool, pods []corev1.Pod) bool {
+	bound := 0
+	unplaced := 0
+	for i := range pods {
+		pod := &pods[i]
+		if !isAlive(pod) {
+			continue
+		}
+		if pod.Spec.NodeName == "" {
+			unplaced++
+			continue
+		}
+		bound++
+	}
+	return unplaced > 0 || bound < int(pool.Spec.Replicas)
+}
+
+// unplacedPodName names an unplaced Pod for the reservation log line.
+// Purely for reporting — the decision is the pool-level clock above.
+func unplacedPodName(pods []corev1.Pod) string {
+	for i := range pods {
+		pod := &pods[i]
+		if isAlive(pod) && pod.Spec.NodeName == "" {
+			return pod.Name
+		}
+	}
+	return ""
+}
+
+// longerStarvedPool names a sibling on this fleet that has been unable
+// to place for longer than this pool and could still use a reservation.
+// Empty when this pool is first in line.
+func (r *RunnerPoolReconciler) longerStarvedPool(
+	ctx context.Context,
+	pool *tuistv1.RunnerPool,
+	nodes []corev1.Node,
+	now time.Time,
+) (string, error) {
+	mine := pool.Status.UnplaceableSince
+	if mine == nil {
+		return "", nil
+	}
+
+	var pools tuistv1.RunnerPoolList
+	if err := r.List(ctx, &pools, client.InNamespace(pool.Namespace)); err != nil {
+		return "", fmt.Errorf("list runner pools for reservation arbitration: %w", err)
+	}
+
+	for i := range pools.Items {
+		sibling := &pools.Items[i]
+		if sibling.Name == pool.Name || !sibling.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if sibling.Spec.OS != pool.Spec.OS || sibling.Spec.FleetSelector != pool.Spec.FleetSelector {
+			continue
+		}
+		since := sibling.Status.UnplaceableSince
+		if since == nil || !since.Time.Before(mine.Time) {
+			continue
+		}
+		if now.Sub(since.Time) < reservationGrace {
+			continue
+		}
+		// Only yield to a sibling a drain could actually serve. A shape
+		// no host can seat even empty never stops being starved, so
+		// yielding to it would not be waiting for a turn — it would be
+		// a permanent block, trading the starvation this fix removes
+		// for a worse one it introduced.
+		if !shapeSeatableOnFleet(nodes, podShape{
+			cpuMilli: sibling.Spec.PodCPUMilli,
+			memoryMB: sibling.Spec.PodMemoryMB,
+		}) {
+			continue
+		}
+		return sibling.Name, nil
+	}
+	return "", nil
+}
+
+// shapeSeatableOnFleet reports whether any healthy host could seat this
+// shape if it were empty.
+func shapeSeatableOnFleet(nodes []corev1.Node, shape podShape) bool {
+	if shape.cpuMilli <= 0 || shape.memoryMB <= 0 {
+		return false
+	}
+	for i := range nodes {
+		if nodeFilterReason(&nodes[i]) != "" {
+			continue
+		}
+		if nodeSeatsForShape(&nodes[i], shape) >= 1 {
+			return true
+		}
+	}
+	return false
 }
 
 // pickReservationTarget chooses the host to drain: one that could seat

--- a/infra/runners-controller/controllers/reservation_test.go
+++ b/infra/runners-controller/controllers/reservation_test.go
@@ -846,3 +846,148 @@ func TestReservation_SkipsHostsItsOwnPodAlreadyFills(t *testing.T) {
 		t.Fatal("should have reserved the host whose occupants can actually be cleared")
 	}
 }
+
+// starvedSince stamps a pool as having been unable to place since `ago`,
+// the state a pool reaches after its first reconcile with unplaced work.
+func starvedSince(pool *tuistv1.RunnerPool, ago time.Duration) *tuistv1.RunnerPool {
+	stamp := metav1.NewTime(reservationNow.Add(-ago))
+	pool.Status.UnplaceableSince = &stamp
+	return pool
+}
+
+// The regression this whole change exists for. The reaper deletes an
+// unplaced Pod at `startTimeoutSeconds` and the pool recreates it, so
+// every five minutes the pool's Pods are all younger than the two-minute
+// grace period. The old per-Pod age test read that as "pool is served"
+// and released a reservation part-way through draining a host, handing
+// the seats back to the small shapes that had taken them in the first
+// place. Production, 2026-09-04 08:24:24: a reap and a release logged in
+// the same second while the pool went 3 -> 2 -> 1 -> 0 Running.
+func TestReservation_SurvivesTheUnschedulableReapCycle(t *testing.T) {
+	pool := starvedSince(linuxLargePool(), 40*time.Minute)
+	pool.Spec.Replicas = 1
+	node := ax162Node("ax-0")
+	node.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue(pool.Name),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+	node.Annotations = map[string]string{
+		reservationAtAnnotation: reservationNow.Add(-3 * time.Minute).UTC().Format(time.RFC3339),
+	}
+
+	// The replacement the reaper's recreate just produced: far too young
+	// to have counted under the old rule.
+	fresh := pendingPod("large-replacement", pool.Name, 20*time.Second)
+
+	r := reservationReconciler(pool, linuxSmallPool(), node, ax162Node("ax-1"), fresh)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*fresh}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if !isReserved(nodeByName(t, r, "ax-0")) {
+		t.Fatal("released a reservation because the reaper had just recycled the Pod; the pool is not served")
+	}
+	if pool.Status.UnplaceableSince == nil {
+		t.Fatal("starvation clock cleared while demand was still unplaced")
+	}
+	if got := pool.Status.UnplaceableSince.Time; !got.Equal(reservationNow.Add(-40 * time.Minute)) {
+		t.Errorf("starvation clock restarted at %v; the reap must not reset it", got)
+	}
+}
+
+// A pool that has placed everything it wants is served, and must hand
+// the host back rather than sit on it until the timeout.
+func TestReservation_ClearsTheClockOncePlaced(t *testing.T) {
+	pool := starvedSince(linuxLargePool(), 40*time.Minute)
+	pool.Spec.Replicas = 1
+	node := ax162Node("ax-0")
+	node.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue(pool.Name),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+	placed := placedPod("large-0", pool.Name, "ax-0", "acme")
+
+	r := reservationReconciler(pool, linuxSmallPool(), node, ax162Node("ax-1"), placed)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*placed}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "ax-0")) {
+		t.Fatal("held a reservation for a pool whose demand is placed")
+	}
+	if pool.Status.UnplaceableSince != nil {
+		t.Error("starvation clock must clear once the pool places its demand")
+	}
+}
+
+// The fleet has one reservation and it went to whichever pool reconciled
+// first. Small shapes starve often and converge in seconds, so they kept
+// re-taking it while the coarse shape — the only one that cannot be
+// served without a drain — waited over an hour.
+func TestReservation_OldestStarvationGoesFirst(t *testing.T) {
+	small := starvedSince(linuxSmallPool(), 45*time.Minute)
+	small.Spec.Replicas = 1
+	large := starvedSince(linuxLargePool(), 5*time.Minute)
+	large.Spec.Replicas = 1
+	starved := pendingPod("large-0", large.Name, 5*time.Minute)
+
+	r := reservationReconciler(large, small, ax162Node("ax-0"), ax162Node("ax-1"), starved)
+	if err := r.reconcileReservation(context.Background(), large, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if isReserved(nodeByName(t, r, "ax-0")) || isReserved(nodeByName(t, r, "ax-1")) {
+		t.Fatal("took the fleet's only reservation ahead of a pool that has been starved longer")
+	}
+}
+
+// ...and the symmetric case: first in line takes it. Ordering on
+// starvation age rather than shape size is what keeps both the coarse
+// shape and the default shape from being cut in line indefinitely.
+func TestReservation_FirstInLineTakesTheReservation(t *testing.T) {
+	small := starvedSince(linuxSmallPool(), 5*time.Minute)
+	small.Spec.Replicas = 1
+	large := starvedSince(linuxLargePool(), 45*time.Minute)
+	large.Spec.Replicas = 1
+	starved := pendingPod("large-0", large.Name, 45*time.Minute)
+
+	r := reservationReconciler(large, small, ax162Node("ax-0"), ax162Node("ax-1"), starved,
+		placedPod("small-0", small.Name, "ax-0", "acme"),
+	)
+	if err := r.reconcileReservation(context.Background(), large, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if !isReserved(nodeByName(t, r, "ax-0")) && !isReserved(nodeByName(t, r, "ax-1")) {
+		t.Fatal("the longest-starved pool must get the fleet's reservation")
+	}
+}
+
+// Yielding must not become its own starvation. A shape no host can seat
+// even empty never stops being starved, so a pool must step over it
+// rather than queue behind it forever.
+func TestReservation_DoesNotYieldToAnUnseatableShape(t *testing.T) {
+	// 512 GB per Pod: no node on this fleet can seat it, ever.
+	unseatable := starvedSince(linuxLargePool(), 90*time.Minute)
+	unseatable.Name = "runner-pool-linux-impossible"
+	unseatable.Spec.PodMemoryMB = 524288
+	unseatable.Spec.Replicas = 1
+
+	large := starvedSince(linuxLargePool(), 10*time.Minute)
+	large.Spec.Replicas = 1
+	starved := pendingPod("large-0", large.Name, 10*time.Minute)
+
+	r := reservationReconciler(large, unseatable, linuxSmallPool(),
+		ax162Node("ax-0"), ax162Node("ax-1"), starved,
+		placedPod("small-0", linuxSmallPoolName, "ax-0", "acme"),
+	)
+	if err := r.reconcileReservation(context.Background(), large, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	if !isReserved(nodeByName(t, r, "ax-0")) && !isReserved(nodeByName(t, r, "ax-1")) {
+		t.Fatal("blocked forever behind a shape no drain could ever serve")
+	}
+}


### PR DESCRIPTION
## What changed

Two fixes to the runner node-reservation state machine, plus one tuning change.

1. **Starvation is tracked on the pool** (`status.unplaceableSince`) instead of being derived from individual Pod ages.
2. **The fleet's single reservation goes to the longest-starved pool** instead of whichever pool reconciles first.
3. **`linux-2vcpu-8gb`'s `minWarmPoolFloor` drops 12 → 4.**

## Why

The `Runner queue age` alert fired on `tuist-tuist-runner-pool-linux-16vcpu-32gb` on 2026-09-04, oldest dispatchable job waiting 36 minutes.

This was **not** the account concurrency cap that the same fleet hit on 09-02 — that account had full headroom (2 of 8 permitted jobs running), and the new `queue_oldest_dispatchable_age_seconds` gauge from #12765 excludes capped work by construction. It was node fragmentation: the fleet had 35.6 vCPU and 69 GiB free in aggregate, enough for the Pod twice over, but no single node had the contiguous 16.25 vCPU / 34.5 GiB it needs.

Fragmentation is exactly what the node reservation from #12714 exists to resolve, and it was running. It just could not hold a host long enough to converge.

### Root cause 1: the starvation signal did not survive the reaper

`starvedPod` measured starvation from each Pod's own `CreationTimestamp` against a 2-minute grace, while the reaper deletes an unplaced Pod at `provisioning.startTimeoutSeconds` (300s) and the pool immediately recreates it.

So a Pod only counted as starved between 120s and 300s of its life. Whenever a cohort was reaped together, every replacement was too young, the pool read as "served", and a reservation part-way through draining a host was released — handing the seats back to the shapes that had taken them in the first place.

Production, reconstructed from controller logs:

```
08:18:59 RESERVE  (16vcpu) 7s5p8    08:19:01 RELEASE "pool is served"  (2s)
08:21:31 RESERVE  (16vcpu) 2c6zk
08:24:24   !! REAP unschedulable 16vcpu pod
08:24:24 <<< RELEASE (16vcpu) "pool is served"      <-- same second
08:24:24 reserve  (2vcpu-8gb)                       <-- slot immediately taken
```

The pool went 3 → 2 → 1 → 0 Running across that window, so nothing was served. The starvation bound was not loose; it was absent, restarting every five minutes.

### Root cause 2: the reservation was first-come, not fairest

`maxFleetReservations = 1`, granted to whichever pool reconciled while it was free. Granular shapes starve often *and* converge in seconds, so they took the slot, released it, and took it again. The 16 vCPU pool — the only shape that genuinely cannot be served without a drain — waited from 07:23 to 08:36 behind pools that were merely queued.

## The fix

`status.unplaceableSince` is set while a pool holds demand it has not placed, and cleared only when it places it. The clock therefore survives the reap cycle. It seeds from the oldest waiting Pod rather than from `now`, so a controller restart (or the first reconcile after this field ships) does not forgive a starvation already in flight.

Reservations then go to the longest-starved pool on the fleet.

### Why starvation age, not shape size

Ordering by "coarsest shape first" would fix today's incident and make its mirror image worse. That one is on record: a big pool held the fleet-wide provisioning budget while the default shape was admitted zero creations and the production deploy cascade queued behind it, because `Check for releasable changes` runs on `tuist-linux`.

Ordering on *how long each pool has waited* is symmetric — it bounds starvation in both directions with one rule.

A pool steps over a sibling whose shape no host could seat even when empty. Without that guard, yielding to a permanently-unservable shape would trade the starvation this PR removes for a worse one it introduced.

## Why not the alternatives

- **Buy more nodes.** Would dilute the fragmentation without fixing it, and sizes a fleet whose packing is knowingly broken. Worth revisiting *after* this, with clean numbers.
- **Reserve a big-shaped hole per node** (balloon Pods, or a static "1 big + fill" layout). Not work-conserving: it holds ~34.5 GiB per box idle against a workload that is busy ~35 of 168 hours a week.
- **Move the customer to a smaller shape.** Customer-hostile and revenue-negative.

## The warm-floor change

Over the 7 days to 2026-09-04, `linux-2vcpu-8gb` averaged **2.2 occupied runners against 13.2 idle** — 86% idle, with `minWarmPoolFloor: 12` as the reason. That is ~138 GiB of a ~467 GiB fleet held by Pods doing nothing, against a shape that needs a contiguous 34.5 GiB and spent 07:23–08:36 unable to find one. The pool's jobs have a sub-three-minute median, so the marginal cold start is cheap. 4 still covers the p50 of occupied runners with headroom.

## Impact

- The reservation can now actually converge, so a coarse shape gets a host within `reservationGrace` + drain time instead of never.
- Neither the coarse nor the default shape can be cut in line indefinitely.
- Filling stays opportunistic — nothing is held unless something is genuinely starved.
- No customer-visible shape, catalog or billing change.

## Validation

- `go build`, `go vet`, `gofmt` clean; full `runners-controller` suite passes.
- Five new reservation tests: the reap cycle, clock clearing on placement, both directions of the arbitration, and the unseatable-sibling guard.
- **The reap regression test was confirmed to fail against the old per-Pod rule** with the exact production symptom (`released a reservation because the reaper had just recycled the Pod`) before passing against the fix.
- CRD schema updated; the deploy workflow already `kubectl apply`s `crds/` on every run, so the new status field ships without a manual step. This matters — without it the field would be silently pruned and the fix would be inert.

## Open for review

`poolUnplaceable` holds the reservation while `bound < spec.replicas`, not just while an unplaced Pod exists. That is what makes the clock survive the window between a reap and its recreate, but it also means a pool wanting more replicas than the fleet can seat holds its reservation to the 15-minute timeout. The timeout and per-host cooldown bound it, and the new arbitration means the next pool in line is served afterwards — but the semantics are worth a second opinion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
