### PR TITLE
chore(server): follow-ups from Eduardo's review on the Turnstile PR

### DIFF
--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -132,15 +132,6 @@ spec:
             - name: TUIST_TURNSTILE_ENABLED
               value: "1"
             {{- end }}
-            {{- if and .Values.server.turnstile.enabled .Values.server.turnstile.useTestKeys }}
-            # Cloudflare's public always-passing test key pair, safe to embed
-            # in the chart because they only unlock the demo widget.
-            # https://developers.cloudflare.com/turnstile/troubleshooting/testing/
-            - name: TUIST_TURNSTILE_SITE_KEY
-              value: "1x00000000000000000000AA"
-            - name: TUIST_TURNSTILE_SECRET_KEY
-              value: "1x0000000000000000000000000000000AA"
-            {{- end }}
             {{- if .Values.server.kuraCapacityAdmission.enabled }}
             - name: TUIST_KURA_CAPACITY_ADMISSION_ENABLED
               value: "1"

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -448,15 +448,10 @@ server:
   hosted: false
   # Cloudflare Turnstile protects self-service browser registration on hosted
   # deployments. When `enabled` is true, TUIST_TURNSTILE_ENABLED is set on the
-  # deployment and the site/secret keys are wired up. `useTestKeys` uses
-  # Cloudflare's public always-passing test key pair, so pre-production
-  # environments can exercise the widget without needing the real secret
-  # (this is the coverage that would have caught the 2026-09-03 outage).
-  # `secretsFrom: eso` pulls the real keys from the TURNSTILE 1Password item
-  # via external-secrets in production.
+  # deployment and the site/secret keys are synced from the TURNSTILE 1Password
+  # item via external-secrets.
   turnstile:
     enabled: false
-    useTestKeys: false
     secretsFrom: eso
   # Browser real user monitoring. Set collectorUrl to the endpoint the browser
   # posts Grafana Faro payloads to; a same-origin path keeps the request free of

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -41,7 +41,20 @@ defmodule TuistWeb.Router do
 
   def csp_opts(_conn) do
     s3_endpoint = Tuist.Environment.s3_endpoint()
-    turnstile_source = if TuistWeb.Turnstile.required?(), do: " https://challenges.cloudflare.com", else: ""
+
+    # Deliberately reads the env-var toggle directly rather than the
+    # flag-aware `TuistWeb.Turnstile.required?/0`. This plug feeds the
+    # `:content_security_policy` pipeline, which the app, marketing, docs,
+    # image and ueberauth pipelines all use, so a per-request
+    # `FunWithFlags.enabled?(:turnstile_kill_switch)` would fire on every
+    # page load site-wide for a widget only two LiveViews ever render — and
+    # the underlying store `raise`s on a cold cache during a Postgres blip,
+    # which would 500 pages that previously had no DB dependency here.
+    # Flipping the kill switch still turns off the widget and the verify
+    # path everywhere immediately; the only thing left behind is a CSP
+    # source pointing at a host nothing loads from.
+    turnstile_source =
+      if Tuist.Environment.turnstile_required?(), do: " https://challenges.cloudflare.com", else: ""
 
     [
       frame_ancestors: "'self'",


### PR DESCRIPTION
## Summary

Two focused follow-ups from Eduardo's review on #12850. Each is a small, isolated commit; both are safe to land independently but easier to review together.

## 1. Drop the dead `useTestKeys` chart branch

**Root cause.** Cloudflare's public test secret returns a siteverify response with no `action` field and `hostname: \"example.com\"` — neither of which `TuistWeb.Turnstile.verify/2` accepts. So every submit against the test-key pair would come back as `{:error, :rejected}` and surface as \"Please complete the security check and try again\" to the user. That is the exact failure mode that reads as \"the gate is working\" from the outside, while actually being a broken key pair.

Nothing exercises it today (all three managed envs use `enabled: true` without `useTestKeys`, and staging + canary moved to the real widget in #12850 once the hostname allowlist was widened). Deleting the branch is simpler than teaching `Turnstile.verify/2` a test-key path we do not intend to use.

**Changes**
- `infra/helm/tuist/values.yaml`: drop the `useTestKeys` toggle from the chart docstring and default block.
- `infra/helm/tuist/templates/server-deployment.yaml`: drop the inline test-key `env:` branch.

## 2. Keep the CSP Turnstile source off the flag hot path

**Root cause.** `TuistWeb.Router.csp_opts/1` feeds the `:content_security_policy` pipeline, which the app, marketing, docs, image and ueberauth pipelines all plug in. #12850 wired it through `TuistWeb.Turnstile.required?/0`, which is `Environment.turnstile_required?/0 AND NOT FunWithFlags.enabled?(:turnstile_kill_switch)`. So once `TUIST_TURNSTILE_ENABLED=1` is set on an env, every marketing page, docs page, image render and OAuth callback started performing a `FunWithFlags.enabled?(:turnstile_kill_switch)` lookup — for a widget those pages will never show.

Usually that is an ETS hit and free. The concern is that `FunWithFlags.Store.lookup/1` goes to Postgres on a cache miss (TTL 600s per `config/config.exs`), and on a fully-cold cache it `raise`s rather than returning an error. A freshly-started node during a database blip would 500 pages that previously had no database dependency in the CSP plug.

**Fix.** Read `Tuist.Environment.turnstile_required?/0` directly in the CSP builder — the env-var toggle alone, no flag. Every widget-rendering + verify path still consults the flag-aware helper, so the kill switch still turns the gate off everywhere immediately. The only thing left behind is a CSP source pointing at a host nothing loads from, on pages nothing loads from that host on either way.

## Tests

- `mix compile`, `mix format`: clean.
- 18/18 unit tests pass (`Turnstile`, `SignupProtection`, `RateLimit.Registration`, `FeatureFlags`).
- `helm template` with `server.turnstile.enabled=true`: renders `TUIST_TURNSTILE_ENABLED=1` only (no inline test-key env). With `enabled=false`: no Turnstile envs at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YkfzLzKQqbgFpJ1MLod9x