### PR TITLE
fix(cli): backport binary-cache module-map fixes to 4.207

### DIFF
--- a/cli/Sources/TuistCore/Graph/GraphTraverser.swift
+++ b/cli/Sources/TuistCore/Graph/GraphTraverser.swift
@@ -36,6 +36,10 @@ public class GraphTraverser: GraphTraversing {
     private let embeddableFrameworksCache = GraphCache<GraphDependency, Set<GraphDependencyReference>>()
     private let staticXCFrameworksBehindXCFrameworkCache = GraphCache<GraphDependency, Set<GraphDependency>>()
     private let staticObjcXCFrameworksBehindXCFrameworkCache = GraphCache<GraphDependency, Set<GraphDependency>>()
+    private let staticObjcXCFrameworksReachableViaCachedTargetsCache =
+        GraphCache<GraphDependency, Set<GraphDependency>>()
+    private let staticSwiftXCFrameworksReachableViaCachedTargetsCache =
+        GraphCache<GraphDependency, Set<GraphDependency>>()
 
     struct LinkableDependenciesKey: Hashable {
         let target: GraphDependency
@@ -979,6 +983,131 @@ public class GraphTraverser: GraphTraversing {
             }
         )
         staticSwiftXCFrameworksBehindDynamicXCFrameworksCache[cacheKey] = result
+        return result
+    }
+
+    /// Static Objective-C xcframeworks (that ship their own module map) reachable in *this* graph
+    /// from the target through targets that no longer exist in `currentGraph`. Those targets
+    /// were replaced by cached xcframeworks; their `.swiftmodule` still imports the static
+    /// xcframework's module, but the cache substitution can drop the graph edge that pointed
+    /// at the static xcframework, so `staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies`
+    /// on the substituted graph misses it. Walking from the source graph recovers it.
+    public func staticObjcXCFrameworksReachableViaCachedTargets(
+        path: Path.AbsolutePath,
+        name: String,
+        currentGraph: Graph
+    ) -> Set<GraphDependency> {
+        reachableStaticXCFrameworksViaCachedTargets(
+            path: path,
+            name: name,
+            currentGraph: currentGraph,
+            cache: staticObjcXCFrameworksReachableViaCachedTargetsCache,
+            includes: { xcframework in
+                xcframework.linking == .static
+                    && xcframework.swiftModules.isEmpty
+                    && !xcframework.moduleMaps.isEmpty
+            }
+        )
+    }
+
+    /// Static Swift xcframeworks reachable in *this* graph from the target through targets
+    /// that no longer exist in `currentGraph`. Sister to `staticObjcXCFrameworksReachableViaCachedTargets`
+    /// for the Swift-module flavour: the mapper wires `FRAMEWORK_SEARCH_PATHS` for consumers of a
+    /// cached dynamic xcframework whose `.swiftmodule` interface still `import`s a static Swift
+    /// xcframework, and the same substitution edge-drop can happen on that route too.
+    public func staticSwiftXCFrameworksReachableViaCachedTargets(
+        path: Path.AbsolutePath,
+        name: String,
+        currentGraph: Graph
+    ) -> Set<GraphDependency> {
+        reachableStaticXCFrameworksViaCachedTargets(
+            path: path,
+            name: name,
+            currentGraph: currentGraph,
+            cache: staticSwiftXCFrameworksReachableViaCachedTargetsCache,
+            includes: { xcframework in
+                xcframework.linking == .static && !xcframework.swiftModules.isEmpty
+            }
+        )
+    }
+
+    /// Iterative, per-node memoised walk from a source-graph target. Traversal stops at static
+    /// xcframeworks (terminal) and at descendant targets that survive in `currentGraph` (they
+    /// contribute their own settings through the current-graph walkers; walking through them
+    /// here would double-count). The starting target itself always contributes its children —
+    /// it's the surviving root we're walking from; the check gates whether we recurse INTO
+    /// surviving descendants, not whether the walk starts.
+    ///
+    /// The cache stores the standard per-node reachable set (with the terminal check applied),
+    /// so a node cached during one target's walk can be reused as a descendant of another
+    /// target's walk. Every visited node is visited once across all sibling targets, so the
+    /// mapper's cost stays linear in the graph, not in (targets × graph).
+    private func reachableStaticXCFrameworksViaCachedTargets(
+        path: Path.AbsolutePath,
+        name: String,
+        currentGraph: Graph,
+        cache: GraphCache<GraphDependency, Set<GraphDependency>>,
+        includes: (GraphDependency.XCFramework) -> Bool
+    ) -> Set<GraphDependency> {
+        let root: GraphDependency = .target(name: name, path: path)
+        guard let rootChildren = graph.dependencies[root] else { return [] }
+
+        func terminal(_ node: GraphDependency) -> Bool {
+            if case let .xcframework(xcframework) = node, xcframework.linking == .static {
+                return true
+            }
+            if case let .target(dependencyName, dependencyPath, _) = node {
+                return currentGraph.projects[dependencyPath]?.targets[dependencyName] != nil
+            }
+            return false
+        }
+
+        // First pass: iterative DFS from each root child, collecting the reachable subgraph in
+        // visit order. Stops at terminals (their subtrees are irrelevant beyond their own
+        // inclusion) and at nodes already cached (we reuse their memoised result in the second
+        // pass). The root itself is not enqueued — we compute its result at the end from its
+        // children's cached sets, so the cache always holds the "descendant" semantics.
+        var order: [GraphDependency] = []
+        var visited = Set<GraphDependency>()
+        var stack: [GraphDependency] = []
+        for child in rootChildren where cache[child] == nil {
+            stack.append(child)
+        }
+        while let node = stack.popLast() {
+            guard visited.insert(node).inserted else { continue }
+            guard cache[node] == nil else { continue }
+            order.append(node)
+            guard !terminal(node) else { continue }
+            for child in graph.dependencies[node, default: []] where cache[child] == nil {
+                stack.append(child)
+            }
+        }
+
+        // Second pass: reverse-visit order guarantees children are cached before their parents
+        // in a DAG. Each node's set is its own inclusion plus its (non-terminal) children's.
+        for node in order.reversed() where cache[node] == nil {
+            var result: Set<GraphDependency> = []
+            if case let .xcframework(xcframework) = node, includes(xcframework) {
+                result.insert(node)
+            }
+            if !terminal(node) {
+                for child in graph.dependencies[node, default: []] {
+                    if let childResult = cache[child] {
+                        result.formUnion(childResult)
+                    }
+                }
+            }
+            cache[node] = result
+        }
+
+        // Combine the root's children's cached sets. The root itself never matches `includes`
+        // (roots are targets, not xcframeworks) and it's never terminal for its own traversal.
+        var result: Set<GraphDependency> = []
+        for child in rootChildren {
+            if let childResult = cache[child] {
+                result.formUnion(childResult)
+            }
+        }
         return result
     }
 

