### PR TITLE
fix(server): switch to an optimistic-submit gate and let the Turnstile hook own its script load

### DIFF
--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -132,15 +132,6 @@ spec:
             - name: TUIST_TURNSTILE_ENABLED
               value: "1"
             {{- end }}
-            {{- if and .Values.server.turnstile.enabled .Values.server.turnstile.useTestKeys }}
-            # Cloudflare's public always-passing test key pair, safe to embed
-            # in the chart because they only unlock the demo widget.
-            # https://developers.cloudflare.com/turnstile/troubleshooting/testing/
-            - name: TUIST_TURNSTILE_SITE_KEY
-              value: "1x00000000000000000000AA"
-            - name: TUIST_TURNSTILE_SECRET_KEY
-              value: "1x0000000000000000000000000000000AA"
-            {{- end }}
             {{- if .Values.server.kuraCapacityAdmission.enabled }}
             - name: TUIST_KURA_CAPACITY_ADMISSION_ENABLED
               value: "1"

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -448,15 +448,10 @@ server:
   hosted: false
   # Cloudflare Turnstile protects self-service browser registration on hosted
   # deployments. When `enabled` is true, TUIST_TURNSTILE_ENABLED is set on the
-  # deployment and the site/secret keys are wired up. `useTestKeys` uses
-  # Cloudflare's public always-passing test key pair, so pre-production
-  # environments can exercise the widget without needing the real secret
-  # (this is the coverage that would have caught the 2026-09-03 outage).
-  # `secretsFrom: eso` pulls the real keys from the TURNSTILE 1Password item
-  # via external-secrets in production.
+  # deployment and the site/secret keys are synced from the TURNSTILE 1Password
+  # item via external-secrets.
   turnstile:
     enabled: false
-    useTestKeys: false
     secretsFrom: eso
   # Browser real user monitoring. Set collectorUrl to the endpoint the browser
   # posts Grafana Faro payloads to; a same-origin path keeps the request free of

--- a/server/assets/app/js/Turnstile.js
+++ b/server/assets/app/js/Turnstile.js
@@ -1,14 +1,75 @@
-// Ceiling on how long we wait for Cloudflare's api.js to load before we
-// give up and surface an "unavailable" error to the user. 10s is well above
-// a slow first-party bundle load and comfortably below the point where a
-// user would refresh the page on their own.
+const API_URL = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+// Global ceiling for how long we wait between the api.js `<script>` being
+// appended and its onload callback firing. Well above a slow first-party
+// bundle load, comfortably below the point where a user would refresh the
+// page on their own. Only relevant when the download finishes but the
+// script's own initialization stalls — a network failure surfaces sooner
+// through the `<script>` element's error event.
 const API_LOAD_TIMEOUT_MS = 10000;
