### PR TITLE
fix(server): batch active alert event reads

### DIFF
--- a/server/lib/tuist/automations.ex
+++ b/server/lib/tuist/automations.ex
@@ -352,8 +352,8 @@ defmodule Tuist.Automations do
   end
 
   defp active_alert_events(alert_id, baseline_generation, test_case_ids) do
-    # Send each batch as one array parameter in the request body so large scoped
-    # reads stay within both address-length and multipart-field limits.
+    # Send each batch as one array parameter in the request body so the request
+    # address and each ClickHouse query payload stay bounded.
     test_case_ids
     |> Enum.uniq()
     |> Enum.chunk_every(@active_alert_events_batch_size)
@@ -377,7 +377,6 @@ defmodule Tuist.Automations do
   end
 
   defp filter_alert_events_by_test_case_ids(query, nil), do: query
-  defp filter_alert_events_by_test_case_ids(query, []), do: where(query, false)
 
   defp filter_alert_events_by_test_case_ids(query, test_case_ids) do
     where(query, [event], fragment("? IN (?)", event.test_case_id, type(^test_case_ids, {:array, Ecto.UUID})))

--- a/server/lib/tuist/automations.ex
+++ b/server/lib/tuist/automations.ex
@@ -33,6 +33,7 @@ defmodule Tuist.Automations do
   # project-wide identifier set as one scan.
   @max_scoped_evaluation_range_size 2000
   @minimum_scoped_evaluation_ranges 4
+  @active_alert_events_batch_size 2000
   @revision_fields ~w(
     name
     enabled
@@ -344,7 +345,26 @@ defmodule Tuist.Automations do
     active_alert_events(alert_id, baseline_generation, test_case_ids)
   end
 
+  defp active_alert_events(alert_id, baseline_generation, nil) do
+    alert_id
+    |> active_alert_events_query(baseline_generation, nil)
+    |> ClickHouseRepo.all()
+  end
+
   defp active_alert_events(alert_id, baseline_generation, test_case_ids) do
+    # Send each batch as one array parameter in the request body so large scoped
+    # reads stay within both address-length and multipart-field limits.
+    test_case_ids
+    |> Enum.uniq()
+    |> Enum.chunk_every(@active_alert_events_batch_size)
+    |> Enum.flat_map(fn ids_chunk ->
+      alert_id
+      |> active_alert_events_query(baseline_generation, ids_chunk)
+      |> ClickHouseRepo.all(multipart: true)
+    end)
+  end
+
+  defp active_alert_events_query(alert_id, baseline_generation, test_case_ids) do
     AlertEvent
     |> where(alert_id: ^alert_id, baseline_generation: ^baseline_generation)
     |> filter_alert_events_by_test_case_ids(test_case_ids)
@@ -354,14 +374,13 @@ defmodule Tuist.Automations do
       test_case_id: event.test_case_id,
       triggered_at: fragment("argMax(?, ?)", event.triggered_at, event.inserted_at)
     })
-    |> ClickHouseRepo.all()
   end
 
   defp filter_alert_events_by_test_case_ids(query, nil), do: query
   defp filter_alert_events_by_test_case_ids(query, []), do: where(query, false)
 
   defp filter_alert_events_by_test_case_ids(query, test_case_ids) do
-    where(query, [e], e.test_case_id in ^test_case_ids)
+    where(query, [event], fragment("? IN (?)", event.test_case_id, type(^test_case_ids, {:array, Ecto.UUID})))
   end
 
   def enqueue_flaky_alert_evaluations(_project_id, []), do: :ok

--- a/server/test/tuist/automations_test.exs
+++ b/server/test/tuist/automations_test.exs
@@ -317,6 +317,22 @@ defmodule Tuist.AutomationsTest do
       events = Automations.list_active_alert_events(alert.id)
       refute Enum.any?(events, &(&1.test_case_id == test_case_id))
     end
