### PR TITLE
chore(ci): notify Slack when the CLI canary release fails

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -10,6 +10,7 @@ on:
       - Cache Release
       - CLI
       - CLI Cache EE
+      - CLI Canary Release
       - CNPG Restore Drill
       - Gradle
       - Gradle Cache Acceptance


### PR DESCRIPTION
> Describe here the purpose of your PR.

The CLI canary release publishes a prerelease on every CLI-touching commit to `main`, but it was missing from the `workflow_run` listener that pings Slack on red runs. `CLI` and `CLI Cache EE` were both in the list; `CLI Canary Release` was not, so a failed canary was only visible to whoever happened to look at the Actions tab — no Slack ping, unlike every other release and deploy workflow.

**What changed:** one line in `.github/workflows/notify-failure.yml`, adding `CLI Canary Release` to the `workflow_run` workflow list (kept in the file's alphabetical order, after `CLI Cache EE`).

**Why this shape:** the repo already has the mechanism — a single listener workflow that fires on `workflow_run` completion for the named workflows on `main`, reads the Slack webhook from 1Password, and posts `:x: <run> failed on main for <commit>`. Adding the workflow name reuses it verbatim rather than bolting a bespoke failure step onto `cli-release.yml`, so canary failures are reported in exactly the same format and channel as the rest.

**Why no entry for `CLI Build & Publish`:** it is a reusable (`workflow_call`) workflow, so it produces no run of its own. A failure inside it surfaces as a failed `CLI Canary Release` run and is covered by this change.

**Deliberately out of scope** (happy to follow up if wanted):

- `CLI Release Candidate`, `CLI Promote to Stable`, and `CLI Backport Release` are `workflow_dispatch`-only and run off `releases/*.x` branches. Adding them to this listener would be a no-op — its `branches: [main]` filter would drop them. Covering those needs a separate listener without the branch filter, or per-workflow failure steps.
- A canary queued behind the `cli-publish` concurrency group and then cancelled concludes as `cancelled`, not `failure`, so it stays silent. That matches how every other workflow in this list already behaves.

### How to test locally

Workflow-only change; there is no local runtime to exercise. Validation run:

- `actionlint .github/workflows/notify-failure.yml` — clean apart from a pre-existing `SC2086` info on the untouched 1Password step (line 51), which is present on `main` too.
- Parsed the YAML back to confirm the trigger list now contains `CLI`, `CLI Cache EE`, `CLI Canary Release`.
- Confirmed the workflow name matches the `name:` in `.github/workflows/cli-release.yml` exactly (`CLI Canary Release`) — `workflow_run` matches by name, so a typo would fail silently.

End-to-end behaviour can only be observed on `main`: the next CLI canary run that fails should post to the same Slack channel as the other workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
