### PR TITLE
feat(infra): point Kura's Sentry DSN at the self-hosted Hive ingest

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -324,7 +324,14 @@ kuraController:
   sentry:
     externalSecret:
       enabled: true
-      item: kura-sentry
+      # Points at the self-hosted Hive ingest (../hive) so Kura errors land in
+      # the Kura project on hive.tuist.dev. The `kura-sentry-hive` 1P item in
+      # `tuist-k8s-canary` holds the Hive DSN under the default
+      # `KURA_SENTRY_DSN` field and MUST exist before this merges; a
+      # remoteRef whose item is missing fails the whole `kura-shared-secrets`
+      # sync. The prior `kura-sentry` item is kept in the vault as a rollback:
+      # flip this back to `kura-sentry` and reroll.
+      item: kura-sentry-hive
 
 # Only the shared mesh cache pools are listed. The runner-cache pool
 # (kura-scw-fr-par) is intentionally excluded: it advertises no egress budget,

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -338,7 +338,14 @@ kuraController:
   sentry:
     externalSecret:
       enabled: true
-      item: kura-sentry
+      # Points at the self-hosted Hive ingest (../hive) so Kura errors land in
+      # the Kura project on hive.tuist.dev. The `kura-sentry-hive` 1P item in
+      # `tuist-k8s-production` holds the Hive DSN under the default
+      # `KURA_SENTRY_DSN` field and MUST exist before this merges; a
+      # remoteRef whose item is missing fails the whole `kura-shared-secrets`
+      # sync. The prior `kura-sentry` item is kept in the vault as a rollback:
+      # flip this back to `kura-sentry` and reroll.
+      item: kura-sentry-hive
 
 # Only the shared mesh cache pools are listed. The runner-cache pool
 # (kura-scw-fr-par) is intentionally excluded: it advertises no egress budget,


### PR DESCRIPTION
## What

Switches the ExternalSecret that populates `KURA_SENTRY_DSN` on canary and production from the `kura-sentry` 1Password item (Sentry.io DSN) to a new `kura-sentry-hive` item that holds the Hive project DSN. Once the new items are populated in the vaults and this merges, the next Kura pod roll starts posting envelopes to the Kura project on `hive.tuist.dev` instead of Sentry.

Only two lines of substance change, one per env:

```yaml
kuraController:
  sentry:
    externalSecret:
      enabled: true
      item: kura-sentry-hive   # was: kura-sentry
```

## Why

Same motivation as `#12872` on the server: consolidate error tracking on the self-hosted Hive ingest (`../hive`) so we own the pipeline and stop paying for a second SaaS in parallel. Kura already emits Sentry-format envelopes via the `sentry` Rust crate, and Hive exposes a Sentry-compatible ingest, so all this needs is a DSN swap.

## Why not the flag-gated pattern

The server change (`#12872`) added a runtime `hive_error_tracking_enabled` FunWithFlags switch on top of a dual-DSN setup, so envelopes can be flipped between Sentry and Hive without a deploy. That machinery leans on Elixir-side plumbing (a custom `Sentry.HTTPClient` that rewrites URL + `X-Sentry-Auth` per request, `Tuist.Sentry.hive_reroute_target/0`, a FunWithFlags actor). None of that exists on the Rust side, and Kura's error volume is small enough that a redeploy-scoped rollback (flip `item:` back and roll) is cheap. So the simpler shape here is: a straight DSN swap at the ExternalSecret layer, with the old 1P item kept in the vault as the rollback.

Staging is intentionally not touched: it never had `kuraController.sentry.externalSecret.enabled: true` in the first place, so there's no current Sentry integration to redirect. Happy to enable Hive there in a follow-up if we want staging Kura errors visible in Hive too.

## Prerequisite before merge

The `kura-sentry-hive` 1Password item MUST exist in both `tuist-k8s-canary` and `tuist-k8s-production` before this merges. A `remoteRef` whose item is missing fails the whole `kura-shared-secrets` ExternalSecret sync; because that Secret uses `creationPolicy: Merge`, the last synced value keeps working on already-running pods, but a fresh roll would come up without the DSN key.

Create in each of the two vaults:

- Item name: `kura-sentry-hive`
- Field: `KURA_SENTRY_DSN`
- Value: `https://f5418dfeafcae9ce70539daab9bba0ae@hive.tuist.dev/4`

Same DSN in both vaults (single Kura project on Hive, per env-agnostic setup — the env label comes from `otel_deployment_environment`, so events are still separable in Hive).

## What happens on deploy

1. Helm applies the values change, and the `kura-sentry-secrets` ExternalSecret's `remoteRef` now points at `kura-sentry-hive/KURA_SENTRY_DSN`.
2. external-secrets picks the new path up on its next refresh (`refreshInterval: 1h`), or immediately if we annotate it: `kubectl -n kura annotate externalsecret kura-sentry-secrets force-sync=$(date +%s) --overwrite`.
3. The synced value in the `kura-shared-secrets` Secret changes to the Hive DSN.
4. Existing Kura pods keep the old DSN in memory (envFrom is captured at pod start), so a rolling restart is needed to actually cut traffic over: `kubectl -n kura rollout restart daemonset/kura` (adjust workload kind if different) and wait on `rollout status`.

## Rollback

Flip `item: kura-sentry-hive` back to `item: kura-sentry` in the same two files and merge. The Sentry.io DSN is kept in the `kura-sentry` items in both vaults precisely so this stays a one-value revert.

## Verification

After the rollout completes in an env:

- `kubectl -n kura exec <pod> -- printenv KURA_SENTRY_DSN` should return the `hive.tuist.dev` URL.
- The Kura project on Hive should show `last_used_at` move off `null` on the first captured event.
- Sentry.io's Kura project should stop receiving new events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)