--- a/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
+++ b/cli/Sources/TuistCore/GraphTraverser/GraphTraversing.swift
@@ -361,6 +361,25 @@ public protocol GraphTraversing {
         name: String
     ) -> Set<GraphDependency>
 
+    /// Static Objective-C xcframeworks (that ship their own module map) reachable in this graph
+    /// from the target through targets that no longer exist in `currentGraph`. Used to recover
+    /// module visibility after a binary-cache substitution drops the graph edge to the static
+    /// xcframework a cached dynamic dependency still imports in its `.swiftmodule`.
+    func staticObjcXCFrameworksReachableViaCachedTargets(
+        path: AbsolutePath,
+        name: String,
+        currentGraph: Graph
+    ) -> Set<GraphDependency>
+
+    /// Static Swift xcframeworks reachable in this graph from the target through targets
+    /// that no longer exist in `currentGraph`. Sister to
+    /// `staticObjcXCFrameworksReachableViaCachedTargets` for the Swift-module flavour.
+    func staticSwiftXCFrameworksReachableViaCachedTargets(
+        path: AbsolutePath,
+        name: String,
+        currentGraph: Graph
+    ) -> Set<GraphDependency>
+
     /// Given a scheme, it returns the runnable target.
     /// - Parameter scheme: Scheme to check against.
     /// - Returns: The runnable target if any.

--- a/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
+++ b/cli/Sources/TuistKit/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapper.swift
@@ -43,9 +43,11 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
         let derivedDirectory = try await derivedDirectory(for: graph)
         var sideEffects: [SideEffectDescriptor] = []
         let graphTraverser = GraphTraverser(graph: graph)
