### PR TITLE
perf(cli): cut and diagnose what tuist cache keeps on disk while it warms

### DIFF
--- a/cli/Sources/TuistCache/CacheWarmBuildOutputReclaimer.swift
+++ b/cli/Sources/TuistCache/CacheWarmBuildOutputReclaimer.swift
@@ -1,0 +1,81 @@
+import FileSystem
+import Foundation
+import Path
+import TuistLogging
+import TuistSupport
+
+/// Frees the derived data that a cache warm has finished with, while the warm is still running.
+///
+/// `tuist cache` builds every scheme and destination into one derived data directory and only
+/// assembles the XCFrameworks once all of them are done. Nothing removes a destination's output in
+/// between, so the command's peak disk usage is the sum of every destination rather than the
+/// largest one. On a workspace with hundreds of targets that is tens of gigabytes, and it is what
+/// makes the command exhaust an ephemeral CI machine part-way through the last destination — the
+/// failure is reported by the compiler as `No space left on device` on whichever object file
+/// happened to be open, or, when the build system is the one that hits it first, as an opaque
+/// `The Xcode build system has crashed`.
+///
+/// Reclaiming is safe because the outputs are already consumed by the time it runs: a destination's
+/// products are copied into the scratch `artifacts/` tree as soon as its build returns, and its
+/// intermediates are of no use to any other destination — each products directory
+/// (`Debug-iphonesimulator`, `Debug-iphoneos`, `Debug`, …) gets intermediates of its own. The one
+/// exception is a products directory a later scheme of the same warm builds into again, which is
+/// why callers pass the reserved set: removing those would buy nothing and cost a rebuild.
+public struct CacheWarmBuildOutputReclaimer {
+    private let fileSystem: FileSysteming
+
+    public init(fileSystem: FileSysteming = FileSystem()) {
+        self.fileSystem = fileSystem
+    }
+
+    /// Removes the products and intermediates that `productsDirectoryName` produced.
+    ///
+    /// A no-op when the directory is reserved by a later step of the same warm.
+    public func reclaim(
+        derivedDataPath: AbsolutePath,
+        productsDirectoryName: String,
+        reservedProductsDirectoryNames: Set<String>
+    ) async {
+        guard !reservedProductsDirectoryNames.contains(productsDirectoryName) else { return }
+
+        await remove(derivedDataPath.appending(components: ["Build", "Products", productsDirectoryName]))
+        for intermediates in await intermediateDirectories(in: derivedDataPath, for: productsDirectoryName) {
+            await remove(intermediates)
+        }
+    }
+
+    /// Removes the result bundle an `xcodebuild` invocation was given.
+    ///
+    /// The warm passes `-resultBundlePath` only to keep xcodebuild from writing a bundle next to
+    /// the project; nothing reads the bundles back, so one per invocation would otherwise sit in
+    /// derived data until the command ends.
+    public func reclaimResultBundle(at path: AbsolutePath) async {
+        await remove(path)
+    }
+
+    /// Every project in the workspace gets its own `<project>.build` directory under
+    /// `Intermediates.noindex`, each holding one subdirectory per products directory it built into.
+    /// Shared state (`XCBuildData`, precompiled modules) sits beside them and is left alone: it is not
+    /// per-destination, and the next destination is about to read it.
+    private func intermediateDirectories(
+        in derivedDataPath: AbsolutePath,
+        for productsDirectoryName: String
+    ) async -> [AbsolutePath] {
+        let root = derivedDataPath.appending(components: ["Build", "Intermediates.noindex"])
+        guard (try? await fileSystem.exists(root, isDirectory: true)) == true else { return [] }
+        let projectBuildDirectories = (try? await fileSystem.glob(directory: root, include: ["*.build"]).collect()) ?? []
+        return projectBuildDirectories.map { $0.appending(component: productsDirectoryName) }
+    }
+
+    /// Reclaiming is an optimization, so a directory that will not go away is logged and ignored:
+    /// failing the warm over it would trade a slow build for no build at all, and the scratch
+    /// directory is discarded when the command ends regardless.
+    private func remove(_ path: AbsolutePath) async {
+        guard (try? await fileSystem.exists(path)) == true else { return }
+        do {
+            try await fileSystem.remove(path)
+        } catch {
+            Logger.current.debug("Could not reclaim build output at \(path.pathString): \(error)")
+        }
+    }
+}

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -23,6 +23,26 @@ import XcodeGraph
 
 #if canImport(TuistCacheEE)
 
