### PR TITLE
fix(server): normalize Apple private key indentation

### DIFF
--- a/server/lib/tuist/oauth/apple.ex
+++ b/server/lib/tuist/oauth/apple.ex
@@ -43,8 +43,15 @@ defmodule Tuist.OAuth.Apple do
       expires_in: 86_400 * 180,
       key_id: Tuist.Environment.apple_private_key_id(),
       team_id: Tuist.Environment.apple_team_id(),
-      private_key: Tuist.Environment.apple_private_key()
+      private_key: normalize_private_key(Tuist.Environment.apple_private_key())
     })
+  end
+
+  defp normalize_private_key(private_key) do
+    private_key
+    |> String.split("\n")
+    |> Enum.map_join("\n", &String.trim/1)
+    |> String.trim()
   end
 
   @doc """

--- a/server/test/tuist/oauth/apple_client_secret_test.exs
+++ b/server/test/tuist/oauth/apple_client_secret_test.exs
@@ -1,0 +1,33 @@
+defmodule Tuist.OAuth.AppleClientSecretTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Tuist.Environment
+  alias Tuist.KeyValueStore
+  alias Tuist.OAuth.Apple
+
+  test "removes indentation from the configured private key" do
+    private_key =
+      {:ec, :secp256r1}
+      |> JOSE.JWK.generate_key()
+      |> JOSE.JWK.to_pem()
+      |> unwrap_pem()
+
+    indented_private_key =
+      private_key
+      |> String.split("\n")
+      |> Enum.map_join("\n", &("    " <> &1))
+
+    stub(KeyValueStore, :get_or_update, fn _key, _opts, func -> func.() end)
+    stub(Environment, :apple_private_key_id, fn -> "test_key_id" end)
+    stub(Environment, :apple_team_id, fn -> "test_team_id" end)
+    stub(Environment, :apple_private_key, fn -> indented_private_key end)
+
+    client_secret = Apple.client_secret(client_id: "test.app.client.id")
+
+    assert [_header, _payload, _signature] = String.split(client_secret, ".")
+  end
+
+  defp unwrap_pem(pem) when is_binary(pem), do: pem
+  defp unwrap_pem({_modules, pem}) when is_binary(pem), do: pem
+end


### PR DESCRIPTION
Resolves <https://hive.tuist.dev/errors/2ad9232c-c458-51f1-a761-2ad0219c680a>

Sign in with Apple client-secret generation failed in production because the configured private key contained leading spaces. The key parser only recognizes the closing boundary when it starts at the beginning of a line.

This change trims whitespace from every private-key line before generating the client secret. It also adds a regression test that generates a valid key, indents every line as observed in Hive, and confirms that a signed client secret is produced. Existing correctly formatted keys retain the same content.

### How to test locally

From the `server` directory:

- `mix test test/tuist/oauth/apple_client_secret_test.exs`
- `mix credo --strict lib/tuist/oauth/apple.ex test/tuist/oauth/apple_client_secret_test.exs`