-        let unconditionallyDirectlyLinkedXCFrameworkPaths = Self.unconditionallyDirectlyLinkedXCFrameworkPaths(
+        let sourceGraphTraverser = environment.initialGraphWithSources.map { GraphTraverser(graph: $0) }
+        let xcframeworkPlatformsProcessedByGeneratedTargets = Self.xcframeworkPlatformsProcessedByGeneratedTargets(
             in: graph,
-            initialGraphWithSources: environment.initialGraphWithSources
+            initialGraphWithSources: environment.initialGraphWithSources,
+            traverser: graphTraverser
         )
 
         let graph = try await mapGraph(
@@ -54,7 +56,19 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
             let target = graphTarget.target
             let project = graphTarget.project
             let targetDependency = GraphDependency.target(name: target.name, path: project.path)
-            let staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies = graphTraverser
+            let targetPlatforms = target.supportedPlatforms
+            // Xcode's `ProcessXCFramework` publishes `include/<Module>/module.modulemap` in the
+            // per-SDK `$(BUILT_PRODUCTS_DIR)/include`, so a producing target only covers a consumer
+            // whose platform matches. Adding the vendor `Headers/` copy on top of the `include/`
+            // copy on the SAME SDK is what triggers `redefinition of module`; on a different SDK
+            // the consumer has neither map without the vendor copy, and we hit
+            // `unable to resolve module dependency`.
+            let publishesModuleMapOnConsumerSDK: (GraphDependency.XCFramework) -> Bool = { xcframework in
+                guard let producingPlatforms = xcframeworkPlatformsProcessedByGeneratedTargets[xcframework.path]
+                else { return false }
+                return !producingPlatforms.isDisjoint(with: targetPlatforms)
+            }
+            var staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies = graphTraverser
                 .staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies(
                     path: project.path,
                     name: target.name
@@ -69,12 +83,65 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
                     else { return nil }
                     return ConditionedXCFramework(xcframework: xcframework, condition: condition)
                 }
+            // Focus + binary cache can prune a static xcframework out of the substituted graph
+            // even though a cached dynamic dependency of this target still imports it in its
+            // `.swiftmodule`. Recover those xcframeworks from the source graph so the consumer
+            // keeps module visibility. The suppression below still fires when Xcode's
+            // `ProcessXCFramework` publishes the map on this consumer's SDK, so recovering here
+            // cannot re-introduce a redefinition; conversely, when the producing target is on a
+            // different SDK (or the graph does not have one at all), suppression correctly stands
+            // down and this addition is what keeps the module resolvable.
+            var staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies: [ConditionedXCFramework] = []
+            if let sourceGraphTraverser {
+                let alreadyIncludedObjc = Set(
+                    staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies.map(\.xcframework.path)
+                )
+                let sourceReachableObjc = sourceGraphTraverser
+                    .staticObjcXCFrameworksReachableViaCachedTargets(
+                        path: project.path,
+                        name: target.name,
+                        currentGraph: graph
+                    )
+                    .sorted()
+                    .compactMap { dependency -> ConditionedXCFramework? in
+                        guard case let .xcframework(xcframework) = dependency,
+                              !alreadyIncludedObjc.contains(xcframework.path),
+                              case let .condition(condition) = sourceGraphTraverser.combinedCondition(
+                                  to: dependency,
+                                  from: targetDependency
+                              )
+                        else { return nil }
+                        return ConditionedXCFramework(xcframework: xcframework, condition: condition)
+                    }
+                staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies += sourceReachableObjc
+
+                let sourceReachableSwift = sourceGraphTraverser
+                    .staticSwiftXCFrameworksReachableViaCachedTargets(
+                        path: project.path,
+                        name: target.name,
+                        currentGraph: graph
+                    )
+                    .sorted()
+                    .compactMap { dependency -> ConditionedXCFramework? in
+                        guard case let .xcframework(xcframework) = dependency,
+                              case let .condition(condition) = sourceGraphTraverser.combinedCondition(
+                                  to: dependency,
+                                  from: targetDependency
+                              )
+                        else { return nil }
+                        return ConditionedXCFramework(xcframework: xcframework, condition: condition)
+                    }
+                staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies += sourceReachableSwift
+            }
 
             // Static Swift xcframeworks reached through a dynamic xcframework are not relinked
             // at the consumer level (their symbols are already absorbed into the dynamic
             // xcframework's binary). They still need module visibility for the compiler to
             // resolve `import` statements that the dynamic xcframework's swiftinterface references.
-            let staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies = graphTraverser
+            let alreadyIncludedSwift = Set(
+                staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies.map(\.xcframework.path)
+            )
+            staticSwiftXCFrameworksLinkedByDynamicXCFrameworkDependencies += graphTraverser
                 .staticXCFrameworksLinkedByDynamicXCFrameworkDependencies(
                     path: project.path,
                     name: target.name
@@ -82,6 +149,7 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
                 .sorted()
                 .compactMap { dependency -> ConditionedXCFramework? in
                     guard case let .xcframework(xcframework) = dependency,
+                          !alreadyIncludedSwift.contains(xcframework.path),
                           case let .condition(condition) = graphTraverser.combinedCondition(
                               to: dependency,
                               from: targetDependency
@@ -98,7 +166,7 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
                 staticObjcXCFrameworksLinkedByDynamicXCFrameworkDependencies
                     .filter {
                         $0.xcframework.containsLibrary()
-                            && !unconditionallyDirectlyLinkedXCFrameworkPaths.contains($0.xcframework.path)
+                            && !publishesModuleMapOnConsumerSDK($0.xcframework)
                     }
                     .map(\.xcframework)
 
@@ -247,43 +315,81 @@ public struct StaticXCFrameworkModuleMapGraphMapper: GraphMapping { // swiftlint
         return moduleMap.parentDirectory.basename == xcframework.path.basenameWithoutExt ? moduleMap : nil
     }
 
-    /// Xcode processes every unconditionally direct xcframework into the build products directory. That copy is
-    /// visible to the target graph, so adding the same vendor module map from a dynamic route would define the module
-    /// twice. A platform-qualified direct dependency cannot prove that it covers the dynamic route. The original graph
-    /// is retained in the mapper environment before binary-cache replacement, which can otherwise remove the direct
-    /// dependency from the graph being generated. Only the targets that survive into the generated projects count
-    /// there: a target replaced by a cached binary, or dropped by tree shaking, no longer references the xcframework,
-    /// so Xcode never produces the copy that would define the module.
-    private static func unconditionallyDirectlyLinkedXCFrameworkPaths(
+    /// For each xcframework whose `include/<Module>/module.modulemap` copy Xcode's `ProcessXCFramework`
+    /// will publish in some generated target's build-products directory, the set of platforms that
+    /// produce the copy. Consumers on those platforms already resolve the module through
+    /// `$(BUILT_PRODUCTS_DIR)/include`, so the mapper must not add the vendor `Headers/` copy on top —
+    /// two module maps for the same module on the search path is what triggers Clang's
+    /// `redefinition of module`.
+    ///
+    /// The set is keyed by platform because `include/` lives per-SDK: `Debug-iphonesimulator/include`
+    /// and `Debug/include` (macOS) are different directories, so a macOS target that publishes the
+    /// map cannot cover an iOS consumer's search path. Suppressing globally, blind to platform,
+    /// strips module visibility from consumers on other platforms and reintroduces the
+    /// `unable to resolve module dependency` failure this mapper is meant to prevent.
+    ///
+    /// Contributors, unioned per-platform:
+    /// * Direct graph-edge links from generated targets (the pre-existing narrow set).
+    /// * Direct graph-edge links from source-graph targets that survive generation (recovers the
+    ///   binary-cache substitution case where the linker was a source target that got cached; only
+    ///   counted when the linking target is still in the substituted graph, since a target replaced
+    ///   by a cached binary never runs `ProcessXCFramework`).
+    /// * `linkableDependencies` of every generated target — the actual set of xcframeworks that
+    ///   land in the target's Frameworks build phase, including the ones a static consumer relinks
+    ///   transitively through `LinkGenerator.staticDependenciesPrecompiledLibrariesAndFrameworks`.
+    ///   The direct-edge walk misses this shape (a static SwiftPM shim like `GoogleMapsTarget` that
+    ///   wraps `GoogleMaps.xcframework` isn't a direct graph edge for its consumer, but Xcode still
+    ///   processes the transitively-relinked xcframework), which is exactly the redefinition path
+    ///   this mapper needs to cover.
+    private static func xcframeworkPlatformsProcessedByGeneratedTargets(
         in graph: Graph,
-        initialGraphWithSources: Graph?
-    ) -> Set<AbsolutePath> {
-        var paths = unconditionallyDirectlyLinkedXCFrameworkPaths(in: graph)
-        if let initialGraphWithSources {
-            paths.formUnion(
-                unconditionallyDirectlyLinkedXCFrameworkPaths(in: initialGraphWithSources) { name, path in
-                    graph.projects[path]?.targets[name] != nil
-                }
-            )
-        }
-        return paths
-    }
+        initialGraphWithSources: Graph?,
+        traverser: GraphTraverser
+    ) -> [AbsolutePath: Set<Platform>] {
+        var platformsByPath: [AbsolutePath: Set<Platform>] = [:]
 
-    private static func unconditionallyDirectlyLinkedXCFrameworkPaths(
-        in graph: Graph,
-        isGenerated: (String, AbsolutePath) -> Bool = { _, _ in true }
-    ) -> Set<AbsolutePath> {
-        var paths = Set<AbsolutePath>()
-        for (source, dependencies) in graph.dependencies {
-            guard case let .target(name, path, _) = source, isGenerated(name, path) else { continue }
-            for dependency in dependencies {
-                guard graph.dependencyConditions[(source, dependency)] == nil,
-                      case let .xcframework(xcframework) = dependency
-                else { continue }
-                paths.insert(xcframework.path)
+        func record(_ path: AbsolutePath, on platforms: Set<Platform>) {
+            platformsByPath[path, default: []].formUnion(platforms)
+        }
+
+        for project in graph.projects.values {
+            for target in project.targets.values {
+                let sourceDependency: GraphDependency = .target(name: target.name, path: project.path)
+                for dependency in graph.dependencies[sourceDependency, default: []] {
+                    guard graph.dependencyConditions[(sourceDependency, dependency)] == nil,
+                          case let .xcframework(xcframework) = dependency
+                    else { continue }
+                    record(xcframework.path, on: target.supportedPlatforms)
+                }
+                guard let references = try? traverser.linkableDependencies(
+                    path: project.path,
+                    name: target.name,
+                    shouldExcludeHostAppDependencies: false
+                ) else { continue }
+                for reference in references {
+                    guard case let .xcframework(path, _, _, _, condition) = reference,
+                          condition == nil
+                    else { continue }
+                    record(path, on: target.supportedPlatforms)
+                }
             }
         }
-        return paths
+
+        if let initialGraphWithSources {
+            for (source, dependencies) in initialGraphWithSources.dependencies {
+                guard case let .target(name, path, _) = source,
+                      let survivingTarget = graph.projects[path]?.targets[name]
+                else { continue }
+                for dependency in dependencies {
+                    guard initialGraphWithSources.dependencyConditions[(source, dependency)] == nil,
+                          case let .xcframework(xcframework) = dependency
+                    else { continue }
+                    record(xcframework.path, on: survivingTarget.supportedPlatforms)
+                }
+            }
+        }
+
+        return platformsByPath
     }
 
     /// Only called for flat layouts, which point at the derived module map whose umbrella header was

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
@@ -423,6 +423,89 @@ struct TuistCacheEEAcceptanceTests {
         )
     }
 
+    /// A consumer that links a cached STATIC framework wrapping a nested-header xcframework and
+    /// also links a cached DYNAMIC framework that reaches the same xcframework. `LinkGenerator`'s
+    /// `staticDependenciesPrecompiledLibrariesAndFrameworks` relinks the wrapped xcframework at
+    /// the consumer, so Xcode's `ProcessXCFramework` writes `include/<Module>/module.modulemap`
+    /// into `$(BUILT_PRODUCTS_DIR)/include/`. Without widening the mapper's direct-link
+    /// suppression to see `linkableDependencies` (not just direct graph edges), the mapper still
+    /// added the vendor `Headers/<Module>/module.modulemap` on the search path for the dynamic
+    /// route, and Clang's dependency scanner rejected both maps with `redefinition of module`.
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment(inheritingVariables: ["PATH"]),
+        .withMockedNoora,
+        .withMockedLogger(forwardLogs: true),
+        .withFixture("generated_macos_tool_with_cached_nested_header_xcframework")
+    ) func generated_macos_tool_linking_cached_static_and_dynamic_wrappers_over_nested_header_xcframework() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let xcodeprojPath = fixtureDirectory.appending(component: "NestedHeaderXCFramework.xcodeproj")
+
+        try await TuistTest.run(
+            CacheCommand.self,
+            ["Library", "StaticWrapper", "--path", fixtureDirectory.pathString]
+        )
+
+        try await TuistTest.run(
+            GenerateCommand.self,
+            ["--no-open", "--path", fixtureDirectory.pathString, "ToolLinkingStaticAndDynamicWrappers"]
+        )
+
+        try TuistAcceptanceTest.expectXCFrameworkLinked(
+            "Library",
+            by: "ToolLinkingStaticAndDynamicWrappers",
+            xcodeprojPath: xcodeprojPath
+        )
+        try TuistAcceptanceTest.expectXCFrameworkLinked(
+            "StaticWrapper",
+            by: "ToolLinkingStaticAndDynamicWrappers",
+            xcodeprojPath: xcodeprojPath
+        )
+
+        // The mapper's contract: the vendor `Headers/` path from the nested static xcframeworks
+        // must NOT land on `HEADER_SEARCH_PATHS` for the consumer, because Xcode's
+        // `ProcessXCFramework` already publishes `include/<Module>/module.modulemap` under
+        // `$(BUILT_PRODUCTS_DIR)/include`. Two module maps for the same module on the search
+        // path is exactly what triggers Clang's `redefinition of module` failure. Whether
+        // Clang actually rejects the pair at build time depends on the toolchain's tolerance
+        // for byte-identical duplicates (Xcode 26.3 does; some later versions don't), so we
+        // guard the invariant at the settings level — it holds regardless of Clang version.
+        let xcodeproj = try XcodeProj(pathString: xcodeprojPath.pathString)
+        let target = try #require(
+            xcodeproj.pbxproj.projects.flatMap(\.targets)
+                .first(where: { $0.name == "ToolLinkingStaticAndDynamicWrappers" })
+        )
+        let configurations = try #require(target.buildConfigurationList?.buildConfigurations)
+        #expect(configurations.isEmpty == false)
+        for configuration in configurations {
+            let headerSearchPaths = configuration.buildSettings["HEADER_SEARCH_PATHS"]?.arrayValue
+                ?? configuration.buildSettings["HEADER_SEARCH_PATHS"].map { [$0.stringValue ?? ""] }
+                ?? []
+            for xcframework in ["NestedObjC.xcframework", "NestedObjCKit.xcframework"] {
+                #expect(
+                    headerSearchPaths.contains(where: { $0.contains("\(xcframework)/") }) == false,
+                    "The \(configuration.name) HEADER_SEARCH_PATHS must not contain the vendor \(xcframework) Headers path; the include/ copy from ProcessXCFramework already covers module resolution."
+                )
+            }
+        }
+
+        try await TuistTest.run(
+            XcodeBuildBuildCommand.self,
+            [
+                "-project",
+                xcodeprojPath.pathString,
+                "-scheme",
+                "ToolLinkingStaticAndDynamicWrappers",
+                "-derivedDataPath",
+                temporaryDirectory.pathString,
+                "CODE_SIGN_IDENTITY=",
+                "CODE_SIGNING_REQUIRED=NO",
+                "CODE_SIGNING_ALLOWED=NO",
+            ]
+        )
+    }
+
     @Test(
         .inTemporaryDirectory,
         .withMockedEnvironment(inheritingVariables: ["PATH"]),

--- a/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
+++ b/cli/Tests/TuistKitTests/Mappers/Graph/StaticXCFrameworkModuleMapGraphMapperTests.swift
@@ -2423,6 +2423,228 @@ final class StaticXCFrameworkModuleMapGraphMapperTests: TuistUnitTestCase {
         XCTAssertEmpty(gotSideEffects)
     }
 
+    // Regression: focused generation on a scheme whose only tie to a static-objc xcframework is
+    // via a source dynamic framework that becomes a cached xcframework can drop the graph edge to
+    // the static xcframework in the substituted graph. Without recovering it from the source
+    // graph the consumer's dependency scan fails with `unable to resolve module dependency: 'X'`
+    // for every `import X` recorded in the cached module's `.swiftmodule`.
+    func test_map_when_static_xcframework_is_reachable_only_through_a_source_target_that_gets_cached() async throws {
+        // Given
+        let projectPath = try temporaryPath()
+            .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
+        let googleMapsPath = projectPath
+            .parentDirectory
+            .appending(component: "GoogleMaps.xcframework")
+        let googleMapsHeadersPath = googleMapsPath.appending(components: "ios-arm64", "Headers", "GoogleMaps")
+        try await fileSystem.makeDirectory(at: googleMapsHeadersPath)
+        try await fileSystem.writeText(
+            "modulemap",
+            at: googleMapsHeadersPath.appending(component: "module.modulemap")
+        )
+
+        let googleMaps: GraphDependency = .testXCFramework(
+            path: googleMapsPath,
+            infoPlist: .test(
+                libraries: [
+                    .test(
+                        path: try RelativePath(validating: "GoogleMaps.a")
+                    ),
+                ]
+            ),
+            linking: .static,
+            moduleMaps: [
+                googleMapsHeadersPath.appending(component: "module.modulemap"),
+            ]
+        )
+        let cachedSharedUI: GraphDependency = .testXCFramework(
+            path: try temporaryPath().appending(component: "SharedUI.xcframework"),
+            linking: .dynamic
+        )
+
+        // Source graph: AppTestsIndirect → SharedUI (source dynamic target) → GoogleMaps.
+        let graphWithSources: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(name: "AppTestsIndirect"),
+                        .test(name: "SharedUI"),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "AppTestsIndirect", path: projectPath): [
+                    .target(name: "SharedUI", path: projectPath),
+                ],
+                .target(name: "SharedUI", path: projectPath): [
+                    googleMaps,
+                ],
+            ]
+        )
+        // Substituted graph: SharedUI became a cached dynamic xcframework, and the edge to
+        // GoogleMaps.xcframework is no longer present at the AppTestsIndirect reach.
+        let graphWithBinaryCache: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(name: "AppTestsIndirect"),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "AppTestsIndirect", path: projectPath): [
+                    cachedSharedUI,
+                ],
+            ]
+        )
+        var environment = MapperEnvironment()
+        environment.initialGraphWithSources = graphWithSources
+
+        // The GoogleMaps xcframework uses a nested `Headers/GoogleMaps/module.modulemap` layout,
+        // so the mapper adds the `Headers` root to `HEADER_SEARCH_PATHS` and lets clang discover
+        // the module map from there (no `-fmodule-map-file`).
+        var expectedGraph = graphWithBinaryCache
+        expectedGraph.projects = [
+            projectPath: .test(
+                path: projectPath,
+                targets: [
+                    .test(
+                        name: "AppTestsIndirect",
+                        settings: .test(
+                            base: [
+                                "HEADER_SEARCH_PATHS": [
+                                    "\"$(SRCROOT)/../GoogleMaps.xcframework/ios-arm64/Headers\"",
+                                ],
+                            ]
+                        )
+                    ),
+                ]
+            ),
+        ]
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try await subject.map(
+            graph: graphWithBinaryCache,
+            environment: environment
+        )
+
+        // Then
+        XCTAssertBetterEqual(expectedGraph, gotGraph)
+        XCTAssertBetterEqual([], gotSideEffects)
+    }
+
+    // Regression: an app that directly links a cached STATIC xcframework which itself wraps a static
+    // xcframework with a module map (the SwiftPM package-shim pattern — a source `staticLibrary`
+    // target that wraps a `.binaryTarget` xcframework) relinks the wrapped xcframework transitively
+    // at the app level. Xcode runs `ProcessXCFramework` for it and writes
+    // `$(BUILT_PRODUCTS_DIR)/include/<Module>/module.modulemap`. If another consumer reaches the
+    // same xcframework via a cached dynamic wrapper, the mapper must NOT add the vendor `Headers/`
+    // copy — the `include/` copy is already reachable — or Clang's dependency scanner fails with
+    // `redefinition of module`.
+    func test_map_when_static_xcframework_is_transitively_relinked_by_a_static_consumer() async throws {
+        // Given
+        let projectPath = try temporaryPath()
+            .appending(component: "Project")
+        given(manifestFilesLocator)
+            .locatePackageManifest(at: .any)
+            .willReturn(
+                projectPath.appending(components: Constants.tuistDirectoryName, Constants.SwiftPackageManager.packageSwiftName)
+            )
+        let googleMapsPath = projectPath
+            .parentDirectory
+            .appending(component: "GoogleMaps.xcframework")
+        let googleMapsHeadersPath = googleMapsPath.appending(components: "ios-arm64", "Headers", "GoogleMaps")
+        try await fileSystem.makeDirectory(at: googleMapsHeadersPath)
+        try await fileSystem.writeText(
+            "modulemap",
+            at: googleMapsHeadersPath.appending(component: "module.modulemap")
+        )
+
+        let googleMaps: GraphDependency = .testXCFramework(
+            path: googleMapsPath,
+            infoPlist: .test(
+                libraries: [
+                    .test(
+                        path: try RelativePath(validating: "GoogleMaps.a")
+                    ),
+                ]
+            ),
+            linking: .static,
+            moduleMaps: [
+                googleMapsHeadersPath.appending(component: "module.modulemap"),
+            ]
+        )
+        // SwiftPM `GoogleMapsTarget` shim, cached as a static xcframework. It relinks
+        // `GoogleMaps.xcframework` transitively into every consumer.
+        let cachedGoogleMapsShim: GraphDependency = .testXCFramework(
+            path: try temporaryPath().appending(component: "GoogleMapsTarget.xcframework"),
+            infoPlist: .test(
+                libraries: [
+                    .test(
+                        path: try RelativePath(validating: "GoogleMapsTarget.a")
+                    ),
+                ]
+            ),
+            linking: .static
+        )
+        // Dynamic wrapper that also links `GoogleMaps.xcframework`. Reaching `GoogleMaps` through
+        // this route is exactly what the mapper's per-target walker fires on.
+        let cachedSharedUI: GraphDependency = .testXCFramework(
+            path: try temporaryPath().appending(component: "SharedUI.xcframework"),
+            linking: .dynamic
+        )
+        let graph: Graph = .test(
+            name: "App",
+            path: projectPath,
+            projects: [
+                projectPath: .test(
+                    path: projectPath,
+                    targets: [
+                        .test(name: "App"),
+                        .test(name: "Consumer"),
+                    ]
+                ),
+            ],
+            dependencies: [
+                .target(name: "App", path: projectPath): [
+                    cachedGoogleMapsShim,
+                    cachedSharedUI,
+                ],
+                cachedGoogleMapsShim: [
+                    googleMaps,
+                ],
+                .target(name: "Consumer", path: projectPath): [
+                    cachedSharedUI,
+                ],
+                cachedSharedUI: [
+                    googleMaps,
+                ],
+            ]
+        )
+
+        // When
+        let (gotGraph, gotSideEffects, _) = try await subject.map(
+            graph: graph,
+            environment: MapperEnvironment()
+        )
+
+        // Then. Both App and Consumer keep their empty settings — the App because it directly links
+        // the shim (no dynamic-behind route to add), the Consumer because `GoogleMaps.xcframework`
+        // is already reachable via `$(BUILT_PRODUCTS_DIR)/include` from the App's transitive relink.
+        XCTAssertBetterEqual(graph, gotGraph)
+        XCTAssertBetterEqual([], gotSideEffects)
+    }
+
     func test_removeOtherSwithDuplicates() {
         // Given
         let settings: SettingsDictionary = [

--- a/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/Project.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/Project.swift
@@ -60,5 +60,53 @@ let project = Project(
                 .xcframework(path: "NestedObjCKit.xcframework"),
             ]
         ),
+        // A `.staticFramework` that links the same static nested-header xcframeworks. When it's
+        // cached and a consumer links it, `LinkGenerator`'s transitive-static relink pulls the
+        // wrapped xcframeworks into the consumer's Frameworks build phase — Xcode then runs
+        // `ProcessXCFramework` on them and copies `Headers/<Module>/` into
+        // `$(BUILT_PRODUCTS_DIR)/include/<Module>/`. The direct-graph-edge suppression walker
+        // never saw this shape, so a sibling target reaching the same xcframework via the
+        // cached dynamic `Library` still got vendor `Headers/` on `HEADER_SEARCH_PATHS`
+        // added by `StaticXCFrameworkModuleMapGraphMapper`, and Clang's dep scanner rejected
+        // both maps with `redefinition of module`.
+        .target(
+            name: "StaticWrapper",
+            destinations: .macOS,
+            product: .staticFramework,
+            bundleId: "io.tuist.NestedHeaderXCFramework.StaticWrapper",
+            infoPlist: .default,
+            sources: ["StaticWrapper/Sources/**"],
+            dependencies: [
+                .xcframework(path: "NestedObjC.xcframework"),
+                .xcframework(path: "NestedObjCKit.xcframework"),
+            ]
+        ),
+        // Consumes both the cached `StaticWrapper` (which transitively relinks the nested
+        // xcframeworks at this level) and the cached dynamic `Library` (which routes the
+        // same xcframeworks through the mapper's dynamic-behind walker). Without the
+        // linkable-dependencies suppression widening, this target sees both the
+        // `include/<Module>/module.modulemap` copy from `ProcessXCFramework` and the
+        // vendor `Headers/<Module>/module.modulemap` on the search path, and Clang's
+        // dep scanner fails with `redefinition of module`.
+        .target(
+            name: "ToolLinkingStaticAndDynamicWrappers",
+            destinations: .macOS,
+            product: .commandLineTool,
+            bundleId: "io.tuist.NestedHeaderXCFramework.ToolLinkingStaticAndDynamicWrappers",
+            infoPlist: .default,
+            sources: ["ToolLinkingStaticAndDynamicWrappers/Sources/**"],
+            dependencies: [
+                .target(name: "Library"),
+                .target(name: "StaticWrapper"),
+            ],
+            // `redefinition of module` fires from Clang's explicit-modules dependency scanner.
+            // The project-level default disables explicit modules to keep the earlier fixtures
+            // focused on the umbrella-header / shadowed-module class of failures; override it
+            // here so this test actually exercises the dep-scan path where the redefinition
+            // surfaces.
+            settings: .settings(base: [
+                "SWIFT_ENABLE_EXPLICIT_MODULES": "YES",
+            ])
+        ),
     ]
 )

