### PR TITLE
fix(cli): never fail a command because a manifest cache write failed

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -73,10 +73,6 @@ env:
   TUIST_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN }}
   TUIST_EE: ${{ github.event.pull_request.head.repo.fork != true && '1' || '' }}
   TUIST_ENABLE_CACHING: ${{ github.event.pull_request.head.repo.fork != true }}
-  # Jobs are ephemeral and persist .build with actions/cache. Keep Tuist metadata
-  # outside the per-account runner cache volume so a saturated warm cache cannot
-  # prevent authentication before the job starts.
-  TUIST_XDG_CACHE_HOME: /tmp/tuist-cache
   MISE_GITHUB_ATTESTATIONS: 0
   MISE_LOCKED: 1
 

--- a/cli/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
+++ b/cli/Sources/TuistLoader/Loaders/CachedManifestLoader.swift
@@ -168,12 +168,27 @@ public class CachedManifestLoader: ManifestLoading {
 
         let loadedManifest = try await loader()
 
-        try await cacheManifest(
-            manifest: manifest,
-            loadedManifest: loadedManifest,
-            hashes: hashes,
-            to: cachedManifestPath
-        )
+        // Writing the cache entry is an optimization, and failing to write one must never fail the
+        // command: the manifest has already been loaded successfully at this point, and everything
+        // downstream needs the value, not the cache.
+        //
+        // It used to throw, and the blast radius was the whole CLI rather than this one manifest.
+        // `TuistCommand` loads the config manifest before it parses the subcommand, so on a runner
+        // whose cache volume had filled up, every command for that account died on
+        // `Failed to create temp file in '…/Manifests': No space left on device (errno=28)` — a
+        // `tuist auth login` that never got as far as authenticating. A full cache should cost a
+        // cold build, not the build.
+        do {
+            try await cacheManifest(
+                manifest: manifest,
+                loadedManifest: loadedManifest,
+                hashes: hashes,
+                to: cachedManifestPath
+            )
+        } catch {
+            Logger.current
+                .warning("Unable to cache the \(manifest.fileName(path)) manifest at path: \(cachedManifestPath). \(error)")
+        }
 
         return loadedManifest
     }

--- a/cli/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -98,35 +98,6 @@ class CachedManifestLoaderTests {
         #expect(result.name == "App")
     }
 
-    @Test(.inTemporaryDirectory, .withMockedEnvironment())
-    func load_returnsTheManifestWhenTheCacheEntryCannotBeWritten() async throws {
-        // Given
-        // A cache directory that cannot be created, standing in for the runner cache volume that
-        // filled up: the manifest itself loads fine, only the cache write fails. This used to throw,
-        // and because `TuistCommand` loads the config manifest before it parses the subcommand, it
-        // took down every command for the account — a `tuist auth login` that never authenticated.
-        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
-        let blocker = temporaryDirectory.appending(component: "blocked")
-        try await fileSystem.writeText("not a directory", at: blocker)
-        given(cacheDirectoriesProvider)
-            .cacheDirectory(for: .value(.manifests))
-            .willReturn(blocker.appending(component: "Manifests"))
-        subject = try createSubject()
-
-        let path = temporaryDirectory.appending(component: "App")
-        let project = Project.test(name: "App")
-        try await stubProject(project, at: path)
-
-        // When
-        let result = try await subject.loadProject(at: path, disableSandbox: false)
-
-        // Then
-        #expect(result == project)
-        // Nothing was cached, so a second load re-reads the manifest rather than serving a hit.
-        _ = try await subject.loadProject(at: path, disableSandbox: false)
-        #expect(recordedLoadProjectCalls == 2)
-    }
-
     @Test(.inTemporaryDirectory, .withMockedEnvironment()) func load_manifestCached() async throws {
         // Given
         let path = try #require(FileSystem.temporaryTestDirectory).appending(component: "App")
@@ -354,12 +325,16 @@ class CachedManifestLoaderTests {
         })
     }
 