+    enum CacheWarmCommandServiceError: LocalizedError {
+        case diskExhausted(scratchDirectory: AbsolutePath, space: VolumeSpace, underlyingError: Error)
+
+        var errorDescription: String? {
+            switch self {
+            case let .diskExhausted(scratchDirectory, space, underlyingError):
+                return """
+                Warming the cache ran out of disk space. The volume holding the build's scratch directory \
+                (\(scratchDirectory.pathString)) has \(space.formattedFreeSpace).
+
+                A warm builds every scheme and destination before it stores anything, so it needs room for all of \
+                them at once, on top of whatever else shares that volume — the compilation cache store and the \
+                local binary cache included.
+
+                The build reported: \(underlyingError.localizedDescription)
+                """
+            }
+        }
+    }
+
     // swiftlint:disable:next type_body_length
     public struct CacheWarmCommandService: CacheServicing {
         enum Destination {
@@ -51,6 +71,7 @@ import XcodeGraph
         private let cacheStorageFactory: CacheStorageFactorying
         private let scratchDirectoryPreparer: CacheWarmScratchDirectoryPreparing
         private let foreignBuildOutputValidator: CacheWarmForeignBuildOutputValidating
+        private let buildOutputReclaimer: CacheWarmBuildOutputReclaimer
 
         public init() {
             let contentHasher = ContentHasher()
@@ -101,6 +122,7 @@ import XcodeGraph
             self.cacheStorageFactory = cacheStorageFactory
             self.scratchDirectoryPreparer = scratchDirectoryPreparer
             self.foreignBuildOutputValidator = foreignBuildOutputValidator
+            buildOutputReclaimer = CacheWarmBuildOutputReclaimer(fileSystem: fileSystem)
         }
 
         // swiftlint:disable:next function_body_length
@@ -266,6 +288,23 @@ import XcodeGraph
             case .temporary:
                 let compilationCacheCASArgument = try await compilationCacheCASArgument(scratchDirectory: nil)
                 try await fileSystem.runInTemporaryDirectory(prefix: "CacheWarm") { temporaryDirectory in
+                    do {
+                        try await archive(
+                            graph,
+                            projectPath: projectPath,
+                            configuration: configuration,
+                            hashesByTargetToBeCached: hashesByTargetToBeCached,
+                            cacheStorage: cacheStorage,
+                            isReleaseConfiguration: isReleaseConfiguration,
+                            in: temporaryDirectory,
+                            compilationCacheCASArgument: compilationCacheCASArgument
+                        )
+                    } catch {
+                        throw diskExhaustionError(for: error, scratchDirectory: temporaryDirectory) ?? error
+                    }
+                }
+            case let .callerOwned(path):
+                do {
                     try await archive(
                         graph,
                         projectPath: projectPath,
@@ -273,22 +312,31 @@ import XcodeGraph
                         hashesByTargetToBeCached: hashesByTargetToBeCached,
                         cacheStorage: cacheStorage,
                         isReleaseConfiguration: isReleaseConfiguration,
-                        in: temporaryDirectory,
-                        compilationCacheCASArgument: compilationCacheCASArgument
+                        in: path,
+                        compilationCacheCASArgument: try await compilationCacheCASArgument(scratchDirectory: path)
                     )
+                } catch {
+                    throw diskExhaustionError(for: error, scratchDirectory: path) ?? error
                 }
-            case let .callerOwned(path):
-                try await archive(
-                    graph,
-                    projectPath: projectPath,
-                    configuration: configuration,
-                    hashesByTargetToBeCached: hashesByTargetToBeCached,
-                    cacheStorage: cacheStorage,
-                    isReleaseConfiguration: isReleaseConfiguration,
-                    in: path,
-                    compilationCacheCASArgument: try await compilationCacheCASArgument(scratchDirectory: path)
-                )
             }
+        }
+
+        /// Re-reports a failed warm as an out-of-disk failure when the scratch volume has nothing left.
+        ///
+        /// A warm keeps every destination's derived data, the assembled XCFrameworks and the copies the local
+        /// cache stores on one volume, so it is the command most likely to exhaust it. What surfaces when that
+        /// happens is whatever write lost the race — `error closing '…/Foo.o' for output: No space left on
+        /// device`, or just `The Xcode build system has crashed` — and it never says which volume filled, which
+        /// is why this has repeatedly been chased as a compiler or cache-integrity problem instead.
+        ///
+        /// Returns nil on a volume that still has room, so an ordinary build failure is reported as itself.
+        private func diskExhaustionError(for error: Error, scratchDirectory: AbsolutePath) -> Error? {
+            guard let space = VolumeSpace.read(at: scratchDirectory), space.isExhausted else { return nil }
+            return CacheWarmCommandServiceError.diskExhausted(
+                scratchDirectory: scratchDirectory,
+                space: space,
+                underlyingError: error
+            )
         }
 
         // swiftlint:disable:next function_body_length
@@ -326,6 +374,22 @@ import XcodeGraph
 
             let xcodebuildTarget = XcodeBuildTarget(with: projectPath)
 
+            // Products directories that must survive the reclaim each destination's build is followed by.
+            //
+            // The configuration's own directory always does: it is where host products land — macro plugins
+            // and other build tools that every destination, not just the macOS one, links against — and it
+            // is also where the macro pass looks for what it built. It is the last destination built anyway,
+            // so keeping it costs nothing at the point where disk usage peaks.
+            //
+            // The bundle pass then adds the directory it builds into, because it reads its artifacts straight
+            // out of derived data rather than from the scratch `artifacts/` tree.
+            var reservedProductsDirectoryNames: Set<String> = [configuration]
+            for (scheme, _) in bundlesSchemes {
+                guard let platform = Platform.allCases.first(where: { scheme.name.hasSuffix($0.caseValue) })
+                else { continue }
+                reservedProductsDirectoryNames.insert(productsDirectory(platform: platform, configuration: configuration))
+            }
+
             var binaryArtifactDirectories: [Platform: Set<AbsolutePath>] = [:]
             for (scheme, _) in binariesSchemes {
                 try await buildBinarySchemes(
@@ -337,7 +401,8 @@ import XcodeGraph
                     scratchDirectory: scratchDirectory,
                     derivedDataPath: derivedDataPath,
                     isReleaseConfiguration: isReleaseConfiguration,
-                    compilationCacheCASArgument: compilationCacheCASArgument
+                    compilationCacheCASArgument: compilationCacheCASArgument,
+                    reservedProductsDirectoryNames: reservedProductsDirectoryNames
                 )
             }
 
@@ -350,7 +415,8 @@ import XcodeGraph
                     scratchDirectory: scratchDirectory,
                     derivedDataPath: derivedDataPath,
                     isReleaseConfiguration: isReleaseConfiguration,
-                    compilationCacheCASArgument: compilationCacheCASArgument
+                    compilationCacheCASArgument: compilationCacheCASArgument,
+                    reservedProductsDirectoryNames: reservedProductsDirectoryNames
                 )
             }
 
@@ -461,18 +527,11 @@ import XcodeGraph
                 .xcarg("SYMROOT", derivedDataPath.appending(components: ["Build", "Products"]).pathString),
                 compilationCacheCASArgument,
             ]
-            try await xcodeBuildController.build(
+            try await build(
                 xcodebuildTarget,
                 scheme: scheme.name,
-                destination: nil,
-                rosetta: false,
                 derivedDataPath: derivedDataPath,
-                clean: false,
-                arguments: arguments,
-                passthroughXcodeBuildArguments: [
-                    "-resultBundlePath",
-                    derivedDataPath.appending(component: UUID().uuidString).pathString,
-                ]
+                arguments: arguments
             )
 
             var macrosToStore: [CacheGraphTargetBuiltArtifact] = []
@@ -539,18 +598,11 @@ import XcodeGraph
             } else {
                 arguments.append(.destination("generic/platform=\(platform.caseValue)"))
             }