--- a/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/StaticWrapper/Sources/StaticWrapper.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/StaticWrapper/Sources/StaticWrapper.swift
@@ -1,0 +1,10 @@
+import NestedObjC
+import NestedObjCKit
+
+public enum StaticWrapper {
+    public static func trackingState() -> Int {
+        let feature = NestedFeature()
+        feature.anchor = NestedAnchor()
+        return Int(feature.anchor?.trackingState.rawValue ?? 0)
+    }
+}

--- a/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/ToolLinkingStaticAndDynamicWrappers/Sources/main.swift
+++ b/examples/xcode/generated_macos_tool_with_cached_nested_header_xcframework/ToolLinkingStaticAndDynamicWrappers/Sources/main.swift
@@ -1,0 +1,16 @@
+import Library
+// Importing `NestedObjC` / `NestedObjCKit` here forces the compiler to build the
+// clang modules for the nested-header xcframeworks. With Clang's explicit-modules
+// dep scanner, the scan fails if the same module is defined by two module maps —
+// which is exactly what happens if the mapper adds vendor `Headers/` on the
+// search path while `ProcessXCFramework` has already copied the map into
+// `$(BUILT_PRODUCTS_DIR)/include/`.
+import NestedObjC
+import NestedObjCKit
+import StaticWrapper
+
+let feature = NestedFeature()
+feature.anchor = NestedAnchor()
+print(feature.anchor?.trackingState.rawValue ?? 0)
+print(Library.trackingState())
+print(StaticWrapper.trackingState())


