### PR TITLE
fix(infra): split egress-tree first attaches out of the reattach churn metric

### DIFF
--- a/infra/egress-tree-agent/AGENTS.md
+++ b/infra/egress-tree-agent/AGENTS.md
@@ -226,20 +226,25 @@ log — the counter is the only signal), and per-class floor violations under
 contention (`kura_egress_tree_class_sent_bytes` rate vs
 `kura_egress_tree_class_rate_bytes_per_second`).
 
-Do not alert on `kura_egress_tree_link_attach_total`. It counts first
-attaches on new pod devices — one per pod creation — so it tracks pod churn,
-not shaping integrity: a fleet-wide kura rollout replaces every pod, each
-replacement gets a new `lxc` device, and the counter climbs by the node's
-whole pod count with nothing wrong. It is there for rollout visibility and to
-keep that traffic out of the reattach signal, which used to carry both and
-tripped its alert on every kura release. `kura_egress_tree_link_reattach_total`
-now moves only when a link we already installed was stripped or displaced, so
-it should sit flat at zero and any growth is worth a look; the matching
-`reattached pod program` warning names the pod and device. The production
-alert still carries the old `> 5` per-hour threshold that was chosen to ride
-over rollout noise; drop it to `> 0` once this split is deployed across the
-fleet, and not before — until then the running agents still emit the
-conflated counter and a tighter threshold only fires sooner on rollouts.
+Do not alert on `kura_egress_tree_link_attach_total`. It counts first attaches
+on new pod devices — one per pod creation — so it tracks pod churn, not shaping
+integrity: a fleet-wide kura rollout replaces every pod, each replacement gets a
+new `lxc` device, and the counter climbs by the node's whole pod count with
+nothing wrong. Its job is to keep that traffic out of the reattach signal, which
+used to carry both and tripped its alert on every kura release. It has
+deliberately no alert arm and no dashboard panel — the kura dashboard's agent
+panel groups integrity signals, and a pod-churn counter sitting among them is
+the same conflation one level up — so it is an ad-hoc query when you want to
+confirm a rollout attached what it should, not something anyone watches.
+
+`kura_egress_tree_link_reattach_total` now moves only when a link we already
+installed was stripped or displaced, so it should sit flat at zero and any
+growth is worth a look; the matching `reattached pod program` warning names the
+pod and device. The production alert still carries the old `> 5` per-hour
+threshold that was chosen to ride over rollout noise; drop it to `> 0` once this
+split is deployed across the fleet, and not before — until then the running
+agents still emit the conflated counter and a tighter threshold only fires
+sooner on rollouts.
 
 A pod-device convergence error keeps the last known-good program attached
 (the device stays out of the stale sweep) and requeues a fast retry; a

--- a/infra/egress-tree-agent/AGENTS.md
+++ b/infra/egress-tree-agent/AGENTS.md
@@ -62,6 +62,12 @@ dictate this shape — do not regress them:
   and agent restarts and leaves foreign links alone; our pinned links keep
   their first position. The reconcile loop still verifies position every
   cycle and reattaches (plus a churn metric) if something strips them.