-            try await xcodeBuildController.build(
+            try await build(
                 xcodebuildTarget,
                 scheme: scheme.name,
-                destination: nil,
-                rosetta: false,
                 derivedDataPath: derivedDataPath,
-                clean: false,
-                arguments: arguments,
-                passthroughXcodeBuildArguments: [
-                    "-resultBundlePath",
-                    derivedDataPath.appending(component: UUID().uuidString).pathString,
-                ]
+                arguments: arguments
             )
 
             // NOTE: This logic doesn't account for multi-platform bundle targets.
@@ -747,7 +799,8 @@ import XcodeGraph
             scratchDirectory: AbsolutePath,
             derivedDataPath: AbsolutePath,
             isReleaseConfiguration: Bool,
-            compilationCacheCASArgument: XcodeBuildArgument
+            compilationCacheCASArgument: XcodeBuildArgument,
+            reservedProductsDirectoryNames: Set<String>
         ) async throws {
             let platform = Platform.allCases.first { scheme.name.hasSuffix($0.caseValue) }!
             let platformArtifactsDirectory = scratchDirectory.appending(components: ["artifacts", "\(platform.caseValue)"])
@@ -760,13 +813,10 @@ import XcodeGraph
                 try await fileSystem.makeDirectory(at: simulatorArtifactsDirectory)
 
                 Logger.current.info("Building scheme \(scheme.name) for the simulator", metadata: .section)
-                try await xcodeBuildController.build(
+                try await build(
                     xcodebuildTarget,
                     scheme: scheme.name,
-                    destination: nil,
-                    rosetta: false,
                     derivedDataPath: derivedDataPath,
-                    clean: false,
                     arguments: [
                         .destination("generic/platform=\(platform.caseValue) Simulator"),
                         .xcarg("SKIP_INSTALL", "NO"),
@@ -787,25 +837,29 @@ import XcodeGraph
                     ] + (isReleaseConfiguration ? [
                         .xcarg("GCC_INSTRUMENT_PROGRAM_FLOW_ARCS", "NO"),
                         .xcarg("CLANG_ENABLE_CODE_COVERAGE", "NO"),
-                    ] : []),
-                    passthroughXcodeBuildArguments: [
-                        "-resultBundlePath",
-                        derivedDataPath.appending(component: UUID().uuidString).pathString,
-                    ]
+                    ] : [])
                 )
 
+                let productsDirectoryName = productsDirectory(
+                    platform: platform,
+                    configuration: configuration,
+                    destination: .simulator
+                )
                 let productsDirectory = derivedDataPath
                     .appending(
                         // swiftlint:disable:next force_try
-                        try RelativePath(
-                            validating: "Build/Products/\(productsDirectory(platform: platform, configuration: configuration, destination: .simulator))"
-                        )
+                        try RelativePath(validating: "Build/Products/\(productsDirectoryName)")
                     )
                 try await copyDerivedDataArtifacts(
                     into: simulatorArtifactsDirectory,
                     productsDirectory: productsDirectory,
                     platform: platform,
                     binaryArtifactDirectories: &binaryArtifactDirectories
+                )
+                await buildOutputReclaimer.reclaim(
+                    derivedDataPath: derivedDataPath,
+                    productsDirectoryName: productsDirectoryName,
+                    reservedProductsDirectoryNames: reservedProductsDirectoryNames
                 )
             }
 
@@ -843,26 +897,22 @@ import XcodeGraph
                 deviceArguments.append(.destination("generic/platform=\(platform.caseValue)"))
             }
 
-            try await xcodeBuildController.build(
+            try await build(
                 xcodebuildTarget,
                 scheme: scheme.name,
-                destination: nil,
-                rosetta: false,
                 derivedDataPath: derivedDataPath,
-                clean: false,
-                arguments: deviceArguments,
-                passthroughXcodeBuildArguments: [
-                    "-resultBundlePath",
-                    derivedDataPath.appending(component: UUID().uuidString).pathString,
-                ]
+                arguments: deviceArguments
             )
 
+            let productsDirectoryName = productsDirectory(
+                platform: platform,
+                configuration: configuration,
+                destination: .device
+            )
             let productsDirectory = derivedDataPath
                 .appending(
                     // swiftlint:disable:next force_try
-                    try RelativePath(
-                        validating: "Build/Products/\(productsDirectory(platform: platform, configuration: configuration, destination: .device))"
-                    )
+                    try RelativePath(validating: "Build/Products/\(productsDirectoryName)")
                 )
 
             try await copyDerivedDataArtifacts(
@@ -870,6 +920,11 @@ import XcodeGraph
                 productsDirectory: productsDirectory,
                 platform: platform,
                 binaryArtifactDirectories: &binaryArtifactDirectories
+            )
+            await buildOutputReclaimer.reclaim(
+                derivedDataPath: derivedDataPath,
+                productsDirectoryName: productsDirectoryName,
+                reservedProductsDirectoryNames: reservedProductsDirectoryNames
             )
         }
 
@@ -881,7 +936,8 @@ import XcodeGraph
             scratchDirectory: AbsolutePath,
             derivedDataPath: AbsolutePath,
             isReleaseConfiguration: Bool,
-            compilationCacheCASArgument: XcodeBuildArgument
+            compilationCacheCASArgument: XcodeBuildArgument,
+            reservedProductsDirectoryNames: Set<String>
         ) async throws {
             let platformArtifactsDirectory = scratchDirectory.appending(components: ["artifacts", "iOS"])
             try await fileSystem.makeDirectory(at: platformArtifactsDirectory)
@@ -891,13 +947,10 @@ import XcodeGraph
             let macCatalystArtifactsDirectory = platformArtifactsDirectory.appending(component: "mac-catalyst")
             try await fileSystem.makeDirectory(at: macCatalystArtifactsDirectory)
 
-            try await xcodeBuildController.build(
+            try await build(
                 xcodebuildTarget,
                 scheme: scheme.name,
-                destination: nil,
-                rosetta: false,
                 derivedDataPath: derivedDataPath,
-                clean: false,
                 arguments: [
                     .destination("generic/platform=macOS,variant=Mac Catalyst"),
                     .xcarg("SKIP_INSTALL", "NO"),
@@ -916,25 +969,61 @@ import XcodeGraph
                 ] + (isReleaseConfiguration ? [
                     .xcarg("GCC_INSTRUMENT_PROGRAM_FLOW_ARCS", "NO"),
                     .xcarg("CLANG_ENABLE_CODE_COVERAGE", "NO"),
-                ] : []),
-                passthroughXcodeBuildArguments: [
-                    "-resultBundlePath",
-                    derivedDataPath.appending(component: UUID().uuidString).pathString,
-                ]
+                ] : [])
             )
 