+
+// The api.js callback name Cloudflare invokes via `?onload=`. Cloudflare's
+// documented pattern for `render=explicit` under a deferred script tag,
+// and the one thing that must be a shared global — `turnstile.render()`
+// can't be called until the api.js callback has fired, and the callback
+// only fires once for the whole page load.
+const ONLOAD_CALLBACK_NAME = "__tuistTurnstileOnLoad";
+
+// Shared, module-level load promise. Every hook mount reads it: if api.js
+// is already loading (or loaded), the mount joins the existing wait rather
+// than injecting a second `<script>`. Reset to null on a failed load so a
+// later mount can retry from a fresh state.
+let apiPromise = null;
+
+function loadApi() {
+  if (apiPromise) return apiPromise;
+
+  if (window.turnstile) {
+    apiPromise = Promise.resolve(window.turnstile);
+    return apiPromise;
+  }
+
+  apiPromise = new Promise((resolve, reject) => {
+    let timeoutHandle = null;
+    const cleanup = () => {
+      if (timeoutHandle) window.clearTimeout(timeoutHandle);
+      delete window[ONLOAD_CALLBACK_NAME];
+    };
+
+    // Cloudflare's `?onload=` is what tells us api.js has finished its own
+    // initialization. Using turnstile.ready() alongside `defer` is the
+    // combination that threw in the 2026-09-03 outage; this pattern
+    // sidesteps it entirely because the callback fires from api.js itself,
+    // not from a downstream consumer.
+    window[ONLOAD_CALLBACK_NAME] = () => {
+      cleanup();
+      resolve(window.turnstile);
+    };
+
+    const script = document.createElement("script");
+    script.src = `${API_URL}&onload=${ONLOAD_CALLBACK_NAME}`;
+    script.async = true;
+    script.defer = true;
+    script.onerror = () => {
+      cleanup();
+      apiPromise = null;
+      reject(new Error("turnstile-api-load-failed"));
+    };
+
+    timeoutHandle = window.setTimeout(() => {
+      cleanup();
+      apiPromise = null;
+      reject(new Error("turnstile-api-load-timeout"));
+    }, API_LOAD_TIMEOUT_MS);
+
+    document.head.appendChild(script);
+  });
+
+  return apiPromise;
+}
 
 const Turnstile = {
   mounted() {
     this.widgetId = null;
-    this.timeoutHandle = null;
-    this.apiListener = null;
     this.pendingSubmit = false;
     this.responseField = this.el.querySelector("[data-turnstile-response]");
 
@@ -16,64 +77,31 @@ const Turnstile = {
       if (id === this.el.id) this.reset();
     });
 
-    // Optimistic-submit gate. When the LiveView receives a `save` before the
-    // widget has produced a token, it pushes this event and shows a
-    // "Verifying, one moment" message. The hook remembers that intent and
-    // re-fires the form's submit as soon as the token is filled in, so the
-    // user never has to click again.
+    // Optimistic-submit gate. When the LiveView receives a `save` before
+    // the widget has produced a token, it pushes this event and shows a
+    // "Verifying, one moment" message. The hook remembers the intent and
+    // re-fires the form's submit as soon as the token is filled in, so
+    // the user never has to click again.
     this.handleEvent("turnstile:submit-when-ready", ({ id }) => {
       if (id === this.el.id) this.pendingSubmit = true;
     });
 
     this.notifyState("pending");
-    this.waitForApi(() => this.render());
+    loadApi().then(
+      () => this.render(),
+      () => this.notifyState("unavailable"),
+    );
   },
 
   destroyed() {
-    if (this.timeoutHandle) window.clearTimeout(this.timeoutHandle);
-    if (this.apiListener) {
-      window.removeEventListener("tuist:turnstile-api-loaded", this.apiListener);
-    }
     if (this.widgetId !== null && window.turnstile) {
       try {
         window.turnstile.remove(this.widgetId);
       } catch (_e) {
-        // The api.js script tears its own iframes down when the page unloads
-        // and remove() throws if the widget is already gone. Ignore.
+        // api.js tears its own iframes down when the page unloads and
+        // remove() throws if the widget is already gone. Ignore.
       }
     }
-  },
-
-  // Coordinate with the inline shim in app.html.heex that sits alongside the
-  // `?onload=__tuistTurnstileOnLoad` script tag. If the api.js script has
-  // already fired its onload before the hook mounts, the shim leaves a flag
-  // we can read synchronously. Otherwise, we subscribe to the one-shot event
-  // and let the shim tell us. Either way, we never call turnstile.ready(),
-  // which is the combination Cloudflare's script throws on under `defer`.
-  waitForApi(onReady) {
-    if (window.__tuistTurnstileReady && window.turnstile) {
-      onReady();
-      return;
-    }
-
-    this.apiListener = () => {
-      this.apiListener = null;
-      if (this.timeoutHandle) {
-        window.clearTimeout(this.timeoutHandle);
-        this.timeoutHandle = null;
-      }
-      onReady();
-    };
-    window.addEventListener("tuist:turnstile-api-loaded", this.apiListener, { once: true });
-
-    this.timeoutHandle = window.setTimeout(() => {
-      this.timeoutHandle = null;
-      if (this.apiListener) {
-        window.removeEventListener("tuist:turnstile-api-loaded", this.apiListener);
-        this.apiListener = null;
-      }
-      this.notifyState("unavailable");
-    }, API_LOAD_TIMEOUT_MS);
   },
 
   render() {
@@ -133,10 +161,10 @@ const Turnstile = {
 
   reset() {
     if (this.responseField) this.responseField.value = "";
-    // A reset always clears an outstanding auto-submit intent: the previous
-    // attempt was rejected (rate limit, invalid input, expired token), so
-    // re-firing the same submit as soon as a fresh token arrives would just
-    // replay the same failure.
+    // A reset always clears an outstanding auto-submit intent: the
+    // previous attempt was rejected (rate limit, invalid input, expired
+    // token), and re-firing the same submit as soon as a fresh token
+    // arrives would just replay the same failure.
     this.pendingSubmit = false;
     this.notifyState("pending");
     if (this.widgetId !== null && window.turnstile) {

--- a/server/assets/app/js/Turnstile.js
+++ b/server/assets/app/js/Turnstile.js
@@ -9,10 +9,20 @@ const Turnstile = {
     this.widgetId = null;
     this.timeoutHandle = null;
     this.apiListener = null;
+    this.pendingSubmit = false;
     this.responseField = this.el.querySelector("[data-turnstile-response]");
 
     this.handleEvent("turnstile:reset", ({ id }) => {
       if (id === this.el.id) this.reset();
+    });
+
+    // Optimistic-submit gate. When the LiveView receives a `save` before the
+    // widget has produced a token, it pushes this event and shows a
+    // "Verifying, one moment" message. The hook remembers that intent and
+    // re-fires the form's submit as soon as the token is filled in, so the
+    // user never has to click again.
+    this.handleEvent("turnstile:submit-when-ready", ({ id }) => {
+      if (id === this.el.id) this.pendingSubmit = true;
     });
 
     this.notifyState("pending");
@@ -81,6 +91,15 @@ const Turnstile = {
         callback: (token) => {
           this.responseField.value = token;
           this.notifyState("ready");
+          if (this.pendingSubmit) {
+            this.pendingSubmit = false;
+            const form = this.el.closest("form");
+            if (form && typeof form.requestSubmit === "function") {
+              form.requestSubmit();
+            } else if (form) {
+              form.submit();
+            }
+          }
         },
         "expired-callback": () => {
           this.responseField.value = "";
@@ -114,6 +133,11 @@ const Turnstile = {
 
   reset() {
     if (this.responseField) this.responseField.value = "";
+    // A reset always clears an outstanding auto-submit intent: the previous
+    // attempt was rejected (rate limit, invalid input, expired token), so
+    // re-firing the same submit as soon as a fresh token arrives would just
+    // replay the same failure.
+    this.pendingSubmit = false;
     this.notifyState("pending");
     if (this.widgetId !== null && window.turnstile) {
       try {

--- a/server/config/config.exs
+++ b/server/config/config.exs
@@ -249,7 +249,10 @@ config :logger, :console,
     :cap,
     :urls,
     :configured,
-    :reconciling
+    :reconciling,
+    # Turnstile widget-failure signal from the signup LiveViews
+    :turnstile_state,
+    :turnstile_action
   ]
 
 config :mdex_native, syntax_highlighter: :lumis

--- a/server/lib/tuist_web/components/layouts/app.html.heex
+++ b/server/lib/tuist_web/components/layouts/app.html.heex
@@ -37,36 +37,6 @@
     <link phx-track-static rel="stylesheet" href={~p"/app/assets/bundle.css"} />
     <script defer phx-track-static type="module" src={~p"/app/assets/bundle.js"}>
     </script>
-    <%!--
-      Turnstile coordination. `api.js` is loaded with `defer` so it does not
-      block first render, and Cloudflare's own `?onload=` callback is what
-      tells us the widget global is ready. Using `turnstile.ready()` under a
-      deferred `api.js` is the combination Cloudflare's script throws on
-      (`Uncaught TurnstileError: Remove async/defer from the Turnstile api.js
-      script tag before using turnstile.ready()`), which is the load-order
-      race that caused the 2026-09-03 signup outage: the throw aborted
-      `render()` and the LiveView hook was left waiting on a `ready` callback
-      that never fired. The inline shim sets an eager flag so the hook can
-      render immediately when it mounts after `api.js` has already loaded,
-      and dispatches a one-shot event for the reverse ordering.
-    --%>
-    <script
-      :if={TuistWeb.Turnstile.required?() and assigns[:load_turnstile_script?]}
-      nonce={get_csp_nonce()}
-    >
-      window.__tuistTurnstileReady = false;
-      window.__tuistTurnstileOnLoad = function () {
-        window.__tuistTurnstileReady = true;
-        window.dispatchEvent(new CustomEvent("tuist:turnstile-api-loaded"));
-      };
-    </script>
-    <script
-      :if={TuistWeb.Turnstile.required?() and assigns[:load_turnstile_script?]}
-      nonce={get_csp_nonce()}
-      src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=__tuistTurnstileOnLoad&render=explicit"
-      defer
-    >
-    </script>
     <script nonce={get_csp_nonce()}>
       function cssvar(name) {
         return getComputedStyle(document.documentElement).getPropertyValue(name);

--- a/server/lib/tuist_web/live/choose_username_live.ex
+++ b/server/lib/tuist_web/live/choose_username_live.ex
@@ -33,6 +33,7 @@ defmodule TuistWeb.ChooseUsernameLive do
           |> assign(:turnstile_site_key, Turnstile.site_key())
           |> assign(:turnstile_error, nil)
           |> assign(:turnstile_ready?, false)
+          |> assign(:submit_pending?, false)
           |> assign(:load_turnstile_script?, Turnstile.required?())
 
         {:ok, socket}
@@ -89,12 +90,18 @@ defmodule TuistWeb.ChooseUsernameLive do
                 <input data-turnstile-response name="cf-turnstile-response" type="hidden" />
               </div>
               <span :if={@turnstile_error} data-part="turnstile-error">{@turnstile_error}</span>
+              <span
+                :if={@submit_pending?}
+                data-part="turnstile-pending"
+                aria-live="polite"
+              >
+                {dgettext("dashboard_auth", "Verifying, one moment...")}
+              </span>
               <div data-part="actions">
                 <.button
                   type="submit"
                   variant="primary"
                   label={dgettext("dashboard_auth", "Continue")}
-                  disabled={@turnstile_required? and not @turnstile_ready?}
                 />
               </div>
             </.form>
@@ -112,7 +119,28 @@ defmodule TuistWeb.ChooseUsernameLive do
   end
 
   @impl true
-  def handle_event("choose_username", %{"account" => %{"name" => username}} = params, socket) do
+  def handle_event("choose_username", %{"account" => %{"name" => _}} = params, socket) do
+    if socket.assigns.turnstile_required? and not socket.assigns.turnstile_ready? do
+      # Optimistic-submit gate. Mirrors user_registration_live: park the
+      # submit intent, show a verifying message, and let the hook re-fire
+      # the form's submit as soon as the token lands.
+      {:noreply,
+       socket
+       |> assign(:submit_pending?, true)
+       |> assign(:turnstile_error, nil)
+       |> push_event("turnstile:submit-when-ready", %{id: "oauth-signup-turnstile"})}
+    else
+      handle_choose_username(params, socket)
+    end
+  end
+
+  def handle_event("turnstile_state_changed", %{"state" => state}, socket) do
+    {:noreply, apply_turnstile_state(socket, state)}
+  end
+
+  defp handle_choose_username(%{"account" => %{"name" => username}} = params, socket) do
+    socket = assign(socket, :submit_pending?, false)
+
     case SignupProtection.verify(socket.assigns.registration_session_token, params, "oauth_signup") do
       :ok ->
         choose_username(username, assign(socket, :turnstile_error, nil))
@@ -138,11 +166,6 @@ defmodule TuistWeb.ChooseUsernameLive do
          |> assign(:turnstile_error, dgettext("dashboard_auth", "Please complete the security check and try again."))
          |> reset_turnstile()}
     end
-  end
-
-  @impl true
-  def handle_event("turnstile_state_changed", %{"state" => state}, socket) do
-    {:noreply, apply_turnstile_state(socket, state)}
   end
 
   defp apply_turnstile_state(socket, "ready"),
@@ -253,6 +276,8 @@ defmodule TuistWeb.ChooseUsernameLive do
   end
 
   defp reset_turnstile(socket) do
+    socket = assign(socket, :submit_pending?, false)
+
     if socket.assigns.turnstile_required? do
       socket
       |> assign(:turnstile_ready?, false)

--- a/server/lib/tuist_web/live/choose_username_live.ex
+++ b/server/lib/tuist_web/live/choose_username_live.ex
@@ -10,6 +10,8 @@ defmodule TuistWeb.ChooseUsernameLive do
   alias TuistWeb.SignupProtection
   alias TuistWeb.Turnstile
 
+  require Logger
+
   @impl true
   def mount(_params, session, socket) do
     case session["pending_oauth_signup"] do
@@ -171,6 +173,8 @@ defmodule TuistWeb.ChooseUsernameLive do
     do: socket |> assign(:turnstile_ready?, true) |> assign(:turnstile_error, nil)
 
   defp apply_turnstile_state(socket, "unavailable") do
+    log_turnstile_failure(:unavailable, "oauth_signup")
+
     socket
     |> assign(:turnstile_ready?, false)
     |> assign(
@@ -183,6 +187,8 @@ defmodule TuistWeb.ChooseUsernameLive do
   end
 
   defp apply_turnstile_state(socket, "error") do
+    log_turnstile_failure(:error, "oauth_signup")
+
     socket
     |> assign(:turnstile_ready?, false)
     |> assign(
@@ -192,6 +198,22 @@ defmodule TuistWeb.ChooseUsernameLive do
   end
 
   defp apply_turnstile_state(socket, _state), do: assign(socket, :turnstile_ready?, false)
+
+  # Server-side evidence for the failure classes the widget produces before
+  # the user ever clicks Continue. See the twin in user_registration_live.ex
+  # for the full rationale.
+  defp log_turnstile_failure(state, action) do
+    Logger.warning("Turnstile widget reported #{state} on #{action}",
+      turnstile_state: state,
+      turnstile_action: action
+    )
+
+    :telemetry.execute(
+      [:tuist, :turnstile, :failure],
+      %{count: 1},
+      %{state: state, action: action}
+    )
+  end
 
   defp choose_username(username, socket) do
     username = String.trim(username)

--- a/server/lib/tuist_web/live/choose_username_live.ex
+++ b/server/lib/tuist_web/live/choose_username_live.ex
@@ -34,7 +34,6 @@ defmodule TuistWeb.ChooseUsernameLive do
           |> assign(:turnstile_error, nil)
           |> assign(:turnstile_ready?, false)
           |> assign(:submit_pending?, false)
-          |> assign(:load_turnstile_script?, Turnstile.required?())
 
         {:ok, socket}
     end

--- a/server/lib/tuist_web/live/user_registration_live.ex
+++ b/server/lib/tuist_web/live/user_registration_live.ex
@@ -191,12 +191,18 @@ defmodule TuistWeb.UserRegistrationLive do
                 <input data-turnstile-response name="cf-turnstile-response" type="hidden" />
               </div>
               <span :if={@turnstile_error} data-part="turnstile-error">{@turnstile_error}</span>
+              <span
+                :if={@submit_pending?}
+                data-part="turnstile-pending"
+                aria-live="polite"
+              >
+                {dgettext("dashboard_auth", "Verifying, one moment...")}
+              </span>
               <.button
                 variant="primary"
                 size="large"
                 label={dgettext("dashboard_auth", "Sign up")}
                 tabindex={4}
-                disabled={@turnstile_required? and not @turnstile_ready?}
               />
             </.form>
           </div>
@@ -291,6 +297,7 @@ defmodule TuistWeb.UserRegistrationLive do
         |> assign(:turnstile_site_key, Turnstile.site_key())
         |> assign(:turnstile_error, nil)
         |> assign(:turnstile_ready?, false)
+        |> assign(:submit_pending?, false)
         |> assign(:load_turnstile_script?, Turnstile.required?())
         |> assign(:github_configured?, Environment.github_oauth_configured?() and Environment.github_auth_enabled?())
         |> assign(:google_configured?, Environment.google_oauth_configured?() and Environment.google_auth_enabled?())
@@ -308,39 +315,59 @@ defmodule TuistWeb.UserRegistrationLive do
   end
 
   def handle_event("save", params, socket) do
-    if Environment.email_auth_enabled?() do
-      case SignupProtection.verify(socket.assigns.registration_session_token, params, "email_signup") do
-        :ok ->
-          save_user(Map.get(params, "user", %{}), assign(socket, :turnstile_error, nil))
+    cond do
+      not Environment.email_auth_enabled?() ->
+        {:noreply, redirect(socket, to: ~p"/users/log_in")}
 
-        {:error, :rate_limited} ->
-          {:noreply,
-           socket
-           |> assign(:turnstile_error, dgettext("dashboard_auth", "Too many sign-up attempts. Please try again later."))
-           |> reset_turnstile()}
+      socket.assigns.turnstile_required? and not socket.assigns.turnstile_ready? ->
+        # Optimistic-submit gate: the user clicked Sign up before the widget
+        # produced a token. Show a "Verifying, one moment" message and tell
+        # the hook to re-fire the form's submit as soon as the token lands,
+        # so the click is never dropped and the user does not have to click
+        # again. The server-side token check still runs on the re-fire.
+        {:noreply,
+         socket
+         |> assign(:submit_pending?, true)
+         |> assign(:turnstile_error, nil)
+         |> push_event("turnstile:submit-when-ready", %{id: "email-signup-turnstile"})}
 
-        {:error, :missing_session} ->
-          {:noreply,
-           socket
-           |> assign(
-             :turnstile_error,
-             dgettext("dashboard_auth", "Your session has expired. Please reload the page and try again.")
-           )
-           |> reset_turnstile()}
-
-        {:error, :turnstile_failed} ->
-          {:noreply,
-           socket
-           |> assign(:turnstile_error, dgettext("dashboard_auth", "Please complete the security check and try again."))
-           |> reset_turnstile()}
-      end
-    else
-      {:noreply, redirect(socket, to: ~p"/users/log_in")}
+      true ->
+        handle_save(params, socket)
     end
   end
 
   def handle_event("turnstile_state_changed", %{"state" => state}, socket) do
     {:noreply, apply_turnstile_state(socket, state)}
+  end
+
+  defp handle_save(params, socket) do
+    socket = assign(socket, :submit_pending?, false)
+
+    case SignupProtection.verify(socket.assigns.registration_session_token, params, "email_signup") do
+      :ok ->
+        save_user(Map.get(params, "user", %{}), assign(socket, :turnstile_error, nil))
+
+      {:error, :rate_limited} ->
+        {:noreply,
+         socket
+         |> assign(:turnstile_error, dgettext("dashboard_auth", "Too many sign-up attempts. Please try again later."))
+         |> reset_turnstile()}
+
+      {:error, :missing_session} ->
+        {:noreply,
+         socket
+         |> assign(
+           :turnstile_error,
+           dgettext("dashboard_auth", "Your session has expired. Please reload the page and try again.")
+         )
+         |> reset_turnstile()}
+
+      {:error, :turnstile_failed} ->
+        {:noreply,
+         socket
+         |> assign(:turnstile_error, dgettext("dashboard_auth", "Please complete the security check and try again."))
+         |> reset_turnstile()}
+    end
   end
 
   defp apply_turnstile_state(socket, "ready"),
@@ -422,6 +449,8 @@ defmodule TuistWeb.UserRegistrationLive do
   end
 
   defp reset_turnstile(socket) do
+    socket = assign(socket, :submit_pending?, false)
+
     if socket.assigns.turnstile_required? do
       socket
       |> assign(:turnstile_ready?, false)

--- a/server/lib/tuist_web/live/user_registration_live.ex
+++ b/server/lib/tuist_web/live/user_registration_live.ex
@@ -12,6 +12,8 @@ defmodule TuistWeb.UserRegistrationLive do
   alias TuistWeb.SignupProtection
   alias TuistWeb.Turnstile
 
+  require Logger
+
   def render(assigns) do
     ~H"""
     <.noora_registration {assigns} />
@@ -373,6 +375,8 @@ defmodule TuistWeb.UserRegistrationLive do
     do: socket |> assign(:turnstile_ready?, true) |> assign(:turnstile_error, nil)
 
   defp apply_turnstile_state(socket, "unavailable") do
+    log_turnstile_failure(:unavailable, "email_signup")
+
     socket
     |> assign(:turnstile_ready?, false)
     |> assign(
@@ -385,6 +389,8 @@ defmodule TuistWeb.UserRegistrationLive do
   end
 
   defp apply_turnstile_state(socket, "error") do
+    log_turnstile_failure(:error, "email_signup")
+
     socket
     |> assign(:turnstile_ready?, false)
     |> assign(
@@ -394,6 +400,26 @@ defmodule TuistWeb.UserRegistrationLive do
   end
 
   defp apply_turnstile_state(socket, _state), do: assign(socket, :turnstile_ready?, false)
+
+  # Server-side evidence for the failure classes the widget produces before
+  # the user ever clicks Sign up. Turnstile.verify/2's existing warnings only
+  # fire once the token reaches siteverify, which never happens when the
+  # widget itself is broken. Logging + telemetry here mean a silent widget
+  # failure (script blocked, live_navigate stripping the load, challenge
+  # errored out) leaves a countable trail regardless of whether the user
+  # tries to submit or bounces.
+  defp log_turnstile_failure(state, action) do
+    Logger.warning("Turnstile widget reported #{state} on #{action}",
+      turnstile_state: state,
+      turnstile_action: action
+    )
+
+    :telemetry.execute(
+      [:tuist, :turnstile, :failure],
+      %{count: 1},
+      %{state: state, action: action}
+    )
+  end
 
   defp save_user(user_params, socket) do
     case user_params

--- a/server/lib/tuist_web/live/user_registration_live.ex
+++ b/server/lib/tuist_web/live/user_registration_live.ex
@@ -298,7 +298,6 @@ defmodule TuistWeb.UserRegistrationLive do
         |> assign(:turnstile_error, nil)
         |> assign(:turnstile_ready?, false)
         |> assign(:submit_pending?, false)
-        |> assign(:load_turnstile_script?, Turnstile.required?())
         |> assign(:github_configured?, Environment.github_oauth_configured?() and Environment.github_auth_enabled?())
         |> assign(:google_configured?, Environment.google_oauth_configured?() and Environment.google_auth_enabled?())
         |> assign(:okta_configured?, Environment.okta_oauth_configured?() and Environment.okta_auth_enabled?())

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -41,7 +41,20 @@ defmodule TuistWeb.Router do
 
   def csp_opts(_conn) do
     s3_endpoint = Tuist.Environment.s3_endpoint()
-    turnstile_source = if TuistWeb.Turnstile.required?(), do: " https://challenges.cloudflare.com", else: ""
+
+    # Deliberately reads the env-var toggle directly rather than the
+    # flag-aware `TuistWeb.Turnstile.required?/0`. This plug feeds the
+    # `:content_security_policy` pipeline, which the app, marketing, docs,
+    # image and ueberauth pipelines all use, so a per-request
+    # `FunWithFlags.enabled?(:turnstile_kill_switch)` would fire on every
+    # page load site-wide for a widget only two LiveViews ever render — and
+    # the underlying store `raise`s on a cold cache during a Postgres blip,
+    # which would 500 pages that previously had no DB dependency here.
+    # Flipping the kill switch still turns off the widget and the verify
+    # path everywhere immediately; the only thing left behind is a CSP
+    # source pointing at a host nothing loads from.
+    turnstile_source =
+      if Tuist.Environment.turnstile_required?(), do: " https://challenges.cloudflare.com", else: ""
 
     [
       frame_ancestors: "'self'",

--- a/server/priv/gettext/dashboard_auth.pot
+++ b/server/priv/gettext/dashboard_auth.pot
@@ -16,12 +16,12 @@ msgstr ""
 msgid "Account confirmed!"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:413
+#: lib/tuist_web/live/user_registration_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "Account created successfully! Please log in."
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:427
+#: lib/tuist_web/live/user_registration_live.ex:426
 #, elixir-autogen, elixir-format
 msgid "Account name is already taken"
 msgstr ""
@@ -63,7 +63,7 @@ msgstr ""
 msgid "Check your inbox for a confirmation email and click the link to continue."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:61
+#: lib/tuist_web/live/choose_username_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Choose a username"
 msgstr ""
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Contact us"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:104
+#: lib/tuist_web/live/choose_username_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr ""
@@ -137,7 +137,7 @@ msgstr ""
 msgid "Email address"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:433
+#: lib/tuist_web/live/user_registration_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "Email is already taken"
 msgstr ""
@@ -275,7 +275,7 @@ msgstr ""
 msgid "Sign up for Tuist"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:220
+#: lib/tuist_web/live/choose_username_live.ex:219
 #, elixir-autogen, elixir-format
 msgid "This username has already been taken"
 msgstr ""
@@ -285,7 +285,7 @@ msgstr ""
 msgid "Tuist CLI is connected!"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:52
+#: lib/tuist_web/live/choose_username_live.ex:51
 #: lib/tuist_web/live/device_codes_success_live.ex:28
 #: lib/tuist_web/live/sso_login_live.ex:63
 #: lib/tuist_web/live/user_confirmation_instructions_live.ex:18
@@ -324,13 +324,13 @@ msgstr ""
 msgid "User confirmation link is invalid or it has expired."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:76
+#: lib/tuist_web/live/choose_username_live.ex:75
 #: lib/tuist_web/live/user_registration_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Username"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:77
+#: lib/tuist_web/live/choose_username_live.ex:76
 #: lib/tuist_web/live/user_registration_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Username may only contain alphanumeric characters"
@@ -433,7 +433,7 @@ msgstr ""
 msgid "Log in as test user"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:63
+#: lib/tuist_web/live/choose_username_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Choose a username for your account"
 msgstr ""
@@ -484,44 +484,44 @@ msgstr ""
 msgid "Your email isn't confirmed yet"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:166
-#: lib/tuist_web/live/user_registration_live.ex:368
+#: lib/tuist_web/live/choose_username_live.ex:165
+#: lib/tuist_web/live/user_registration_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Please complete the security check and try again."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:179
-#: lib/tuist_web/live/user_registration_live.ex:381
+#: lib/tuist_web/live/choose_username_live.ex:178
+#: lib/tuist_web/live/user_registration_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "The security check could not load. Check for a blocker on challenges.cloudflare.com and reload the page."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:191
-#: lib/tuist_web/live/user_registration_live.ex:393
+#: lib/tuist_web/live/choose_username_live.ex:190
+#: lib/tuist_web/live/user_registration_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "The security check failed. Please reload the page and try again."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:151
-#: lib/tuist_web/live/user_registration_live.ex:353
+#: lib/tuist_web/live/choose_username_live.ex:150
+#: lib/tuist_web/live/user_registration_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "Too many sign-up attempts. Please try again later."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:159
-#: lib/tuist_web/live/user_registration_live.ex:361
+#: lib/tuist_web/live/choose_username_live.ex:158
+#: lib/tuist_web/live/user_registration_live.ex:360
 #, elixir-autogen, elixir-format
 msgid "Your session has expired. Please reload the page and try again."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:235
-#: lib/tuist_web/live/choose_username_live.ex:263
-#: lib/tuist_web/live/choose_username_live.ex:274
+#: lib/tuist_web/live/choose_username_live.ex:234
+#: lib/tuist_web/live/choose_username_live.ex:262
+#: lib/tuist_web/live/choose_username_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:98
+#: lib/tuist_web/live/choose_username_live.ex:97
 #: lib/tuist_web/live/user_registration_live.ex:199
 #, elixir-autogen, elixir-format
 msgid "Verifying, one moment..."

--- a/server/priv/gettext/dashboard_auth.pot
+++ b/server/priv/gettext/dashboard_auth.pot
@@ -16,17 +16,17 @@ msgstr ""
 msgid "Account confirmed!"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:386
+#: lib/tuist_web/live/user_registration_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "Account created successfully! Please log in."
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:400
+#: lib/tuist_web/live/user_registration_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "Account name is already taken"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:204
+#: lib/tuist_web/live/user_registration_live.ex:210
 #, elixir-autogen, elixir-format
 msgid "Already have an account?"
 msgstr ""
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Check your email"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:238
+#: lib/tuist_web/live/user_registration_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Check your inbox for a confirmation email and click the link to continue."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:60
+#: lib/tuist_web/live/choose_username_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Choose a username"
 msgstr ""
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Confirm password"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:236
+#: lib/tuist_web/live/user_registration_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Confirm your account"
 msgstr ""
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Contact us"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:96
+#: lib/tuist_web/live/choose_username_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr ""
@@ -137,7 +137,7 @@ msgstr ""
 msgid "Email address"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:406
+#: lib/tuist_web/live/user_registration_live.ex:433
 #, elixir-autogen, elixir-format
 msgid "Email is already taken"
 msgstr ""
@@ -190,7 +190,7 @@ msgstr ""
 #: lib/tuist_web/live/sso_login_live.ex:97
 #: lib/tuist_web/live/user_login_live.ex:18
 #: lib/tuist_web/live/user_login_live.ex:182
-#: lib/tuist_web/live/user_registration_live.ex:209
+#: lib/tuist_web/live/user_registration_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
@@ -264,8 +264,8 @@ msgid "Selective testing"
 msgstr ""
 
 #: lib/tuist_web/live/user_login_live.ex:212
-#: lib/tuist_web/live/user_registration_live.ex:197
-#: lib/tuist_web/live/user_registration_live.ex:285
+#: lib/tuist_web/live/user_registration_live.ex:204
+#: lib/tuist_web/live/user_registration_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Sign up"
 msgstr ""
@@ -275,7 +275,7 @@ msgstr ""
 msgid "Sign up for Tuist"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:197
+#: lib/tuist_web/live/choose_username_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "This username has already been taken"
 msgstr ""
@@ -285,7 +285,7 @@ msgstr ""
 msgid "Tuist CLI is connected!"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:51
+#: lib/tuist_web/live/choose_username_live.ex:52
 #: lib/tuist_web/live/device_codes_success_live.ex:28
 #: lib/tuist_web/live/sso_login_live.ex:63
 #: lib/tuist_web/live/user_confirmation_instructions_live.ex:18
@@ -293,7 +293,7 @@ msgstr ""
 #: lib/tuist_web/live/user_forgot_password_live.ex:24
 #: lib/tuist_web/live/user_login_live.ex:43
 #: lib/tuist_web/live/user_registration_live.ex:70
-#: lib/tuist_web/live/user_registration_live.ex:227
+#: lib/tuist_web/live/user_registration_live.ex:233
 #: lib/tuist_web/live/user_reset_password_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Tuist Logo"
@@ -324,13 +324,13 @@ msgstr ""
 msgid "User confirmation link is invalid or it has expired."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:75
+#: lib/tuist_web/live/choose_username_live.ex:76
 #: lib/tuist_web/live/user_registration_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Username"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:76
+#: lib/tuist_web/live/choose_username_live.ex:77
 #: lib/tuist_web/live/user_registration_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Username may only contain alphanumeric characters"
@@ -433,7 +433,7 @@ msgstr ""
 msgid "Log in as test user"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:62
+#: lib/tuist_web/live/choose_username_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Choose a username for your account"
 msgstr ""
@@ -484,39 +484,45 @@ msgstr ""
 msgid "Your email isn't confirmed yet"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:138
-#: lib/tuist_web/live/user_registration_live.ex:334
+#: lib/tuist_web/live/choose_username_live.ex:166
+#: lib/tuist_web/live/user_registration_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "Please complete the security check and try again."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:156
-#: lib/tuist_web/live/user_registration_live.ex:354
+#: lib/tuist_web/live/choose_username_live.ex:179
+#: lib/tuist_web/live/user_registration_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "The security check could not load. Check for a blocker on challenges.cloudflare.com and reload the page."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:168
-#: lib/tuist_web/live/user_registration_live.ex:366
+#: lib/tuist_web/live/choose_username_live.ex:191
+#: lib/tuist_web/live/user_registration_live.ex:393
 #, elixir-autogen, elixir-format
 msgid "The security check failed. Please reload the page and try again."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:123
-#: lib/tuist_web/live/user_registration_live.ex:319
+#: lib/tuist_web/live/choose_username_live.ex:151
+#: lib/tuist_web/live/user_registration_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Too many sign-up attempts. Please try again later."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:131
-#: lib/tuist_web/live/user_registration_live.ex:327
+#: lib/tuist_web/live/choose_username_live.ex:159
+#: lib/tuist_web/live/user_registration_live.ex:361
 #, elixir-autogen, elixir-format
 msgid "Your session has expired. Please reload the page and try again."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:212
-#: lib/tuist_web/live/choose_username_live.ex:240
-#: lib/tuist_web/live/choose_username_live.ex:251
+#: lib/tuist_web/live/choose_username_live.ex:235
+#: lib/tuist_web/live/choose_username_live.ex:263
+#: lib/tuist_web/live/choose_username_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
+msgstr ""
+
+#: lib/tuist_web/live/choose_username_live.ex:98
+#: lib/tuist_web/live/user_registration_live.ex:199
+#, elixir-autogen, elixir-format
+msgid "Verifying, one moment..."
 msgstr ""

--- a/server/priv/gettext/dashboard_auth.pot
+++ b/server/priv/gettext/dashboard_auth.pot
@@ -16,17 +16,17 @@ msgstr ""
 msgid "Account confirmed!"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:412
+#: lib/tuist_web/live/user_registration_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Account created successfully! Please log in."
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:426
+#: lib/tuist_web/live/user_registration_live.ex:452
 #, elixir-autogen, elixir-format
 msgid "Account name is already taken"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:210
+#: lib/tuist_web/live/user_registration_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Already have an account?"
 msgstr ""
@@ -42,7 +42,7 @@ msgstr ""
 msgid "Back to log in"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:42
+#: lib/tuist_web/live/user_registration_live.ex:44
 #, elixir-autogen, elixir-format
 msgid "Binary caching"
 msgstr ""
@@ -58,12 +58,12 @@ msgstr ""
 msgid "Check your email"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:244
+#: lib/tuist_web/live/user_registration_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "Check your inbox for a confirmation email and click the link to continue."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:60
+#: lib/tuist_web/live/choose_username_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Choose a username"
 msgstr ""
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Confirm password"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:242
+#: lib/tuist_web/live/user_registration_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "Confirm your account"
 msgstr ""
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Contact us"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:103
+#: lib/tuist_web/live/choose_username_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr ""
@@ -118,7 +118,7 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:33
+#: lib/tuist_web/live/user_registration_live.ex:35
 #, elixir-autogen, elixir-format
 msgid "Discover how selective testing is reducing your test time."
 msgstr ""
@@ -132,12 +132,12 @@ msgstr ""
 #: lib/tuist_web/live/user_confirmation_instructions_live.ex:77
 #: lib/tuist_web/live/user_forgot_password_live.ex:56
 #: lib/tuist_web/live/user_login_live.ex:144
-#: lib/tuist_web/live/user_registration_live.ex:152
+#: lib/tuist_web/live/user_registration_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:432
+#: lib/tuist_web/live/user_registration_live.ex:458
 #, elixir-autogen, elixir-format
 msgid "Email is already taken"
 msgstr ""
@@ -147,7 +147,7 @@ msgstr ""
 msgid "Explore Tuist features like binary caching and selective testing to speed up your development."
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:45
+#: lib/tuist_web/live/user_registration_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Explore how binary caching is enhancing your build times."
 msgstr ""
@@ -172,7 +172,7 @@ msgstr ""
 msgid "Install Tuist CLI"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:57
+#: lib/tuist_web/live/user_registration_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "Instantly share your app using a URL."
 msgstr ""
@@ -190,7 +190,7 @@ msgstr ""
 #: lib/tuist_web/live/sso_login_live.ex:97
 #: lib/tuist_web/live/user_login_live.ex:18
 #: lib/tuist_web/live/user_login_live.ex:182
-#: lib/tuist_web/live/user_registration_live.ex:215
+#: lib/tuist_web/live/user_registration_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
@@ -222,7 +222,7 @@ msgid "OR"
 msgstr ""
 
 #: lib/tuist_web/live/user_login_live.ex:155
-#: lib/tuist_web/live/user_registration_live.ex:162
+#: lib/tuist_web/live/user_registration_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Password"
 msgstr ""
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Password reset successfully."
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:54
+#: lib/tuist_web/live/user_registration_live.ex:56
 #, elixir-autogen, elixir-format
 msgid "Previews"
 msgstr ""
@@ -258,24 +258,24 @@ msgstr ""
 msgid "Run this command to link your project to the dashboard."
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:30
+#: lib/tuist_web/live/user_registration_live.ex:32
 #, elixir-autogen, elixir-format
 msgid "Selective testing"
 msgstr ""
 
 #: lib/tuist_web/live/user_login_live.ex:212
-#: lib/tuist_web/live/user_registration_live.ex:204
-#: lib/tuist_web/live/user_registration_live.ex:291
+#: lib/tuist_web/live/user_registration_live.ex:206
+#: lib/tuist_web/live/user_registration_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Sign up"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:79
+#: lib/tuist_web/live/user_registration_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Sign up for Tuist"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:219
+#: lib/tuist_web/live/choose_username_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "This username has already been taken"
 msgstr ""
@@ -285,15 +285,15 @@ msgstr ""
 msgid "Tuist CLI is connected!"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:51
+#: lib/tuist_web/live/choose_username_live.ex:53
 #: lib/tuist_web/live/device_codes_success_live.ex:28
 #: lib/tuist_web/live/sso_login_live.ex:63
 #: lib/tuist_web/live/user_confirmation_instructions_live.ex:18
 #: lib/tuist_web/live/user_confirmation_live.ex:18
 #: lib/tuist_web/live/user_forgot_password_live.ex:24
 #: lib/tuist_web/live/user_login_live.ex:43
-#: lib/tuist_web/live/user_registration_live.ex:70
-#: lib/tuist_web/live/user_registration_live.ex:233
+#: lib/tuist_web/live/user_registration_live.ex:72
+#: lib/tuist_web/live/user_registration_live.ex:235
 #: lib/tuist_web/live/user_reset_password_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Tuist Logo"
@@ -324,14 +324,14 @@ msgstr ""
 msgid "User confirmation link is invalid or it has expired."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:75
-#: lib/tuist_web/live/user_registration_live.ex:174
+#: lib/tuist_web/live/choose_username_live.ex:77
+#: lib/tuist_web/live/user_registration_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Username"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:76
-#: lib/tuist_web/live/user_registration_live.ex:177
+#: lib/tuist_web/live/choose_username_live.ex:78
+#: lib/tuist_web/live/user_registration_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Username may only contain alphanumeric characters"
 msgstr ""
@@ -351,7 +351,7 @@ msgstr ""
 msgid "Welcome back! Please log in to continue"
 msgstr ""
 
-#: lib/tuist_web/live/user_registration_live.ex:81
+#: lib/tuist_web/live/user_registration_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Welcome! Create an account to continue"
 msgstr ""
@@ -433,7 +433,7 @@ msgstr ""
 msgid "Log in as test user"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:62
+#: lib/tuist_web/live/choose_username_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Choose a username for your account"
 msgstr ""
@@ -484,45 +484,45 @@ msgstr ""
 msgid "Your email isn't confirmed yet"
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:165
-#: lib/tuist_web/live/user_registration_live.ex:367
+#: lib/tuist_web/live/choose_username_live.ex:167
+#: lib/tuist_web/live/user_registration_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Please complete the security check and try again."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:178
-#: lib/tuist_web/live/user_registration_live.ex:380
+#: lib/tuist_web/live/choose_username_live.ex:182
+#: lib/tuist_web/live/user_registration_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "The security check could not load. Check for a blocker on challenges.cloudflare.com and reload the page."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:190
-#: lib/tuist_web/live/user_registration_live.ex:392
+#: lib/tuist_web/live/choose_username_live.ex:196
+#: lib/tuist_web/live/user_registration_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "The security check failed. Please reload the page and try again."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:150
-#: lib/tuist_web/live/user_registration_live.ex:352
+#: lib/tuist_web/live/choose_username_live.ex:152
+#: lib/tuist_web/live/user_registration_live.ex:354
 #, elixir-autogen, elixir-format
 msgid "Too many sign-up attempts. Please try again later."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:158
-#: lib/tuist_web/live/user_registration_live.ex:360
+#: lib/tuist_web/live/choose_username_live.ex:160
+#: lib/tuist_web/live/user_registration_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "Your session has expired. Please reload the page and try again."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:234
-#: lib/tuist_web/live/choose_username_live.ex:262
-#: lib/tuist_web/live/choose_username_live.ex:273
+#: lib/tuist_web/live/choose_username_live.ex:256
+#: lib/tuist_web/live/choose_username_live.ex:284
+#: lib/tuist_web/live/choose_username_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Please try again."
 msgstr ""
 
-#: lib/tuist_web/live/choose_username_live.ex:97
-#: lib/tuist_web/live/user_registration_live.ex:199
+#: lib/tuist_web/live/choose_username_live.ex:99
+#: lib/tuist_web/live/user_registration_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Verifying, one moment..."
 msgstr ""

--- a/server/test/tuist_web/live/choose_username_live_test.exs
+++ b/server/test/tuist_web/live/choose_username_live_test.exs
@@ -97,6 +97,8 @@ defmodule TuistWeb.ChooseUsernameLiveTest do
         |> init_test_session(%{"pending_oauth_signup" => oauth_data})
         |> live(~p"/users/choose-username")
 
+      render_hook(lv, "turnstile_state_changed", %{"id" => "oauth-signup-turnstile", "state" => "ready"})
+
       html =
         lv
         |> form("#choose-username-form", %{"account" => %{"name" => "missingsession"}, "cf-turnstile-response" => ""})
@@ -104,6 +106,39 @@ defmodule TuistWeb.ChooseUsernameLiveTest do
 
       assert html =~ "Your session has expired"
       assert {:error, :not_found} = Accounts.get_user_by_email(email)
+    end
+
+    test "parks the submit and shows a verifying message when the user clicks before the widget is ready",
+         %{conn: conn} do
+      oauth_data = %{
+        "provider" => "google",
+        "uid" => "unique-uid-#{System.unique_integer([:positive])}",
+        "email" => "oauth-optimistic-#{System.unique_integer([:positive])}@example.com",
+        "provider_organization_id" => nil,
+        "oauth_return_url" => nil
+      }
+
+      stub(Turnstile, :required?, fn -> true end)
+      stub(Turnstile, :site_key, fn -> "site-key" end)
+      reject(&Registration.hit/1)
+      reject(&Turnstile.verify/2)
+
+      {:ok, lv, html} =
+        conn
+        |> init_test_session(%{"pending_oauth_signup" => oauth_data})
+        |> live(~p"/users/choose-username")
+
+      # Button is not pre-disabled.
+      refute html =~ ~s(<button[^>]*disabled)
+
+      after_submit =
+        lv
+        |> form("#choose-username-form", %{"account" => %{"name" => "optimistic"}})
+        |> render_submit()
+
+      assert after_submit =~ "Verifying, one moment"
+      refute after_submit =~ "Please complete the security check"
+      assert {:error, :not_found} = Accounts.get_user_by_email(oauth_data["email"])
     end
 
     test "does not create an OAuth user when the security check is rejected", %{conn: conn} do
@@ -126,6 +161,8 @@ defmodule TuistWeb.ChooseUsernameLiveTest do
         conn
         |> init_test_session(%{"pending_oauth_signup" => oauth_data})
         |> live(~p"/users/choose-username")
+
+      render_hook(lv, "turnstile_state_changed", %{"id" => "oauth-signup-turnstile", "state" => "ready"})
 
       html =
         lv

--- a/server/test/tuist_web/live/user_registration_live_test.exs
+++ b/server/test/tuist_web/live/user_registration_live_test.exs
@@ -72,6 +72,8 @@ defmodule TuistWeb.UserRegistrationLiveTest do
 
       {:ok, lv, _html} = live(conn, ~p"/users/register")
 
+      render_hook(lv, "turnstile_state_changed", %{"id" => "email-signup-turnstile", "state" => "ready"})
+
       html =
         lv
         |> form("#login_form", %{
@@ -88,18 +90,79 @@ defmodule TuistWeb.UserRegistrationLiveTest do
       refute html =~ "Too many sign-up attempts"
     end
 
-    test "disables the submit button until the Turnstile widget reports ready", %{conn: conn} do
+    test "parks the submit and shows a verifying message when the user clicks before the widget is ready",
+         %{conn: conn} do
       stub(Turnstile, :required?, fn -> true end)
       stub(Turnstile, :site_key, fn -> "site-key" end)
+      reject(&Registration.hit/1)
+      reject(&Turnstile.verify/2)
 
       {:ok, lv, html} = live(conn, ~p"/users/register")
+      # Button is not pre-disabled; the optimistic-submit gate handles the wait.
+      refute html =~ ~s(<button[^>]*disabled)
 
-      assert html =~ ~s(disabled)
+      after_submit =
+        lv
+        |> form("#login_form", %{
+          "user" => %{
+            "email" => "optimistic@example.com",
+            "password" => "StrongP@ssword!2028",
+            "username" => "optimistic"
+          }
+        })
+        |> render_submit()
 
-      after_ready =
-        render_hook(lv, "turnstile_state_changed", %{"id" => "email-signup-turnstile", "state" => "ready"})
+      # No Turnstile.verify was called (that would fail with a missing token);
+      # the LiveView parked the intent and told the hook to re-fire the form
+      # once the token arrives.
+      assert after_submit =~ "Verifying, one moment"
+      refute after_submit =~ "Please complete the security check"
+      assert {:error, :not_found} = Tuist.Accounts.get_user_by_email("optimistic@example.com")
+    end
 
-      refute after_ready =~ ~s(name="user[email]"[^>]*disabled)
+    test "clears the verifying message once the Turnstile-driven re-fire completes",
+         %{conn: conn} do
+      stub(Turnstile, :required?, fn -> true end)
+      stub(Turnstile, :site_key, fn -> "site-key" end)
+      stub(Registration, :hit, fn _session_token -> {:allow, 2} end)
+
+      stub(Turnstile, :verify, fn "token", [expected_action: "email_signup"] -> :ok end)
+
+      stub(Tuist.Environment, :skip_email_confirmation?, fn -> true end)
+      stub(Tuist.Environment, :skip_email_confirmation?, fn _ -> true end)
+
+      {:ok, lv, _html} = live(conn, ~p"/users/register")
+
+      # 1st click before ready parks the intent and renders the verifying banner.
+      pending_html =
+        lv
+        |> form("#login_form", %{
+          "user" => %{
+            "email" => "verify-pending@example.com",
+            "password" => "StrongP@ssword!2028",
+            "username" => "verifypending"
+          }
+        })
+        |> render_submit()
+
+      assert pending_html =~ "Verifying, one moment"
+
+      # Widget produces the token, hook re-fires with `cf-turnstile-response` set.
+      render_hook(lv, "turnstile_state_changed", %{"id" => "email-signup-turnstile", "state" => "ready"})
+
+      lv
+      |> form("#login_form", %{
+        "cf-turnstile-response" => "token",
+        "user" => %{
+          "email" => "verify-pending@example.com",
+          "password" => "StrongP@ssword!2028",
+          "username" => "verifypending"
+        }
+      })
+      |> render_submit()
+
+      assert {:ok, user} = Tuist.Accounts.get_user_by_email("verify-pending@example.com")
+      assert user.account.name == "verifypending"
     end
 
     test "surfaces a distinct error when the Turnstile bundle cannot load", %{conn: conn} do
@@ -135,6 +198,8 @@ defmodule TuistWeb.UserRegistrationLiveTest do
       stub(Turnstile, :verify, fn _token, [expected_action: "email_signup"] -> {:error, :rejected} end)
 
       {:ok, lv, _html} = live(conn, ~p"/users/register")
+
+      render_hook(lv, "turnstile_state_changed", %{"id" => "email-signup-turnstile", "state" => "ready"})
 
       html =
         lv

--- a/server/test/tuist_web/live/user_registration_live_test.exs
+++ b/server/test/tuist_web/live/user_registration_live_test.exs
@@ -147,11 +147,15 @@ defmodule TuistWeb.UserRegistrationLiveTest do
 
       assert pending_html =~ "Verifying, one moment"
 
-      # Widget produces the token, hook re-fires with `cf-turnstile-response` set.
+      # Widget produces the token, hook re-fires with `cf-turnstile-response`
+      # set. Emitted directly as a live_view event because Phoenix.LiveViewTest
+      # `form/3` refuses to override a rendered hidden input's value, and
+      # `cf-turnstile-response` is empty in the initial HTML — the hook fills
+      # it in-browser before `requestSubmit()`, which the test simulates by
+      # sending the save event with the token in the payload.
       render_hook(lv, "turnstile_state_changed", %{"id" => "email-signup-turnstile", "state" => "ready"})
 
-      lv
-      |> form("#login_form", %{
+      render_submit(lv, "save", %{
         "cf-turnstile-response" => "token",
         "user" => %{
           "email" => "verify-pending@example.com",
@@ -159,7 +163,6 @@ defmodule TuistWeb.UserRegistrationLiveTest do
           "username" => "verifypending"
         }
       })
-      |> render_submit()
 
       assert {:ok, user} = Tuist.Accounts.get_user_by_email("verify-pending@example.com")
       assert user.account.name == "verifypending"


### PR DESCRIPTION
## Summary

Consolidated follow-ups to #12850, all in the same subsystem: the Turnstile signup gate. Five commits, each addressing one concern reviewers raised.

1. **Optimistic-submit gate on the widget.** The Sign up / Continue button is no longer disabled while Turnstile is solving. A user who clicks before the widget has produced a token sees a "Verifying, one moment..." message next to the button, and the client hook re-fires the form's submit as soon as the token lands.
2. **The hook owns its script load.** The `api.js` script is now injected by the `Turnstile.js` hook itself on first mount, from a module-level promise shared across every hook instance. The root-layout `<script>` block, both LiveViews' `load_turnstile_script?` assigns, the global ready flag, and the one-shot custom event are all deleted.
3. **Server-side signal on widget failures.** `unavailable` and `error` state transitions from the browser now emit a `Logger.warning` + `[:tuist, :turnstile, :failure]` telemetry event with the state and signup action as metadata.
4. **Delete the dead `useTestKeys` chart branch.** Cloudflare's public test secret returns a siteverify response missing the `action` field and with the wrong hostname, so the chart branch never worked. Nothing exercised it either.
5. **Keep the CSP Turnstile source off the FunWithFlags hot path.** `csp_opts/1` feeds every browser pipeline (app, marketing, docs, image, ueberauth). Reading `TuistWeb.Turnstile.required?/0` there did a per-request flag lookup site-wide once Turnstile was enabled on an env; on a cold cache during a Postgres blip the store `raise`s, which would 500 pages that had no DB dependency in that plug.

## Why each one

### 1. Optimistic-submit gate

The pre-disabled button we shipped in the postmortem fix works when Turnstile resolves before the user finishes typing, which is the usual case. Its weak point: a user who clicks before the widget lands the token sees the click silently dropped, with nothing on screen to explain why. Cloudflare's own recommended pattern is to submit optimistically and hold on the token check instead of pre-disabling. Same security posture — `SignupProtection.verify/3` still runs server-side for every real submit, and a widget that never solves cannot get through — with better UX.

### 2. Hook-owned script load

Reviewer feedback flagged that the previous design coordinated the "has api.js loaded?" question across five artifacts (layout `<script>`, inline shim, global window flag, custom event, hook-side timeout). All of that existed to answer one question the hook could answer itself.

That refactor also fixes a live bug I did not flag in #12850:

- `app.html.heex` is a root layout: it renders once per full HTTP GET and its `:if={... load_turnstile_script?}` is evaluated there.
- A `live_navigate` between two LiveViews sharing that layout does not re-render the root layout.
- `user_login_live.ex:209` links to `/users/register` with `navigate={...}` — a LiveView-to-LiveView navigation. A user landing on `/users/log_in` first and clicking Sign up reached the register page without the api.js `<script>` on it. The widget silently never rendered. Same class of failure as the outage, at smaller scale.

Moving the load into the hook fixes that as a side effect: the code that needs api.js is the code that loads it, and it runs on every mount of the widget div, cold GET or client-side navigation alike.

### 3. Widget-failure telemetry

The postmortem said the missing operator signal was a signup-drop metric, which will come as its own follow-up. But the `"unavailable"` and `"error"` state transitions from real browsers arrive over the socket and were being dropped into an assign with no server-side evidence. That is exactly the signal we said we were missing, hitting the server and going unrecorded. And because the widget failing means the user never gets a submit that could reach `Turnstile.verify/2`, the existing `Logger.warning` calls in that module never fire for these failure modes either.

A single `Logger.warning` + telemetry event per state transition measures the failure directly rather than inferring it from a conversion dip, fires even for users who bounce without ever clicking submit, and would have caught the live-navigation regression above.

### 4. Dead `useTestKeys` chart branch

Cloudflare's public test secret (`1x0000000000000000000000000000000AA`) returns a siteverify response with no `action` field and `hostname: "example.com"` — neither of which `TuistWeb.Turnstile.verify/2` accepts. Every submit against the test-key pair would come back as `{:error, :rejected}` and surface as "Please complete the security check and try again". That is the failure mode that reads as "the gate is working" from the outside, while actually being a broken key pair.

Nothing exercises it today (all three managed envs use `enabled: true` without `useTestKeys`, and staging + canary moved to the real widget in #12850 once the hostname allowlist was widened). Deleting is simpler than teaching `Turnstile.verify/2` a test-key path we do not intend to use.

### 5. CSP off the flag hot path

`csp_opts/1` feeds the `:content_security_policy` pipeline, which the app, marketing, docs, image and ueberauth pipelines all plug in. Reading `TuistWeb.Turnstile.required?/0` there did a `FunWithFlags.enabled?(:turnstile_kill_switch)` lookup on every request. Usually an ETS hit and free, but `FunWithFlags.Store.lookup/1` goes to Postgres on a cache miss (TTL 600s) and `raise`s on a fully-cold cache rather than returning an error. A freshly-started node during a database blip would 500 pages that previously had no database dependency in that plug.

Reading the env-var toggle directly (`Tuist.Environment.turnstile_required?/0`) keeps the flag lookup on the two LiveViews and the verify call, where it belongs. The kill switch still turns everything off everywhere immediately; the only leftover is a CSP source pointing at a host nothing loads from on those other pages.

## Tests

- `mix compile`, `mix format`, `mix credo` on the touched files: clean, zero new issues.
- 18/18 unit tests pass locally (`Turnstile`, `SignupProtection`, `RateLimit.Registration`, `FeatureFlags`).
- Two new LiveView tests cover the optimistic gate: (a) clicking before the widget is ready parks the intent, shows the verifying message, and does NOT call `SignupProtection.verify/3`; (b) the ready-then-re-fire path actually creates the user.
- The two tests that exercised missing-session / rejected-token now pre-fire `turnstile_state_changed "ready"` before submitting so they still land in `SignupProtection`, not in the optimistic gate.
- `mix gettext.extract` picks up the new "Verifying, one moment..." string.
- `mix assets.build` embeds both the hook loader (`loadApi`, `API_URL`, `__tuistTurnstileOnLoad`) and the optimistic-submit surface (`pendingSubmit`, `turnstile:submit-when-ready`) in `app/assets/bundle.js`.
- `mise exec -- prettier --check assets`: clean.
- `helm template` with `server.turnstile.enabled=true`: renders `TUIST_TURNSTILE_ENABLED=1` only, no inline test-key env. With `enabled=false`: no Turnstile envs at all.

## Follow-up test plan (post-deploy)

- [ ] Cold-cache canary browser load of `/users/register`: widget iframe appears, button is not pre-disabled, click while widget is still solving shows the verifying banner and auto-submits when the token lands.
- [ ] From canary `/users/log_in`, click "Sign up" (the `navigate` link) and confirm the widget renders on the register page. This is the R1 regression the layout-owned load path had.
- [ ] Same two checks on production after promotion.
- [ ] `[:tuist, :turnstile, :failure]` telemetry visible in Grafana with `state` + `action` dimensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YkfzLzKQqbgFpJ1MLod9x