+  Because Cilium leaves our links alone, a reattach means external
+  interference, and the metric counts only that: a brand-new pod device has
+  no pin yet and lands on `kura_egress_tree_link_attach_total` instead. The
+  discriminator is pin existence, not `linkAttached`, which deliberately
+  reads a present-but-unreadable pin as detached — that case is interference
+  to report, not a pod that never had a program.
 - Sibling traffic (headless DNS → the co-located replica's pod IP) takes a
   bypass branch before stamping and stays on Cilium's fast path
   (`redirect_peer`, measured at node-local line rate). The bypass is an
@@ -212,13 +218,28 @@ Alert on: `kura_egress_tree_direct_packets` growth,
 `kura_egress_tree_return_dropped_packets` growth,
 `kura_egress_tree_return_attach_failures_total` growth (a failing return
 attach blackholes shaped pods until the detach threshold),
-`kura_egress_tree_link_reattach_total` churn after steady state,
+`kura_egress_tree_link_reattach_total` growth at all (see below),
 `kura_egress_tree_skipped_pods` > 0,
 `kura_egress_tree_sibling_overflow_total` growth (an account outgrew the
 16-entry sibling map; extra siblings run shaped instead of bypassed, with no
 log — the counter is the only signal), and per-class floor violations under
 contention (`kura_egress_tree_class_sent_bytes` rate vs
 `kura_egress_tree_class_rate_bytes_per_second`).
+
+Do not alert on `kura_egress_tree_link_attach_total`. It counts first
+attaches on new pod devices — one per pod creation — so it tracks pod churn,
+not shaping integrity: a fleet-wide kura rollout replaces every pod, each
+replacement gets a new `lxc` device, and the counter climbs by the node's
+whole pod count with nothing wrong. It is there for rollout visibility and to
+keep that traffic out of the reattach signal, which used to carry both and
+tripped its alert on every kura release. `kura_egress_tree_link_reattach_total`
+now moves only when a link we already installed was stripped or displaced, so
+it should sit flat at zero and any growth is worth a look; the matching
+`reattached pod program` warning names the pod and device. The production
+alert still carries the old `> 5` per-hour threshold that was chosen to ride
+over rollout noise; drop it to `> 0` once this split is deployed across the
+fleet, and not before — until then the running agents still emit the
+conflated counter and a tighter threshold only fires sooner on rollouts.
 
 A pod-device convergence error keeps the last known-good program attached
 (the device stays out of the stale sweep) and requeues a fast retry; a

--- a/infra/egress-tree-agent/internal/agent/agent.go
+++ b/infra/egress-tree-agent/internal/agent/agent.go
@@ -165,7 +165,7 @@ func (a *Agent) reconcile(ctx context.Context) (bool, error) {
 				"pod", key)
 			continue
 		}
-		reattached, err := a.Attacher.EnsurePod(device, trampoline.Index, attachment)
+		outcome, err := a.Attacher.EnsurePod(device, trampoline.Index, attachment)
 		if err != nil {
 			skipped++
 			requeue = true
@@ -177,10 +177,13 @@ func (a *Agent) reconcile(ctx context.Context) (bool, error) {
 				"pod", key, "device", device, "error", err)
 			continue
 		}