### PR DESCRIPTION
## What changed

Backport #12807 (88312396e55dfbd096dc50e05de7b89a7b593ec5) unchanged onto `releases/4.207.x`, so the upcoming 4.207 stable release includes the static xcframework module-map fixes verified in `4.208.0-canary.2`.

`4.207.0-rc.1` already contains #12683, #12691, #12745, and #12757. Only the final follow-up is missing; no other 4.208 changes are needed for this regression. All eight changed files matched the upstream fix's parent on the release branch, and the resulting files match the merged fix exactly.

## Why and root cause

Full binary-cache builds can still fail on the current RC with either `redefinition of module 'GoogleMaps'` or `unable to resolve module dependency: 'GoogleMaps'`, even when from-source and external-only cache builds succeed.

The mapper only recognized direct xcframework links when deciding whether Xcode would publish a module map under `$(BUILT_PRODUCTS_DIR)/include`. It missed static frameworks relinked transitively through a SwiftPM shim, then added the vendor module map as well, producing duplicate definitions. Focused binary-cache generation can also remove the source-graph edge to an xcframework that a cached wrapper still imports, leaving consumers without a module map.

The backport accounts for the xcframeworks actually processed by surviving targets, including transitive static relinks, scoped to their platforms. It also recovers dependencies lost during cache substitution from the original source graph and retains the existing suppression checks. This preserves module visibility without adding a second module definition. Keeping the already verified upstream patch intact avoids changing cache substitution or widening this release backport.