+
+    test "scopes a large active event read within ClickHouse request limits" do
+      alert = AutomationsFixtures.automation_alert_fixture()
+      test_case_ids = Enum.map(1..4001, fn _ -> Ecto.UUID.generate() end)
+      test_case_id = List.last(test_case_ids)
+
+      assert :ok =
+               Automations.create_alert_event(%{
+                 alert_id: alert.id,
+                 test_case_id: test_case_id,
+                 status: "triggered",
+                 triggered_at: NaiveDateTime.utc_now()
+               })
+
+      assert [%{test_case_id: ^test_case_id}] = Automations.list_active_alert_events(alert, test_case_ids)
+    end
   end
 
   describe "enqueue_flaky_alert_evaluations/2" do

--- a/server/test/tuist/automations_test.exs
+++ b/server/test/tuist/automations_test.exs
@@ -321,17 +321,25 @@ defmodule Tuist.AutomationsTest do
     test "scopes a large active event read within ClickHouse request limits" do
       alert = AutomationsFixtures.automation_alert_fixture()
       test_case_ids = Enum.map(1..4001, fn _ -> Ecto.UUID.generate() end)
-      test_case_id = List.last(test_case_ids)
+      event_test_case_ids = Enum.take_every(test_case_ids, 2000)
+      triggered_at = NaiveDateTime.utc_now()
 
-      assert :ok =
-               Automations.create_alert_event(%{
-                 alert_id: alert.id,
-                 test_case_id: test_case_id,
-                 status: "triggered",
-                 triggered_at: NaiveDateTime.utc_now()
-               })
+      Enum.each(event_test_case_ids, fn test_case_id ->
+        assert :ok =
+                 Automations.create_alert_event(%{
+                   alert_id: alert.id,
+                   test_case_id: test_case_id,
+                   status: "triggered",
+                   triggered_at: triggered_at
+                 })
+      end)
 
-      assert [%{test_case_id: ^test_case_id}] = Automations.list_active_alert_events(alert, test_case_ids)
+      active_test_case_ids =
+        alert
+        |> Automations.list_active_alert_events(test_case_ids)
+        |> MapSet.new(& &1.test_case_id)
+
+      assert active_test_case_ids == MapSet.new(event_test_case_ids)
     end
   end
 


### PR DESCRIPTION
## What changed

- Split scoped active alert-event reads into batches of 2,000 test-case identifiers.
- Bind each batch as one typed array in the multipart request body and combine the results.
- Add a regression test that queries 4,001 identifiers and verifies that events from all three batches are returned.

## Why

The alert evaluation worker prereads active alert events for the test cases it is about to evaluate. Project-wide evaluations can contain thousands of identifiers, and one such evaluation repeatedly failed instead of completing.

The failure was captured in [Hive](https://hive.tuist.dev/errors/e8fa1e48-24e3-5cb8-a1c1-4c64ff4d7200).

## Root cause

The project-wide preread passed every test-case identifier to one `in` expression. Ecto expanded that collection into one request parameter per identifier, which caused the request address to exceed the ClickHouse client limit when the evaluation contained 4,001 identifiers.

## Approach

Keep the project-wide preread optimization, but bound its transport shape. The identifiers are deduplicated, divided into batches of 2,000, and bound as one typed array per request. Sending the parameter through the multipart request body keeps the request address bounded, while batching bounds each ClickHouse query payload.

Unscoped reads keep their existing single-query path. Scoped reads combine the result of every batch, preserving the active-event semantics for the worker.

## Impact

Large alert evaluations no longer fail because their active-event lookup exceeds the request-address limit. Evaluations below the batch size still use one scoped query, while larger evaluations use one bounded query per batch. There is no database schema or migration impact.

## Validation

- The 4,001-identifier regression test passed and returned the events placed in the first, second, and final batches.
- The alert evaluation worker tests passed: 34 cases in the complete suite run, followed by both database-backed cases in a focused rerun against the current temporary ClickHouse schema.
- A second adversarial review returned an approve verdict with no remaining actionable findings.
- `mix format --check-formatted lib/tuist/automations.ex test/tuist/automations_test.exs`
- `git diff --check`