+            let productsDirectoryName = productsDirectory(
+                platform: .iOS,
+                configuration: configuration,
+                destination: .device,
+                isMacCatalystVariant: true
+            )
             let productsDirectory = derivedDataPath
-                .appending(
-                    try RelativePath(
-                        validating: "Build/Products/\(productsDirectory(platform: .iOS, configuration: configuration, destination: .device, isMacCatalystVariant: true))"
-                    )
-                )
+                .appending(try RelativePath(validating: "Build/Products/\(productsDirectoryName)"))
             try await copyDerivedDataArtifacts(
                 into: macCatalystArtifactsDirectory,
                 productsDirectory: productsDirectory,
                 platform: .iOS,
                 binaryArtifactDirectories: &binaryArtifactDirectories
             )
+            await buildOutputReclaimer.reclaim(
+                derivedDataPath: derivedDataPath,
+                productsDirectoryName: productsDirectoryName,
+                reservedProductsDirectoryNames: reservedProductsDirectoryNames
+            )
+        }
+
+        /// Runs one of the warm's builds, giving it a result bundle that is removed as soon as it returns.
+        ///
+        /// `-resultBundlePath` is passed only so xcodebuild does not drop a bundle next to the project. The
+        /// warm never reads them back, so without this every invocation leaves one behind in derived data for
+        /// the rest of the command.
+        private func build(
+            _ xcodebuildTarget: XcodeBuildTarget,
+            scheme: String,
+            derivedDataPath: AbsolutePath,
+            arguments: [XcodeBuildArgument]
+        ) async throws {
+            let resultBundlePath = derivedDataPath.appending(component: UUID().uuidString)
+            do {
+                try await xcodeBuildController.build(
+                    xcodebuildTarget,
+                    scheme: scheme,
+                    destination: nil,
+                    rosetta: false,
+                    derivedDataPath: derivedDataPath,
+                    clean: false,
+                    arguments: arguments,
+                    passthroughXcodeBuildArguments: [
+                        "-resultBundlePath",
+                        resultBundlePath.pathString,
+                    ]
+                )
+            } catch {
+                await buildOutputReclaimer.reclaimResultBundle(at: resultBundlePath)
+                throw error
+            }
+            await buildOutputReclaimer.reclaimResultBundle(at: resultBundlePath)
         }
 
         private func copyDerivedDataArtifacts(

--- a/cli/Sources/TuistSupport/Utils/VolumeSpace.swift
+++ b/cli/Sources/TuistSupport/Utils/VolumeSpace.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Path
+
+/// A point-in-time reading of the volume that backs a path.
+public struct VolumeSpace: Equatable, Sendable {
+    /// Bytes still writable on the volume.
+    public let freeBytes: Int64
+    /// The volume's total size.
+    public let totalBytes: Int64
+
+    public init(freeBytes: Int64, totalBytes: Int64) {
+        self.freeBytes = freeBytes
+        self.totalBytes = totalBytes
+    }
+
+    /// Reads the free and total space of the volume backing `path`, walking up to the nearest existing
+    /// ancestor so a path a failed build never got to create still reports the volume it would have used.
+    ///
+    /// Deliberately `statfs`-based (`systemFreeSize`) rather than
+    /// `volumeAvailableCapacityForImportantUsageKey`: the latter counts space macOS would have to purge
+    /// first, so it reports capacity a build cannot actually write and would describe a volume that has
+    /// just failed with `ENOSPC` as having gigabytes to spare.
+    public static func read(at path: AbsolutePath) -> VolumeSpace? {
+        var candidate: AbsolutePath? = path
+        while let current = candidate {
+            if let attributes = try? FileManager.default.attributesOfFileSystem(forPath: current.pathString),
+               let free = (attributes[.systemFreeSize] as? NSNumber)?.int64Value,
+               let total = (attributes[.systemSize] as? NSNumber)?.int64Value
+            {
+                return VolumeSpace(freeBytes: free, totalBytes: total)
+            }
+            candidate = current.isRoot ? nil : current.parentDirectory
+        }
+        return nil
+    }
+
+    /// Whether the volume has so little room left that a build failure is more likely to be the disk than
+    /// the code. A build that failed on a healthy volume leaves far more than this behind; one that failed
+    /// because the volume filled is sitting on tens of megabytes, since the writes that did not fit were
+    /// the last ones attempted.
+    public var isExhausted: Bool {
+        freeBytes < VolumeSpace.exhaustionThresholdBytes
+    }
+
+    static let exhaustionThresholdBytes: Int64 = 512 * 1024 * 1024
+
+    public var formattedFreeSpace: String {
+        let free = ByteCountFormatter.string(fromByteCount: freeBytes, countStyle: .file)
+        let total = ByteCountFormatter.string(fromByteCount: totalBytes, countStyle: .file)
+        return "\(free) free of \(total)"
+    }
+}

--- a/cli/Tests/TuistCacheTests/CacheWarmBuildOutputReclaimerTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheWarmBuildOutputReclaimerTests.swift
@@ -1,0 +1,126 @@
+import FileSystem
+import FileSystemTesting
+import Foundation
+import Path
+import Testing
+
+@testable import TuistCache
+
+struct CacheWarmBuildOutputReclaimerTests {
+    private let fileSystem = FileSystem()
+    private let subject = CacheWarmBuildOutputReclaimer()
+
+    @Test(.inTemporaryDirectory)
+    func reclaimRemovesTheProductsAndIntermediatesOfTheDestinationJustBuilt() async throws {
+        let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
+        try await seedBuild(in: derivedDataPath, productsDirectoryName: "Debug-iphonesimulator", projects: ["Tuist", "Rosalind"])
+
+        await subject.reclaim(
+            derivedDataPath: derivedDataPath,
+            productsDirectoryName: "Debug-iphonesimulator",
+            reservedProductsDirectoryNames: []
+        )
+
+        #expect(try await fileSystem.exists(
+            derivedDataPath.appending(components: ["Build", "Products", "Debug-iphonesimulator"])
+        ) == false)
+        #expect(try await fileSystem.exists(
+            derivedDataPath.appending(components: ["Build", "Intermediates.noindex", "Tuist.build", "Debug-iphonesimulator"])
+        ) == false)
+        // Every project in the workspace has intermediates of its own, so reclaiming one destination has to
+        // reach all of them and not just the first match.
+        #expect(try await fileSystem.exists(
+            derivedDataPath.appending(components: ["Build", "Intermediates.noindex", "Rosalind.build", "Debug-iphonesimulator"])
+        ) == false)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func reclaimLeavesTheDestinationsThatHaveNotBeenBuiltYet() async throws {
+        let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
+        try await seedBuild(in: derivedDataPath, productsDirectoryName: "Debug-iphonesimulator", projects: ["Tuist"])
+        try await seedBuild(in: derivedDataPath, productsDirectoryName: "Debug-iphoneos", projects: ["Tuist"])
+        try await seedBuild(in: derivedDataPath, productsDirectoryName: "Debug", projects: ["Tuist"])
+        // Shared build state lives beside the per-destination directories and must survive.
+        let sharedBuildData = derivedDataPath.appending(components: ["Build", "Intermediates.noindex", "XCBuildData"])
+        try await fileSystem.makeDirectory(at: sharedBuildData)
+
+        await subject.reclaim(
+            derivedDataPath: derivedDataPath,
+            productsDirectoryName: "Debug-iphonesimulator",
+            reservedProductsDirectoryNames: []
+        )
+
+        for surviving in ["Debug-iphoneos", "Debug"] {
+            #expect(try await fileSystem.exists(
+                derivedDataPath.appending(components: ["Build", "Products", surviving])
+            ))
+            #expect(try await fileSystem.exists(
+                derivedDataPath.appending(components: ["Build", "Intermediates.noindex", "Tuist.build", surviving])
+            ))
+        }
+        #expect(try await fileSystem.exists(sharedBuildData))
+    }
+
+    @Test(.inTemporaryDirectory)
+    func reclaimKeepsAProductsDirectoryALaterSchemeBuildsIntoAgain() async throws {
+        let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
+        try await seedBuild(in: derivedDataPath, productsDirectoryName: "Debug-iphonesimulator", projects: ["Tuist"])
+
+        await subject.reclaim(
+            derivedDataPath: derivedDataPath,
+            productsDirectoryName: "Debug-iphonesimulator",
+            reservedProductsDirectoryNames: ["Debug-iphonesimulator"]
+        )
+
+        #expect(try await fileSystem.exists(
+            derivedDataPath.appending(components: ["Build", "Products", "Debug-iphonesimulator"])
+        ))
+        #expect(try await fileSystem.exists(
+            derivedDataPath.appending(components: ["Build", "Intermediates.noindex", "Tuist.build", "Debug-iphonesimulator"])
+        ))
+    }
+
+    @Test(.inTemporaryDirectory)
+    func reclaimDoesNotThrowWhenTheBuildWroteNothing() async throws {
+        let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
+
+        await subject.reclaim(
+            derivedDataPath: derivedDataPath,
+            productsDirectoryName: "Debug",
+            reservedProductsDirectoryNames: []
+        )
+    }
+
+    @Test(.inTemporaryDirectory)
+    func reclaimResultBundleRemovesTheBundle() async throws {
+        let derivedDataPath = try #require(FileSystem.temporaryTestDirectory)
+        let resultBundlePath = derivedDataPath.appending(component: UUID().uuidString)
+        try await fileSystem.makeDirectory(at: resultBundlePath)
+        try await fileSystem.writeText("result", at: resultBundlePath.appending(component: "Info.plist"))
+
+        await subject.reclaimResultBundle(at: resultBundlePath)
+
+        #expect(try await fileSystem.exists(resultBundlePath) == false)
+    }
+
+    private func seedBuild(
+        in derivedDataPath: AbsolutePath,
+        productsDirectoryName: String,
+        projects: [String]
+    ) async throws {
+        let products = derivedDataPath.appending(components: ["Build", "Products", productsDirectoryName])
+        try await fileSystem.makeDirectory(at: products)
+        try await fileSystem.writeText("framework", at: products.appending(component: "Product.framework"))
+
+        for project in projects {
+            let intermediates = derivedDataPath.appending(components: [
+                "Build",
+                "Intermediates.noindex",
+                "\(project).build",
+                productsDirectoryName,
+            ])
+            try await fileSystem.makeDirectory(at: intermediates)
+            try await fileSystem.writeText("object", at: intermediates.appending(component: "Object.o"))
+        }
+    }
+}

