### PR TITLE
fix(server): snooze FetchLogsWorker on 404 to keep Sentry clean

### DIFF
--- a/server/lib/tuist/runners/workers/fetch_logs_worker.ex
+++ b/server/lib/tuist/runners/workers/fetch_logs_worker.ex
@@ -38,15 +38,18 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
   ## Retries
 
   GitHub returns 404 for ~30 s after the job completes while it
-  finalises the log archive. We let Oban retry with backoff up to
-  5 attempts before giving up.
+  finalises the log archive. Those first misses are expected, so
+  we snooze the job instead of returning an error: a snooze
+  records no exception and keeps Sentry clean for the log fetches
+  that are genuinely broken. Oban bumps `max_attempts` per snooze,
+  so real retries for other failure modes stay intact.
 
-  A 404 on the last attempt is not raised. Some jobs have no log
-  archive at all — `Tuist.Runners.Dispatch` filters out the known
-  class (a completed job with no steps never ran), but a webhook
-  that predates that filter, or an archive GitHub simply never
-  publishes, would otherwise discard the job with an error nobody
-  can act on.
+  After the snooze budget is exhausted, a 404 is quietly accepted.
+  Some jobs have no log archive at all — `Tuist.Runners.Dispatch`
+  filters out the known class (a completed job with no steps never
+  ran), but a webhook that predates that filter, or an archive
+  GitHub simply never publishes, would otherwise discard the job
+  with an error nobody can act on.
   """
   use Oban.Worker,
     queue: :webhooks,
@@ -60,6 +63,11 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
   alias Tuist.VCS
 
   require Logger
+
+  # Cover GitHub's ~30 s archive-finalisation window with a
+  # handful of quiet snoozes before we give up.
+  @log_not_ready_snoozes 5
+  @log_not_ready_snooze_seconds 15
 
   # Lines per ClickHouse insert. Sized so the in-memory accumulator
   # stays bounded (~hundreds of KB for typical messages) while
@@ -76,8 +84,7 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
           "installation_id" => installation_id,
           "repository" => repository
         },
-        attempt: attempt,
-        max_attempts: max_attempts
+        attempt: attempt
       }) do
     with {:ok, installation} <- fetch_installation(installation_id),
          api_url = VCS.installation_api_url(installation),
@@ -96,10 +103,13 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
 
         :ok
 
-      {:error, :log_not_ready_yet} when attempt >= max_attempts ->
-        # Out of retries and GitHub still has no archive. Nothing here
-        # is actionable, so record it and let the job complete rather
-        # than discarding it with an error.
+      {:error, :log_not_ready_yet} when attempt <= @log_not_ready_snoozes ->
+        {:snooze, @log_not_ready_snooze_seconds}
+
+      {:error, :log_not_ready_yet} ->
+        # Out of the snooze budget and GitHub still has no archive.
+        # Nothing here is actionable, so record it and let the job
+        # complete rather than discarding it with an error.
         Logger.warning("runners: fetch-logs gave up; no log archive published",
           workflow_job_id: workflow_job_id,
           repository: repository
@@ -154,7 +164,8 @@ defmodule Tuist.Runners.Workers.FetchLogsWorker do
         {:ok, state.line_number}
 
       # 404 happens for ~30 s after completion while GitHub finalises
-      # the log archive. Oban's exponential backoff covers this.
+      # the log archive. `perform/1` snoozes on this so the wait
+      # doesn't surface as a Sentry error.
       {:ok, %{status: 404}} ->
         {:error, :log_not_ready_yet}
 

--- a/server/test/tuist/runners/workers/fetch_logs_worker_test.exs
+++ b/server/test/tuist/runners/workers/fetch_logs_worker_test.exs
@@ -185,7 +185,7 @@ defmodule Tuist.Runners.Workers.FetchLogsWorkerTest do
       assert {:snooze, seconds} =
                FetchLogsWorker.perform(%Oban.Job{args: args(9_910_002, account.id), attempt: 1, max_attempts: 5})
 
-      assert is_integer(seconds) and seconds > 0
+      assert seconds > 0
 
       assert JobLogs.list_for_job(9_910_002) == []
       refute_enqueued(worker: ArchiveLogsWorker, args: %{workflow_job_id: 9_910_002})
@@ -205,7 +205,7 @@ defmodule Tuist.Runners.Workers.FetchLogsWorkerTest do
       assert {:snooze, seconds} =
                FetchLogsWorker.perform(%Oban.Job{args: args(9_910_007, account.id), attempt: 4, max_attempts: 8})
 
-      assert is_integer(seconds) and seconds > 0
+      assert seconds > 0
     end
 
     test "gives up quietly after the snooze budget is exhausted (404)" do

--- a/server/test/tuist/runners/workers/fetch_logs_worker_test.exs
+++ b/server/test/tuist/runners/workers/fetch_logs_worker_test.exs
@@ -171,7 +171,7 @@ defmodule Tuist.Runners.Workers.FetchLogsWorkerTest do
       )
     end
 
-    test "returns the error so Oban retries when GitHub hasn't published the log yet (404)" do
+    test "snoozes without noise while the log archive is still being finalised (404)" do
       account = account_fixture()
       enqueue(account, 9_910_002)
       stub_gh_installation_token()
@@ -180,14 +180,35 @@ defmodule Tuist.Runners.Workers.FetchLogsWorkerTest do
         {:ok, %Req.Response{status: 404, body: ""}}
       end)
 
-      assert {:error, :log_not_ready_yet} =
+      # A 404 is the expected response for ~30s after job completion while
+      # GitHub finalises the archive. Snoozing keeps the retry off Sentry.
+      assert {:snooze, seconds} =
                FetchLogsWorker.perform(%Oban.Job{args: args(9_910_002, account.id), attempt: 1, max_attempts: 5})
+
+      assert is_integer(seconds) and seconds > 0
 
       assert JobLogs.list_for_job(9_910_002) == []
       refute_enqueued(worker: ArchiveLogsWorker, args: %{workflow_job_id: 9_910_002})
     end
 
-    test "gives up quietly on the last attempt when GitHub never publishes a log (404)" do
+    test "keeps snoozing on later attempts inside the snooze budget (404)" do
+      account = account_fixture()
+      enqueue(account, 9_910_007)
+      stub_gh_installation_token()
+
+      expect(Req, :get, fn _opts ->
+        {:ok, %Req.Response{status: 404, body: ""}}
+      end)
+
+      # A 4th attempt is still inside the snooze budget covering GitHub's
+      # publication delay, so we keep snoozing rather than surfacing an error.
+      assert {:snooze, seconds} =
+               FetchLogsWorker.perform(%Oban.Job{args: args(9_910_007, account.id), attempt: 4, max_attempts: 8})
+
+      assert is_integer(seconds) and seconds > 0
+    end
+
+    test "gives up quietly after the snooze budget is exhausted (404)" do
       account = account_fixture()
       enqueue(account, 9_910_004)
       stub_gh_installation_token()
@@ -196,10 +217,11 @@ defmodule Tuist.Runners.Workers.FetchLogsWorkerTest do
         {:ok, %Req.Response{status: 404, body: ""}}
       end)
 
-      # A permanent 404 (a job that never ran a step) is not actionable,
-      # so the last attempt completes rather than discarding with an error.
+      # After the snooze budget, a persistent 404 (a job that never ran
+      # a step, an archive GitHub never published) is not actionable, so
+      # the worker completes rather than discarding with an error.
       assert :ok =
-               FetchLogsWorker.perform(%Oban.Job{args: args(9_910_004, account.id), attempt: 5, max_attempts: 5})
+               FetchLogsWorker.perform(%Oban.Job{args: args(9_910_004, account.id), attempt: 6, max_attempts: 10})
 
       assert JobLogs.list_for_job(9_910_004) == []
       refute_enqueued(worker: ArchiveLogsWorker, args: %{workflow_job_id: 9_910_004})


### PR DESCRIPTION
Resolves the [Hive issue](https://hive.tuist.dev/errors/1de26558-a275-53ee-a93d-14ea103e334d) for `Tuist.Runners.Workers.FetchLogsWorker failed with {:error, :log_not_ready_yet}`.

## What changed

- `Tuist.Runners.Workers.FetchLogsWorker` now returns `{:snooze, 15}` on the 404 that GitHub's Actions Logs API returns while the log archive is still being finalised, for the first 5 attempts. On the 6th attempt it quietly completes with `:ok` and a warning log.
- Two module attributes, `@log_not_ready_snoozes` and `@log_not_ready_snooze_seconds`, replace the previous "let Oban's retry budget cover it" behavior.
- The module docstring and the inline comment on the 404 branch of `stream_log_url/6` were rewritten to describe the snooze semantics.
- The pre-existing "log not ready" test now asserts `{:snooze, seconds}` on attempt 1, a new test asserts snooze at attempt 4 (still inside the budget), and the "give up quietly" test now uses attempt 6 with `max_attempts: 10` to represent the state after Oban has bumped `max_attempts` five times.

## Why

The Hive issue captured 8 events in about a minute, all raised at attempts 3 and 4 of a max-5 retry budget. Every event was the expected 404 that GitHub returns for roughly 30 s while it finalises the log archive after a workflow job completes. The condition is self-healing and not actionable, but each `{:error, :log_not_ready_yet}` returned from `perform/1` was surfacing through Oban's Sentry integration as a captured exception, drowning out log-fetch failures that would actually warrant a look.

## Root cause

`perform/1` returned `{:error, :log_not_ready_yet}` on every intermediate attempt and only softened to `:ok` when `attempt >= max_attempts`. Oban's telemetry treats any `{:error, _}` result as a failure and forwards it to Sentry, so a job that ultimately succeeded on its second or third real fetch still produced 2 to 4 Sentry events on the way there.

## Approach

Mirror the pattern already used by `Tuist.Builds.Workers.ProcessBuildWorker` for its `{:error, :object_not_found}` window right after an upload completes:

- Snooze for the first N attempts against the expected transient condition. A snooze re-schedules the job without emitting a telemetry failure, so nothing reaches Sentry.
- Oban's basic engine (`deps/oban/lib/oban/engines/basic.ex` line 263-272) bumps `max_attempts` by 1 per snooze and leaves `attempt` untouched, so the "real" retry budget for other failure modes is preserved.
- After the snooze budget is exhausted the branch falls through to a warning log plus `:ok`, matching the previous "give up quietly" behavior. A persistent 404 means either a job that never ran a step (already filtered by `Tuist.Runners.Dispatch`) or an archive GitHub never publishes; neither is actionable.

The alternative of raising the `max_attempts` on the worker itself was rejected because it would extend the retry budget for genuine failures (network errors, unexpected 5xx, etc.) too, which is the opposite of what we want.

Sizing: 5 snoozes × 15 s = 75 s of quiet coverage, which comfortably brackets GitHub's ~30 s finalisation window while staying well inside the worker's 5-minute uniqueness period.

## Impact

- Sentry stops receiving `Oban.PerformError: FetchLogsWorker failed with {:error, :log_not_ready_yet}` for the expected finalisation window.
- No user-facing behavior change: the same jobs still end up ingesting the same logs on the same timeline. The only observable difference is that a job that used to run 3 or 4 times before succeeding now sees the same underlying `Req.get` calls but with the intermediate results reported as snoozes rather than errors.
- Oban's per-job retry budget for genuine, non-404 failures is unchanged: `max_attempts: 5` still applies before the snooze branch fires, and the snooze branch only reacts to `{:error, :log_not_ready_yet}`.

## Validation

- Wrote the tests first: `snoozes without noise while the log archive is still being finalised (404)` (attempt 1), `keeps snoozing on later attempts inside the snooze budget (404)` (attempt 4), and `gives up quietly after the snooze budget is exhausted (404)` (attempt 6).
- The DataCase ExUnit suite could not run in this worktree because the shared local ClickHouse instance is up without Keeper on port 9181 (a known cross-worktree environmental issue), so verification fell back to `mix compile` (no new warnings), `mix credo lib/tuist/runners/workers/fetch_logs_worker.ex test/tuist/runners/workers/fetch_logs_worker_test.exs` (no issues), and `mix format --check-formatted` on the same two files (clean). CI will exercise the tests against a properly-configured ClickHouse.
- Two adversarial code-review passes (`/code-review xhigh`) converged on zero remaining findings after the first round's stale inline comment was corrected.

## How to test locally

1. From `server/`, run `mix test test/tuist/runners/workers/fetch_logs_worker_test.exs` against a ClickHouse instance that has Keeper enabled on port 9181. All 12 cases should pass.
2. Optional manual verification: enqueue a `FetchLogsWorker` job for a `workflow_job_id` whose Actions log archive is still being finalised by GitHub. The Oban dashboard should show the job cycling through `scheduled` states via snoozes rather than accumulating errors, and Sentry should stay quiet for the finalisation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9HrhPrpVJRfksR3BG2wJc
