### PR TITLE
feat(cli): configure Bazel during setup

### DIFF
--- a/cli/Sources/TuistBazelCommand/BazelCredentialHelperCommand.swift
+++ b/cli/Sources/TuistBazelCommand/BazelCredentialHelperCommand.swift
@@ -33,10 +33,17 @@ public struct BazelCredentialHelperCommand: AsyncParsableCommand, NooraReadyComm
     )
     var path: String?
 
+    @Option(
+        name: .long,
+        help: "The path to the directory containing the generated .bazelrc.tuist file."
+    )
+    var bazelrcPath: String?
+
     public func run() async throws {
         try await BazelCredentialHelperCommandService().run(
             helperCommand: command,
-            directory: path
+            directory: path,
+            bazelrcDirectory: bazelrcPath
         )
     }
 }

--- a/cli/Sources/TuistBazelCommand/BazelCredentialHelperCommandService.swift
+++ b/cli/Sources/TuistBazelCommand/BazelCredentialHelperCommandService.swift
@@ -62,9 +62,24 @@ public struct BazelCredentialHelperCommandService: BazelCredentialHelperCommandS
         helperCommand: String,
         directory: String?
     ) async throws {
+        try await run(
+            helperCommand: helperCommand,
+            directory: directory,
+            bazelrcDirectory: nil
+        )
+    }
+
+    public func run(
+        helperCommand: String,
+        directory: String?,
+        bazelrcDirectory: String?
+    ) async throws {
         let response = try await credentials(helperCommand: helperCommand, directory: directory)
         try Noora.current.json(response)
-        await refreshBazelrcEndpoint(directory: directory)
+        await refreshBazelrcEndpoint(
+            directory: directory,
+            bazelrcDirectory: bazelrcDirectory
+        )
     }
 
     /// Points `.bazelrc.tuist` at wherever the account's cache is now.
@@ -95,10 +110,16 @@ public struct BazelCredentialHelperCommandService: BazelCredentialHelperCommandS
     /// nothing about where the cache went, and a build should not fail because
     /// its `.bazelrc` could not be tidied. The rewrite lands on the next
     /// build, since this one read the file before we ran.