-		if reattached {
+		switch outcome {
+		case AttachFirst:
+			a.Metrics.LinkAttaches.Inc()
+		case AttachReattach:
 			a.Metrics.LinkReattaches.Inc()
 		}
-		a.logPodChange(key, device, attachment, reattached)
+		a.logPodChange(key, device, attachment, outcome)
 		active[device] = true
 		deviceOf[key] = device
 		attached++
@@ -262,11 +265,17 @@ func (a *Agent) logClassChanges(classes map[uint16]TenantClass) {
 
 // logPodChange logs one pod's attach or config transition and records the
 // new fingerprint. A quiet cycle (attached, first, same config) logs nothing.
-func (a *Agent) logPodChange(key, device string, attachment PodAttachment, reattached bool) {
+func (a *Agent) logPodChange(key, device string, attachment PodAttachment, outcome AttachOutcome) {
 	old, existed := a.appliedPods[key]
 	current := appliedPod{Device: device, Minor: attachment.Minor, Siblings: attachment.SiblingIPs}
 	switch {
-	case reattached:
+	case outcome == AttachReattach:
+		// A link we had already installed was stripped or displaced. Cilium
+		// replaces its own link in place and leaves ours alone, so this is
+		// external interference: warn, and pair with link_reattach_total.
+		a.Log.Warn("reattached pod program", "pod", key, "device", device,
+			"classid", ClassIDString(attachment.Minor), "siblings", attachment.SiblingIPs)
+	case outcome == AttachFirst:
 		a.Log.Info("attached pod program", "pod", key, "device", device,
 			"classid", ClassIDString(attachment.Minor), "siblings", attachment.SiblingIPs)
 	case !existed:

--- a/infra/egress-tree-agent/internal/agent/bpf.go
+++ b/infra/egress-tree-agent/internal/agent/bpf.go
@@ -102,48 +102,77 @@ func (a Attacher) EnsureReturn(returnDev string) error {
 	return nil
 }
 
+// AttachOutcome describes what EnsurePod did to a pod device's tcx link.
+// The distinction matters to the metrics: a first attach is routine (every
+// pod creation produces exactly one), while a reattach means something
+// stripped or displaced a link we had already installed.
+type AttachOutcome int
+
+const (
+	// AttachUnchanged: the pinned link was already attached and still first
+	// in the chain, so only the maps were synced.
+	AttachUnchanged AttachOutcome = iota
+	// AttachFirst: no link pin existed, so this is a new pod device. A
+	// rolling update of N pods produces exactly N of these.
+	AttachFirst
+	// AttachReattach: a link pin existed, but the link was missing, bound to
+	// a stale ifindex, unreadable, or no longer first in the chain. Cilium
+	// replaces its own link in place and leaves foreign links alone, so this
+	// means something else manipulated the chain.
+	AttachReattach
+)
+
 // EnsurePod converges one pod device: program attached first in the tcx
-// chain (before cil_from_container) and maps in sync. Returns whether the
-// link was (re)attached, which feeds the churn metric — repeated reattaches
-// mean something else is manipulating the chain.
-func (a Attacher) EnsurePod(dev string, trampolineIfindex int, attachment PodAttachment) (bool, error) {
+// chain (before cil_from_container) and maps in sync. The returned outcome
+// feeds the attach and churn metrics — repeated reattaches mean something
+// else is manipulating the chain.
+func (a Attacher) EnsurePod(dev string, trampolineIfindex int, attachment PodAttachment) (AttachOutcome, error) {
 	iface, err := net.InterfaceByName(dev)
 	if err != nil {
-		return false, fmt.Errorf("resolving %s: %w", dev, err)
+		return AttachUnchanged, fmt.Errorf("resolving %s: %w", dev, err)
 	}
 	dir := a.podDir(dev)
+
+	// Pin existence, not linkAttached, is what separates a new pod device
+	// from a displaced link: linkAttached deliberately reads a present but
+	// unreadable pin as detached, and that case is interference to report,
+	// not a pod that never had a program.
+	outcome := AttachFirst
+	if pathExists(filepath.Join(dir, "link")) {
+		outcome = AttachReattach
+	}
 
 	if a.linkAttached(dir, iface.Index) {
 		first, err := a.linkIsFirst(dir, iface.Index)
 		if err != nil {
-			return false, err
+			return AttachUnchanged, err
 		}
 		if first {
-			return false, a.syncPodMaps(dir, trampolineIfindex, attachment)
+			return AttachUnchanged, a.syncPodMaps(dir, trampolineIfindex, attachment)
 		}
 	}
 	a.removePins(dir)
 
 	objects := redirectObjects{}
 	if err := loadRedirectObjects(&objects, nil); err != nil {
-		return false, fmt.Errorf("loading pod program: %w", err)
+		return AttachUnchanged, fmt.Errorf("loading pod program: %w", err)
 	}
 	defer objects.Close()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return false, err
+		return AttachUnchanged, err
 	}
 	if err := objects.Config.Pin(filepath.Join(dir, "config")); err != nil {
-		return false, err
+		return AttachUnchanged, err
 	}
 	if err := objects.Siblings.Pin(filepath.Join(dir, "siblings")); err != nil {
-		return false, err
+		return AttachUnchanged, err
 	}
 	if err := objects.Counters.Pin(filepath.Join(dir, "counters")); err != nil {
-		return false, err
+		return AttachUnchanged, err
 	}
 	// Maps are fully populated before the program can see a packet.
 	if err := a.syncPodMaps(dir, trampolineIfindex, attachment); err != nil {
-		return false, err
+		return AttachUnchanged, err
 	}
 	l, err := link.AttachTCX(link.TCXOptions{
 		Interface: iface.Index,
@@ -152,13 +181,13 @@ func (a Attacher) EnsurePod(dev string, trampolineIfindex int, attachment PodAtt
 		Anchor:    link.Head(),
 	})
 	if err != nil {
-		return false, fmt.Errorf("attaching pod program to %s: %w", dev, err)
+		return AttachUnchanged, fmt.Errorf("attaching pod program to %s: %w", dev, err)
 	}
 	defer l.Close()
 	if err := l.Pin(filepath.Join(dir, "link")); err != nil {
-		return false, err
+		return AttachUnchanged, err
 	}
-	return true, nil
+	return outcome, nil
 }
 
 func (a Attacher) syncPodMaps(dir string, trampolineIfindex int, attachment PodAttachment) error {

--- a/infra/egress-tree-agent/internal/agent/metrics.go
+++ b/infra/egress-tree-agent/internal/agent/metrics.go
@@ -14,6 +14,7 @@ type Metrics struct {
 	AttachedPods         prometheus.Gauge
 	ReturnAttachFailures prometheus.Counter
 	SkippedPods          prometheus.Gauge
+	LinkAttaches         prometheus.Counter
 	LinkReattaches       prometheus.Counter
 	SiblingOverflow      prometheus.Counter
 	NodeBudgetMbps       prometheus.Gauge
@@ -61,9 +62,13 @@ func NewMetrics(registry prometheus.Registerer) *Metrics {
 			Name: "kura_egress_tree_skipped_pods",
 			Help: "Annotated pods not attached this cycle (unresolvable device or malformed annotation).",
 		}),
+		LinkAttaches: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "kura_egress_tree_link_attach_total",
+			Help: "First tcx link attaches on new pod devices; one per pod creation.",
+		}),
 		LinkReattaches: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "kura_egress_tree_link_reattach_total",
-			Help: "tcx link attach or reattach operations on pod devices.",
+			Help: "tcx links put back after being stripped or displaced from the head of a pod device's chain.",
 		}),
 		SiblingOverflow: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "kura_egress_tree_sibling_overflow_total",
@@ -129,7 +134,7 @@ func NewMetrics(registry prometheus.Registerer) *Metrics {
 	registry.MustRegister(
 		m.ReconcileTotal, m.ReconcileErrors, m.AttachedPods, m.ReturnAttachFailures,
 		m.SkippedPods,
-		m.LinkReattaches, m.SiblingOverflow, m.NodeBudgetMbps, m.ClassSentBytes, m.ClassDrops,
+		m.LinkAttaches, m.LinkReattaches, m.SiblingOverflow, m.NodeBudgetMbps, m.ClassSentBytes, m.ClassDrops,
 		m.ClassBacklogBytes, m.ClassLendedPackets, m.ClassBorrowedPackets,
 		m.ClassRateBytes, m.ClassCeilBytes,
 		m.DirectPackets, m.PodRedirected, m.PodGuardPass,

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -2962,8 +2962,19 @@ or label_replace(
   the return program failed to attach, shaped pods blackholed until the detach
   threshold. reconcile_errors: the loop is failing. sibling_overflow: an
   account outgrew the 16-entry sibling map, extra replicas run shaped with no
-  log. reattach_churn: links re-attaching after steady state. skipped_pods:
-  annotated pods not attached (unresolvable device or malformed annotation).
+  log. reattach_churn: a tcx link the agent had already installed was stripped
+  or displaced from the head of a pod device's chain. Cilium replaces its own
+  link in place and leaves ours alone, so this means external interference; the
+  matching 'reattached pod program' warning in the agent log names the pod and
+  device. CAVEAT on agent versions older than the metric split (those not
+  exporting kura_egress_tree_link_attach_total): there this counter ALSO counted
+  the first attach on every new pod device, so any kura rollout replaces every
+  pod, each replacement gets a new lxc device, and this signal trips with
+  nothing wrong. Before treating it as real on those versions, check that
+  kura_egress_tree_attached_pods moved (a rollout leaves it flat because deploys
+  are gapless) and that the pods on the node are not all freshly created.
+  skipped_pods: annotated pods not attached (unresolvable device or malformed
+  annotation).
   budget_mismatch: the tree's root ceiling disagrees with the node's advertised
   tuist.dev/egress-mbps. softnet_drops: per-CPU backlog overflow on a shaped
   box, a silent kernel drop no agent counter sees. no_agent: a box with a
@@ -2973,7 +2984,12 @@ or label_replace(
 
 Every arm is one of the alarms the agent's own notes ask for
 (`infra/egress-tree-agent/AGENTS.md`, *Metrics / alerts*), collected into one
-rule with a `signal` label so a single summary names the tripwire. Without
+rule with a `signal` label so a single summary names the tripwire. The one
+counter those notes deliberately exclude is `kura_egress_tree_link_attach_total`:
+it counts first attaches on new pod devices, one per pod creation, so it tracks
+pod churn rather than shaping integrity and climbs by a node's whole pod count
+on any rollout. It exists to keep that traffic out of `reattach_churn`, and
+must not become an arm here. Without
 them **Kura egress budget heavily used** measures a number the tree may not
 be enforcing, and **Kura account at its egress ceiling** reads a ceiling that
 may not be applied.
@@ -2993,10 +3009,22 @@ other boxes' agents still answer).
 Windows and bars: the tc/BPF counters are kernel counters exported as gauges,
 so every counting arm uses `increase()` over 30 minutes (a rebuild of the tree
 resets them, which reads as nothing, not as a spike), with the 15 minute
-pending period on top so a controller rollout, which re-attaches every pod
-once and briefly reports skipped pods, passes. `reattach_churn` is the one arm
-with a bar above zero: a rollout re-attaches each pod once, so more than five
-re-attaches on a box in an hour is churn. `no_agent` and `softnet_drops` are
+pending period on top so a rollout, which replaces every pod and so attaches
+each new device once and briefly reports the replacements as skipped while
+their Cilium endpoints appear, passes. `reattach_churn` is the one arm
+with a bar above zero, and the bar is a workaround being retired, not a
+property of the signal. It was set on the reasoning that "a rollout re-attaches
+each pod once, so more than five on a box in an hour is churn"; that premise is
+wrong twice. A rollout does not *re*-attach — each replaced pod is a new veth
+getting its *first* attach — and the count scales with the node's pod count, so
+no fixed bar is safe: the 2026-09-04 kura 0.33.0 -> 0.34.0 rollout replaced 47
+of 51 production pods and produced 18 on one box, with `attached_pods` flat and
+every other arm at zero. `kura_egress_tree_link_reattach_total` now counts only
+displaced links (`infra/egress-tree-agent/AGENTS.md`, *Metrics / alerts*), so
+this bar drops to `> 0` — but **only once that agent build is deployed
+fleet-wide**, since agents predating the split still emit the conflated counter
+and a tighter bar would fire sooner on rollouts, not less. `no_agent` and
+`softnet_drops` are
 scoped to boxes that advertise a budget, which keeps the deliberately
 unshaped runner-cache box out. The agent's pod name is joined to its node
 through `kube_pod_info`; the agent's series carry no `node` label.
@@ -3004,7 +3032,10 @@ through `kube_pod_info`; the agent's series carry no `node` label.
 Measured on 2026-09-02, every arm is zero across production over the last 7
 days (no unshaped or dropped packets, no attach failures, no softnet drops,
 every governed box has a healthy agent and its budget matches the advertised
-capacity). Quiet on creation.
+capacity). Quiet on creation. That held for every arm except `reattach_churn`,
+which was found on 2026-09-04 to fire on every kura release — roughly six
+windows in the preceding two weeks, all false — for the reason described under
+*Windows and bars* above.
 
 ### Kura response streams waiting or degraded
 


### PR DESCRIPTION
> Describe here the purpose of your PR.

The `Kura - egress shaping integrity` alert fires `reattach_churn` on every kura fleet rollout. It is a false positive, and this fixes the metric it reads.

### Root cause

`kura_egress_tree_link_reattach_total` counted **every** tcx link attach on a pod device, including the *first* attach on a device the agent had never shaped. `Attacher.EnsurePod` returned one bool that was true for any attach, and the help string admitted it — *"tcx link attach **or reattach** operations"*.

But `AGENTS.md` and the alert both read it in the narrow sense the name implies: a link that lost its first position in the chain. Cilium replaces its own tcx link in place and leaves foreign links alone, so under that reading a reattach means external interference — which is why it is alertable at all.

Because a new pod gets a new veth (`lxc*`) device, a rollout replacing N pods climbs the counter by N. The alert's `increase(...[1h]) > 5` clause therefore trips on any node hosting more than five kura pods, so any fleet-wide kura release fires it on every shaped node.

### Evidence from the 2026-09-04 misfire

The `ghcr.io/tuist/kura` `0.33.0` → `0.34.0` rollout replaced **47 of 51** production pods between ~08:55 and ~09:13 UTC. The alert went active at 09:16/09:26.

| agent pod | node | `attached_pods` | reattaches | attach log lines |
|---|---|---|---|---|
| `f9rp7` | dedibox-x47qf | 12 (flat 12h) | 10 | 12 |
| `gm9b7` | ovh-us-east-jjgbg | 18 (flat) | 18 | 18 |
| `tck25` | ovh-us-west-9ntgg | 6 (flat 12h) | 6 | 6 |

- Reattaches equalled each node's **entire pod count** while `attached_pods` never moved — a gapless rolling replacement, not stripped links.
- Every kura pod on all three nodes was younger than 90 minutes.
- Loki showed **exactly one** `attached pod program` line per pod, each naming a **distinct new `lxc` device**, in StatefulSet ordinal order (`-1` then `-0`). Genuine re-attachment would re-name the *same* device.
- The two agents that did **not** alert are precisely the two with **0** attached pods.
- Every real tripwire was flat at zero across the window: `direct_packets`, `return_dropped_packets`, `return_attach_failures_total`, `reconcile_errors_total`, `sibling_overflow_total`. Nothing ran unshaped or blackholed.

The threshold had already been breached in roughly **six windows over the preceding two weeks**, each matching a rollout.

### What changed

- `EnsurePod` returns an `AttachOutcome` (`AttachUnchanged` / `AttachFirst` / `AttachReattach`) instead of a bare bool.
- First attaches land on a new counter, `kura_egress_tree_link_attach_total`. `kura_egress_tree_link_reattach_total` keeps its name and now moves only when a link we already installed was stripped or displaced.
- A genuine reattach logs `reattached pod program` at **Warn** with pod and device. Previously a real interference event was textually identical to a routine rollout attach, so there was nothing to grep when the alert fired.
- `AGENTS.md` documents the split and adds an explicit *do not alert on `link_attach_total`* note.

**Why pin existence is the discriminator, not `linkAttached`:** `linkAttached` deliberately reads a present-but-unreadable pin as detached (so the agent self-heals rather than wedging a pod unshaped). That case *is* real interference and must stay in the reattach bucket — keying off it would misfile it as a new device. An absent pin is the only unambiguous signal of a device that never had a program.

Enforcement behaviour is unchanged; this only reclassifies what the counters mean.

### Reviewer notes

- The production alert's **description** has already been updated in Grafana (the rule is Grafana-managed, not in this repo) to describe the corrected semantics, with a caveat for agents predating this split.
- Its `> 5` threshold is **deliberately left alone**. It should drop to `> 0` only once this is deployed fleet-wide — until then the running agents still emit the conflated counter, and tightening it now would fire *sooner* on rollouts, not less. This ordering is recorded in `AGENTS.md`.
- The `tuist-kura-details` dashboard is intentionally untouched: its panel groups integrity signals, and adding the new attach counter there would blur the distinction this change draws.

### How to test locally

> Document how to test your changes locally

The agent needs Linux (tcx attach, kernel >= 6.6) and the bpf2go bindings are not committed:

```
cd infra/egress-tree-agent
go generate ./internal/agent   # needs clang + libbpf headers
go test ./... && go vet ./...
```

Cross-compile check without generating BPF objects (what was run for this PR, alongside `gofmt`):

```
cd infra/egress-tree-agent && GOOS=linux GOARCH=amd64 go build ./...
```

On a shaped node after deploy, `kura_egress_tree_link_attach_total` should climb by the node's pod count during a kura rollout while `kura_egress_tree_link_reattach_total` stays flat at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
