### PR TITLE
fix(infra): stop the Kura retention alerts firing on a rebuilt ring

### DIFF
--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -2220,7 +2220,7 @@
         "spec": {
           "id": 8,
           "title": "Disk by region",
-          "description": "**Fit (disk)** counts how many more instances (two replicas of `$instance_claim_gib` GiB) the region's allocatable ephemeral-storage still admits, `floor()` per node first; each replica requests its storage claim as an `ephemeral-storage` request with no limit, so the request is the only admission control the claim has and it is what **Kura region cannot place another instance** counts as its `disk` row. **Disk requested** is the scheduler's view (claims against allocatable, the disk minus kubelet's eviction reserve); **Host disk used** is the filesystem holding the local-path cache. Rings run full by design, so usage says little: **Shortest retention** is the lowest one-day median of `kura_segment_shed_age_seconds` among the region's full rings (how soon after being written an artifact can be evicted), the number the customer feels; under two days warns, under a day pages (**Kura instance retention horizon**). Its lever is the account's storage claim (`Tuist.Kura.ClaimSizing`), and the region only enters when the claim cannot grow because the boxes are full.",
+          "description": "**Fit (disk)** counts how many more instances (two replicas of `$instance_claim_gib` GiB) the region's allocatable ephemeral-storage still admits, `floor()` per node first; each replica requests its storage claim as an `ephemeral-storage` request with no limit, so the request is the only admission control the claim has and it is what **Kura region cannot place another instance** counts as its `disk` row. **Disk requested** is the scheduler's view (claims against allocatable, the disk minus kubelet's eviction reserve); **Host disk used** is the filesystem holding the local-path cache. Rings run full by design, so usage says little: **Shortest retention** is the lowest one-day median of `kura_segment_shed_age_seconds` among the region's full rings (how soon after being written an artifact can be evicted), the number the customer feels; under a day pages (**Kura instance retention horizon under a day**). A ring is only counted once it has been full for the whole day, because a ring rebuilt more recently (an instance that landed on a new node) holds nothing older than itself and would read as its own age. Its lever is the account's storage claim (`Tuist.Kura.ClaimSizing`), and the region only enters when the claim cannot grow because the boxes are full.",
           "links": [],
           "data": {
             "kind": "QueryGroup",
@@ -2330,7 +2330,7 @@
                       "group": "prometheus",
                       "kind": "DataQuery",
                       "spec": {
-                        "expr": "min by (cluster, region) (histogram_quantile(0.5, sum by (cluster, region, tenant_id, pod, le) (increase(kura_segment_shed_age_seconds_bucket{env=\"$env\"}[1d]) * on (cluster, pod) group_left(region, tenant_id) max by (cluster, pod, region, tenant_id) (kura_node_geo_info{env=\"$env\"}))) and on (cluster, pod) (max by (cluster, pod) (kura_backfill_ring_fullness_percent{env=\"$env\"}) >= 100))",
+                        "expr": "min by (cluster, region) (histogram_quantile(0.5, sum by (cluster, region, tenant_id, pod, le) (increase(kura_segment_shed_age_seconds_bucket{env=\"$env\"}[1d]) * on (cluster, pod) group_left(region, tenant_id) max by (cluster, pod, region, tenant_id) (kura_node_geo_info{env=\"$env\"}))) and on (cluster, pod) (min by (cluster, pod) (min_over_time(kura_backfill_ring_fullness_percent{env=\"$env\"}[1d])) >= 100))",
                         "legendFormat": "__auto",
                         "instant": true,
                         "range": false,
@@ -2753,7 +2753,7 @@
                       "group": "prometheus",
                       "kind": "DataQuery",
                       "spec": {
-                        "expr": "histogram_quantile(0.5, sum by (cluster, region, tenant_id, pod, le) (increase(kura_segment_shed_age_seconds_bucket{env=\"$env\"}[1d]) * on (cluster, pod) group_left(region, tenant_id) max by (cluster, pod, region, tenant_id) (kura_node_geo_info{env=\"$env\"}))) and on (cluster, pod) (max by (cluster, pod) (kura_backfill_ring_fullness_percent{env=\"$env\"}) >= 100)",
+                        "expr": "histogram_quantile(0.5, sum by (cluster, region, tenant_id, pod, le) (increase(kura_segment_shed_age_seconds_bucket{env=\"$env\"}[1d]) * on (cluster, pod) group_left(region, tenant_id) max by (cluster, pod, region, tenant_id) (kura_node_geo_info{env=\"$env\"}))) and on (cluster, pod) (min by (cluster, pod) (min_over_time(kura_backfill_ring_fullness_percent{env=\"$env\"}[1d])) >= 100)",
                         "legendFormat": "__auto",
                         "instant": true,
                         "range": false,
@@ -3693,7 +3693,7 @@
                       "group": "prometheus",
                       "kind": "DataQuery",
                       "spec": {
-                        "expr": "min by (cluster, region) (histogram_quantile(0.5, sum by (cluster, region, tenant_id, pod, le) (increase(kura_segment_shed_age_seconds_bucket{env=\"$env\"}[1d]) * on (cluster, pod) group_left(region, tenant_id) max by (cluster, pod, region, tenant_id) (kura_node_geo_info{env=\"$env\"}))) and on (cluster, pod) (max by (cluster, pod) (kura_backfill_ring_fullness_percent{env=\"$env\"}) >= 100))",
+                        "expr": "min by (cluster, region) (histogram_quantile(0.5, sum by (cluster, region, tenant_id, pod, le) (increase(kura_segment_shed_age_seconds_bucket{env=\"$env\"}[1d]) * on (cluster, pod) group_left(region, tenant_id) max by (cluster, pod, region, tenant_id) (kura_node_geo_info{env=\"$env\"}))) and on (cluster, pod) (min by (cluster, pod) (min_over_time(kura_backfill_ring_fullness_percent{env=\"$env\"}[1d])) >= 100))",
                         "legendFormat": "{{region}}",
                         "instant": false,
                         "range": true

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1141,7 +1141,9 @@ histogram_quantile(0.5,
   )
 )
 and on (cluster, pod) (
-  max by (cluster, pod) (kura_backfill_ring_fullness_percent{cluster="tuist-production"}) >= 100
+  min by (cluster, pod) (
+    min_over_time(kura_backfill_ring_fullness_percent{cluster="tuist-production"}[1d])
+  ) >= 100
 )
 ```
 
@@ -1161,13 +1163,90 @@ and on (cluster, pod) (
   younger than a day (median age of the youngest artifact in each segment the
   ring rotated out over the last day). Overnight and weekend builds will miss.
   Rings run full by design; what this measures is whether the claim is enough
-  for the account's write rate, so the lever is the account's storage claim
-  (Tuist.Kura.ClaimSizing proposes the size), not the region. If several
-  accounts in one region fire together, the region is the problem, see "Kura
-  region cannot place another instance" for disk.`
+  for the account's write rate. The lever is the account's storage claim,
+  which Tuist.Kura.ClaimSizing sizes and applies on its own, so this fires
+  only where that loop cannot fix it: the claim is clamped at the plan ceiling
+  (64Gi air and pro, 256Gi enterprise), the region has no disk to grow into
+  (see "Kura region cannot place another instance"), or sizing itself is
+  stuck. Only rings that have been full for the whole day count: a ring
+  rebuilt more recently cannot report an eviction older than itself, so it
+  would fire on its own age.`
 
-The critical tier of **Kura instance retention horizon short** below, which
-carries the reasoning.
+Kura instances are expected to use all the disk they are given: every
+production ring runs at 100% of its desired segment count, and a full ring is
+not a signal of anything. What the customer feels is how long an artifact
+survives before ring rotation sheds it. `kura_segment_shed_age_seconds`
+records, for every segment the ring rotates out, the age of the youngest
+content in it, which is exactly "how soon after being written can an artifact
+disappear". Under a day, overnight and weekend builds miss.
+
+**Per instance, not per region.** The write rate that empties a ring is one
+account's, and so is the lever: the storage claim, which
+`Tuist.Kura.ClaimSizing` sizes per account. The region only enters when the
+claim cannot grow because the box is full, which is the disk row of **Kura
+region cannot place another instance**. A region-level median would also hide
+the case that matters: on 2026-09-02 one account's instances sat at about
+three days in both US regions while every other instance in the fleet sat
+above ten, and the region medians read as "about three days" purely because
+of it.
+
+**There is no warning tier, because sizing is the actor.**
+`Tuist.Kura.ClaimSizing` does not merely propose: `ClaimSizingWorker` applies
+its proposals unattended every ten minutes, within a fleet-wide budget of five
+applies an hour. Its own `retention_floor_days` is 3, so any instance whose
+retention falls under two days is already inside the band sizing is working
+on, and it is deliberately unhurried there: the rung that matches a one-day
+shed age needs five consecutive qualifying days before it grows the claim. A
+two-day rule therefore alerts on a control loop that is mid-confirmation and
+would keep alerting for days while it does its job. A rule at two days was
+deployed with this one on 2026-09-02 and removed on 2026-09-04, having fired
+only on the artifact described below. One day is the tier worth waking
+someone: it means the loop did not keep up, or cannot act at all.
+
+What is genuinely actionable and still has no rule of its own is *sizing
+blocked*: the claim clamped at the plan ceiling, or open proposals the worker
+is not draining. Neither is visible to Prometheus today, because the server
+exports no claim-size or ceiling metric. That is the rule to add, in place of
+the two-day tier.
+
+**Only a ring that has been full for a whole day counts.** Fullness is the
+segment count against the ring's desired total, so it reads 100 in steady
+state on every instance; the gate keeps a ring that is still filling (after a
+bootstrap, or while the segment count is converging) out of the rule even if
+it rotates a segment early. It has to be `min_over_time` across the
+threshold's own window, not the instantaneous value: a ring is rebuilt from
+empty whenever its instance lands on a new node, since the cache is
+local-path, and a rebuilt ring holds nothing older than itself, so the oldest
+eviction it can possibly report is its own age. An instantaneous gate opens
+the moment the refill completes and the rule then fires on the rebuild, every
+time, for as long as the threshold. `min_over_time(...[1d]) >= 100` is exactly
+the invariant the threshold needs: content *could* be a day old, so a median
+under a day is real.
+
+This is not hypothetical. On 2026-09-03 at 10:20 UTC both
+`kura-tuist-eu-central-1` replicas moved from node `...fleet-tkhrc-wktsj` to
+`...-x47qf`; ring fullness went 100 to 1 on both and climbed back to 100 about
+25 hours later. The rollup median shed age for that account-region went from
+1,124,768s (13d) on 09-03 to 86,347s (~24h) on 09-04, with
+`median_ring_span_seconds` collapsing identically (1,169,349 to 85,242) while
+its scw-fr-par instance held at ~11 days. Both tiers fired within an hour of
+the refill completing, on rings whose entire contents were younger than the
+threshold. Sizing correctly proposed nothing: one day of evidence, and the
+matching rung needs five.
+
+**Bucket edges are coarse but sit where the threshold is.** The histogram's
+edges are 1h, 6h, 12h, 1d, 2d, 3d, 7d, 14d and 30d, so the median is
+interpolated inside a bucket, but the threshold coincides with an edge. The
+`[1d]` window is one day of rotations: long enough that a single early
+rotation does not set the median, short enough to react within the day the
+claim became too small.
+
+Measured on 2026-09-04 with the gate in place, the rule returns ten instances
+and the shortest median is 216,000s (2.5 days, one account's four instances);
+the rest read between ten and thirty days, and three instances have shed no
+segment at all in the window (`NaN`, which the `< 86400` threshold does not
+match). Nothing is under a day, so the rule is quiet; the 2.5-day account is
+the one to watch as its usage grows.
 
 ### Kura egress budget almost entirely consumed
 
@@ -2725,68 +2804,6 @@ Measured on 2026-09-02, every production pod's one-hour average sits well
 under half its request; over the previous 7 days a few pods peaked above their
 request at a single 10-minute sample, which is the allowed behaviour and which
 the hour average filters out.
-
-### Kura instance retention horizon short
-
-Same query as **Kura instance retention horizon under a day**.
-
-- Threshold: `< 172800` seconds (two days), as a separate threshold expression
-  on `A`
-- Pending period: 60 minutes
-- Severity: warning
-- Production only (see **Recording rules for Kura regions** for where the
-  scope lives). Folder `Alerts`, group `Cache`, receiver
-  `Slack #notifications 2`; **No Data: Normal**, **Error: Alerting**. Add
-  `affected_service` for the cache component.
-- Summary: `Kura instance {{ $labels.pod }} ({{ $labels.tenant_id }}) in
-  {{ $labels.region }} evicts artifacts after a median of
-  {{ $values.A.Value | humanizeDuration }}; grow its storage claim`
-- Description: `The instance's ring is full and the median age of the
-  artifacts it evicts has dropped under two days. Rings run full by design;
-  this measures whether the account's claim is enough for its write rate, so
-  the lever is the account's storage claim (Tuist.Kura.ClaimSizing proposes
-  the size). Under a day is paged separately.`
-
-Kura instances are expected to use all the disk they are given: every
-production ring runs at 100% of its desired segment count, and a full ring is
-not a signal of anything. What the customer feels is how long an artifact
-survives before ring rotation sheds it. `kura_segment_shed_age_seconds`
-records, for every segment the ring rotates out, the age of the youngest
-content in it, which is exactly "how soon after being written can an artifact
-disappear". A median under two days means a build that reuses yesterday's
-artifacts is starting to miss; under a day, overnight and weekend builds miss.
-
-**Per instance, not per region.** The write rate that empties a ring is one
-account's, and so is the lever: the storage claim, which
-`Tuist.Kura.ClaimSizing` already proposes growing or shrinking per account.
-The region only enters when the claim cannot grow because the box is full,
-which is the disk row of **Kura region cannot place another instance**. A
-region-level median would also hide the case that matters: on 2026-09-02 one
-account's instances sat at about three days in both US regions while every
-other instance in the fleet sat above ten, and the region medians read as
-"about three days" purely because of it.
-
-**Only a full ring counts.** A new or recently restarted instance starts with
-an empty ring and fills over days; it has not shed anything, so it has no
-samples here and cannot fire, but the `and` on
-`kura_backfill_ring_fullness_percent >= 100` makes the intent explicit and
-keeps a ring that is still filling (after a bootstrap, or while the segment
-count is converging) out of the rule even if it rotates a segment early.
-Fullness is the segment count against the ring's desired total, so it reads
-100 in steady state on every instance and is the right gate, not an alarm.
-
-**Bucket edges are coarse but sit where the thresholds are.** The histogram's
-edges are 1h, 6h, 12h, 1d, 2d, 3d, 7d, 14d and 30d, so the median is
-interpolated inside a bucket, but both thresholds coincide with an edge. The
-`[1d]` window is one day of rotations: long enough that a single early
-rotation does not set the median, short enough to react within the day the
-claim became too small.
-
-Measured on 2026-09-02 across production with the rule's own one-day window,
-every full ring's median is five days or more (one account's four instances
-at about five, the rest between ten and thirty); over a seven-day window that
-same account reads about three days. Nothing is under two days, so both rules
-are quiet on creation; that account is the one to watch as its usage grows.
 
 ### Kura egress budget heavily used
 


### PR DESCRIPTION
## What happened

At 11:56 CEST today both `Kura - instance retention horizon short` (warning, <2d) and `Kura - instance retention horizon under a day` (critical, <1d) fired for `kura-tuist-eu-central-1-0/1`, at medians of 24h and 18h. Neither was a capacity problem.

Both replicas moved node on 2026-09-03 at 10:20 UTC (`tuist-tuist-dedibox-fleet-tkhrc-wktsj` → `...-x47qf`). The Kura cache is local-path, so a node move rebuilds the ring from empty: `kura_backfill_ring_fullness_percent` went 100 → 1 on both pods and climbed back to 100 about an hour before the alerts fired. The rollup agrees — that account-region's median shed age went from 1,124,768s (13d) on 09-03 to 86,347s (~24h) on 09-04, with `median_ring_span_seconds` collapsing identically (1,169,349 → 85,242), while the same account's scw-fr-par instance held at ~11 days.

## Root cause

The rules gated on `max by (cluster, pod) (kura_backfill_ring_fullness_percent) >= 100`, evaluated at the instant of the check. That gate was meant to exclude a ring that is *still filling*. It does not exclude a ring that has *just finished* filling — and a rebuilt ring holds nothing older than itself, so the oldest eviction it can possibly report is its own age. The gate therefore opens the moment the refill completes, and the rule fires on the rebuild, every time, for as long as the threshold: ~1 day of critical pages and ~2 days of warnings after every node move or disk wipe.

## The fix

`min_over_time(kura_backfill_ring_fullness_percent[1d]) >= 100`. Requiring the ring to have been full across the threshold's own window is exactly the invariant the threshold needs: if it has been full for a day, its content *could* be a day old, so a median under a day is real. The refill samples (1…99) are what disqualify a rebuilt ring, and they are always there — backfill takes hours.

Verified against production: with the gate the query returns ten instances, the shortest median is 216,000s (2.5d) and nothing is under a day. The critical rule went back to Normal on the next evaluation.

## Why the warning tier is gone

`Tuist.Kura.ClaimSizing` no longer merely proposes — `ClaimSizingWorker` applies its proposals unattended every ten minutes, within a fleet-wide budget of five applies an hour (#12606). Its own `retention_floor_days` is **3**, stricter than the two-day warning, so anything the warning caught was already inside the band sizing was working on. And sizing is deliberately unhurried there: the rung matching a one-day shed age needs five consecutive qualifying days before it grows the claim. A two-day rule therefore alerts on a control loop that is mid-confirmation and would keep alerting for days while it does its job. In this incident sizing correctly proposed nothing — one day of evidence, and the rung needs five — while the alert said "grow its storage claim".

One day stays, because it means the loop did not keep up or cannot act at all. The alert text also said "ClaimSizing *proposes* the size", written for the propose-only loop; the description now says sizing applies on its own and names the three cases where it cannot fix the problem (claim clamped at the plan ceiling, region out of disk, sizing stuck).

The rule genuinely worth adding is **sizing blocked** — claim at the plan ceiling, or open proposals the worker is not draining. Neither is visible to Prometheus today because the server exports no claim-size or ceiling metric, so this PR documents it as the replacement to build rather than leaving a two-day tier that cannot distinguish it.

## Applied to production

Grafana-managed rules are edited in the UI, so these are already live:

- `Kura - instance retention horizon under a day` (`afx2mswafmvi8a`): new gate, new description. Its `No Data` / `Error` had also drifted to `NoData` / `Error` against the documented `Normal` / `Alerting` (its deleted sibling had the documented pair) — set back to `OK` / `Alerting`, which removes a `DatasourceNoData` page path that the gate makes more likely.
- `Kura - instance retention horizon short` (`dfx2mzgh20bggd`): deleted.

This PR is the runbook and dashboard catching up.

## Also in the diff

`infra/grafana-dashboards/tuist-kura-region-scalability.json` (Git Sync'd, so merging propagates it): the same gate on the three retention queries — `Disk by region` → *Shortest retention*, `Retention by instance`, and the `Shortest retention` timeseries — since a rebuilt ring would otherwise make a region look retention-starved for capacity planning. The `Full rings` count keeps the instantaneous gate: a rebuilt ring that is full is still full. Its panel description no longer refers to the removed warning tier.

Left alone deliberately: the per-pod shed-age columns on `Tuist Kura / Customer overview` and `Details`, which are browsing views where the raw number is legitimate.

## Validation

- Ran the gated query against production Prometheus: excludes both rebuilt `kura-tuist-eu-central-1` pods, keeps every other full ring, shortest remaining median 2.5 days.
- Confirmed the node move and the ring rebuild from `kube_pod_info` and `kura_backfill_ring_fullness_percent` over 3 days.
- Cross-checked the shed-age collapse against `kura_storage_rollups` in production Postgres, and confirmed the account has never had a claim proposal (so sizing was not mid-resize).
- Confirmed the critical rule is `normal` after the edit; the warning rule no longer exists.
- Dashboard JSON re-parsed after editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)