--- a/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
@@ -168,6 +168,93 @@
                 .called(1)
         }
 
+        @Test(.inTemporaryDirectory) func run_reclaimsADestinationsBuildOutputBeforeBuildingTheNextOne() async throws {
+            let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+            let scratchDirectory = temporaryDirectory.appending(component: "cache-warm")
+            let recorder = BuildRecorder()
+            let fileSystem = FileSystem()
+
+            given(xcodeBuildController)
+                .build(
+                    .any,
+                    scheme: .any,
+                    destination: .any,
+                    rosetta: .any,
+                    derivedDataPath: .any,
+                    clean: .any,
+                    arguments: .any,
+                    passthroughXcodeBuildArguments: .any
+                )
+                .willProduce { _, _, _, _, derivedDataPath, _, arguments, passthroughXcodeBuildArguments in
+                    let derivedDataPath = try #require(derivedDataPath)
+                    let productsDirectoryName = if arguments.contains(.destination("generic/platform=iOS Simulator")) {
+                        "Debug-iphonesimulator"
+                    } else if arguments.contains(.destination("generic/platform=iOS")) {
+                        "Debug-iphoneos"
+                    } else {
+                        "Debug"
+                    }
+
+                    // macOS is built last, so what it sees is the peak the whole command has to fit on disk.
+                    if productsDirectoryName == "Debug" {
+                        var stillPresent: [AbsolutePath] = []
+                        for path in [
+                            derivedDataPath.appending(components: ["Build", "Products", "Debug-iphonesimulator"]),
+                            derivedDataPath.appending(components: ["Build", "Products", "Debug-iphoneos"]),
+                            derivedDataPath.appending(components: [
+                                "Build",
+                                "Intermediates.noindex",
+                                "Fixtures.build",
+                                "Debug-iphonesimulator",
+                            ]),
+                        ] {
+                            if try await fileSystem.exists(path) { stillPresent.append(path) }
+                        }
+                        recorder.iOSOutputAtLastBuild = stillPresent
+                    }
+
+                    let index = try #require(passthroughXcodeBuildArguments.firstIndex(of: "-resultBundlePath"))
+                    let resultBundlePath = try AbsolutePath(validating: passthroughXcodeBuildArguments[index + 1])
+                    recorder.resultBundlePaths.append(resultBundlePath)
+
+                    for directory in [
+                        resultBundlePath,
+                        derivedDataPath.appending(components: ["Build", "Products", productsDirectoryName]),
+                        derivedDataPath.appending(components: [
+                            "Build",
+                            "Intermediates.noindex",
+                            "Fixtures.build",
+                            productsDirectoryName,
+                        ]),
+                    ] {
+                        try await fileSystem.makeDirectory(at: directory)
+                        try await fileSystem.writeText("output", at: directory.appending(component: "Output"))
+                    }
+                }
+
+            try await run(
+                noUpload: false,
+                scratchDirectory: scratchDirectory,
+                schemes: [.test(name: "Binaries-Cache-iOS"), .test(name: "Binaries-Cache-macOS")]
+            )
+
+            #expect(recorder.iOSOutputAtLastBuild == [])
+            // The configuration's own directory holds host products every destination links against, so it is
+            // the one the warm keeps.
+            #expect(try await fileSystem.exists(
+                scratchDirectory.appending(components: ["derived-data", "Build", "Products", "Debug"])
+            ))
+            #expect(recorder.resultBundlePaths.count == 3)
+            for resultBundlePath in recorder.resultBundlePaths {
+                #expect(try await fileSystem.exists(resultBundlePath) == false)
+            }
+        }
+
+        private final class BuildRecorder: @unchecked Sendable {
+            var iOSOutputAtLastBuild: [AbsolutePath]?
+            var resultBundlePaths: [AbsolutePath] = []
+        }
+
         private func run(
             noUpload: Bool,
             configuration: String? = nil,

--- a/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
@@ -172,7 +172,6 @@
             let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
             let scratchDirectory = temporaryDirectory.appending(component: "cache-warm")
             let recorder = BuildRecorder()
-            let fileSystem = FileSystem()
 
             given(xcodeBuildController)
                 .build(
@@ -185,7 +184,10 @@
                     arguments: .any,
                     passthroughXcodeBuildArguments: .any
                 )
+                // Mockable hands this a synchronous closure even for an async requirement, so the seeding
+                // and the observation both go through FileManager rather than FileSystem.
                 .willProduce { _, _, _, _, derivedDataPath, _, arguments, passthroughXcodeBuildArguments in
+                    let fileManager = FileManager.default
                     let derivedDataPath = try #require(derivedDataPath)
                     let productsDirectoryName = if arguments.contains(.destination("generic/platform=iOS Simulator")) {
                         "Debug-iphonesimulator"
@@ -197,8 +199,7 @@
 
                     // macOS is built last, so what it sees is the peak the whole command has to fit on disk.
                     if productsDirectoryName == "Debug" {
-                        var stillPresent: [AbsolutePath] = []
-                        for path in [
+                        recorder.iOSOutputAtLastBuild = [
                             derivedDataPath.appending(components: ["Build", "Products", "Debug-iphonesimulator"]),
                             derivedDataPath.appending(components: ["Build", "Products", "Debug-iphoneos"]),
                             derivedDataPath.appending(components: [
@@ -207,10 +208,7 @@
                                 "Fixtures.build",
                                 "Debug-iphonesimulator",
                             ]),
-                        ] {
-                            if try await fileSystem.exists(path) { stillPresent.append(path) }
-                        }
-                        recorder.iOSOutputAtLastBuild = stillPresent
+                        ].filter { fileManager.fileExists(atPath: $0.pathString) }
                     }
 
                     let index = try #require(passthroughXcodeBuildArguments.firstIndex(of: "-resultBundlePath"))
@@ -227,8 +225,11 @@
                             productsDirectoryName,
                         ]),
                     ] {
-                        try await fileSystem.makeDirectory(at: directory)
-                        try await fileSystem.writeText("output", at: directory.appending(component: "Output"))
+                        try fileManager.createDirectory(atPath: directory.pathString, withIntermediateDirectories: true)
+                        #expect(fileManager.createFile(
+                            atPath: directory.appending(component: "Output").pathString,
+                            contents: Data("output".utf8)
+                        ))
                     }
                 }
 