-    @Test(.inTemporaryDirectory, .withMockedEnvironment()) func throwing_writeErrors() async throws {
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func load_returnsTheManifestWhenTheCacheEntryCannotBeWritten() async throws {
         // Given
-        let expectedError = TestError.writeFailed
+        // The manifest itself loads fine and only the cache write fails — a full cache volume, say.
+        // This used to rethrow, and because `TuistCommand` loads the config manifest before it parses
+        // the subcommand, it took down every command for the account rather than costing this one
+        // manifest a cache entry.
         let fileSystem = MockFileSystem()
         fileSystem.writeTextOverride = { _, _, _ in
-            throw expectedError
+            throw TestError.writeFailed
         }
 
         subject = try createSubject(fileSystem: fileSystem)
@@ -368,10 +343,11 @@ class CachedManifestLoaderTests {
         let project = Project.test(name: "App")
         try await stubProject(project, at: path)
 
-        // When/Then
-        await #expect(throws: expectedError, performing: {
-            try await self.subject.loadProject(at: path, disableSandbox: false)
-        })
+        // When
+        let result = try await subject.loadProject(at: path, disableSandbox: false)
+
+        // Then
+        #expect(result == project)
     }
 
     // MARK: - Helpers

--- a/cli/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
+++ b/cli/Tests/TuistLoaderTests/Loaders/CachedManifestLoaderTests.swift
@@ -98,6 +98,35 @@ class CachedManifestLoaderTests {
         #expect(result.name == "App")
     }
 
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func load_returnsTheManifestWhenTheCacheEntryCannotBeWritten() async throws {
+        // Given
+        // A cache directory that cannot be created, standing in for the runner cache volume that
+        // filled up: the manifest itself loads fine, only the cache write fails. This used to throw,
+        // and because `TuistCommand` loads the config manifest before it parses the subcommand, it
+        // took down every command for the account — a `tuist auth login` that never authenticated.
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let blocker = temporaryDirectory.appending(component: "blocked")
+        try await fileSystem.writeText("not a directory", at: blocker)
+        given(cacheDirectoriesProvider)
+            .cacheDirectory(for: .value(.manifests))
+            .willReturn(blocker.appending(component: "Manifests"))
+        subject = try createSubject()
+
+        let path = temporaryDirectory.appending(component: "App")
+        let project = Project.test(name: "App")
+        try await stubProject(project, at: path)
+
+        // When
+        let result = try await subject.loadProject(at: path, disableSandbox: false)
+
+        // Then
+        #expect(result == project)
+        // Nothing was cached, so a second load re-reads the manifest rather than serving a hit.
+        _ = try await subject.loadProject(at: path, disableSandbox: false)
+        #expect(recordedLoadProjectCalls == 2)
+    }
+
     @Test(.inTemporaryDirectory, .withMockedEnvironment()) func load_manifestCached() async throws {
         // Given
         let path = try #require(FileSystem.temporaryTestDirectory).appending(component: "App")


### PR DESCRIPTION
Fixes the defect behind the 2026-09-02 runner cache-volume outage, and retires the workaround that was put in place for it.

### 1. A cache write must never fail a command

`CachedManifestLoader.cacheManifest` threw when it could not write its entry:

```swift
try await fileSystem.writeText(cachedManifestContent, at: cachedManifestPath)
```

By that point the manifest has already been loaded successfully — the throw discards a good value because an *optimization* failed. And because `TuistCommand` loads the config manifest before it parses the subcommand, the blast radius was not one manifest but the entire CLI for that account:

```
Failed to create temp file in '/Users/runner/.tuist-cache-volume/tuist/Manifests':
No space left on device (errno=28)
```

That is a `tuist auth login` that never got as far as authenticating, and on 2026-09-02 it failed `Lint`, `Unit Tests`, `Build Acceptance Tests` and `SwiftPM Build` in 45–70s each, on every branch, for every job on the account — because one shared cache volume had filled up. A full cache should cost a cold build, not the build.

The write is now best-effort with a warning, matching how the same function already degrades when it cannot compute a hash a few lines earlier.

Note this is the CLI half of that incident. [#12758](https://github.com/tuist/tuist/pull/12758) fixed the host half — it stops a full image being promoted to the account's master, so the fill can no longer propagate fleet-wide — but it only touched `dispatch-poll.sh`, and a job landing on an already-full master still died here.

### 2. Retire the `TUIST_XDG_CACHE_HOME` workaround

[#12737](https://github.com/tuist/tuist/pull/12737) added this to `cli.yml` to route around the above:

```yaml
TUIST_XDG_CACHE_HOME: /tmp/tuist-cache
```

It works, but it points every `cli.yml` job's Tuist cache at the runner VM's boot volume instead of the mounted per-account cache volume, which means:

- the binary cache the `Cache` job writes is thrown away with the VM instead of being promoted, so CI warms nothing;
- roughly 6 GiB of writes, plus the LRU pruner's churn, move onto a volume with no budget, no monitoring and no promote gate — while the purpose-built volume goes unused.

With the throw fixed, the workaround's reason is gone.

### Why this is worth doing before the `Cache` job's ENOSPC is fully diagnosed

The `Cache` job has been failing intermittently on `No space left on device`, and the mechanism is genuinely not settled — the per-job metrics show a job that **succeeded** holding *more* disk (66.1 GB) than the one that failed (64.3 GB), so resident bytes are not the variable.

But every explanation still standing — APFS purgeable/snapshot pinning inside the guest, or host-side growth of the guest's sparse disk image — is driven by **bytes written**, not bytes resident. Moving ~6 GiB of writes and their churn back off that volume helps under all of them, so it does not depend on which one turns out to be true.

This is not claimed as the fix for that failure. It removes load and restores a cache that is currently doing nothing.

### ⚠️ Merge order matters

`cli.yml` runs the `tuist` that `mise` pins (`4.208.0-canary.1`), **not this checkout**. So the CLI fix reaches CI only after a canary ships and `update-tuist-cli` bumps the pin — while the `cli.yml` revert takes effect on the very next run.

Landing them together re-exposes the outage for any account whose cache master is already full. The safe order is:

1. the CLI fix → canary release → `update-tuist-cli` bumps `mise.toml`;
2. **then** the `cli.yml` revert.

**The commits do not map cleanly onto those two stages, and I should flag why.** There are three:

| commit | contents | stage |
| --- | --- | --- |
| `534cd03` | `CachedManifestLoader.swift` (+ a test later removed) | 1 |
| `b3acdcb` | `.github/workflows/cli.yml` | **2** |
| `b484abd` | `CachedManifestLoaderTests.swift` — the contract update | **1** |

The test update belongs with the CLI fix and is last only because I committed it against the wrong HEAD after the branch was already pushed, and corrected it forward rather than rewriting published history. So stage 1 is `534cd03` + `b484abd`, and stage 2 is the single `cli.yml` hunk in `b3acdcb`. If you want to defer stage 2, revert that one hunk rather than dropping a commit.

### A deliberate behaviour change, flagged

`throwing_writeErrors` existed and asserted that the write error propagates, so this is not fixing an oversight — it is reversing tested behaviour. Its history shows characterisation rather than a documented requirement (it was last only rewritten when SwiftNIO was dropped, in #10241), and I could find no caller that benefits from the throw. I have replaced the assertion rather than deleting the test, so the change is visible in the diff — but it is a contract change and worth your judgement, not just mine.

### How to test locally

```bash
xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests -only-testing:TuistLoaderTests/CachedManifestLoaderTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

The test stubs `writeText` to throw, standing in for the volume that filled, and asserts the manifest is still returned.

### Validation

`** TEST EXECUTE SUCCEEDED **` — 32 passed, 0 failed, over the whole `CachedManifestLoaderTests` suite, against `build-for-testing` of `TuistUnitTests`. `swiftformat --lint` clean on both changed files.

Worth noting how the contract change surfaced: the first run went **red**, on `throwing_writeErrors` asserting the old behaviour. That is the test doing its job, and it is why the change is called out above rather than slipped in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