-    private func refreshBazelrcEndpoint(directory: String?) async {
+    private func refreshBazelrcEndpoint(
+        directory: String?,
+        bazelrcDirectory: String?
+    ) async {
         do {
             let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(directory)
-            let bazelrcPath = directoryPath.appending(component: BazelrcFile.name)
+            let bazelrcDirectoryPath = try await Environment.current.pathRelativeToWorkingDirectory(
+                bazelrcDirectory ?? directory
+            )
+            let bazelrcPath = bazelrcDirectoryPath.appending(component: BazelrcFile.name)
             guard try await fileSystem.exists(bazelrcPath) else { return }
 
             let config = try await configLoader.loadConfig(path: directoryPath)

--- a/cli/Sources/TuistBazelCommand/BazelSetupCommand.swift
+++ b/cli/Sources/TuistBazelCommand/BazelSetupCommand.swift
@@ -27,10 +27,18 @@ public struct BazelSetupCommand: AsyncParsableCommand {
     )
     var buildInsights = true
 
+    @Flag(
+        name: .long,
+        inversion: .prefixedNo,
+        help: "Add the generated .bazelrc.tuist import to .bazelrc."
+    )
+    var addBazelrcImport = true
+
     public func run() async throws {
         try await BazelSetupCommandService().run(
             directory: path,
-            buildInsights: buildInsights
+            buildInsights: buildInsights,
+            addBazelrcImport: addBazelrcImport
         )
     }
 }

--- a/cli/Sources/TuistBazelCommand/BazelSetupCommandService.swift
+++ b/cli/Sources/TuistBazelCommand/BazelSetupCommandService.swift
@@ -1,5 +1,6 @@
 import FileSystem
 import Foundation
+import Noora
 import Path
 import TuistAlert
 import TuistCAS
@@ -9,13 +10,126 @@ import TuistHTTP
 import TuistREAPI
 import TuistServer
 
-public protocol BazelSetupCommandServicing {
-    func run(
-        directory: String?
-    ) async throws
+private enum BazelrcImportResult {
+    case added
+    case alreadyImported
+    case disabled
+    case workspaceNotFound
+    case symbolicLink
+    case managedOptionsPresent
+    case fileUpdateFailed
 }
 
-public struct BazelSetupCommandService: BazelSetupCommandServicing {
+private struct BazelrcImportEditor {
+    private let fileSystem: FileSysteming
+
+    init(fileSystem: FileSysteming) {
+        self.fileSystem = fileSystem
+    }
+
+    func add(to directoryPath: AbsolutePath) async -> BazelrcImportResult {
+        let bazelrcPath = directoryPath.appending(component: ".bazelrc")
+        let importLine = "try-import %workspace%/.bazelrc.tuist"
+
+        do {
+            let existingContent: String
+            if isSymbolicLink(bazelrcPath) {
+                return .symbolicLink
+            } else if try await fileSystem.exists(bazelrcPath) {
+                existingContent = try await fileSystem.readTextFile(at: bazelrcPath)
+            } else {
+                existingContent = ""
+            }
+
+            guard !hasBazelrcImport(existingContent) else { return .alreadyImported }
+            guard !hasManagedBazelOptions(existingContent) else { return .managedOptionsPresent }
+
+            try await fileSystem.writeText(
+                insertingBazelrcImport(importLine, into: existingContent),
+                at: bazelrcPath,
+                encoding: .utf8,
+                options: Set([.overwrite])
+            )
+
+            return .added
+        } catch {
+            return .fileUpdateFailed
+        }
+    }
+
+    private func isSymbolicLink(_ path: AbsolutePath) -> Bool {
+        guard let type = try? FileManager.default.attributesOfItem(atPath: path.pathString)[.type] as? FileAttributeType else {
+            return false
+        }
+        return type == .typeSymbolicLink
+    }
+
+    private func hasBazelrcImport(_ content: String) -> Bool {
+        content
+            .split(whereSeparator: \.isNewline)
+            .contains { line in
+                let tokens = line.split(whereSeparator: \.isWhitespace)
+                guard tokens.count == 2 else { return false }
+                return (tokens[0] == "try-import" || tokens[0] == "import")
+                    && tokens[1] == "%workspace%/.bazelrc.tuist"
+            }
+    }
+
+    private func hasManagedBazelOptions(_ content: String) -> Bool {
+        content
+            .split(whereSeparator: \.isNewline)
+            .contains { line in
+                let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+                guard !trimmedLine.hasPrefix("#") else { return false }
+
+                return trimmedLine.split(whereSeparator: \.isWhitespace).contains { token in
+                    token == "--remote_cache"
+                        || token.hasPrefix("--remote_cache=")
+                        || token == "--bes_backend"
+                        || token.hasPrefix("--bes_backend=")
+                }
+            }
+    }
+
+    private func insertingBazelrcImport(_ importLine: String, into content: String) -> String {
+        let newline = content.contains("\r\n") ? "\r\n" : "\n"
+        let normalizedContent = content
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        var lines = normalizedContent.components(separatedBy: "\n")
+        var insertionIndex = lines.endIndex
+
+        while insertionIndex > lines.startIndex {
+            let line = lines[lines.index(before: insertionIndex)]
+            if line.trimmingCharacters(in: .whitespaces).isEmpty || isBazelrcImportDirective(line) {
+                insertionIndex = lines.index(before: insertionIndex)
+            } else {
+                break
+            }
+        }
+
+        lines.insert(importLine, at: insertionIndex)
+        var result = lines.joined(separator: newline)
+        if !result.hasSuffix(newline) {
+            result.append(contentsOf: newline)
+        }
+        return result
+    }
+
+    private func isBazelrcImportDirective(_ line: String) -> Bool {
+        guard let directive = line.split(whereSeparator: \.isWhitespace).first else { return false }
+        return directive == "try-import" || directive == "import"
+    }
+}
+
+private struct BazelSetupConfiguration {
+    let endpoint: GRPCEndpoint
+    let accountHandle: String
+    let projectHandle: String
+    let fullHandle: String
+}
+
+public struct BazelSetupCommandService {
     private let serverEnvironmentService: ServerEnvironmentServicing
     private let serverAuthenticationController: ServerAuthenticationControlling
     private let cacheURLStore: CacheURLStoring
@@ -43,72 +157,129 @@ public struct BazelSetupCommandService: BazelSetupCommandServicing {
     }
 
     public func run(
-        directory: String?
-    ) async throws {
-        try await run(directory: directory, buildInsights: true)
-    }
-
-    public func run(
         directory: String?,
-        buildInsights: Bool
+        buildInsights: Bool = true,
+        addBazelrcImport shouldAddBazelrcImport: Bool = true
     ) async throws {
         let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(directory)
+        let canonicalDirectoryPath = try canonicalPath(directoryPath)
+        let setupConfiguration = try await setupConfiguration(directoryPath: directoryPath)
+
+        let bazelWorkspacePath = try await bazelWorkspacePath(startingAt: canonicalDirectoryPath)
+        let bazelrcDirectoryPath = bazelWorkspacePath ?? canonicalDirectoryPath
+        let credentialHelperPath = try await createCredentialHelperScriptIfNeeded(
+            directoryPath: canonicalDirectoryPath,
+            bazelrcDirectoryPath: bazelrcDirectoryPath,
+            fullHandle: setupConfiguration.fullHandle
+        )
+        let bazelrcPath = bazelrcDirectoryPath.appending(component: BazelrcFile.name)
+        let bazelrcContent = BazelrcFile.render(
+            endpoint: setupConfiguration.endpoint,
+            accountHandle: setupConfiguration.accountHandle,
+            projectHandle: setupConfiguration.projectHandle,
+            credentialHelperPath: credentialHelperPath,
+            buildInsights: buildInsights
+        )
+        try await fileSystem.writeText(bazelrcContent, at: bazelrcPath, encoding: .utf8, options: Set([.overwrite]))
+
+        let bazelrcImportResult =
+            if !shouldAddBazelrcImport {
+                BazelrcImportResult.disabled
+            } else if bazelWorkspacePath != nil {
+                await BazelrcImportEditor(fileSystem: fileSystem).add(to: bazelrcDirectoryPath)
+            } else {
+                BazelrcImportResult.workspaceNotFound
+            }
+
+        showSuccess(
+            bazelrcPath: bazelrcPath,
+            bazelrcImportResult: bazelrcImportResult,
+            buildInsights: buildInsights
+        )
+    }
+
+    private func setupConfiguration(directoryPath: AbsolutePath) async throws -> BazelSetupConfiguration {
         let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverEnvironmentService.url(configServerURL: config.url)
-
         guard let fullHandle = config.fullHandle else {
             throw BazelSetupCommandServiceError.missingFullHandle
         }
         let (accountHandle, projectHandle) = try fullHandleService.parse(fullHandle)
-
-        guard let token = try await serverAuthenticationController.authenticationToken(serverURL: serverURL)
-        else {
+        guard let token = try await serverAuthenticationController.authenticationToken(serverURL: serverURL) else {
             throw BazelSetupCommandServiceError.notAuthenticated
         }
-
         let cacheURL = try await cacheURLStore.getCacheURL(for: serverURL, accountHandle: accountHandle)
         guard let host = cacheURL.host else {
             throw BazelSetupCommandServiceError.invalidCacheEndpoint(cacheURL.absoluteString)
         }
         let endpoint = GRPCEndpoint(host: host, explicitPort: cacheURL.port, isTLS: cacheURL.scheme != "http")
 
-        // Probe the resolved endpoint before writing the configuration so setup fails when the
-        // cache is unreachable or misbehaving, regardless of whether the URL came from
-        // TUIST_CACHE_ENDPOINT or from server-side endpoint selection. The latter measures
-        // latency and discards unreachable endpoints, but an override short-circuits that path,
-        // so this guarantees the endpoint we hand Bazel actually answers the REAPI handshake.
         try await remoteCacheProbeService.probe(
             endpoint: endpoint,
             accountHandle: accountHandle,
             instanceName: projectHandle,
             token: token.value
         )
-
-        let credentialHelperPath = try await createCredentialHelperScriptIfNeeded()
-
-        let bazelrcPath = directoryPath.appending(component: BazelrcFile.name)
-        let bazelrcContent = BazelrcFile.render(
+        return BazelSetupConfiguration(
             endpoint: endpoint,
             accountHandle: accountHandle,
             projectHandle: projectHandle,
-            credentialHelperPath: credentialHelperPath,
-            buildInsights: buildInsights
+            fullHandle: fullHandle
         )
-        try await fileSystem.writeText(bazelrcContent, at: bazelrcPath, encoding: .utf8, options: Set([.overwrite]))
+    }
 
+    private func showSuccess(
+        bazelrcPath: AbsolutePath,
+        bazelrcImportResult: BazelrcImportResult,
+        buildInsights: Bool
+    ) {
         AlertController.current.success(
             .alert(
                 "Generated \(bazelrcPath.pathString)",
                 takeaways: [
-                    "Add 'try-import %workspace%/.bazelrc.tuist' to your .bazelrc to enable the Tuist remote cache\(buildInsights ? " and invocation insights" : "")",
+                    bazelrcImportTakeaway(
+                        result: bazelrcImportResult,
+                        buildInsights: buildInsights
+                    ),
+                    "Run Bazel normally to use the Tuist remote cache\(buildInsights ? " and record build insights" : "")",
                 ]
             )
         )
     }
 
-    private func createCredentialHelperScriptIfNeeded() async throws -> AbsolutePath {
+    private func bazelrcImportTakeaway(
+        result: BazelrcImportResult,
+        buildInsights: Bool
+    ) -> TerminalText {
+        let capabilities = buildInsights ? "remote cache and build insights" : "remote cache"
+
+        switch result {
+        case .added:
+            return "Added 'try-import %workspace%/.bazelrc.tuist' to your .bazelrc to enable the Tuist \(capabilities)"
+        case .alreadyImported:
+            return "Your .bazelrc already imports .bazelrc.tuist"
+        case .disabled:
+            return "Add 'try-import %workspace%/.bazelrc.tuist' to your .bazelrc to enable the Tuist \(capabilities)"
+        case .workspaceNotFound:
+            return "No Bazel workspace marker was found. Run setup from the workspace or import the generated file manually"
+        case .symbolicLink:
+            return "Your .bazelrc is a symbolic link. Add 'try-import %workspace%/.bazelrc.tuist' to its target to enable the Tuist \(capabilities)"
+        case .managedOptionsPresent:
+            return "Your .bazelrc already configures a remote cache or Build Event Service. Review the generated .bazelrc.tuist before importing it"
+        case .fileUpdateFailed:
+            return "Could not update your .bazelrc. Add 'try-import %workspace%/.bazelrc.tuist' manually to enable the Tuist \(capabilities)"
+        }
+    }
+
+    private func createCredentialHelperScriptIfNeeded(
+        directoryPath: AbsolutePath,
+        bazelrcDirectoryPath: AbsolutePath,
+        fullHandle: String
+    ) async throws -> AbsolutePath {
         let credentialsDirectory = Environment.current.configDirectory.appending(component: "credentials")
-        let scriptPath = credentialsDirectory.appending(component: "tuist-bazel-credential-helper")
+        let helperName =
+            "tuist-bazel-credential-helper-\(fullHandle.replacingOccurrences(of: "/", with: "-"))-\(directoryIdentifier(directoryPath: directoryPath, bazelrcDirectoryPath: bazelrcDirectoryPath))"
+        let scriptPath = credentialsDirectory.appending(component: helperName)
 
         if try await fileSystem.exists(scriptPath) {
             return scriptPath
@@ -118,9 +289,32 @@ public struct BazelSetupCommandService: BazelSetupCommandServicing {
             try await fileSystem.makeDirectory(at: credentialsDirectory)
         }
 
+        let directoryPathArgument = shellSingleQuoted(directoryPath.pathString)
+        let bazelrcDirectoryPathArgument = shellSingleQuoted(bazelrcDirectoryPath.pathString)
+        let relativeDirectoryPathArgument = shellSingleQuoted(directoryPath.relative(to: bazelrcDirectoryPath).pathString)
         let script = """
         #!/bin/sh
-        exec tuist bazel credential-helper "$@"
+        project_path='\(directoryPathArgument)'
+        bazelrc_path='\(bazelrcDirectoryPathArgument)'
+        relative_project_path='\(relativeDirectoryPathArgument)'
+
+        if [ ! -d "$project_path" ] || [ ! -f "$bazelrc_path/.bazelrc.tuist" ]; then
+          workspace_path="$PWD"
+          while [ "$workspace_path" != "/" ] && [ ! -f "$workspace_path/.bazelrc.tuist" ]; do
+            workspace_path=${workspace_path%/*}
+            [ -n "$workspace_path" ] || workspace_path=/
+          done
+          if [ -f "$workspace_path/.bazelrc.tuist" ]; then
+            project_path="$workspace_path/$relative_project_path"
+            bazelrc_path="$workspace_path"
+          fi
+        fi
+
+        if [ -d "$project_path" ] && [ -f "$bazelrc_path/.bazelrc.tuist" ]; then
+          exec tuist bazel credential-helper --path "$project_path" --bazelrc-path "$bazelrc_path" "$@"
+        else
+          exec tuist bazel credential-helper "$@"
+        fi
 
         """
         try await fileSystem.writeText(script, at: scriptPath)
@@ -129,6 +323,44 @@ public struct BazelSetupCommandService: BazelSetupCommandServicing {
             ofItemAtPath: scriptPath.pathString
         )
         return scriptPath
+    }
+
+    private func shellSingleQuoted(_ value: String) -> String {
+        value.replacingOccurrences(of: "'", with: "'\"'\"'")
+    }
+
+    private func directoryIdentifier(
+        directoryPath: AbsolutePath,
+        bazelrcDirectoryPath: AbsolutePath
+    ) -> String {
+        let identity = directoryPath.pathString + "\0" + bazelrcDirectoryPath.pathString
+        let hash = identity.utf8.reduce(UInt64(14_695_981_039_346_656_037)) { hash, byte in
+            (hash ^ UInt64(byte)) &* 1_099_511_628_211
+        }
+        return String(hash, radix: 16)
+    }
+
+    private func canonicalPath(_ path: AbsolutePath) throws -> AbsolutePath {
+        try AbsolutePath(validating: URL(fileURLWithPath: path.pathString).resolvingSymlinksInPath().path)
+    }
+
+    private func bazelWorkspacePath(startingAt directoryPath: AbsolutePath) async throws -> AbsolutePath? {
+        var candidate = directoryPath
+        let markers = ["MODULE.bazel", "REPO.bazel", "WORKSPACE.bazel", "WORKSPACE"]
+
+        while true {
+            for marker in markers where try await fileSystem.exists(candidate.appending(component: marker)) {
+                return candidate
+            }
+
+            if try await fileSystem.exists(candidate.appending(component: ".git")) {
+                return nil
+            }
+
+            let parent = candidate.parentDirectory
+            guard parent != candidate else { return nil }
+            candidate = parent
+        }
     }
 }
 

--- a/cli/Tests/TuistBazelCommandTests/BazelSetupCommandServiceTests.swift
+++ b/cli/Tests/TuistBazelCommandTests/BazelSetupCommandServiceTests.swift
@@ -67,9 +67,18 @@ struct BazelSetupCommandServiceTests {
         )
     }
 
-    private func credentialHelperPath() throws -> AbsolutePath {
-        let environment = try #require(Environment.mocked)
-        return environment.configDirectory.appending(components: ["credentials", "tuist-bazel-credential-helper"])
+    private func credentialHelperPath(from bazelrcContent: String) throws -> AbsolutePath {
+        let prefix = "build --credential_helper="
+        let line = try #require(
+            bazelrcContent.split(whereSeparator: \.isNewline).first { $0.hasPrefix(prefix) }
+        )
+        let assignment = line.dropFirst(prefix.count)
+        let separatorIndex = try #require(assignment.firstIndex(of: "="))
+        return try AbsolutePath(validating: String(assignment[assignment.index(after: separatorIndex)...]))
+    }
+
+    private func canonicalPathString(_ path: AbsolutePath) -> String {
+        URL(fileURLWithPath: path.pathString).resolvingSymlinksInPath().path
     }
 
     @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
@@ -80,15 +89,16 @@ struct BazelSetupCommandServiceTests {
         given(serverAuthenticationController)
             .authenticationToken(serverURL: .any)
             .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
 
         // When
         try await subject.run(directory: temporaryDirectory.pathString)
 
         // Then
-        let scriptPath = try credentialHelperPath()
         let bazelrcContent = try await fileSystem.readTextFile(
             at: temporaryDirectory.appending(component: ".bazelrc.tuist")
         )
+        let scriptPath = try credentialHelperPath(from: bazelrcContent)
         #expect(bazelrcContent.contains("build --remote_cache=grpcs://cache.tuist.dev"))
         #expect(bazelrcContent.contains("build --remote_header=x-tuist-account-handle=my-account"))
         #expect(bazelrcContent.contains("build --credential_helper=cache.tuist.dev=\(scriptPath.pathString)"))
@@ -99,14 +109,16 @@ struct BazelSetupCommandServiceTests {
         #expect(bazelrcContent.contains("build --bes_timeout=30s"))
         #expect(bazelrcContent.contains("build --bes_upload_mode=fully_async"))
 
-        let scriptContent = try await fileSystem.readTextFile(at: scriptPath)
         #expect(
-            scriptContent == """
-            #!/bin/sh
-            exec tuist bazel credential-helper "$@"
-
-            """
+            try await fileSystem.readTextFile(at: temporaryDirectory.appending(component: ".bazelrc"))
+                == "try-import %workspace%/.bazelrc.tuist\n"
         )
+
+        let scriptContent = try await fileSystem.readTextFile(at: scriptPath)
+        #expect(scriptContent.contains("project_path='"))
+        #expect(scriptContent.contains("bazelrc_path='"))
+        #expect(scriptContent.contains("--bazelrc-path \"$bazelrc_path\""))
+        #expect(scriptContent.contains("exec tuist bazel credential-helper \"$@\""))
         #expect(FileManager.default.isExecutableFile(atPath: scriptPath.pathString))
     }
 
@@ -125,10 +137,10 @@ struct BazelSetupCommandServiceTests {
         try await subject.run(directory: temporaryDirectory.pathString)
 
         // Then
-        let scriptPath = try credentialHelperPath()
         let bazelrcContent = try await fileSystem.readTextFile(
             at: temporaryDirectory.appending(component: ".bazelrc.tuist")
         )
+        let scriptPath = try credentialHelperPath(from: bazelrcContent)
         #expect(bazelrcContent.contains("build --remote_cache=grpcs://cache.tuist.dev:8443"))
         #expect(bazelrcContent.contains("build --credential_helper=cache.tuist.dev=\(scriptPath.pathString)"))
         verify(remoteCacheProbeService)
@@ -156,10 +168,10 @@ struct BazelSetupCommandServiceTests {
         try await subject.run(directory: temporaryDirectory.pathString)
 
         // Then
-        let scriptPath = try credentialHelperPath()
         let bazelrcContent = try await fileSystem.readTextFile(
             at: temporaryDirectory.appending(component: ".bazelrc.tuist")
         )
+        let scriptPath = try credentialHelperPath(from: bazelrcContent)
         #expect(bazelrcContent.contains("build --remote_cache=grpc://localhost:5091"))
         #expect(bazelrcContent.contains("build --credential_helper=localhost=\(scriptPath.pathString)"))
         verify(remoteCacheProbeService)
@@ -181,8 +193,11 @@ struct BazelSetupCommandServiceTests {
             .authenticationToken(serverURL: .any)
             .willReturn(.project("token"))
 
-        let scriptPath = try credentialHelperPath()
-        try await fileSystem.makeDirectory(at: scriptPath.parentDirectory)
+        try await subject.run(directory: temporaryDirectory.pathString)
+        let bazelrcContent = try await fileSystem.readTextFile(
+            at: temporaryDirectory.appending(component: ".bazelrc.tuist")
+        )
+        let scriptPath = try credentialHelperPath(from: bazelrcContent)
         try await fileSystem.writeText("#!/bin/sh\n# custom helper\n", at: scriptPath)
 
         // When
@@ -191,6 +206,340 @@ struct BazelSetupCommandServiceTests {
         // Then
         let scriptContent = try await fileSystem.readTextFile(at: scriptPath)
         #expect(scriptContent == "#!/bin/sh\n# custom helper\n")
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_scopes_credential_helpers_to_the_configured_checkout() async throws {
+        // Given
+        let firstDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let secondDirectory = firstDirectory.appending(component: "second-checkout")
+        try await fileSystem.makeDirectory(at: secondDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+
+        // When
+        try await subject.run(directory: firstDirectory.pathString)
+        try await subject.run(directory: secondDirectory.pathString)
+
+        // Then
+        let firstHelperPath = try credentialHelperPath(
+            from: try await fileSystem.readTextFile(at: firstDirectory.appending(component: ".bazelrc.tuist"))
+        )
+        let secondHelperPath = try credentialHelperPath(
+            from: try await fileSystem.readTextFile(at: secondDirectory.appending(component: ".bazelrc.tuist"))
+        )
+        #expect(firstHelperPath != secondHelperPath)
+        let firstHelperContent = try await fileSystem.readTextFile(at: firstHelperPath)
+        let secondHelperContent = try await fileSystem.readTextFile(at: secondHelperPath)
+        #expect(firstHelperContent.contains("project_path='\(canonicalPathString(firstDirectory))'"))
+        #expect(!firstHelperContent.contains(canonicalPathString(secondDirectory)))
+        #expect(secondHelperContent.contains("project_path='\(canonicalPathString(secondDirectory))'"))
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_adds_bazelrc_import_once() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        try await fileSystem.writeText("build --keep_going\n", at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(
+            try await fileSystem.readTextFile(at: bazelrcPath)
+                == "build --keep_going\ntry-import %workspace%/.bazelrc.tuist\n"
+        )
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_does_not_add_bazelrc_import_when_disabled() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        let existingContent = "build --keep_going\n"
+        try await fileSystem.writeText(existingContent, at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString, addBazelrcImport: false)
+
+        // Then
+        #expect(try await fileSystem.readTextFile(at: bazelrcPath) == existingContent)
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_adds_bazelrc_import_after_content_without_a_trailing_newline() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        try await fileSystem.writeText("build --keep_going", at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(
+            try await fileSystem.readTextFile(at: bazelrcPath)
+                == "build --keep_going\ntry-import %workspace%/.bazelrc.tuist\n"
+        )
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_recognizes_an_existing_bazelrc_import_with_flexible_whitespace() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        let existingContent = "import  %workspace%/.bazelrc.tuist\n"
+        try await fileSystem.writeText(existingContent, at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(try await fileSystem.readTextFile(at: bazelrcPath) == existingContent)
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_adds_bazelrc_import_before_trailing_user_imports() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        try await fileSystem.writeText("build --keep_going\r\ntry-import %workspace%/.bazelrc.user\r\n", at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(
+            try await fileSystem.readTextFile(at: bazelrcPath)
+                == "build --keep_going\r\ntry-import %workspace%/.bazelrc.tuist\r\ntry-import %workspace%/.bazelrc.user\r\n"
+        )
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_preserves_existing_remote_configuration() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        let existingContent = "build --remote_cache=grpcs://example.com\n"
+        try await fileSystem.writeText(existingContent, at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(try await fileSystem.readTextFile(at: bazelrcPath) == existingContent)
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_preserves_existing_build_event_service_configuration() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        let existingContent = "build --bes_backend=grpcs://example.com\n"
+        try await fileSystem.writeText(existingContent, at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(try await fileSystem.readTextFile(at: bazelrcPath) == existingContent)
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_ignores_commented_remote_configuration() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        try await fileSystem.writeText("# build --remote_cache=grpcs://example.com\n", at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(
+            try await fileSystem.readTextFile(at: bazelrcPath)
+                == "# build --remote_cache=grpcs://example.com\ntry-import %workspace%/.bazelrc.tuist\n"
+        )
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_writes_bazel_configuration_at_the_workspace_root() async throws {
+        // Given
+        let workspaceDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let nestedDirectory = workspaceDirectory.appending(components: ["sources", "app"])
+        try await fileSystem.makeDirectory(at: nestedDirectory)
+        try await fileSystem.touch(workspaceDirectory.appending(component: "REPO.bazel"))
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+
+        // When
+        try await subject.run(directory: nestedDirectory.pathString)
+
+        // Then
+        #expect(try await fileSystem.exists(workspaceDirectory.appending(component: ".bazelrc.tuist")))
+        #expect(try await fileSystem.exists(workspaceDirectory.appending(component: ".bazelrc")))
+        #expect(try await !fileSystem.exists(nestedDirectory.appending(component: ".bazelrc.tuist")))
+        let bazelrcContent = try await fileSystem.readTextFile(
+            at: workspaceDirectory.appending(component: ".bazelrc.tuist")
+        )
+        let helperPath = try credentialHelperPath(from: bazelrcContent)
+        let helperContent = try await fileSystem.readTextFile(at: helperPath)
+        #expect(helperContent.contains("project_path='\(canonicalPathString(nestedDirectory))'"))
+        #expect(helperContent.contains("bazelrc_path='\(canonicalPathString(workspaceDirectory))'"))
+        #expect(helperContent.contains("--bazelrc-path \"$bazelrc_path\""))
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_creates_a_new_helper_when_the_workspace_root_changes() async throws {
+        // Given
+        let rootDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let projectDirectory = rootDirectory.appending(components: ["apps", "ios"])
+        try await fileSystem.makeDirectory(at: projectDirectory)
+        let nestedWorkspaceMarker = projectDirectory.appending(component: "WORKSPACE")
+        try await fileSystem.touch(nestedWorkspaceMarker)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await subject.run(directory: projectDirectory.pathString)
+        let nestedBazelrcContent = try await fileSystem.readTextFile(
+            at: projectDirectory.appending(component: ".bazelrc.tuist")
+        )
+        let nestedHelperPath = try credentialHelperPath(from: nestedBazelrcContent)
+
+        try await fileSystem.remove(nestedWorkspaceMarker)
+        try await fileSystem.touch(rootDirectory.appending(component: "MODULE.bazel"))
+
+        // When
+        try await subject.run(directory: projectDirectory.pathString)
+
+        // Then
+        let rootBazelrcContent = try await fileSystem.readTextFile(
+            at: rootDirectory.appending(component: ".bazelrc.tuist")
+        )
+        let rootHelperPath = try credentialHelperPath(from: rootBazelrcContent)
+        #expect(rootHelperPath != nestedHelperPath)
+        #expect(
+            try await fileSystem.readTextFile(at: rootHelperPath)
+                .contains("bazelrc_path='\(canonicalPathString(rootDirectory))'")
+        )
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_does_not_discover_a_workspace_above_the_repository_root() async throws {
+        // Given
+        let outerDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let repositoryDirectory = outerDirectory.appending(component: "repository")
+        let nestedDirectory = repositoryDirectory.appending(component: "sources")
+        try await fileSystem.makeDirectory(at: nestedDirectory)
+        try await fileSystem.touch(outerDirectory.appending(component: "WORKSPACE"))
+        try await fileSystem.touch(repositoryDirectory.appending(component: ".git"))
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+
+        // When
+        try await subject.run(directory: nestedDirectory.pathString)
+
+        // Then
+        #expect(try await fileSystem.exists(nestedDirectory.appending(component: ".bazelrc.tuist")))
+        #expect(try await !fileSystem.exists(outerDirectory.appending(component: ".bazelrc.tuist")))
+        #expect(try await !fileSystem.exists(repositoryDirectory.appending(component: ".bazelrc")))
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_does_not_replace_a_symbolic_bazelrc() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let sharedBazelrcPath = temporaryDirectory.appending(component: "shared.bazelrc")
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        try await fileSystem.writeText("build --keep_going\n", at: sharedBazelrcPath)
+        try await fileSystem.createSymbolicLink(from: bazelrcPath, to: sharedBazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(try await fileSystem.resolveSymbolicLink(bazelrcPath) == sharedBazelrcPath)
+        #expect(try await fileSystem.readTextFile(at: sharedBazelrcPath) == "build --keep_going\n")
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_does_not_replace_a_dangling_symbolic_bazelrc() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let missingBazelrcPath = temporaryDirectory.appending(component: "missing.bazelrc")
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        try await fileSystem.createSymbolicLink(from: bazelrcPath, to: missingBazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(
+            try FileManager.default.destinationOfSymbolicLink(atPath: bazelrcPath.pathString)
+                == missingBazelrcPath.pathString
+        )
+        #expect(try await !fileSystem.exists(missingBazelrcPath))
     }
 
     @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)

--- a/server/priv/docs/en/guides/features/cache/bazel-cache.md
+++ b/server/priv/docs/en/guides/features/cache/bazel-cache.md
@@ -17,11 +17,13 @@ Create a project with Bazel as its build system, authenticate the Tuist command-
 tuist bazel setup
 ```
 
-Add the generated file to your repository's `.bazelrc`:
+By default, setup adds the generated file to your repository's `.bazelrc`:
 
 ```text
 try-import %workspace%/.bazelrc.tuist
 ```
+
+Pass `--no-add-bazelrc-import` if you want to manage the import yourself. Setup also leaves `.bazelrc` unchanged when it cannot find a Bazel workspace marker, when the file is a symbolic link, or when the file already configures a remote cache or Build Event Service.
 
 The generated configuration points both Bazel's [Remote Execution API](https://github.com/bazelbuild/remote-apis) cache and Build Event Service at Kura. It uses the existing Tuist credential helper for both connections.
 


### PR DESCRIPTION
## What changed

`tuist bazel setup` now activates the generated Tuist configuration automatically by adding `try-import %workspace%/.bazelrc.tuist` to the workspace `.bazelrc` file.

The command also:

- discovers the Bazel workspace root from nested project directories
- preserves user configuration precedence by inserting the Tuist import before trailing imports
- leaves existing remote cache and [Build Event Service](https://bazel.build/remote/bep) configuration untouched
- avoids modifying symbolic links and reports a manual setup instruction when an edit is unsafe
- adds `--no-add-bazelrc-import` for teams that want to manage the import themselves
- scopes credential helpers to the Tuist project and Bazel workspace, and recovers their paths when a checkout moves

## Why

A Bazel project should require one setup command. After setup, developers and automation can use normal `bazel build` and `bazel test` commands while Tuist receives cache traffic and build insights. Requiring a separate manual `.bazelrc` edit made that path incomplete and harder for coding agents to perform reliably.

## Approach

The setup command treats `.bazelrc` as user-owned configuration. It only adds the exact Tuist import when there is a recognized workspace marker and no conflicting remote cache or Build Event Service configuration. Existing import order, line endings, and missing trailing newlines are preserved.

The generated credential helper keeps the project path separate from the directory containing `.bazelrc.tuist`. This supports nested projects and lets the helper rediscover a moved checkout without writing credentials into the repository.

## Generated configuration

The repository's `.bazelrc` receives only the stable import:

```text
try-import %workspace%/.bazelrc.tuist
```

The generated, machine-local `.bazelrc.tuist` contains the configuration that can vary by account, project, endpoint, and checkout:

```text
build --remote_cache=<Tuist endpoint>
build --remote_header=x-tuist-account-handle=<account handle>
build --credential_helper=<endpoint host>=<credential helper path>
build --remote_instance_name=<project handle>

build --bes_backend=<Tuist endpoint>
build --bes_header=x-tuist-account-handle=<account handle>
build --bes_header=x-tuist-project-handle=<project handle>
build --bes_timeout=30s
build --bes_upload_mode=fully_async
```

The Build Event Service lines are omitted when setup runs with `--no-build-insights`. Authentication tokens are not stored in either file. Bazel obtains credentials dynamically from the generated credential helper.

## Impact

New setup runs configure Bazel immediately. Existing projects can rerun `tuist bazel setup` to receive the import. Projects that prefer a manual configuration can use `tuist bazel setup --no-add-bazelrc-import`.

## Validation

- `mise run cli:lint`
- `git diff --check`
- `xcodebuild test -quiet -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing:TuistBazelCommandTests/BazelSetupCommandServiceTests -only-testing:TuistBazelCommandTests/BazelCredentialHelperCommandServiceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- verified `tuist bazel setup --help` includes the automatic import option and its opt-out
- verified `tuist bazel credential-helper --help` includes the Bazel configuration path option

### How to test locally

1. Authenticate with Tuist in a linked Bazel project.
2. Run `tuist bazel setup` from the workspace root or a nested project directory.
3. Confirm `.bazelrc.tuist` is generated at the workspace root and `.bazelrc` contains `try-import %workspace%/.bazelrc.tuist`.
4. Run a normal `bazel build` or `bazel test` command and confirm it uses the configured Tuist services.
5. Run setup with `--no-add-bazelrc-import` and confirm `.bazelrc` remains unchanged.
