### PR TITLE
feat(server): record the runner volume's available bytes

### DIFF
--- a/cli/Sources/TuistServer/OpenAPI/Client.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Client.swift
@@ -3973,13 +3973,6 @@ public struct Client: APIProtocol {
                     in: &request,
                     style: .form,
                     explode: true,
-                    name: "page_size",
-                    value: input.query.page_size
-                )
-                try converter.setQueryItemAsURI(
-                    in: &request,
-                    style: .form,
-                    explode: true,
                     name: "page",
                     value: input.query.page
                 )
@@ -3989,6 +3982,13 @@ public struct Client: APIProtocol {
                     explode: true,
                     name: "git_branch",
                     value: input.query.git_branch
+                )
+                try converter.setQueryItemAsURI(
+                    in: &request,
+                    style: .form,
+                    explode: true,
+                    name: "page_size",
+                    value: input.query.page_size
                 )
                 converter.setAcceptHeader(
                     in: &request.headerFields,

--- a/cli/Sources/TuistServer/OpenAPI/Types.swift
+++ b/cli/Sources/TuistServer/OpenAPI/Types.swift
@@ -10651,6 +10651,8 @@ public enum Components {
             public var cpu_iowait_percent: Swift.Double
             /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/cpu_usage_percent`.
             public var cpu_usage_percent: Swift.Double
+            /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/disk_available_bytes`.
+            public var disk_available_bytes: Swift.Int?
             /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/disk_total_bytes`.
             public var disk_total_bytes: Swift.Int
             /// - Remark: Generated from `#/components/schemas/RunnerJobMetric/disk_used_bytes`.
@@ -10670,6 +10672,7 @@ public enum Components {
             /// - Parameters:
             ///   - cpu_iowait_percent:
             ///   - cpu_usage_percent:
+            ///   - disk_available_bytes:
             ///   - disk_total_bytes:
             ///   - disk_used_bytes:
             ///   - memory_total_bytes:
@@ -10680,6 +10683,7 @@ public enum Components {
             public init(
                 cpu_iowait_percent: Swift.Double,
                 cpu_usage_percent: Swift.Double,
+                disk_available_bytes: Swift.Int? = nil,
                 disk_total_bytes: Swift.Int,
                 disk_used_bytes: Swift.Int,
                 memory_total_bytes: Swift.Int,
@@ -10690,6 +10694,7 @@ public enum Components {
             ) {
                 self.cpu_iowait_percent = cpu_iowait_percent
                 self.cpu_usage_percent = cpu_usage_percent
+                self.disk_available_bytes = disk_available_bytes
                 self.disk_total_bytes = disk_total_bytes
                 self.disk_used_bytes = disk_used_bytes
                 self.memory_total_bytes = memory_total_bytes
@@ -10701,6 +10706,7 @@ public enum Components {
             public enum CodingKeys: String, CodingKey {
                 case cpu_iowait_percent
                 case cpu_usage_percent
+                case disk_available_bytes
                 case disk_total_bytes
                 case disk_used_bytes
                 case memory_total_bytes
@@ -15211,6 +15217,8 @@ public enum Operations {
                             public var cpu_iowait_percent: Swift.Double
                             /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/cpu_usage_percent`.
                             public var cpu_usage_percent: Swift.Double
+                            /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/disk_available_bytes`.
+                            public var disk_available_bytes: Swift.Int?
                             /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/disk_total_bytes`.
                             public var disk_total_bytes: Swift.Int
                             /// - Remark: Generated from `#/paths/api/accounts/{account_handle}/runners/jobs/{workflow_job_id}/metrics/GET/responses/200/content/json/metricsPayload/disk_used_bytes`.
@@ -15230,6 +15238,7 @@ public enum Operations {
                             /// - Parameters:
                             ///   - cpu_iowait_percent:
                             ///   - cpu_usage_percent:
+                            ///   - disk_available_bytes:
                             ///   - disk_total_bytes:
                             ///   - disk_used_bytes:
                             ///   - memory_total_bytes:
@@ -15240,6 +15249,7 @@ public enum Operations {
                             public init(
                                 cpu_iowait_percent: Swift.Double,
                                 cpu_usage_percent: Swift.Double,
+                                disk_available_bytes: Swift.Int? = nil,
                                 disk_total_bytes: Swift.Int,
                                 disk_used_bytes: Swift.Int,
                                 memory_total_bytes: Swift.Int,
@@ -15250,6 +15260,7 @@ public enum Operations {
                             ) {
                                 self.cpu_iowait_percent = cpu_iowait_percent
                                 self.cpu_usage_percent = cpu_usage_percent
+                                self.disk_available_bytes = disk_available_bytes
                                 self.disk_total_bytes = disk_total_bytes
                                 self.disk_used_bytes = disk_used_bytes
                                 self.memory_total_bytes = memory_total_bytes
@@ -15261,6 +15272,7 @@ public enum Operations {
                             public enum CodingKeys: String, CodingKey {
                                 case cpu_iowait_percent
                                 case cpu_usage_percent
+                                case disk_available_bytes
                                 case disk_total_bytes
                                 case disk_used_bytes
                                 case memory_total_bytes
@@ -23670,10 +23682,6 @@ public enum Operations {
             public var path: Operations.listBundles.Input.Path
             /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query`.
             public struct Query: Sendable, Hashable {
-                /// Number of items per page.
-                ///
-                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
-                public var page_size: Swift.Int?
                 /// Page number for pagination.
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page`.
@@ -23682,20 +23690,24 @@ public enum Operations {
                 ///
                 /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/git_branch`.
                 public var git_branch: Swift.String?
+                /// Number of items per page.
+                ///
+                /// - Remark: Generated from `#/paths/api/projects/{account_handle}/{project_handle}/bundles/GET/query/page_size`.
+                public var page_size: Swift.Int?
                 /// Creates a new `Query`.
                 ///
                 /// - Parameters:
-                ///   - page_size: Number of items per page.
                 ///   - page: Page number for pagination.
                 ///   - git_branch: Filter bundles by git branch.
+                ///   - page_size: Number of items per page.
                 public init(
-                    page_size: Swift.Int? = nil,
                     page: Swift.Int? = nil,
-                    git_branch: Swift.String? = nil
+                    git_branch: Swift.String? = nil,
+                    page_size: Swift.Int? = nil
                 ) {
-                    self.page_size = page_size
                     self.page = page
                     self.git_branch = git_branch
+                    self.page_size = page_size
                 }
             }
             public var query: Operations.listBundles.Input.Query

--- a/cli/Sources/TuistServer/OpenAPI/server.yml
+++ b/cli/Sources/TuistServer/OpenAPI/server.yml
@@ -5648,6 +5648,11 @@ components:
           type: number
           x-struct:
           x-validate:
+        disk_available_bytes:
+          nullable: true
+          type: integer
+          x-struct:
+          x-validate:
         disk_total_bytes:
           type: integer
           x-struct:
@@ -5686,6 +5691,7 @@ components:
         - network_bytes_out
         - disk_used_bytes
         - disk_total_bytes
+        - disk_available_bytes
       title: RunnerJobMetric
       type: object
       x-struct:
@@ -7903,6 +7909,11 @@ paths:
                           type: number
                           x-struct:
                           x-validate:
+                        disk_available_bytes:
+                          nullable: true
+                          type: integer
+                          x-struct:
+                          x-validate:
                         disk_total_bytes:
                           type: integer
                           x-struct:
@@ -7941,6 +7952,7 @@ paths:
                         - network_bytes_out
                         - disk_used_bytes
                         - disk_total_bytes
+                        - disk_available_bytes
                       title: RunnerJobMetric
                       type: object
                       x-struct:
@@ -10540,22 +10552,6 @@ paths:
       callbacks: {}
       operationId: listBundles
       parameters:
-        - description: The handle of the account.
-          in: path
-          name: account_handle
-          required: true
-          schema:
-            type: string
-            x-struct:
-            x-validate:
-        - description: Number of items per page.
-          in: query
-          name: page_size
-          required: false
-          schema:
-            type: integer
-            x-struct:
-            x-validate:
         - description: Page number for pagination.
           in: query
           name: page
@@ -10570,6 +10566,22 @@ paths:
           required: false
           schema:
             type: string
+            x-struct:
+            x-validate:
+        - description: The handle of the account.
+          in: path
+          name: account_handle
+          required: true
+          schema:
+            type: string
+            x-struct:
+            x-validate:
+        - description: Number of items per page.
+          in: query
+          name: page_size
+          required: false
+          schema:
+            type: integer
             x-struct:
             x-validate:
         - description: The handle of the project.

--- a/infra/runner-image/metrics-poll.sh
+++ b/infra/runner-image/metrics-poll.sh
@@ -77,11 +77,26 @@ net_totals() {
     END { printf "%d %d", rx + 0, tx + 0 }'
 }
 
-# disk_totals echoes "used total" bytes for the volume the job writes
-# to. On APFS `/` is the sealed, read-only system volume (a few GB);
+# disk_totals echoes "used total available" bytes for the volume the job
+# writes to. On APFS `/` is the sealed, read-only system volume (a few GB);
 # the runner's work lands on the firmlinked Data volume, so sample that.
+#
+# Available ($4) is reported SEPARATELY because on APFS it is not
+# `total - used`. The 1024-blocks column is the whole container, `Used` is
+# this volume's own usage, and the rest of the container goes to the other
+# volumes in it, to snapshots, and to purgeable space — so `total - used`
+# is an upper bound that can overstate what a build may actually write by
+# several times. Measured on a developer Mac: 45.8 GB from `total - used`
+# against 12.8 GB actually available, at 98% capacity.
+#
+# That gap is not academic. It is the difference between "this job filled
+# the disk" and "this job failed for another reason", and without this
+# column the two are indistinguishable after the fact: a runner job that
+# died on `No space left on device` was seen holding a LOWER `used` than a
+# job that completed on the same image.
 disk_totals() {
-  df -k /System/Volumes/Data 2>/dev/null | awk 'NR == 2 { printf "%d %d", $3 * 1024, $2 * 1024 }'
+  df -k /System/Volumes/Data 2>/dev/null |
+    awk 'NR == 2 { printf "%d %d %d", $3 * 1024, $2 * 1024, $4 * 1024 }'
 }
 
 delta() {
@@ -90,12 +105,12 @@ delta() {
 }
 
 emit_sample() {
-  local ts cpu mem_used rx tx disk_used disk_total net_in net_out payload
+  local ts cpu mem_used rx tx disk_used disk_total disk_available net_in net_out payload
   ts="$(date +%s)"
   cpu="$(cpu_busy_percent)"
   mem_used="$(mem_used_bytes)"
   read -r rx tx <<<"$(net_totals)"
-  read -r disk_used disk_total <<<"$(disk_totals)"
+  read -r disk_used disk_total disk_available <<<"$(disk_totals)"
 
   if [ -n "${prev_rx}" ]; then
     net_in="$(delta "${rx:-0}" "${prev_rx}")"
@@ -107,8 +122,17 @@ emit_sample() {
   prev_rx="${rx:-0}"
   prev_tx="${tx:-0}"
 
-  payload="$(printf '{"samples":[{"timestamp":%s,"cpu_usage_percent":%s,"memory_used_bytes":%s,"memory_total_bytes":%s,"network_bytes_in":%s,"network_bytes_out":%s,"disk_used_bytes":%s,"disk_total_bytes":%s}]}' \
-    "${ts}" "${cpu:-0}" "${mem_used:-0}" "${mem_total:-0}" "${net_in}" "${net_out}" "${disk_used:-0}" "${disk_total:-0}")"
+  # `disk_available_bytes` is omitted rather than sent as 0 when `df` gave us
+  # nothing, because the server stores it nullable: on this field 0 is a real,
+  # load-bearing reading (the volume is full) and must not be confused with
+  # "this runner did not report it".
+  local disk_available_field=""
+  if [ -n "${disk_available}" ]; then
+    disk_available_field="$(printf ',"disk_available_bytes":%s' "${disk_available}")"
+  fi
+
+  payload="$(printf '{"samples":[{"timestamp":%s,"cpu_usage_percent":%s,"memory_used_bytes":%s,"memory_total_bytes":%s,"network_bytes_in":%s,"network_bytes_out":%s,"disk_used_bytes":%s,"disk_total_bytes":%s%s}]}' \
+    "${ts}" "${cpu:-0}" "${mem_used:-0}" "${mem_total:-0}" "${net_in}" "${net_out}" "${disk_used:-0}" "${disk_total:-0}" "${disk_available_field}")"
 
   curl -sS -o /dev/null --max-time 10 \
     --request POST \

--- a/server/lib/tuist/mcp/components/tools/runner_tools.ex
+++ b/server/lib/tuist/mcp/components/tools/runner_tools.ex
@@ -164,7 +164,11 @@ defmodule Tuist.MCP.Components.Tools.RunnerTools do
         "network_bytes_in" => %{"type" => "integer"},
         "network_bytes_out" => %{"type" => "integer"},
         "disk_used_bytes" => %{"type" => "integer"},
-        "disk_total_bytes" => %{"type" => "integer"}
+        "disk_total_bytes" => %{"type" => "integer"},
+        # Nullable: absent on samples from runner images predating the field.
+        # Not `disk_total_bytes - disk_used_bytes` — on APFS those do not
+        # subtract, so this is the only trustworthy capacity figure.
+        "disk_available_bytes" => %{"type" => ["integer", "null"]}
       },
       "required" => [
         "timestamp",
@@ -175,7 +179,8 @@ defmodule Tuist.MCP.Components.Tools.RunnerTools do
         "network_bytes_in",
         "network_bytes_out",
         "disk_used_bytes",
-        "disk_total_bytes"
+        "disk_total_bytes",
+        "disk_available_bytes"
       ],
       "additionalProperties" => false
     }

--- a/server/lib/tuist/runners/job_machine_metric.ex
+++ b/server/lib/tuist/runners/job_machine_metric.ex
@@ -24,6 +24,11 @@ defmodule Tuist.Runners.JobMachineMetric do
     field :network_bytes_out, Ch, type: "Int64", default: 0
     field :disk_used_bytes, Ch, type: "Int64", default: 0
     field :disk_total_bytes, Ch, type: "Int64", default: 0
+    # Nullable, unlike every other metric here: on this column 0 is a real
+    # reading (the volume is full), so it must stay distinguishable from a
+    # runner image that predates the field. See the migration for why
+    # `total - used` cannot substitute for it on APFS.
+    field :disk_available_bytes, Ch, type: "Nullable(Int64)"
     field :inserted_at, Ch, type: "DateTime64(6, 'UTC')"
   end
 end

--- a/server/lib/tuist/runners/job_metrics.ex
+++ b/server/lib/tuist/runners/job_metrics.ex
@@ -24,7 +24,11 @@ defmodule Tuist.Runners.JobMetrics do
     :disk_used_bytes,
     :disk_total_bytes
   ]
-  @sample_fields @float_fields ++ @integer_fields
+  # Stored `Nullable(Int64)` and so defaulted to `nil`, not `0`, when a sample
+  # omits it: on this column zero is a real reading (the volume is full) and has
+  # to stay distinguishable from a runner image that predates the field.
+  @nullable_integer_fields [:disk_available_bytes]
+  @sample_fields @float_fields ++ @integer_fields ++ @nullable_integer_fields
 
   @doc """
   Inserts a batch of metric samples for a job. Each sample carries
@@ -43,7 +47,9 @@ defmodule Tuist.Runners.JobMetrics do
     rows =
       Enum.map(samples, fn sample ->
         @sample_fields
-        |> Map.new(fn field -> {field, coerce(field, Map.get(sample, field, 0))} end)
+        |> Map.new(fn field ->
+          {field, coerce(field, Map.get(sample, field, default_for(field)))}
+        end)
         |> Map.merge(%{
           workflow_job_id: workflow_job_id,
           account_id: account_id,
@@ -61,6 +67,11 @@ defmodule Tuist.Runners.JobMetrics do
   # coerce each value to its column's type before insert.
   defp coerce(field, value) when field in @float_fields, do: value / 1
   defp coerce(field, value) when field in @integer_fields, do: trunc(value)
+  defp coerce(field, nil) when field in @nullable_integer_fields, do: nil
+  defp coerce(field, value) when field in @nullable_integer_fields, do: trunc(value)
+
+  defp default_for(field) when field in @nullable_integer_fields, do: nil
+  defp default_for(_field), do: 0
 
   @doc """
   Lists a job's metric samples in time order. Returns maps with
@@ -85,7 +96,8 @@ defmodule Tuist.Runners.JobMetrics do
           network_bytes_in: fragment("argMax(?, ?)", m.network_bytes_in, m.inserted_at),
           network_bytes_out: fragment("argMax(?, ?)", m.network_bytes_out, m.inserted_at),
           disk_used_bytes: fragment("argMax(?, ?)", m.disk_used_bytes, m.inserted_at),
-          disk_total_bytes: fragment("argMax(?, ?)", m.disk_total_bytes, m.inserted_at)
+          disk_total_bytes: fragment("argMax(?, ?)", m.disk_total_bytes, m.inserted_at),
+          disk_available_bytes: fragment("argMax(?, ?)", m.disk_available_bytes, m.inserted_at)
         }
       )
     )

--- a/server/lib/tuist_web/controllers/api/runners_controller.ex
+++ b/server/lib/tuist_web/controllers/api/runners_controller.ex
@@ -148,7 +148,13 @@ defmodule TuistWeb.API.RunnersController do
       network_bytes_in: %Schema{type: :integer},
       network_bytes_out: %Schema{type: :integer},
       disk_used_bytes: %Schema{type: :integer},
-      disk_total_bytes: %Schema{type: :integer}
+      disk_total_bytes: %Schema{type: :integer},
+      # Nullable because it is absent on samples from runner images predating
+      # the field, and because 0 is a real reading here (a full volume) that
+      # must not be conflated with "not reported". It is deliberately not
+      # derivable as `disk_total_bytes - disk_used_bytes`: on APFS those do not
+      # subtract, so this is the only trustworthy capacity figure.
+      disk_available_bytes: %Schema{type: :integer, nullable: true}
     },
     required: [
       :timestamp,
@@ -159,7 +165,8 @@ defmodule TuistWeb.API.RunnersController do
       :network_bytes_in,
       :network_bytes_out,
       :disk_used_bytes,
-      :disk_total_bytes
+      :disk_total_bytes,
+      :disk_available_bytes
     ]
   }
 

--- a/server/lib/tuist_web/controllers/runner_job_metrics_controller.ex
+++ b/server/lib/tuist_web/controllers/runner_job_metrics_controller.ex
@@ -43,14 +43,22 @@ defmodule TuistWeb.RunnerJobMetricsController do
             "network_bytes_in": 10485760,
             "network_bytes_out": 5242880,
             "disk_used_bytes": 48318382080,
-            "disk_total_bytes": 68719476736
+            "disk_total_bytes": 68719476736,
+            "disk_available_bytes": 20401093656
           }
         ]
       }
 
-  Every metric field but `timestamp` is optional and defaults to 0,
-  so a Linux-only or macOS-only collector can omit what it can't
-  measure. Delivery is at-least-once; the ReplacingMergeTree
+  Every metric field but `timestamp` is optional. They default to 0, so
+  a Linux-only or macOS-only collector can omit what it can't measure —
+  with one exception. `disk_available_bytes` defaults to `nil` and is
+  stored nullable, because on that field 0 is a real reading (the volume
+  is full) and must stay distinguishable from a runner image that
+  predates it. It is also not `disk_total_bytes - disk_used_bytes`: on
+  APFS those do not subtract, and the difference is what separates
+  "this job filled the disk" from "this job failed for another reason".
+
+  Delivery is at-least-once; the ReplacingMergeTree
   `(workflow_job_id, timestamp)` key collapses re-POSTed batches.
   """
 
@@ -69,6 +77,10 @@ defmodule TuistWeb.RunnerJobMetricsController do
     network_bytes_in network_bytes_out
     disk_used_bytes disk_total_bytes
   )a
+
+  # Absent from a sample means "not reported", so these are read with a `nil`
+  # default rather than the 0 the other metrics fall back to.
+  @nullable_metric_fields ~w(disk_available_bytes)a
 
   @doc """
   `POST /api/internal/runners/pods/:pod_name/metrics`
@@ -161,11 +173,19 @@ defmodule TuistWeb.RunnerJobMetricsController do
         {field, numeric(Map.get(sample, Atom.to_string(field), 0))}
       end)
 
-    {:ok, Map.put(metrics, :timestamp, timestamp)}
+    nullable_metrics =
+      Map.new(@nullable_metric_fields, fn field ->
+        {field, optional_numeric(Map.get(sample, Atom.to_string(field)))}
+      end)
+
+    {:ok, metrics |> Map.merge(nullable_metrics) |> Map.put(:timestamp, timestamp)}
   end
 
   defp parse_sample(_), do: {:error, {:invalid_field, "sample timestamp"}}
 
   defp numeric(value) when is_number(value), do: value
   defp numeric(_), do: 0
+
+  defp optional_numeric(value) when is_number(value), do: value
+  defp optional_numeric(_), do: nil
 end

--- a/server/priv/ingest_repo/migrations/20260904120000_add_disk_available_to_runner_job_machine_metrics.exs
+++ b/server/priv/ingest_repo/migrations/20260904120000_add_disk_available_to_runner_job_machine_metrics.exs
@@ -1,0 +1,35 @@
+defmodule Tuist.IngestRepo.Migrations.AddDiskAvailableToRunnerJobMachineMetrics do
+  use Ecto.Migration
+
+  # `disk_used_bytes` / `disk_total_bytes` cannot answer "did this job run the
+  # volume out of space?".
+  #
+  # The collector reads them from `df` columns `Used` and `1024-blocks`, and on
+  # APFS those do not subtract: the blocks column is the whole container, `Used`
+  # is one volume's usage, and the remainder is held by the container's other
+  # volumes, by snapshots and by purgeable space. `total - used` is therefore an
+  # upper bound that can overstate what a build may actually write several times
+  # over — measured on a developer Mac at 45.8 GB against 12.8 GB truly
+  # available, with the volume at 98% capacity.
+  #
+  # The gap changed a diagnosis. A runner job that failed with
+  # `No space left on device` was holding 64.3 GB used of 139.5 GB, while a job
+  # that SUCCEEDED on the same image held 66.1 GB — more. Resident bytes simply
+  # do not discriminate, and the number that would have is the one we never
+  # stored.
+  #
+  # `Nullable` rather than `DEFAULT 0`, because on this column zero is the
+  # interesting reading. Every other metric here defaults to 0 for collectors
+  # that cannot measure it, which is safe when 0 means "nothing happened"; here
+  # it would be indistinguishable from "the volume is full", the exact state we
+  # added the column to catch. NULL means the runner image predates this field.
+  def up do
+    execute(
+      "ALTER TABLE runner_job_machine_metrics ADD COLUMN IF NOT EXISTS disk_available_bytes Nullable(Int64)"
+    )
+  end
+
+  def down do
+    execute("ALTER TABLE runner_job_machine_metrics DROP COLUMN IF EXISTS disk_available_bytes")
+  end
+end

--- a/server/test/tuist/runners/job_metrics_test.exs
+++ b/server/test/tuist/runners/job_metrics_test.exs
@@ -14,7 +14,8 @@ defmodule Tuist.Runners.JobMetricsTest do
         network_bytes_in: 10_485_760,
         network_bytes_out: 5_242_880,
         disk_used_bytes: 48_318_382_080,
-        disk_total_bytes: 68_719_476_736
+        disk_total_bytes: 68_719_476_736,
+        disk_available_bytes: 20_401_093_656
       },
       attrs
     )
@@ -47,6 +48,22 @@ defmodule Tuist.Runners.JobMetricsTest do
       assert_in_delta cpu_second, 90.0, 0.01
     end
 
+    test "keeps a reported zero available distinct from an unreported one" do
+      # The whole point of the nullable column: a full volume reports 0, and a
+      # runner image predating the field reports nothing. Collapsing both to 0
+      # would hide exactly the state this metric exists to catch.
+      :ok =
+        JobMetrics.record(910_006, 42, [
+          sample(1_750_000_000.0, %{disk_available_bytes: 0}),
+          1_750_000_001.0 |> sample() |> Map.delete(:disk_available_bytes)
+        ])
+
+      assert [
+               %{timestamp: 1_750_000_000.0, disk_available_bytes: 0},
+               %{timestamp: 1_750_000_001.0, disk_available_bytes: nil}
+             ] = JobMetrics.list_for_job(910_006)
+    end
+
     test "defaults omitted metric fields to zero" do
       :ok = JobMetrics.record(910_002, 42, [%{timestamp: 1_750_000_000.0, cpu_usage_percent: 12.0}])
 
@@ -55,7 +72,9 @@ defmodule Tuist.Runners.JobMetricsTest do
                  cpu_iowait_percent: iowait,
                  memory_used_bytes: 0,
                  disk_total_bytes: 0,
-                 network_bytes_in: 0
+                 network_bytes_in: 0,
+                 # Nullable, so it is the one field that does not fall back to 0.
+                 disk_available_bytes: nil
                }
              ] = JobMetrics.list_for_job(910_002)
 

--- a/server/test/tuist_web/controllers/runner_job_metrics_controller_test.exs
+++ b/server/test/tuist_web/controllers/runner_job_metrics_controller_test.exs
@@ -55,7 +55,8 @@ defmodule TuistWeb.RunnerJobMetricsControllerTest do
         "network_bytes_in" => 10_485_760,
         "network_bytes_out" => 5_242_880,
         "disk_used_bytes" => 48_318_382_080,
-        "disk_total_bytes" => 68_719_476_736
+        "disk_total_bytes" => 68_719_476_736,
+        "disk_available_bytes" => 20_401_093_656
       },
       attrs
     )
@@ -83,6 +84,33 @@ defmodule TuistWeb.RunnerJobMetricsControllerTest do
 
       assert [%{timestamp: 1_750_000_000.0, cpu_usage_percent: cpu}] = JobMetrics.list_for_job(33_001)
       assert_in_delta cpu, 88.0, 0.01
+    end
+
+    test "distinguishes a reported zero available from an omitted one", %{conn: conn} do
+      # A full volume POSTs 0; a runner image predating the field POSTs nothing.
+      # Defaulting the second to 0 the way every other metric does would make an
+      # old runner indistinguishable from one that just ran out of disk.
+      account = account_fixture()
+      session(account, 33_010, "runner-pod-avail", "runner-avail")
+      prove_execution(account, "runner-avail", 33_010)
+      runner_token_stub("runner-pod-avail")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer valid-token")
+        |> post_metrics("runner-pod-avail", %{
+          "samples" => [
+            sample(1_750_000_000.0, %{"disk_available_bytes" => 0}),
+            Map.delete(sample(1_750_000_001.0), "disk_available_bytes")
+          ]
+        })
+
+      assert response(conn, 204)
+
+      assert [
+               %{timestamp: 1_750_000_000.0, disk_available_bytes: 0},
+               %{timestamp: 1_750_000_001.0, disk_available_bytes: nil}
+             ] = JobMetrics.list_for_job(33_010)
     end
 
     test "records under the executed job, not the job the Pod was minted for", %{conn: conn} do


### PR DESCRIPTION
Records `df`'s `Available` column for runner jobs as `disk_available_bytes`. It is the number that would have explained a `Cache` job failure we could not otherwise account for, and it is the one machine metric we were not collecting.

### The problem

`cli.yml`'s `Cache` job has been failing on `main` with `No space left on device`. The obvious question — did the job fill the disk? — turns out to be unanswerable with what we store.

The collector reads `df -k /System/Volumes/Data` and records column `$3` (`Used`) and `$2` (`1024-blocks`), never `$4` (`Available`). **On APFS those do not subtract.** The blocks column is the whole container; `Used` is one volume's own usage; the remainder is held by the container's other volumes, by snapshots, and by purgeable space. Measured on a developer Mac:

```
blocks=482797652  used=438065212  avail=12499772   |  $2-$3 = 44732440
```

`total - used` claims **45.8 GB**. Actually available: **12.8 GB**. A 3.6x overstatement, on a volume sitting at 98% capacity.

That gap is not academic — it inverted a diagnosis:

| runner job | peak `disk_used_bytes` | outcome |
| --- | --- | --- |
| 100961123734 | 64.3 GB / 139.5 GB | **failed**, `No space left on device` |
| 100817414239 | **66.1 GB** / 139.5 GB | succeeded |

The job that **succeeded held more** than the job that failed. Resident bytes do not discriminate between them, so the samples we keep cannot say whether that failure was a full volume or something else entirely — and the one column that could was never stored.

### What changed

- `infra/runner-image/metrics-poll.sh` reports `Available` alongside used/total, and **omits the key rather than sending 0** when `df` gives it nothing.
- A ClickHouse migration adds `disk_available_bytes` as **`Nullable(Int64)`**, unlike every other metric in the table, which defaults to 0.
- The ingest path (`JobMetrics`, `RunnerJobMetricsController`) defaults it to `nil` rather than `0`, and the read paths (`list_for_job`, the MCP tool schema, the public `RunnerJobMetric` API schema) expose it.

### Why nullable, when nothing else here is

Every other metric defaults to 0 so a collector that cannot measure something may omit it. That is safe when 0 means "nothing happened". Here it does not: **0 available is the single most interesting reading this column can take** — it is the volume being full, the exact state the field exists to catch. Defaulting to 0 would make a runner image that predates the field indistinguishable from a runner that just ran out of disk, which is the same class of ambiguity that made the original failure unreadable. `NULL` means "not reported"; `0` means "full".

### Rollout

Inert until the runner image is rebuilt and the fleet rolls onto it; older images keep reporting `NULL`, which is exactly what nullable is for. Nothing else changes behaviour — this only adds a column and a field.

### How to test locally

```bash
mix test test/tuist/runners/job_metrics_test.exs test/tuist_web/controllers/runner_job_metrics_controller_test.exs
```

To see the discrepancy the change is about, on any Mac:

```bash
df -k /System/Volumes/Data | awk 'NR==2 {printf "avail=%d  total-used=%d (%.1fx)\n", $4, $2-$3, ($2-$3)/$4}'
```

### Validation

- `mix test` on both affected files: **19 passed, 0 failures**, including two new tests asserting a reported `0` stays distinct from an omitted value, end to end (ingest through ClickHouse read-back).
- The new `awk` extraction run against real `df` output on a Mac, reproducing the 3.6x figure above.
- `shellcheck` clean on `metrics-poll.sh`; `mix format` clean on the Elixir changes.

### Note on the generated-client churn

The public `RunnerJobMetric` schema gained the field, so `mise run generate-api-cli-code` was re-run and `server.yml`, `Types.swift` and `Client.swift` are regenerated here.

Those diffs carry a little more than the new field: a `page_size` / `account_handle` parameter block moves. That content is **identical, only reordered** — the committed generated files had already drifted from what the generator emits, and regenerating normalises them. Nothing about this change caused it. Worth a glance to confirm, since CI cannot: the spec-drift check in `server.yml` is currently commented out.

The CLI itself is unaffected either way — `listRunnerJobMetrics` exists in the generated client but has no call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