## Validation

- Applied cleanly to `releases/4.207.x`; verified exact file equality with #12807 for every changed file.
- `git diff --check` passed.
- `mise run cli:lint --fix` passed; no formatting changes were needed.
- Focused local Xcode validation passed on the backport: 25 `StaticXCFrameworkModuleMapGraphMapperTests` and 166 `GraphTraverserTests`, with zero failures. Command: `xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing:TuistKitTests/StaticXCFrameworkModuleMapGraphMapperTests -only-testing:TuistCoreTests/GraphTraverserTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' COMPILATION_CACHE_ENABLE_CACHING=NO`.
- Upstream #12807 passed CLI unit tests, both acceptance-test shards, SwiftPM build, Linux build, Linux unit tests, and lint. Its focused validation also reported 25 mapper tests and 166 graph-traverser tests passing, plus successful from-source and binary-cache builds of the reproduction.
- The reported full binary-cache integration passes with `4.208.0-canary.2`, which contains this fix.
- [Release-branch CI](https://github.com/tuist/tuist/actions/runs/33898612158) has independently passed lint, SwiftPM build, Linux build, Linux unit tests, unit tests, and the acceptance-test build. Both acceptance-test shards are still running at the time of this update.

## Release follow-through

After merging, publish the next 4.207 RC with `CLI Release Candidate`, setting `branch` to `releases/4.207.x`, then promote the validated line with `CLI Promote to Stable`.

The [previous stable-promotion attempt](https://github.com/tuist/tuist/actions/runs/33855245341) failed while bundling macOS with missing CAS objects and an out-of-space runner cache volume. No stable release was published. That publishing failure is separate from the module-map regression and should be checked on the next release build.
