### PR TITLE
fix(kura): answer artifact HEAD reads without metering a phantom transfer

### DIFF
--- a/kura/src/http.rs
+++ b/kura/src/http.rs
@@ -10,7 +10,7 @@ use axum::{
     Json, Router,
     body::{Body, to_bytes},
     extract::{MatchedPath, Path as AxumPath, Query, Request, State},
-    http::{HeaderMap, HeaderValue, StatusCode, Uri, Version},
+    http::{HeaderMap, HeaderValue, Method, StatusCode, Uri, Version},
     middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{delete, get, head, post, put},
@@ -1123,6 +1123,7 @@ async fn track_http_metrics(
     };
     let _request_guard = state.start_http_request(traffic_class);
     let method = req.method().to_string();
+    let is_head_request = req.method() == Method::HEAD;
     let request_id = request_id(
         req.headers()
             .get(REQUEST_ID_HEADER)
@@ -1188,12 +1189,19 @@ async fn track_http_metrics(
         .get::<ObservedStreamingResponse>()
         .is_none()
     {
-        let response_bytes = response
-            .headers()
-            .get(axum::http::header::CONTENT_LENGTH)
-            .and_then(|value| value.to_str().ok())
-            .and_then(|value| value.parse::<u64>().ok())
-            .unwrap_or(0);
+        // A HEAD advertises the length it would have sent and sends none of
+        // it, so reading `Content-Length` here would log bytes that never
+        // reached the client.
+        let response_bytes = if is_head_request {
+            0
+        } else {
+            response
+                .headers()
+                .get(axum::http::header::CONTENT_LENGTH)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse::<u64>().ok())
+                .unwrap_or(0)
+        };
         let result = if response.status().is_server_error() {
             "server_error"
         } else {
@@ -1869,6 +1877,7 @@ async fn get_keyvalue(
 async fn get_nx(
     AxumPath(hash): AxumPath<String>,
     State(state): State<SharedState>,
+    method: Method,
     headers: HeaderMap,
 ) -> Response {
     let usage = UsageContext {
@@ -1885,6 +1894,7 @@ async fn get_nx(
         None,
         Some(usage),
         request_range(&headers),
+        ArtifactRead::from_method(&method),
     )
     .await
 }
@@ -1920,6 +1930,7 @@ async fn put_nx(
 async fn get_metro(
     AxumPath(cache_key): AxumPath<String>,
     State(state): State<SharedState>,
+    method: Method,
     headers: HeaderMap,
 ) -> Response {
     let usage = UsageContext {
@@ -1936,6 +1947,7 @@ async fn get_metro(
         None,
         Some(usage),
         request_range(&headers),
+        ArtifactRead::from_method(&method),
     )
     .await
 }
@@ -2070,6 +2082,7 @@ async fn get_xcode(
     AxumPath(id): AxumPath<String>,
     Query(params): Query<HashMap<String, String>>,
     State(state): State<SharedState>,
+    method: Method,
     headers: HeaderMap,
 ) -> Response {
     let namespace = match NamespaceQuery::from_params(&params) {
@@ -2089,6 +2102,7 @@ async fn get_xcode(
         analytics,
         Some(usage),
         request_range(&headers),
+        ArtifactRead::from_method(&method),
     )
     .await
 }
@@ -2129,6 +2143,7 @@ async fn get_gradle(
     AxumPath(cache_key): AxumPath<String>,
     Query(params): Query<HashMap<String, String>>,
     State(state): State<SharedState>,
+    method: Method,
     headers: HeaderMap,
 ) -> Response {
     let namespace = match NamespaceQuery::from_params(&params) {
@@ -2148,6 +2163,7 @@ async fn get_gradle(
         analytics,
         Some(usage),
         request_range(&headers),
+        ArtifactRead::from_method(&method),
     )
     .await
 }
@@ -2221,6 +2237,7 @@ async fn head_module(
 async fn get_module(
     Query(params): Query<HashMap<String, String>>,
     State(state): State<SharedState>,
+    method: Method,
     headers: HeaderMap,
 ) -> Response {
     let query = match ModuleQuery::from_params(&params) {
@@ -2238,6 +2255,7 @@ async fn get_module(
         None,
         Some(usage),
         request_range(&headers),
+        ArtifactRead::from_method(&method),
     )
     .await
 }
@@ -3748,6 +3766,7 @@ async fn get_artifact(
     analytics: Option<ProjectAnalyticsContext<'_>>,
     usage: Option<UsageContext>,
     range_request: RangeRequest<'_>,
+    read: ArtifactRead,
 ) -> Response {
     let lookup_span = if trace_export_active() {
         tracing::info_span!(
@@ -3780,6 +3799,14 @@ async fn get_artifact(
                     return range_not_satisfiable_response(manifest.size);
                 }
             };
+            // A HEAD lands here because axum answers it with the GET route.
+            // Building a body for it would hand Hyper a stream it never polls,
+            // and the drop would book the probe as a transfer that delivered
+            // none of its bytes. The metadata is the whole answer: no stream,
+            // no stream-memory admission, no egress sample.
+            if matches!(read, ArtifactRead::MetadataOnly) {
+                return artifact_metadata_response(&manifest, range);
+            }
             // A streaming response's status is decided when the stream is
             // built, long before a byte reaches the client, so metering here
             // would book an artifact the client may never receive and book it
@@ -4437,6 +4464,19 @@ impl<S> InstrumentedArtifactStream<S> {
         self.yielded_bytes >= self.expected_bytes
     }
 
+    /// How a body that ended without an error should be labelled.
+    ///
+    /// Completion is measured in bytes, not in how the body ended: a source
+    /// that runs out early still promised `Content-Length`, and a client that
+    /// got less than that did not receive the response.
+    fn completion_result(&self) -> &'static str {
+        if self.delivered_in_full() {
+            "ok"
+        } else {
+            "aborted"
+        }
+    }
+
     fn record_once(&mut self, result: &str, error: Option<&str>) {
         if self.recorded {
             return;
@@ -4537,7 +4577,12 @@ where
                 Poll::Ready(Some(Err(error)))
             }
             Poll::Ready(None) => {
-                this.record_once("ok", None);
+                // Reached when the source ends on its own. That is usually a
+                // complete body, but a source shorter than the manifest says
+                // also ends here, and the client is left with a truncated
+                // response rather than a served one.
+                let result = this.completion_result();
+                this.record_once(result, None);
                 Poll::Ready(None)
             }
             Poll::Pending => Poll::Pending,
@@ -4552,11 +4597,7 @@ impl<S> Drop for InstrumentedArtifactStream<S> {
         // the peer went away mid-transfer. Only the second is waste, and
         // conflating them made `result="aborted"` a label for "served by the
         // streaming path" rather than for a transfer nobody received.
-        let result = if self.delivered_in_full() {
-            "ok"
-        } else {
-            "aborted"
-        };
+        let result = self.completion_result();
         self.record_once(result, None);
     }
 }
@@ -4597,6 +4638,37 @@ fn request_range(headers: &HeaderMap) -> RangeRequest<'_> {
 
 fn header_str(headers: &HeaderMap, name: axum::http::header::HeaderName) -> Option<&str> {
     headers.get(name).and_then(|value| value.to_str().ok())
+}
+
+/// Whether a read wants the artifact bytes or only the metadata describing them.
+///
+/// axum answers a HEAD on a GET-only route with the GET handler, so the read
+/// path has to tell the two apart itself.
+#[derive(Clone, Copy)]
+enum ArtifactRead {
+    Bytes,
+    MetadataOnly,
+}
+
+impl ArtifactRead {
+    fn from_method(method: &Method) -> Self {
+        if method == Method::HEAD {
+            Self::MetadataOnly
+        } else {
+            Self::Bytes
+        }
+    }
+}
+
+/// The headers a read would have answered with, and no body.
+///
+/// Same status, validator, length and range headers as the streamed response,
+/// so a client can size a download or test a resume without one being served.
+fn artifact_metadata_response(manifest: &ArtifactManifest, range: ServedRange) -> Response {
+    let mut response = Response::new(Body::empty());
+    *response.status_mut() = artifact_response_status(range);
+    apply_artifact_response_headers(&mut response, manifest, range);
+    response
 }
 
 fn artifact_response_status(range: ServedRange) -> StatusCode {
@@ -9095,6 +9167,106 @@ mod tests {
         );
     }
 
+    /// A source that ends early still promised `Content-Length` bytes. Ending
+    /// on `None` rather than on a drop does not make that a served response.
+    #[tokio::test]
+    async fn a_body_whose_source_ends_early_is_not_recorded_as_ok() {
+        let context = test_context(|_| {}).await;
+        let chunks = vec![Ok(Bytes::from_static(b"0123"))];
+        let mut stream = InstrumentedArtifactStream::new(
+            context.state.metrics.clone(),
+            ArtifactProducer::Module,
+            futures_util::stream::iter(chunks),
+            None,
+            ArtifactStreamObservation {
+                status: StatusCode::OK,
+                serving_path: "reader",
+                expected_bytes: 10,
+                attribution: None,
+            },
+        );
+
+        // Polled all the way to the terminal `None`, four bytes short.
+        while stream.next().await.is_some() {}
+        drop(stream);
+
+        let rendered = context.state.metrics.render();
+        assert!(
+            rendered.contains(r#"producer="module",result="aborted""#),
+            "a truncated body must not count as delivered, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains(r#"producer="module",result="ok""#),
+            "a truncated body must not record ok, got:\n{rendered}"
+        );
+    }
+
+    /// The terminal `None` and the drop must not both book a completion.
+    #[tokio::test]
+    async fn a_body_polled_to_completion_records_one_sample() {
+        let context = test_context(|_| {}).await;
+        let chunks = vec![Ok(Bytes::from_static(b"0123456789"))];
+        let mut stream = InstrumentedArtifactStream::new(
+            context.state.metrics.clone(),
+            ArtifactProducer::Module,
+            futures_util::stream::iter(chunks),
+            None,
+            ArtifactStreamObservation {
+                status: StatusCode::OK,
+                serving_path: "reader",
+                expected_bytes: 10,
+                attribution: None,
+            },
+        );
+
+        while stream.next().await.is_some() {}
+        drop(stream);
+
+        let rendered = context.state.metrics.render();
+        assert!(
+            rendered.contains(
+                r#"kura_artifact_egress_completions_total_total{producer="module",result="ok"} 1"#
+            ),
+            "completion must be booked exactly once, got:\n{rendered}"
+        );
+    }
+
+    /// A failed read stays a failed read: the drop must not relabel it.
+    #[tokio::test]
+    async fn a_failed_body_is_not_relabelled_on_drop() {
+        let context = test_context(|_| {}).await;
+        let chunks = vec![
+            Ok(Bytes::from_static(b"0123")),
+            Err(std::io::Error::other("read failed")),
+        ];
+        let mut stream = InstrumentedArtifactStream::new(
+            context.state.metrics.clone(),
+            ArtifactProducer::Module,
+            futures_util::stream::iter(chunks),
+            None,
+            ArtifactStreamObservation {
+                status: StatusCode::OK,
+                serving_path: "reader",
+                expected_bytes: 10,
+                attribution: None,
+            },
+        );
+
+        assert!(stream.next().await.expect("first chunk").is_ok());
+        assert!(stream.next().await.expect("second chunk").is_err());
+        drop(stream);
+
+        let rendered = context.state.metrics.render();
+        assert!(
+            rendered.contains(r#"producer="module",result="error""#),
+            "a failed read must record error, got:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains(r#"producer="module",result="aborted""#),
+            "the drop must not relabel a failed read, got:\n{rendered}"
+        );
+    }
+
     fn download_attribution(context: &crate::test_support::TestContext) -> DownloadAttribution {
         DownloadAttribution {
             state: context.state.clone(),
@@ -9295,6 +9467,118 @@ mod tests {
         // A full response must not claim to be partial.
         assert!(response.headers().get("content-range").is_none());
         assert_eq!(response_bytes(response).await, body);
+    }
+
+    /// axum answers a HEAD on a GET-only route with the GET handler. Serving a
+    /// body there would hand Hyper a stream it never polls, and the drop would
+    /// book an existence check as a transfer that delivered nothing — putting
+    /// a floor of probes under `result="aborted"`.
+    #[tokio::test]
+    async fn a_head_read_answers_with_metadata_and_meters_no_egress() {
+        let context = test_context(|_| {}).await;
+        let app = router(context.state.clone());
+        let body: Vec<u8> = (0..4096_u32).map(|index| index as u8).collect();
+        seed_ranged_artifact(&app, &body).await;
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("HEAD")
+                    .uri("/v1/cache/ranged-key")
+                    .body(Body::empty())
+                    .expect("failed to build head request"),
+            )
+            .await
+            .expect("head request failed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-length")
+                .and_then(|value| value.to_str().ok()),
+            Some("4096"),
+            "a HEAD must describe the artifact it would have served"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("accept-ranges")
+                .and_then(|value| value.to_str().ok()),
+            Some("bytes")
+        );
+        assert!(response.headers().get("etag").is_some());
+        assert!(response_bytes(response).await.is_empty());
+
+        // Scoped to the egress family: the PUT that seeded the artifact
+        // records a write under the same producer and result labels.
+        let rendered = context.state.metrics.render();
+        assert!(
+            !rendered.contains(r#"kura_artifact_egress_completions_total_total{producer="nx""#),
+            "a HEAD serves no body and must not meter an egress completion, got:\n{rendered}"
+        );
+    }
+
+    /// A HEAD is how a client tests whether a resume is worth starting, so it
+    /// has to answer the range question the same way the GET would.
+    #[tokio::test]
+    async fn a_ranged_head_read_describes_the_window_without_serving_it() {
+        let context = test_context(|_| {}).await;
+        let app = router(context.state.clone());
+        let body: Vec<u8> = (0..4096_u32).map(|index| index as u8).collect();
+        seed_ranged_artifact(&app, &body).await;
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("HEAD")
+                    .uri("/v1/cache/ranged-key")
+                    .header("range", "bytes=4000-")
+                    .body(Body::empty())
+                    .expect("failed to build ranged head request"),
+            )
+            .await
+            .expect("ranged head request failed");
+
+        assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(
+            response
+                .headers()
+                .get("content-range")
+                .and_then(|value| value.to_str().ok()),
+            Some("bytes 4000-4095/4096")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("content-length")
+                .and_then(|value| value.to_str().ok()),
+            Some("96")
+        );
+        assert!(response_bytes(response).await.is_empty());
+    }
+
+    /// A HEAD for something that is not stored is still a miss.
+    #[tokio::test]
+    async fn a_head_read_for_a_missing_artifact_is_not_found() {
+        let context = test_context(|_| {}).await;
+        let app = router(context.state.clone());
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("HEAD")
+                    .uri("/v1/cache/absent-key")
+                    .body(Body::empty())
+                    .expect("failed to build head request"),
+            )
+            .await
+            .expect("head request failed");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

Artifact reads now distinguish a request for the bytes from a request for the metadata describing them, and the response-body stream applies one completeness test on both of its terminal paths.

**HEAD reads** (`kura/src/http.rs`)

- `ArtifactRead::from_method` classifies a read as `Bytes` or `MetadataOnly`; the five artifact GET handlers (`get_nx`, `get_metro`, `get_xcode`, `get_gradle`, `get_module`) pass it into `get_artifact`.
- A `MetadataOnly` read returns `artifact_metadata_response`: the same status (`200`/`206`), `ETag`, `Content-Type`, `Content-Length`, `Accept-Ranges` and `Content-Range` the streamed response would have carried, with an empty body. It never opens the artifact, never takes a response-stream memory permit, and never builds an instrumented stream.
- Misses and unsatisfiable ranges are unaffected: both are resolved before this point, so a HEAD still gets `404` and `416` exactly as a GET does.
- `track_http_metrics` no longer reads `Content-Length` as delivered bytes for a HEAD. A HEAD advertises the length it *would* have sent, so the request log would otherwise record a body that never went on the wire.

**Completion labelling** (`InstrumentedArtifactStream`)

- `completion_result()` is now the single classifier, used by both `Drop` and `poll_next`'s `Poll::Ready(None)` arm.

## Why

`kura_artifact_egress_completions_total{result="aborted"}` is supposed to mean "a transfer the client did not receive". Two paths were putting things in it that are not that.

## Root cause

**HEAD.** axum routes a HEAD to the GET handler when no HEAD route is registered (`axum-0.8.9/src/routing/method_routing.rs:1157-1158`: `call!(req, HEAD, head); call!(req, HEAD, get);`). Of the artifact routes only `ROUTE_API_CACHE_MODULE` registers its own `head()`; `ROUTE_API_CACHE_CAS`, `ROUTE_API_CACHE_GRADLE`, `ROUTE_V1_CACHE`, `ROUTE_API_METRO_CACHE` and `ROUTE_API_CACHE_KEYVALUE_ID` are GET-only. Neither the handlers nor `serve_file`/`serve_file_reader` inspected the method, so a HEAD ran the whole read path and built a body.

Hyper then gives a HEAD response an `Encoder::length(0)` — already at EOF (`hyper-1.9.0/src/proto/h1/role.rs:774` asserts exactly this). `can_write_body()` is false on the first dispatcher turn, so `dispatch.rs:364-371` sets `clear_body = true` and releases the body without polling it. `Drop` therefore saw `yielded_bytes = 0 < expected_bytes` and recorded `aborted`.

The accelerated (sendfile) plane is not involved: it only takes over `GET` (`kura/src/accelerated_file_serving.rs:528`), so every HEAD fell through to this path.

**The terminal `None` arm.** #12551 made `Drop` compare yielded bytes against the promised length, but left `Poll::Ready(None)` recording `"ok"` unconditionally. A source that ends early — an artifact whose stored bytes are shorter than its manifest says — ends there, so a body the client received truncated was labelled a success.

## Why this fix over the alternatives

- **Register a `head()` handler per route**, mirroring `head_module`. This is the shape the route table already uses, but it duplicates the namespace parsing, manifest lookup, conditional-range resolution and header application five times, and a sixth route added later would silently regress. Deciding once inside the single funnel (`get_artifact`) covers every current and future artifact route.
- **Strip the body in middleware.** The stream is already constructed by then, so dropping it there still fires the same `Drop` and still records `aborted`. It would hide nothing and cost the same admission.
- **Skip instrumentation when the body cannot be polled**, leaving the rest of the read path intact. That fixes the label but keeps the wasted work — a probe would still open the artifact and hold a stream-memory permit for a body nobody will read.

## Impact

**Users:** none. A HEAD now answers with the headers it always advertised and no body, which is what a HEAD is supposed to be; a GET is byte-for-byte unchanged. Safe under mixed-version rollout — no wire format, header set or status code changes, and old and new pods emit the same metric families with the same label names.

**Operators (please note):** `result="aborted"` loses a floor it has been carrying. If anything HEADs the artifact routes, those probes were being counted as aborted transfers and will now disappear from the counter entirely rather than move to `ok`. Combined with #12551, `aborted` finally means only "a transfer that ended short of what it promised". Anything keyed on the current rate should be re-baselined.

## Open question for review

For the `Poll::Ready(None)` arm I used the existing `aborted` label so both terminal paths agree, which is the minimal change. It is arguably imprecise: a source that ends early is a server-side integrity problem, not a client abort, and folding them together repeats the mistake this line of work has been undoing. A distinct value (`incomplete`, say) would keep each label meaning one thing and would only ever appear on a real defect, at the cost of a new series. I left that call to you rather than expanding the metric surface unilaterally.

## Tests

Six added to `kura/src/http.rs`:

Request-level, through the router:
- `a_head_read_answers_with_metadata_and_meters_no_egress` — `200`, `Content-Length: 4096`, `Accept-Ranges`, an `ETag`, an empty body, and no `kura_artifact_egress_completions_total` sample for the producer at all.
- `a_ranged_head_read_describes_the_window_without_serving_it` — a HEAD carrying `Range` answers `206` with `Content-Range: bytes 4000-4095/4096` and `Content-Length: 96`, so a client can test a resume before committing to one.
- `a_head_read_for_a_missing_artifact_is_not_found` — a HEAD for something unstored is still `404`.

Stream-level:
- `a_body_whose_source_ends_early_is_not_recorded_as_ok` — polled all the way to `None` four bytes short, records `aborted`, not `ok`. This is the case the shared classifier fixes.
- `a_body_polled_to_completion_records_one_sample` — the terminal `None` and the drop together book exactly one completion.
- `a_failed_body_is_not_relabelled_on_drop` — a read error stays `error` through the drop.

The egress assertions are scoped to the `kura_artifact_egress_*` family rather than to a `producer=…,result=…` label pair. The first draft was not, and the negative assertion matched the artifact *write* metric emitted by the PUT that seeds the fixture — the suite caught it.

## Validation

Run from `kura/`:

- `mise run clippy` (rules_rust clippy aspect over `//...`, warnings as errors) — **passed**, `Build completed successfully, 6 total actions`. It caught a borrow-after-move on the middleware's `method` on the first run, fixed before this commit.
- `mise run test-unit` (`bazel test //...`) — **passed**: `860 passed; 0 failed; 48 ignored`, `//:kura_lib_test PASSED`, `//:kura_bin_test PASSED`. All six new tests confirmed present and passing in the run output.
- `mise run format` — run before committing, no further changes.

The end-to-end shellspec suite was not run.

## Relationship to #12353

#12353 proposed the byte-count comparison in `Drop`. That landed independently in #12551 while adding Range support, so #12353 is now obsolete and conflicts entirely in the code that superseded it — it should be closed. This PR carries the two points from its review that #12551 did not address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