--- a/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
@@ -4,6 +4,7 @@
     import Foundation
     import Mockable
     import Path
+    import Synchronization
     import Testing
     import TuistAutomation
     import TuistCache
@@ -199,7 +200,7 @@
 
                     // macOS is built last, so what it sees is the peak the whole command has to fit on disk.
                     if productsDirectoryName == "Debug" {
-                        recorder.iOSOutputAtLastBuild = [
+                        recorder.recordIOSOutputAtLastBuild([
                             derivedDataPath.appending(components: ["Build", "Products", "Debug-iphonesimulator"]),
                             derivedDataPath.appending(components: ["Build", "Products", "Debug-iphoneos"]),
                             derivedDataPath.appending(components: [
@@ -208,12 +209,12 @@
                                 "Fixtures.build",
                                 "Debug-iphonesimulator",
                             ]),
-                        ].filter { fileManager.fileExists(atPath: $0.pathString) }
+                        ].filter { fileManager.fileExists(atPath: $0.pathString) })
                     }
 
                     let index = try #require(passthroughXcodeBuildArguments.firstIndex(of: "-resultBundlePath"))
                     let resultBundlePath = try AbsolutePath(validating: passthroughXcodeBuildArguments[index + 1])
-                    recorder.resultBundlePaths.append(resultBundlePath)
+                    recorder.recordResultBundle(resultBundlePath)
 
                     for directory in [
                         resultBundlePath,
@@ -251,9 +252,24 @@
             }
         }
 
