### PR TITLE
fix(infra): match the Kura region runbook to the deployed rules

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -66,9 +66,13 @@ that hosts no cache pod count towards its region: one cache pod anywhere in the
 pool names the region, and every node of that pool inherits it.
 
 Create them under **Alerting → Recording rules**, folder `Alerts`, group
-`Kura region joins`, evaluated every minute. Rules in a group evaluate in
-order, so keep the order below: `kura:pool_region` reads the two rules above
-it and `kura:node_region` reads them both.
+`Kura Recording`, evaluated every minute. Each rule writes its result back to
+the metrics datasource and the next one reads it from there, so the chain
+settles over a few evaluation cycles rather than within one, and position
+inside the group does not order it. When extending the chain, create the new
+rule and wait for it to populate before pointing an existing rule at it:
+switching a consumer first leaves it evaluating against a missing series, and
+`kura:node_region` feeds every region rule in this document.
 
 ```promql
 # kura:pod_region
@@ -2607,7 +2611,9 @@ spent above a threshold.
 
 ### Kura region has room for one more instance
 
-Same query as **Kura region cannot place another instance**.
+The `ceiling` and `memory` rows of **Kura region cannot place another
+instance**, carrying the same zero default. The `disk` and `egress` rows are
+on the critical rule only.
 
 - Threshold: `< 2`, as a separate threshold expression on `A`
 - Pending period: 30 minutes
@@ -2622,11 +2628,10 @@ Same query as **Kura region cannot place another instance**.
 - Description: `Counts how many more two-replica enterprise instances the
   region can place, per placement constraint (ceiling = the
   tuist.dev/memory-ceiling-mib extended resource, memory = native requests
-  against allocatable, disk = ephemeral-storage claims against allocatable
-  disk, egress = 25 Mbps floors against the advertised budget). One means the next enterprise sign-up is the last that fits; zero is
-  paged separately. Plan a node for the region before it lands.`
+  against allocatable). One means the next enterprise sign-up is the last that
+  fits; zero is paged separately. Plan a node for the region before it lands.`
 
-The lead-time tier, on all three constraints: the next enterprise instance is
+The lead-time tier, on both constraints: the next enterprise instance is
 the last one that fits.
 It also holds at zero, alongside the critical rule; that is intended, the
 critical one pages and this one keeps the Slack thread.


### PR DESCRIPTION
## What changed

Three corrections to the **Recording rules for Kura regions** section and the **Kura region has room for one more instance** section of `alerts.md`, so the runbook matches the rules that are actually deployed in Grafana.

## Why

Follow-up to [#12836](https://github.com/tuist/tuist/pull/12836), found while applying that change to Grafana. `alerts.md` is the source of record for these hand-created rules, so a reader who follows it as written would have created a rule group that does not exist and expected an ordering guarantee that is not there.

## The corrections

**1. The group is `Kura Recording`, not `Kura region joins`.** That is the group `kura:pod_region` and `kura:node_region` have always lived in.

**2. Position inside the group does not order the chain.** Each Grafana recording rule writes its result back to the metrics datasource and the next one reads it from there, so a dependency is not visible within the same evaluation tick regardless of where it sits in the group; the chain settles over a few cycles instead.

The requirement that does matter, and that the old text obscured by framing it as ordering, is operational: create a new rule and let it populate **before** pointing an existing rule at it. Switching a consumer first leaves it evaluating against a missing series, and `kura:node_region` feeds every region rule in the document. Applying #12836 followed exactly that sequence, with `kura:node_pool` and `kura:pool_region` created and confirmed populated before `kura:node_region` was switched over, so the join was never empty.

**3. The warning tier carries two rows, not four.** The section claimed "Same query as Kura region cannot place another instance" while the deployed rule has only the `ceiling` and `memory` rows, and its description annotation names only those two. The section also said "all three constraints", which matched neither. Documented as it is.

## Impact

Documentation only. No query, threshold, or alert behaviour changes here.

Note that the deployed warning rule having two rows rather than four is real drift between it and what this section previously claimed. This PR documents the deployed state rather than changing what warns, since widening the lead-time tier is a policy call rather than a fix. For reference, adding the `disk` and `egress` rows would be quiet today: the tightest region by disk is at 2 against a `< 2` threshold, and by egress at 34.

## Validation

`git diff` against `main` touches `alerts.md` only, and only in the two sections named above. The claims were each checked against the live rules via the Grafana API: group name, rule expressions, and the warning rule's row count and description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