-        private final class BuildRecorder: @unchecked Sendable {
-            var iOSOutputAtLastBuild: [AbsolutePath]?
-            var resultBundlePaths: [AbsolutePath] = []
+        private final class BuildRecorder: Sendable {
+            private struct State {
+                var iOSOutputAtLastBuild: [AbsolutePath]?
+                var resultBundlePaths: [AbsolutePath] = []
+            }
+
+            private let state = Mutex(State())
+
+            func recordIOSOutputAtLastBuild(_ paths: [AbsolutePath]) {
+                state.withLock { $0.iOSOutputAtLastBuild = paths }
+            }
+
+            func recordResultBundle(_ path: AbsolutePath) {
+                state.withLock { $0.resultBundlePaths.append(path) }
+            }
+
+            var iOSOutputAtLastBuild: [AbsolutePath]? { state.withLock { $0.iOSOutputAtLastBuild } }
+            var resultBundlePaths: [AbsolutePath] { state.withLock { $0.resultBundlePaths } }
         }
 
         private func run(

--- a/cli/Tests/TuistSupportTests/Utils/VolumeSpaceTests.swift
+++ b/cli/Tests/TuistSupportTests/Utils/VolumeSpaceTests.swift
@@ -27,7 +27,10 @@ struct VolumeSpaceTests {
 
         let space = try #require(VolumeSpace.read(at: neverCreated))
 
-        #expect(space == VolumeSpace.read(at: directory))
+        // `totalBytes` identifies the volume and does not move; `freeBytes` is a live reading that any
+        // unrelated write on the machine can change between two calls, so it is not comparable across them.
+        #expect(space.totalBytes == VolumeSpace.read(at: directory)?.totalBytes)
+        #expect(space.freeBytes > 0)
     }
 
     @Test func isExhaustedTracksTheThreshold() {

--- a/cli/Tests/TuistSupportTests/Utils/VolumeSpaceTests.swift
+++ b/cli/Tests/TuistSupportTests/Utils/VolumeSpaceTests.swift
@@ -1,0 +1,45 @@
+import FileSystem
+import FileSystemTesting
+import Foundation
+import Path
+import Testing
+
+@testable import TuistSupport
+
+struct VolumeSpaceTests {
+    @Test(.inTemporaryDirectory)
+    func readReportsTheVolumeBackingAnExistingDirectory() throws {
+        let directory = try #require(FileSystem.temporaryTestDirectory)
+
+        let space = try #require(VolumeSpace.read(at: directory))
+
+        #expect(space.totalBytes > 0)
+        #expect(space.freeBytes >= 0)
+        #expect(space.freeBytes <= space.totalBytes)
+    }
+
+    @Test(.inTemporaryDirectory)
+    func readWalksUpToTheNearestExistingAncestor() throws {
+        let directory = try #require(FileSystem.temporaryTestDirectory)
+        // A build that failed on a full volume may never have created the directory it was writing into,
+        // and the volume it would have landed on is exactly what we need to report.
+        let neverCreated = directory.appending(components: ["Build", "Products", "Debug"])
+
+        let space = try #require(VolumeSpace.read(at: neverCreated))
+
+        #expect(space == VolumeSpace.read(at: directory))
+    }
+
+    @Test func isExhaustedTracksTheThreshold() {
+        let total: Int64 = 100 * 1024 * 1024 * 1024
+
+        #expect(VolumeSpace(freeBytes: 16 * 1024 * 1024, totalBytes: total).isExhausted)
+        #expect(!VolumeSpace(freeBytes: 40 * 1024 * 1024 * 1024, totalBytes: total).isExhausted)
+    }
+
+    @Test func formattedFreeSpaceNamesBothNumbers() {
+        let space = VolumeSpace(freeBytes: 500 * 1024 * 1024, totalBytes: 100 * 1024 * 1024 * 1024)
+
+        #expect(space.formattedFreeSpace.contains("free of"))
+    }
+}


### PR DESCRIPTION
> **Correction (post-review): this does not fix the `Cache` job's ENOSPC, and the volume's fill level is not the cause.**
> The runner records per-job disk samples. For
> [the failing job](https://github.com/tuist/tuist/actions/runs/33853412632/job/100961123734)
> the volume peaked at 64.3 GB used of 139.5 GB; a **successful** `Cache` job on the same image
> (job 100817414239) peaked *higher*, at 66.1 GB. Resident bytes are therefore not the
> discriminating variable, and the reclaim below would not have prevented the failure.
>
> Note also that `metrics-poll.sh` records `df` columns `$2` (blocks) and `$3` (Used) but never
> `$4` (Available), and on APFS those do not subtract — measured 3.6x overstatement on a
> developer Mac (45.8 GB from `total - used` against 12.8 GB actually available). So how much
> room either job really had is **unknown**, and any "N GB free" figure derived from these
> samples is unsound.
>
> What this PR still does: cut a real ~11-13 GB peak, stop leaking a result bundle per
> `xcodebuild` invocation, and make the next occurrence self-describing. The cause is open —
> see follow-up 0.

## What changed

`tuist cache` now frees each destination's build output as soon as it has been consumed, and reports an out-of-disk failure as one.

- **`CacheWarmBuildOutputReclaimer`** (new, `TuistCache`) removes `Build/Products/<products dir>` and every project's `Build/Intermediates.noindex/*.build/<products dir>` for the destination that just finished, plus the `-resultBundlePath` bundle each `xcodebuild` invocation is handed.
- **`CacheWarmCommandService`** calls it right after `copyDerivedDataArtifacts`, and reserves the products directories a later step still needs: the configuration's own directory (`Debug`) always, plus whatever the bundle pass builds into.
- **`VolumeSpace`** (new, `TuistSupport`) reads `statfs` free/total for a path's volume. When a warm fails on a volume with under 512 MB left, the error now names the volume and its free space instead of surfacing whichever write happened to lose the race.

The five `xcodeBuildController.build` call sites are consolidated into one private `build(...)` helper, which is what owns the result-bundle lifetime.

## Why

This started as an investigation into `cli.yml`'s `Cache` job failing on `main` with `No space left on device`, most recently in [run 33853412632](https://github.com/tuist/tuist/actions/runs/33853412632/job/100961123734):

```
error closing '/var/folders/…/T/CacheWarm-…/derived-data/Build/Intermediates.noindex/
  Tuist.build/Debug/TuistInspectCommand.build/Objects-normal/arm64/GraphImportsLinter.o'
  for output: No space left on device
```

### What the warm actually keeps on disk

`tuist cache` builds every scheme and destination into **one** derived data directory and only assembles the XCFrameworks once all of them are done. Each destination's products are copied out into the scratch `artifacts/` tree the moment its build returns, so from that point its products *and* intermediates are dead weight — but nothing removed them. Peak disk usage is therefore the **sum** of every destination rather than the largest one, and the peak lands during the last build. Measured on the failing CI job, the whole command adds ~11 GB, with both iOS destinations still fully resident while macOS builds.

For scale: a single-arch Debug build of this workspace is 3.8 GB of derived data locally (2.2 GB intermediates, 1.0 GB products); on CI the remote cache means most objects are replayed rather than compiled, so the three destinations together come to ~11 GB.

On top of that, every `xcodebuild` invocation was given a `-resultBundlePath` inside derived data. Nothing reads those bundles back — the flag is only there so xcodebuild does not drop one next to the project — so one accumulated per build for the rest of the command.

### Why the earlier fixes did not cover it

`#12657`, `#12758` and `#12764` all bound the **mounted per-account cache volume** (`~/.tuist-cache-volume`). The write that fails here is in `$TMPDIR` on the runner VM's boot volume, which is a different filesystem and one nothing budgets — but per the correction above, that volume was not full either, so this is about footprint hygiene rather than the failure's cause.

### Why reclaiming is safe

- A destination's products are already copied into `artifacts/`, and `buildXCFrameworks` reads only from there.
- Intermediates are per-products-directory (`Debug-iphonesimulator`, `Debug-iphoneos`, `Debug`, …), so no other destination reads them. Shared state (`XCBuildData`, precompiled modules) sits beside those directories and is left alone.
- The configuration's own directory is always reserved. Host products — macro plugins and other build tools that *every* destination links against — land there, and so does what the macro pass looks for. It is also the last destination built, so keeping it costs nothing at the point where usage peaks.
- The bundle pass reads its artifacts straight out of derived data rather than from `artifacts/`, so the directory it builds into is reserved too.
- Reclaiming is best-effort: a directory that will not go away is logged at debug and ignored, because failing the warm over it would trade a slow build for no build.

### Why the error message

The disk is never named in what surfaces today, and — as the correction above shows — the volume may not even be the problem. Depending on which write loses the race it is `error closing '…/Foo.o' for output: No space left on device`, or — as in the run immediately before this one — `error: unexpected service error: The Xcode build system has crashed` with `LLVM ERROR: Inconvertible error value`. Both have been chased as compiler or cache-integrity problems more than once. The new error is threshold-gated at 512 MB free, so an ordinary build failure on a healthy volume is still reported as itself. **Worth changing before merge:** report the volume's state on *every* warm build failure rather than only below the threshold, and report `Available` explicitly. A line saying the volume still had tens of gigabytes available is exactly what would have redirected this investigation on the first failure instead of after a day of chasing the wrong volume — and `VolumeSpace` already reads `Available` correctly (`systemFreeSize`), unlike `metrics-poll.sh`.

### How to test locally

```bash
tuist generate TuistKit TuistCacheTests TuistSupportTests TuistKitTests --no-open
```

```bash
xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing:TuistCacheTests/CacheWarmBuildOutputReclaimerTests -only-testing:TuistSupportTests/VolumeSpaceTests -only-testing:TuistKitTests/CacheWarmCommandServiceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

To see the reclaim on a real warm, run `tuist cache` on a multi-platform project and watch `$TMPDIR/CacheWarm-*/derived-data/Build`: `Debug-iphonesimulator` and `Debug-iphoneos` disappear as each destination finishes, and only `Debug` plus the scratch `artifacts/` tree remain while the last scheme builds.

## Validation

`xcodebuild build-for-testing -scheme TuistUnitTests` builds clean, and the three suites below run green locally (`** TEST EXECUTE SUCCEEDED **`, 34 cases, no failures).

- New `CacheWarmBuildOutputReclaimerTests` cover: both products and every project's intermediates removed for the destination just built; other destinations and shared `XCBuildData` untouched; a reserved directory kept; no throw when the build wrote nothing; result bundle removed.
- New `VolumeSpaceTests` cover the reading, the walk up to the nearest existing ancestor, and the exhaustion threshold.
- `CacheWarmCommandServiceTests.run_reclaimsADestinationsBuildOutputBeforeBuildingTheNextOne` drives a two-scheme warm with a mocked `xcodeBuildController` that seeds derived data per destination, and asserts the iOS output is gone by the time the macOS scheme builds, that `Debug` survives, and that all three result bundles are removed.
- `mise x -- swiftformat --lint` and `swiftlint` clean on the changed files (the remaining warnings on `CacheWarmCommandService.swift` are pre-existing on `main`).

## Follow-ups this does not fix

0. **The actual cause of the `Cache` job's ENOSPC is still unknown, and we lack the one number that would settle it.** A failing job peaked *lower* than a succeeding one, so resident usage is not it. Two live hypotheses: (a) the guest's `Available` really did reach zero while `Used` stayed flat — on APFS, snapshots and purgeable space pin blocks, so a job that churns (writes then deletes) drains `Available` far faster than `Used` grows, and `tuist cache`'s churn scales with cache misses; or (b) host-side exhaustion — the guest's virtual disk is a sparse file the host could not grow, which a guest's `df` is structurally blind to. Weak signal for (b): the host golden-image GC fires on this fleet (`"reclaimed disk", stale_golden_bases: 4`) and only runs below a 15% host-free floor; I could not map this VM to its host. **The cheapest discriminator is recording `df` column `$4` in `infra/runner-image/metrics-poll.sh`** — either as a new `disk_available_bytes` field, or by redefining `disk_used_bytes` as `($2-$4)` so the existing gauge means "unavailable". A host-root free-bytes metric would cover (b); today only `tart_kubelet_cache_volume_root_free_bytes` exists, which is a different volume.

1. **`tuist cache` overrides the runner's compilation-cache store.** It passes `COMPILATION_CACHE_CAS_PATH` as an xcodebuild command-line setting, and I measured on Xcode 26.5 that a command-line build setting beats `XCODE_XCCONFIG_FILE` — which is how `infra/runner-image/dispatch-poll.sh` points the CAS at the mounted cache volume. So on runners the store lands on the boot volume instead, dies with the VM, and is never promoted; the macOS build reports `322 hits / 921 cacheable tasks (35%)` with every hit coming from the remote. Moving it back is only safe once the store is bounded, because `COMPILATION_CACHE_LIMIT_SIZE` does not bound the directory.
2. **The guest disk probe is blind exactly when it matters.** `tart_kubelet_guest_disk_usage_percent` read 16–21% fleet-wide during the failure and DiskPressure never fired — but `diskPressureFromGuests` runs `tart exec <vm> /bin/df -k /` under a 15 s bound and logs-and-skips on timeout, and there were 14 such timeouts across 8 hosts in the 25 minutes around the failure. A guest running a heavy parallel build is precisely the one that times out. Separately, on macOS `df /` reports the sealed system volume, so its capacity only reaches the 90% threshold at roughly 1 GB free.

Note that `cli.yml` runs the `tuist` that `mise` installs, so the `Cache` job picks this up through the canary release train rather than from this PR's checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



