### PR TITLE
feat(server): guide agents through Bazel setup

### DIFF
--- a/cli/Sources/TuistBazelCommand/BazelCredentialHelperCommand.swift
+++ b/cli/Sources/TuistBazelCommand/BazelCredentialHelperCommand.swift
@@ -33,10 +33,17 @@ public struct BazelCredentialHelperCommand: AsyncParsableCommand, NooraReadyComm
     )
     var path: String?
 
+    @Option(
+        name: .long,
+        help: "The path to the directory containing the generated .bazelrc.tuist file."
+    )
+    var bazelrcPath: String?
+
     public func run() async throws {
         try await BazelCredentialHelperCommandService().run(
             helperCommand: command,
-            directory: path
+            directory: path,
+            bazelrcDirectory: bazelrcPath
         )
     }
 }

--- a/cli/Sources/TuistBazelCommand/BazelCredentialHelperCommandService.swift
+++ b/cli/Sources/TuistBazelCommand/BazelCredentialHelperCommandService.swift
@@ -62,9 +62,24 @@ public struct BazelCredentialHelperCommandService: BazelCredentialHelperCommandS
         helperCommand: String,
         directory: String?
     ) async throws {
+        try await run(
+            helperCommand: helperCommand,
+            directory: directory,
+            bazelrcDirectory: nil
+        )
+    }
+
+    public func run(
+        helperCommand: String,
+        directory: String?,
+        bazelrcDirectory: String?
+    ) async throws {
         let response = try await credentials(helperCommand: helperCommand, directory: directory)
         try Noora.current.json(response)
-        await refreshBazelrcEndpoint(directory: directory)
+        await refreshBazelrcEndpoint(
+            directory: directory,
+            bazelrcDirectory: bazelrcDirectory
+        )
     }
 
     /// Points `.bazelrc.tuist` at wherever the account's cache is now.
@@ -95,10 +110,16 @@ public struct BazelCredentialHelperCommandService: BazelCredentialHelperCommandS
     /// nothing about where the cache went, and a build should not fail because
     /// its `.bazelrc` could not be tidied. The rewrite lands on the next
     /// build, since this one read the file before we ran.
-    private func refreshBazelrcEndpoint(directory: String?) async {
+    private func refreshBazelrcEndpoint(
+        directory: String?,
+        bazelrcDirectory: String?
+    ) async {
         do {
             let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(directory)
-            let bazelrcPath = directoryPath.appending(component: BazelrcFile.name)
+            let bazelrcDirectoryPath = try await Environment.current.pathRelativeToWorkingDirectory(
+                bazelrcDirectory ?? directory
+            )
+            let bazelrcPath = bazelrcDirectoryPath.appending(component: BazelrcFile.name)
             guard try await fileSystem.exists(bazelrcPath) else { return }
 
             let config = try await configLoader.loadConfig(path: directoryPath)

--- a/cli/Sources/TuistBazelCommand/BazelSetupCommand.swift
+++ b/cli/Sources/TuistBazelCommand/BazelSetupCommand.swift
@@ -27,10 +27,18 @@ public struct BazelSetupCommand: AsyncParsableCommand {
     )
     var buildInsights = true
 
+    @Flag(
+        name: .long,
+        inversion: .prefixedNo,
+        help: "Add the generated .bazelrc.tuist import to .bazelrc."
+    )
+    var addBazelrcImport = true
+
     public func run() async throws {
         try await BazelSetupCommandService().run(
             directory: path,
-            buildInsights: buildInsights
+            buildInsights: buildInsights,
+            addBazelrcImport: addBazelrcImport
         )
     }
 }

--- a/cli/Sources/TuistBazelCommand/BazelSetupCommandService.swift
+++ b/cli/Sources/TuistBazelCommand/BazelSetupCommandService.swift
@@ -1,5 +1,6 @@
 import FileSystem
 import Foundation
+import Noora
 import Path
 import TuistAlert
 import TuistCAS
@@ -9,13 +10,126 @@ import TuistHTTP
 import TuistREAPI
 import TuistServer
 
-public protocol BazelSetupCommandServicing {
-    func run(
-        directory: String?
-    ) async throws
+private enum BazelrcImportResult {
+    case added
+    case alreadyImported
+    case disabled
+    case workspaceNotFound
+    case symbolicLink
+    case managedOptionsPresent
+    case fileUpdateFailed
 }
 
-public struct BazelSetupCommandService: BazelSetupCommandServicing {
+private struct BazelrcImportEditor {
+    private let fileSystem: FileSysteming
+
+    init(fileSystem: FileSysteming) {
+        self.fileSystem = fileSystem
+    }
+
+    func add(to directoryPath: AbsolutePath) async -> BazelrcImportResult {
+        let bazelrcPath = directoryPath.appending(component: ".bazelrc")
+        let importLine = "try-import %workspace%/.bazelrc.tuist"
+
+        do {
+            let existingContent: String
+            if isSymbolicLink(bazelrcPath) {
+                return .symbolicLink
+            } else if try await fileSystem.exists(bazelrcPath) {
+                existingContent = try await fileSystem.readTextFile(at: bazelrcPath)
+            } else {
+                existingContent = ""
+            }
+
+            guard !hasBazelrcImport(existingContent) else { return .alreadyImported }
+            guard !hasManagedBazelOptions(existingContent) else { return .managedOptionsPresent }
+
+            try await fileSystem.writeText(
+                insertingBazelrcImport(importLine, into: existingContent),
+                at: bazelrcPath,
+                encoding: .utf8,
+                options: Set([.overwrite])
+            )
+
+            return .added
+        } catch {
+            return .fileUpdateFailed
+        }
+    }
+
+    private func isSymbolicLink(_ path: AbsolutePath) -> Bool {
+        guard let type = try? FileManager.default.attributesOfItem(atPath: path.pathString)[.type] as? FileAttributeType else {
+            return false
+        }
+        return type == .typeSymbolicLink
+    }
+
+    private func hasBazelrcImport(_ content: String) -> Bool {
+        content
+            .split(whereSeparator: \.isNewline)
+            .contains { line in
+                let tokens = line.split(whereSeparator: \.isWhitespace)
+                guard tokens.count == 2 else { return false }
+                return (tokens[0] == "try-import" || tokens[0] == "import")
+                    && tokens[1] == "%workspace%/.bazelrc.tuist"
+            }
+    }
+
+    private func hasManagedBazelOptions(_ content: String) -> Bool {
+        content
+            .split(whereSeparator: \.isNewline)
+            .contains { line in
+                let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+                guard !trimmedLine.hasPrefix("#") else { return false }
+
+                return trimmedLine.split(whereSeparator: \.isWhitespace).contains { token in
+                    token == "--remote_cache"
+                        || token.hasPrefix("--remote_cache=")
+                        || token == "--bes_backend"
+                        || token.hasPrefix("--bes_backend=")
+                }
+            }
+    }
+
+    private func insertingBazelrcImport(_ importLine: String, into content: String) -> String {
+        let newline = content.contains("\r\n") ? "\r\n" : "\n"
+        let normalizedContent = content
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        var lines = normalizedContent.components(separatedBy: "\n")
+        var insertionIndex = lines.endIndex
+
+        while insertionIndex > lines.startIndex {
+            let line = lines[lines.index(before: insertionIndex)]
+            if line.trimmingCharacters(in: .whitespaces).isEmpty || isBazelrcImportDirective(line) {
+                insertionIndex = lines.index(before: insertionIndex)
+            } else {
+                break
+            }
+        }
+
+        lines.insert(importLine, at: insertionIndex)
+        var result = lines.joined(separator: newline)
+        if !result.hasSuffix(newline) {
+            result.append(contentsOf: newline)
+        }
+        return result
+    }
+
+    private func isBazelrcImportDirective(_ line: String) -> Bool {
+        guard let directive = line.split(whereSeparator: \.isWhitespace).first else { return false }
+        return directive == "try-import" || directive == "import"
+    }
+}
+
+private struct BazelSetupConfiguration {
+    let endpoint: GRPCEndpoint
+    let accountHandle: String
+    let projectHandle: String
+    let fullHandle: String
+}
+
+public struct BazelSetupCommandService {
     private let serverEnvironmentService: ServerEnvironmentServicing
     private let serverAuthenticationController: ServerAuthenticationControlling
     private let cacheURLStore: CacheURLStoring
@@ -43,72 +157,129 @@ public struct BazelSetupCommandService: BazelSetupCommandServicing {
     }
 
     public func run(
-        directory: String?
-    ) async throws {
-        try await run(directory: directory, buildInsights: true)
-    }
-
-    public func run(
         directory: String?,
-        buildInsights: Bool
+        buildInsights: Bool = true,
+        addBazelrcImport shouldAddBazelrcImport: Bool = true
     ) async throws {
         let directoryPath = try await Environment.current.pathRelativeToWorkingDirectory(directory)
+        let canonicalDirectoryPath = try canonicalPath(directoryPath)
+        let setupConfiguration = try await setupConfiguration(directoryPath: directoryPath)
+
+        let bazelWorkspacePath = try await bazelWorkspacePath(startingAt: canonicalDirectoryPath)
+        let bazelrcDirectoryPath = bazelWorkspacePath ?? canonicalDirectoryPath
+        let credentialHelperPath = try await createCredentialHelperScriptIfNeeded(
+            directoryPath: canonicalDirectoryPath,
+            bazelrcDirectoryPath: bazelrcDirectoryPath,
+            fullHandle: setupConfiguration.fullHandle
+        )
+        let bazelrcPath = bazelrcDirectoryPath.appending(component: BazelrcFile.name)
+        let bazelrcContent = BazelrcFile.render(
+            endpoint: setupConfiguration.endpoint,
+            accountHandle: setupConfiguration.accountHandle,
+            projectHandle: setupConfiguration.projectHandle,
+            credentialHelperPath: credentialHelperPath,
+            buildInsights: buildInsights
+        )
+        try await fileSystem.writeText(bazelrcContent, at: bazelrcPath, encoding: .utf8, options: Set([.overwrite]))
+
+        let bazelrcImportResult =
+            if !shouldAddBazelrcImport {
+                BazelrcImportResult.disabled
+            } else if bazelWorkspacePath != nil {
+                await BazelrcImportEditor(fileSystem: fileSystem).add(to: bazelrcDirectoryPath)
+            } else {
+                BazelrcImportResult.workspaceNotFound
+            }
+
+        showSuccess(
+            bazelrcPath: bazelrcPath,
+            bazelrcImportResult: bazelrcImportResult,
+            buildInsights: buildInsights
+        )
+    }
+
+    private func setupConfiguration(directoryPath: AbsolutePath) async throws -> BazelSetupConfiguration {
         let config = try await configLoader.loadConfig(path: directoryPath)
         let serverURL = try serverEnvironmentService.url(configServerURL: config.url)
-
         guard let fullHandle = config.fullHandle else {
             throw BazelSetupCommandServiceError.missingFullHandle
         }
         let (accountHandle, projectHandle) = try fullHandleService.parse(fullHandle)
-
-        guard let token = try await serverAuthenticationController.authenticationToken(serverURL: serverURL)
-        else {
+        guard let token = try await serverAuthenticationController.authenticationToken(serverURL: serverURL) else {
             throw BazelSetupCommandServiceError.notAuthenticated
         }
-
         let cacheURL = try await cacheURLStore.getCacheURL(for: serverURL, accountHandle: accountHandle)
         guard let host = cacheURL.host else {
             throw BazelSetupCommandServiceError.invalidCacheEndpoint(cacheURL.absoluteString)
         }
         let endpoint = GRPCEndpoint(host: host, explicitPort: cacheURL.port, isTLS: cacheURL.scheme != "http")
 
-        // Probe the resolved endpoint before writing the configuration so setup fails when the
-        // cache is unreachable or misbehaving, regardless of whether the URL came from
-        // TUIST_CACHE_ENDPOINT or from server-side endpoint selection. The latter measures
-        // latency and discards unreachable endpoints, but an override short-circuits that path,
-        // so this guarantees the endpoint we hand Bazel actually answers the REAPI handshake.
         try await remoteCacheProbeService.probe(
             endpoint: endpoint,
             accountHandle: accountHandle,
             instanceName: projectHandle,
             token: token.value
         )
-
-        let credentialHelperPath = try await createCredentialHelperScriptIfNeeded()
-
-        let bazelrcPath = directoryPath.appending(component: BazelrcFile.name)
-        let bazelrcContent = BazelrcFile.render(
+        return BazelSetupConfiguration(
             endpoint: endpoint,
             accountHandle: accountHandle,
             projectHandle: projectHandle,
-            credentialHelperPath: credentialHelperPath,
-            buildInsights: buildInsights
+            fullHandle: fullHandle
         )
-        try await fileSystem.writeText(bazelrcContent, at: bazelrcPath, encoding: .utf8, options: Set([.overwrite]))
+    }
 
+    private func showSuccess(
+        bazelrcPath: AbsolutePath,
+        bazelrcImportResult: BazelrcImportResult,
+        buildInsights: Bool
+    ) {
         AlertController.current.success(
             .alert(
                 "Generated \(bazelrcPath.pathString)",
                 takeaways: [
-                    "Add 'try-import %workspace%/.bazelrc.tuist' to your .bazelrc to enable the Tuist remote cache\(buildInsights ? " and invocation insights" : "")",
+                    bazelrcImportTakeaway(
+                        result: bazelrcImportResult,
+                        buildInsights: buildInsights
+                    ),
+                    "Run Bazel normally to use the Tuist remote cache\(buildInsights ? " and record build insights" : "")",
                 ]
             )
         )
     }
 
-    private func createCredentialHelperScriptIfNeeded() async throws -> AbsolutePath {
+    private func bazelrcImportTakeaway(
+        result: BazelrcImportResult,
+        buildInsights: Bool
+    ) -> TerminalText {
+        let capabilities = buildInsights ? "remote cache and build insights" : "remote cache"
+
+        switch result {
+        case .added:
+            return "Added 'try-import %workspace%/.bazelrc.tuist' to your .bazelrc to enable the Tuist \(capabilities)"
+        case .alreadyImported:
+            return "Your .bazelrc already imports .bazelrc.tuist"
+        case .disabled:
+            return "Add 'try-import %workspace%/.bazelrc.tuist' to your .bazelrc to enable the Tuist \(capabilities)"
+        case .workspaceNotFound:
+            return "No Bazel workspace marker was found. Run setup from the workspace or import the generated file manually"
+        case .symbolicLink:
+            return "Your .bazelrc is a symbolic link. Add 'try-import %workspace%/.bazelrc.tuist' to its target to enable the Tuist \(capabilities)"
+        case .managedOptionsPresent:
+            return "Your .bazelrc already configures a remote cache or Build Event Service. Review the generated .bazelrc.tuist before importing it"
+        case .fileUpdateFailed:
+            return "Could not update your .bazelrc. Add 'try-import %workspace%/.bazelrc.tuist' manually to enable the Tuist \(capabilities)"
+        }
+    }
+
+    private func createCredentialHelperScriptIfNeeded(
+        directoryPath: AbsolutePath,
+        bazelrcDirectoryPath: AbsolutePath,
+        fullHandle: String
+    ) async throws -> AbsolutePath {
         let credentialsDirectory = Environment.current.configDirectory.appending(component: "credentials")
-        let scriptPath = credentialsDirectory.appending(component: "tuist-bazel-credential-helper")
+        let helperName =
+            "tuist-bazel-credential-helper-\(fullHandle.replacingOccurrences(of: "/", with: "-"))-\(directoryIdentifier(directoryPath: directoryPath, bazelrcDirectoryPath: bazelrcDirectoryPath))"
+        let scriptPath = credentialsDirectory.appending(component: helperName)
 
         if try await fileSystem.exists(scriptPath) {
             return scriptPath
@@ -118,9 +289,32 @@ public struct BazelSetupCommandService: BazelSetupCommandServicing {
             try await fileSystem.makeDirectory(at: credentialsDirectory)
         }
 
+        let directoryPathArgument = shellSingleQuoted(directoryPath.pathString)
+        let bazelrcDirectoryPathArgument = shellSingleQuoted(bazelrcDirectoryPath.pathString)
+        let relativeDirectoryPathArgument = shellSingleQuoted(directoryPath.relative(to: bazelrcDirectoryPath).pathString)
         let script = """
         #!/bin/sh
-        exec tuist bazel credential-helper "$@"
+        project_path='\(directoryPathArgument)'
+        bazelrc_path='\(bazelrcDirectoryPathArgument)'
+        relative_project_path='\(relativeDirectoryPathArgument)'
+
+        if [ ! -d "$project_path" ] || [ ! -f "$bazelrc_path/.bazelrc.tuist" ]; then
+          workspace_path="$PWD"
+          while [ "$workspace_path" != "/" ] && [ ! -f "$workspace_path/.bazelrc.tuist" ]; do
+            workspace_path=${workspace_path%/*}
+            [ -n "$workspace_path" ] || workspace_path=/
+          done
+          if [ -f "$workspace_path/.bazelrc.tuist" ]; then
+            project_path="$workspace_path/$relative_project_path"
+            bazelrc_path="$workspace_path"
+          fi
+        fi
+
+        if [ -d "$project_path" ] && [ -f "$bazelrc_path/.bazelrc.tuist" ]; then
+          exec tuist bazel credential-helper --path "$project_path" --bazelrc-path "$bazelrc_path" "$@"
+        else
+          exec tuist bazel credential-helper "$@"
+        fi
 
         """
         try await fileSystem.writeText(script, at: scriptPath)
@@ -129,6 +323,44 @@ public struct BazelSetupCommandService: BazelSetupCommandServicing {
             ofItemAtPath: scriptPath.pathString
         )
         return scriptPath
+    }
+
+    private func shellSingleQuoted(_ value: String) -> String {
+        value.replacingOccurrences(of: "'", with: "'\"'\"'")
+    }
+
+    private func directoryIdentifier(
+        directoryPath: AbsolutePath,
+        bazelrcDirectoryPath: AbsolutePath
+    ) -> String {
+        let identity = directoryPath.pathString + "\0" + bazelrcDirectoryPath.pathString
+        let hash = identity.utf8.reduce(UInt64(14_695_981_039_346_656_037)) { hash, byte in
+            (hash ^ UInt64(byte)) &* 1_099_511_628_211
+        }
+        return String(hash, radix: 16)
+    }
+
+    private func canonicalPath(_ path: AbsolutePath) throws -> AbsolutePath {
+        try AbsolutePath(validating: URL(fileURLWithPath: path.pathString).resolvingSymlinksInPath().path)
+    }
+
+    private func bazelWorkspacePath(startingAt directoryPath: AbsolutePath) async throws -> AbsolutePath? {
+        var candidate = directoryPath
+        let markers = ["MODULE.bazel", "REPO.bazel", "WORKSPACE.bazel", "WORKSPACE"]
+
+        while true {
+            for marker in markers where try await fileSystem.exists(candidate.appending(component: marker)) {
+                return candidate
+            }
+
+            if try await fileSystem.exists(candidate.appending(component: ".git")) {
+                return nil
+            }
+
+            let parent = candidate.parentDirectory
+            guard parent != candidate else { return nil }
+            candidate = parent
+        }
     }
 }
 

--- a/cli/Tests/TuistBazelCommandTests/BazelSetupCommandServiceTests.swift
+++ b/cli/Tests/TuistBazelCommandTests/BazelSetupCommandServiceTests.swift
@@ -67,9 +67,18 @@ struct BazelSetupCommandServiceTests {
         )
     }
 
-    private func credentialHelperPath() throws -> AbsolutePath {
-        let environment = try #require(Environment.mocked)
-        return environment.configDirectory.appending(components: ["credentials", "tuist-bazel-credential-helper"])
+    private func credentialHelperPath(from bazelrcContent: String) throws -> AbsolutePath {
+        let prefix = "build --credential_helper="
+        let line = try #require(
+            bazelrcContent.split(whereSeparator: \.isNewline).first { $0.hasPrefix(prefix) }
+        )
+        let assignment = line.dropFirst(prefix.count)
+        let separatorIndex = try #require(assignment.firstIndex(of: "="))
+        return try AbsolutePath(validating: String(assignment[assignment.index(after: separatorIndex)...]))
+    }
+
+    private func canonicalPathString(_ path: AbsolutePath) -> String {
+        URL(fileURLWithPath: path.pathString).resolvingSymlinksInPath().path
     }
 
     @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
@@ -80,15 +89,16 @@ struct BazelSetupCommandServiceTests {
         given(serverAuthenticationController)
             .authenticationToken(serverURL: .any)
             .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
 
         // When
         try await subject.run(directory: temporaryDirectory.pathString)
 
         // Then
-        let scriptPath = try credentialHelperPath()
         let bazelrcContent = try await fileSystem.readTextFile(
             at: temporaryDirectory.appending(component: ".bazelrc.tuist")
         )
+        let scriptPath = try credentialHelperPath(from: bazelrcContent)
         #expect(bazelrcContent.contains("build --remote_cache=grpcs://cache.tuist.dev"))
         #expect(bazelrcContent.contains("build --remote_header=x-tuist-account-handle=my-account"))
         #expect(bazelrcContent.contains("build --credential_helper=cache.tuist.dev=\(scriptPath.pathString)"))
@@ -99,14 +109,16 @@ struct BazelSetupCommandServiceTests {
         #expect(bazelrcContent.contains("build --bes_timeout=30s"))
         #expect(bazelrcContent.contains("build --bes_upload_mode=fully_async"))
 
-        let scriptContent = try await fileSystem.readTextFile(at: scriptPath)
         #expect(
-            scriptContent == """
-            #!/bin/sh
-            exec tuist bazel credential-helper "$@"
-
-            """
+            try await fileSystem.readTextFile(at: temporaryDirectory.appending(component: ".bazelrc"))
+                == "try-import %workspace%/.bazelrc.tuist\n"
         )
+
+        let scriptContent = try await fileSystem.readTextFile(at: scriptPath)
+        #expect(scriptContent.contains("project_path='"))
+        #expect(scriptContent.contains("bazelrc_path='"))
+        #expect(scriptContent.contains("--bazelrc-path \"$bazelrc_path\""))
+        #expect(scriptContent.contains("exec tuist bazel credential-helper \"$@\""))
         #expect(FileManager.default.isExecutableFile(atPath: scriptPath.pathString))
     }
 
@@ -125,10 +137,10 @@ struct BazelSetupCommandServiceTests {
         try await subject.run(directory: temporaryDirectory.pathString)
 
         // Then
-        let scriptPath = try credentialHelperPath()
         let bazelrcContent = try await fileSystem.readTextFile(
             at: temporaryDirectory.appending(component: ".bazelrc.tuist")
         )
+        let scriptPath = try credentialHelperPath(from: bazelrcContent)
         #expect(bazelrcContent.contains("build --remote_cache=grpcs://cache.tuist.dev:8443"))
         #expect(bazelrcContent.contains("build --credential_helper=cache.tuist.dev=\(scriptPath.pathString)"))
         verify(remoteCacheProbeService)
@@ -156,10 +168,10 @@ struct BazelSetupCommandServiceTests {
         try await subject.run(directory: temporaryDirectory.pathString)
 
         // Then
-        let scriptPath = try credentialHelperPath()
         let bazelrcContent = try await fileSystem.readTextFile(
             at: temporaryDirectory.appending(component: ".bazelrc.tuist")
         )
+        let scriptPath = try credentialHelperPath(from: bazelrcContent)
         #expect(bazelrcContent.contains("build --remote_cache=grpc://localhost:5091"))
         #expect(bazelrcContent.contains("build --credential_helper=localhost=\(scriptPath.pathString)"))
         verify(remoteCacheProbeService)
@@ -181,8 +193,11 @@ struct BazelSetupCommandServiceTests {
             .authenticationToken(serverURL: .any)
             .willReturn(.project("token"))
 
-        let scriptPath = try credentialHelperPath()
-        try await fileSystem.makeDirectory(at: scriptPath.parentDirectory)
+        try await subject.run(directory: temporaryDirectory.pathString)
+        let bazelrcContent = try await fileSystem.readTextFile(
+            at: temporaryDirectory.appending(component: ".bazelrc.tuist")
+        )
+        let scriptPath = try credentialHelperPath(from: bazelrcContent)
         try await fileSystem.writeText("#!/bin/sh\n# custom helper\n", at: scriptPath)
 
         // When
@@ -191,6 +206,340 @@ struct BazelSetupCommandServiceTests {
         // Then
         let scriptContent = try await fileSystem.readTextFile(at: scriptPath)
         #expect(scriptContent == "#!/bin/sh\n# custom helper\n")
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_scopes_credential_helpers_to_the_configured_checkout() async throws {
+        // Given
+        let firstDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let secondDirectory = firstDirectory.appending(component: "second-checkout")
+        try await fileSystem.makeDirectory(at: secondDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+
+        // When
+        try await subject.run(directory: firstDirectory.pathString)
+        try await subject.run(directory: secondDirectory.pathString)
+
+        // Then
+        let firstHelperPath = try credentialHelperPath(
+            from: try await fileSystem.readTextFile(at: firstDirectory.appending(component: ".bazelrc.tuist"))
+        )
+        let secondHelperPath = try credentialHelperPath(
+            from: try await fileSystem.readTextFile(at: secondDirectory.appending(component: ".bazelrc.tuist"))
+        )
+        #expect(firstHelperPath != secondHelperPath)
+        let firstHelperContent = try await fileSystem.readTextFile(at: firstHelperPath)
+        let secondHelperContent = try await fileSystem.readTextFile(at: secondHelperPath)
+        #expect(firstHelperContent.contains("project_path='\(canonicalPathString(firstDirectory))'"))
+        #expect(!firstHelperContent.contains(canonicalPathString(secondDirectory)))
+        #expect(secondHelperContent.contains("project_path='\(canonicalPathString(secondDirectory))'"))
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_adds_bazelrc_import_once() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        try await fileSystem.writeText("build --keep_going\n", at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(
+            try await fileSystem.readTextFile(at: bazelrcPath)
+                == "build --keep_going\ntry-import %workspace%/.bazelrc.tuist\n"
+        )
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_does_not_add_bazelrc_import_when_disabled() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        let existingContent = "build --keep_going\n"
+        try await fileSystem.writeText(existingContent, at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString, addBazelrcImport: false)
+
+        // Then
+        #expect(try await fileSystem.readTextFile(at: bazelrcPath) == existingContent)
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_adds_bazelrc_import_after_content_without_a_trailing_newline() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        try await fileSystem.writeText("build --keep_going", at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(
+            try await fileSystem.readTextFile(at: bazelrcPath)
+                == "build --keep_going\ntry-import %workspace%/.bazelrc.tuist\n"
+        )
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_recognizes_an_existing_bazelrc_import_with_flexible_whitespace() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        let existingContent = "import  %workspace%/.bazelrc.tuist\n"
+        try await fileSystem.writeText(existingContent, at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(try await fileSystem.readTextFile(at: bazelrcPath) == existingContent)
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_adds_bazelrc_import_before_trailing_user_imports() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        try await fileSystem.writeText("build --keep_going\r\ntry-import %workspace%/.bazelrc.user\r\n", at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(
+            try await fileSystem.readTextFile(at: bazelrcPath)
+                == "build --keep_going\r\ntry-import %workspace%/.bazelrc.tuist\r\ntry-import %workspace%/.bazelrc.user\r\n"
+        )
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_preserves_existing_remote_configuration() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        let existingContent = "build --remote_cache=grpcs://example.com\n"
+        try await fileSystem.writeText(existingContent, at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(try await fileSystem.readTextFile(at: bazelrcPath) == existingContent)
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_preserves_existing_build_event_service_configuration() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        let existingContent = "build --bes_backend=grpcs://example.com\n"
+        try await fileSystem.writeText(existingContent, at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(try await fileSystem.readTextFile(at: bazelrcPath) == existingContent)
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_ignores_commented_remote_configuration() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        try await fileSystem.writeText("# build --remote_cache=grpcs://example.com\n", at: bazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(
+            try await fileSystem.readTextFile(at: bazelrcPath)
+                == "# build --remote_cache=grpcs://example.com\ntry-import %workspace%/.bazelrc.tuist\n"
+        )
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_writes_bazel_configuration_at_the_workspace_root() async throws {
+        // Given
+        let workspaceDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let nestedDirectory = workspaceDirectory.appending(components: ["sources", "app"])
+        try await fileSystem.makeDirectory(at: nestedDirectory)
+        try await fileSystem.touch(workspaceDirectory.appending(component: "REPO.bazel"))
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+
+        // When
+        try await subject.run(directory: nestedDirectory.pathString)
+
+        // Then
+        #expect(try await fileSystem.exists(workspaceDirectory.appending(component: ".bazelrc.tuist")))
+        #expect(try await fileSystem.exists(workspaceDirectory.appending(component: ".bazelrc")))
+        #expect(try await !fileSystem.exists(nestedDirectory.appending(component: ".bazelrc.tuist")))
+        let bazelrcContent = try await fileSystem.readTextFile(
+            at: workspaceDirectory.appending(component: ".bazelrc.tuist")
+        )
+        let helperPath = try credentialHelperPath(from: bazelrcContent)
+        let helperContent = try await fileSystem.readTextFile(at: helperPath)
+        #expect(helperContent.contains("project_path='\(canonicalPathString(nestedDirectory))'"))
+        #expect(helperContent.contains("bazelrc_path='\(canonicalPathString(workspaceDirectory))'"))
+        #expect(helperContent.contains("--bazelrc-path \"$bazelrc_path\""))
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_creates_a_new_helper_when_the_workspace_root_changes() async throws {
+        // Given
+        let rootDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let projectDirectory = rootDirectory.appending(components: ["apps", "ios"])
+        try await fileSystem.makeDirectory(at: projectDirectory)
+        let nestedWorkspaceMarker = projectDirectory.appending(component: "WORKSPACE")
+        try await fileSystem.touch(nestedWorkspaceMarker)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await subject.run(directory: projectDirectory.pathString)
+        let nestedBazelrcContent = try await fileSystem.readTextFile(
+            at: projectDirectory.appending(component: ".bazelrc.tuist")
+        )
+        let nestedHelperPath = try credentialHelperPath(from: nestedBazelrcContent)
+
+        try await fileSystem.remove(nestedWorkspaceMarker)
+        try await fileSystem.touch(rootDirectory.appending(component: "MODULE.bazel"))
+
+        // When
+        try await subject.run(directory: projectDirectory.pathString)
+
+        // Then
+        let rootBazelrcContent = try await fileSystem.readTextFile(
+            at: rootDirectory.appending(component: ".bazelrc.tuist")
+        )
+        let rootHelperPath = try credentialHelperPath(from: rootBazelrcContent)
+        #expect(rootHelperPath != nestedHelperPath)
+        #expect(
+            try await fileSystem.readTextFile(at: rootHelperPath)
+                .contains("bazelrc_path='\(canonicalPathString(rootDirectory))'")
+        )
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_does_not_discover_a_workspace_above_the_repository_root() async throws {
+        // Given
+        let outerDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let repositoryDirectory = outerDirectory.appending(component: "repository")
+        let nestedDirectory = repositoryDirectory.appending(component: "sources")
+        try await fileSystem.makeDirectory(at: nestedDirectory)
+        try await fileSystem.touch(outerDirectory.appending(component: "WORKSPACE"))
+        try await fileSystem.touch(repositoryDirectory.appending(component: ".git"))
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+
+        // When
+        try await subject.run(directory: nestedDirectory.pathString)
+
+        // Then
+        #expect(try await fileSystem.exists(nestedDirectory.appending(component: ".bazelrc.tuist")))
+        #expect(try await !fileSystem.exists(outerDirectory.appending(component: ".bazelrc.tuist")))
+        #expect(try await !fileSystem.exists(repositoryDirectory.appending(component: ".bazelrc")))
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_does_not_replace_a_symbolic_bazelrc() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let sharedBazelrcPath = temporaryDirectory.appending(component: "shared.bazelrc")
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        try await fileSystem.writeText("build --keep_going\n", at: sharedBazelrcPath)
+        try await fileSystem.createSymbolicLink(from: bazelrcPath, to: sharedBazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(try await fileSystem.resolveSymbolicLink(bazelrcPath) == sharedBazelrcPath)
+        #expect(try await fileSystem.readTextFile(at: sharedBazelrcPath) == "build --keep_going\n")
+    }
+
+    @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)
+    func run_does_not_replace_a_dangling_symbolic_bazelrc() async throws {
+        // Given
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let (subject, serverAuthenticationController, _, _) = makeSubject()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(.project("token"))
+        try await fileSystem.touch(temporaryDirectory.appending(component: "MODULE.bazel"))
+        let missingBazelrcPath = temporaryDirectory.appending(component: "missing.bazelrc")
+        let bazelrcPath = temporaryDirectory.appending(component: ".bazelrc")
+        try await fileSystem.createSymbolicLink(from: bazelrcPath, to: missingBazelrcPath)
+
+        // When
+        try await subject.run(directory: temporaryDirectory.pathString)
+
+        // Then
+        #expect(
+            try FileManager.default.destinationOfSymbolicLink(atPath: bazelrcPath.pathString)
+                == missingBazelrcPath.pathString
+        )
+        #expect(try await !fileSystem.exists(missingBazelrcPath))
     }
 
     @Test(.withMockedEnvironment(), .withMockedDependencies(), .inTemporaryDirectory)

--- a/server/lib/tuist/mcp/AGENTS.md
+++ b/server/lib/tuist/mcp/AGENTS.md
@@ -12,6 +12,7 @@ This directory contains the Tuist [Model Context Protocol (MCP)](https://modelco
 - If the skill workflow changes (steps, heuristics, verification, checklist), update the MCP prompt in the same change.
 - If MCP tools or tool payloads change, update the skill or document intentional divergence.
 - Keep the Gradle integration workflow in `gradle_integration_guide.ex` shared by the `integrate_gradle_project` prompt and `get_gradle_integration_guide` tool. When its plugin version changes, update `Constants.gradlePluginVersion`, the Gradle plugin source example, and the installation guide in the same change.
+- Keep the Bazel integration workflow in `bazel_integration_guide.ex` shared by the `integrate_bazel_project` prompt and `get_bazel_integration_guide` tool. Keep its command and diagnostic-tool names aligned with the command-line implementation and the registered Model Context Protocol tools.
 
 ## Documentation Sync
 

--- a/server/lib/tuist/mcp/bazel_integration_guide.ex
+++ b/server/lib/tuist/mcp/bazel_integration_guide.ex
@@ -1,0 +1,146 @@
+defmodule Tuist.MCP.BazelIntegrationGuide do
+  @moduledoc false
+
+  @server_origin_regex ~r/\Ahttps?:\/\/(?:\[[0-9A-Fa-f:]+\]|[A-Za-z0-9._-]+)(?::\d{1,5})?\/?\z/
+
+  def build(args \\ %{}) do
+    account_handle = Map.get(args, "account_handle")
+    project_handle = Map.get(args, "project_handle")
+
+    project =
+      if account_handle && project_handle,
+        do: "`#{account_handle}/#{project_handle}`",
+        else: "the Tuist project selected during setup"
+
+    with {:ok, server_url} <- server_origin(args) do
+      {:ok, render(project, server_url)}
+    end
+  end
+
+  defp render(project, server_url) do
+    """
+    # Integrate an existing Bazel project with Tuist
+
+    Connect #{project} to the Tuist server at `#{server_url}`. The goal is a normal `bazel build` that uses the Tuist remote cache and publishes build insights without wrapping or decorating the Bazel command.
+
+    ## 1. Discover or create the Tuist project
+
+    1. Call `list_accounts` and `list_projects` to identify an account and reuse a matching Bazel project when one exists.
+    2. If needed, call `create_project` with `build_system=bazel`. Create an organization only when the user explicitly asks for one.
+    3. Keep the full handle returned by the tool. It has the form `ACCOUNT_HANDLE/PROJECT_HANDLE`.
+
+    ## 2. Complete both authentication layers
+
+    [Model Context Protocol](https://modelcontextprotocol.io/) authentication authorizes this agent to call Tuist tools. It is not a credential for Bazel's remote cache or build-event service.
+
+    If the Model Context Protocol connection is unauthenticated, follow the deployment-local `auth.md` document advertised by its `401 Unauthorized` response. Do not invent an email address, password, or token. Before starting a claim, ask the user to confirm the email address for their Tuist account.
+
+    Verify command-line authentication against the same server URL:
+
+    ```sh
+    tuist auth whoami --url "#{server_url}"
+    ```
+
+    If that command is not authenticated, stop and ask the user to run:
+
+    ```sh
+    tuist auth login --url "#{server_url}"
+    ```
+
+    Do not reuse a Model Context Protocol token as a Bazel credential or continue to a verification build before command-line authentication succeeds. Keep the server origin identical everywhere, including the hostname spelling.
+
+    ## 3. Bind the repository and configure Bazel
+
+    First inspect the repository's existing Tuist configuration. When it does not have a `Tuist.swift` or legacy `Tuist/Config.swift` manifest, create or update `tuist.toml` at the repository root so it contains the Tuist project identity and server URL. This format works on both macOS and Linux:
+
+    ```toml
+    project = "ACCOUNT_HANDLE/PROJECT_HANDLE"
+    url = "#{server_url}"
+    ```
+
+    Replace the handle with the project selected in step 1. On macOS, if the repository already has either Swift manifest, preserve it and set `fullHandle` and `url` on its existing `Tuist(...)` value instead of introducing a second source of truth. Linux does not load Swift manifests, so create or update `tuist.toml` there and keep its identity aligned with any tracked Swift manifest. Then run:
+
+    ```sh
+    tuist bazel setup
+    ```
+
+    This writes `.bazelrc.tuist`, installs a credential helper outside the repository, and normally adds `try-import %workspace%/.bazelrc.tuist` to `.bazelrc`. Use `--no-add-bazelrc-import` only when the user explicitly asks to manage the import manually.
+
+    Read the setup takeaway and inspect `.bazelrc` before verification. Confirm that the exact `try-import` line is present and active. Setup can leave `.bazelrc` unchanged when it cannot identify the workspace, the file is a symbolic link, it already contains managed remote-service options, or the write fails. Add the import manually when it is safe. If existing `--remote_cache` or `--bes_backend` options conflict, do not combine configurations silently; explain the conflict and ask the user which service to keep.
+
+    `.bazelrc.tuist` contains a machine-local credential-helper path. It must never be committed. Add it to `.gitignore` when it is not already ignored, and commit only the stable import in `.bazelrc`. Never copy an access token into either file.
+
+    Build insights are enabled by default. Bazel's [Build Event Protocol](https://bazel.build/remote/bep) stream can include command-line arguments, environment values, and command output. If the user does not want to publish build insights, run `tuist bazel setup --no-build-insights` instead.
+
+    ## 4. Prove the integration
+
+    Choose the smallest meaningful existing target. When build insights are enabled, run it normally without `tuist bazel` or any command wrapper, while making this verification upload deterministic:
+
+    ```sh
+    bazel build --bes_upload_mode=wait_for_upload_complete TARGET
+    ```
+
+    The upload flag makes this verification run wait for the build-event upload; normal builds can use the generated default. Run the same target a second time after clearing only Bazel's local outputs when that is safe for the repository. Then inspect `list_bazel_invocations`, `get_bazel_invocation`, and `list_bazel_cache_events`. If the invocation is not visible immediately, poll `list_bazel_invocations` every few seconds for no more than 60 seconds before concluding that ingestion failed. Do not report success until the build succeeds, the invocation appears under the intended project, and the remote-cache observations show the expected reads or writes.
+
+    When the user chose `--no-build-insights`, run `bazel build TARGET` without a build-event upload flag. No invocation is expected in Tuist. Verify only that the build succeeds and `list_bazel_cache_events` shows the expected remote-cache reads or writes. Never re-enable build insights merely because no invocation appears.
+
+    For a failed `bazel build`, use the local Bazel output together with `get_bazel_invocation` for the command status and exit code. The invocation-log tools contain sanitized `test.log` artifacts, not general build output. For a failed `bazel test`, call `list_bazel_invocation_logs`, then use `get_bazel_invocation_log` when a specific test-log chunk needs closer inspection. Inspect the invocation and cache events before reporting the exact target, files changed, configuration endpoint, and cache outcome.
+    """
+  end
+
+  defp server_origin(args) do
+    case Map.fetch(args, "server_url") do
+      :error ->
+        {:ok, Tuist.Environment.app_url()}
+
+      {:ok, nil} ->
+        {:ok, Tuist.Environment.app_url()}
+
+      {:ok, candidate} when is_binary(candidate) ->
+        if String.trim(candidate) == "" do
+          {:ok, Tuist.Environment.app_url()}
+        else
+          parse_server_origin(candidate)
+        end
+
+      {:ok, candidate} ->
+        parse_server_origin(candidate)
+    end
+  end
+
+  defp parse_server_origin(candidate) when is_binary(candidate) do
+    trimmed_candidate = String.trim(candidate)
+
+    case URI.new(trimmed_candidate) do
+      {:ok,
+       %URI{
+         scheme: scheme,
+         host: host,
+         port: port,
+         userinfo: nil,
+         query: nil,
+         fragment: nil,
+         path: path
+       }}
+      when scheme in ["http", "https"] and is_binary(host) and host != "" and
+             path in [nil, "", "/"] ->
+        if Regex.match?(@server_origin_regex, trimmed_candidate) and valid_port?(port) do
+          {:ok, String.trim_trailing(trimmed_candidate, "/")}
+        else
+          invalid_server_origin()
+        end
+
+      _ ->
+        invalid_server_origin()
+    end
+  end
+
+  defp parse_server_origin(_candidate), do: invalid_server_origin()
+
+  defp valid_port?(nil), do: true
+  defp valid_port?(port), do: port in 1..65_535
+
+  defp invalid_server_origin do
+    {:error, "server_url must be an HTTP or HTTPS origin without credentials, a path, query parameters, or a fragment."}
+  end
+end

--- a/server/lib/tuist/mcp/components/prompts/integrate_bazel_project.ex
+++ b/server/lib/tuist/mcp/components/prompts/integrate_bazel_project.ex
@@ -1,0 +1,32 @@
+defmodule Tuist.MCP.Components.Prompts.IntegrateBazelProject do
+  @moduledoc """
+  Guides you through integrating Tuist into an existing Bazel project.
+  """
+
+  use Tuist.MCP.Prompt,
+    name: "integrate_bazel_project",
+    arguments: [
+      %{name: "account_handle", description: "The Tuist account or organization handle."},
+      %{name: "project_handle", description: "The Tuist project handle."},
+      %{name: "server_url", description: "The Tuist HTTP or HTTPS server origin."}
+    ]
+
+  alias Tuist.MCP.BazelIntegrationGuide
+
+  @impl EMCP.Prompt
+  def description, do: "Guides you through integrating Tuist into an existing Bazel project."
+
+  @impl EMCP.Prompt
+  def template(_conn, args) do
+    text =
+      case BazelIntegrationGuide.build(args) do
+        {:ok, guide} ->
+          guide
+
+        {:error, message} ->
+          "The Bazel integration guide could not be generated: #{message} Do not edit files or run authentication commands until the user supplies a valid server origin."
+      end
+
+    %{messages: [Tuist.MCP.Prompt.message(text)]}
+  end
+end

--- a/server/lib/tuist/mcp/components/tools/create_project.ex
+++ b/server/lib/tuist/mcp/components/tools/create_project.ex
@@ -20,7 +20,7 @@ defmodule Tuist.MCP.Components.Tools.CreateProject do
         },
         "build_system" => %{
           "type" => "string",
-          "enum" => ["xcode", "gradle"],
+          "enum" => ["xcode", "gradle", "bazel"],
           "description" => "The project's build system. Defaults to xcode."
         }
       },
@@ -33,7 +33,7 @@ defmodule Tuist.MCP.Components.Tools.CreateProject do
         "name" => %{"type" => "string"},
         "account_handle" => %{"type" => "string"},
         "full_handle" => %{"type" => "string"},
-        "build_system" => %{"type" => "string", "enum" => ["xcode", "gradle"]},
+        "build_system" => %{"type" => "string", "enum" => ["xcode", "gradle", "bazel"]},
         "default_branch" => %{"type" => "string"}
       },
       "required" => [

--- a/server/lib/tuist/mcp/components/tools/get_bazel_integration_guide.ex
+++ b/server/lib/tuist/mcp/components/tools/get_bazel_integration_guide.ex
@@ -1,0 +1,50 @@
+defmodule Tuist.MCP.Components.Tools.GetBazelIntegrationGuide do
+  @moduledoc """
+  Return the complete workflow for connecting an existing Bazel project to Tuist.
+  """
+
+  use Tuist.MCP.Tool,
+    name: "get_bazel_integration_guide",
+    title: "Get Bazel Integration Guide",
+    read_only_hint: true,
+    schema: %{
+      "type" => "object",
+      "properties" => %{
+        "account_handle" => %{
+          "type" => "string",
+          "description" => "The Tuist account handle, when already known."
+        },
+        "project_handle" => %{
+          "type" => "string",
+          "description" => "The Tuist project handle, when already known."
+        },
+        "server_url" => %{
+          "type" => "string",
+          "description" => "The Tuist HTTP or HTTPS server origin. Defaults to the deployment serving this tool."
+        }
+      },
+      "additionalProperties" => false
+    },
+    output_schema: %{
+      "type" => "object",
+      "properties" => %{
+        "guide" => %{"type" => "string"}
+      },
+      "required" => ["guide"],
+      "additionalProperties" => false
+    }
+
+  alias Tuist.MCP.BazelIntegrationGuide
+
+  @impl EMCP.Tool
+  def description do
+    "Return the workflow for connecting an existing Bazel project to Tuist. Use when the user asks to connect, configure, or debug that build. Covers project creation, authentication, setup, and verification."
+  end
+
+  def execute(_conn, args) do
+    case BazelIntegrationGuide.build(args) do
+      {:ok, guide} -> {:ok, %{guide: guide}}
+      {:error, message} -> {:error, message}
+    end
+  end
+end

--- a/server/lib/tuist/mcp/components/tools/get_project.ex
+++ b/server/lib/tuist/mcp/components/tools/get_project.ex
@@ -30,7 +30,7 @@ defmodule Tuist.MCP.Components.Tools.GetProject do
         "full_handle" => %{"type" => "string"},
         "default_branch" => %{"type" => "string"},
         "visibility" => %{"type" => "string", "enum" => ["private", "public"]},
-        "build_system" => %{"type" => "string", "enum" => ["xcode", "gradle"]},
+        "build_system" => %{"type" => "string", "enum" => ["xcode", "gradle", "bazel"]},
         "repository_url" => %{"type" => ["string", "null"]}
       },
       "required" => ["id", "full_handle", "default_branch", "visibility", "build_system", "repository_url"],

--- a/server/lib/tuist/mcp/components/tools/list_projects.ex
+++ b/server/lib/tuist/mcp/components/tools/list_projects.ex
@@ -23,7 +23,7 @@ defmodule Tuist.MCP.Components.Tools.ListProjects do
               "name" => %{"type" => "string"},
               "account_handle" => %{"type" => "string"},
               "full_handle" => %{"type" => "string"},
-              "build_system" => %{"type" => "string", "enum" => ["xcode", "gradle"]},
+              "build_system" => %{"type" => "string", "enum" => ["xcode", "gradle", "bazel"]},
               "default_branch" => %{"type" => "string"}
             },
             "required" => [

--- a/server/lib/tuist/mcp/server.ex
+++ b/server/lib/tuist/mcp/server.ex
@@ -19,6 +19,7 @@ defmodule Tuist.MCP.Server do
 
   @tools [
     Tools.GetGradleIntegrationGuide,
+    Tools.GetBazelIntegrationGuide,
     Tools.ListAccounts,
     Tools.GetOrganization,
     Tools.ListAccountTokens,
@@ -97,6 +98,7 @@ defmodule Tuist.MCP.Server do
     Prompts.CompareCacheRuns,
     Prompts.AnalyzeSelectiveTesting,
     Prompts.IntegrateGradleProject,
+    Prompts.IntegrateBazelProject,
     Prompts.IntegrateXcodeProject
   ]
 
@@ -109,13 +111,13 @@ defmodule Tuist.MCP.Server do
   """
 
   @agent_workflow_instructions """
-  If this server is unauthenticated, fetch the `auth_md` URL from the 401 response. If only the discovery documents are available, read `agent_auth.skill` from the authorization-server metadata. Follow that deployment-local document through registration, identity-assertion exchange, and claim polling before falling back to browser Open Authorization. Never invent credentials. Prefer anonymous registration when no trusted provider assertion is available. Before sending a service-authenticated email or starting an anonymous claim, explicitly ask the user to confirm the email address for their Tuist account; do not derive it from a provider profile, Git configuration, environment variables, or session metadata. During a claim, show the verification link and six-digit code together, and tell the user to enter the code on the Tuist page rather than sending it back to the agent. The `get_gradle_integration_guide` tool provides the Gradle and Android integration workflow. Use `list_accounts` when an account handle is unknown. Model Context Protocol authentication only authorizes Tuist tools; Gradle requires separate `tuist auth whoami --url` authentication. Never continue a verification build after that check fails. Verify integrations through Tuist read-back tools before reporting success.
+  If this server is unauthenticated, fetch the `auth_md` URL from the 401 response. If only the discovery documents are available, read `agent_auth.skill` from the authorization-server metadata. Follow that deployment-local document through registration, identity-assertion exchange, and claim polling before falling back to browser Open Authorization. Never invent credentials. Prefer anonymous registration when no trusted provider assertion is available. Before sending a service-authenticated email or starting an anonymous claim, explicitly ask the user to confirm the email address for their Tuist account; do not derive it from a provider profile, Git configuration, environment variables, or session metadata. During a claim, show the verification link and six-digit code together, and tell the user to enter the code on the Tuist page rather than sending it back to the agent. The `get_gradle_integration_guide` and `get_bazel_integration_guide` tools provide the Gradle, Android, and Bazel integration workflows. Use `list_accounts` when an account handle is unknown. Model Context Protocol authentication only authorizes Tuist tools; Gradle and Bazel require separate `tuist auth whoami --url` authentication. Never continue a verification build after that check fails. Verify integrations through Tuist read-back tools before reporting success.
   """
 
   def server do
     EMCP.Server.new(
       name: "tuist",
-      version: "1.25.0",
+      version: "1.26.0",
       title: "Tuist",
       description: "Tuist project setup, build, cache, and test insights.",
       instructions: instructions(),

--- a/server/priv/docs/en/guides/features/agentic-coding/mcp.md
+++ b/server/priv/docs/en/guides/features/agentic-coding/mcp.md
@@ -171,9 +171,9 @@ Open **Agent panel → Settings → Add Custom Server**, then set:
 
 If your agent supports `auth.md`, it can start anonymously without opening a browser. A trusted provider identity can also complete without a browser when the provider identity is already linked. For service-authenticated email, anonymous claiming, or a first provider link, the agent shows you a Tuist verification link and six-digit code. Open the link, sign in, and enter the agent's code on the Tuist page. Never send the code back to the agent. Tuist's authorization-server metadata points directly to the deployment's own `/auth.md`, which contains the exact request and polling shapes.
 
-## Gradle authentication uses two credentials
+## Build-system integrations use two credentials
 
-The credential used for Model Context Protocol tools does not authenticate the Gradle plugin. Before an agent edits or verifies a Gradle integration, it should run:
+The credential used for Model Context Protocol tools does not authenticate the Gradle plugin or Bazel's remote services. Before an agent edits or verifies a Gradle or Bazel integration, it should run:
 
 ```bash
 tuist auth whoami --url https://tuist.dev
@@ -288,6 +288,7 @@ Webhook tools use the same administrator-only permission as the dashboard. Deliv
 
 | Tool | Description | Required parameters |
 |------|-------------|---------------------|
+| `get_bazel_integration_guide` | Return the authentication, project setup, Bazel configuration, and verification workflow. | None |
 | `list_bazel_invocations` | List completed [Bazel Build Event Protocol](https://bazel.build/remote/bep) invocations and their correlated remote-cache totals for a project. | `account_handle`, `project_handle` |
 | `get_bazel_invocation` | Get one completed Bazel invocation and its correlated remote-cache totals. | `account_handle`, `project_handle`, `invocation_id` |
 | `list_bazel_invocation_logs` | List sanitized test logs captured for a Bazel invocation in execution order. | `account_handle`, `project_handle`, `invocation_id` |
@@ -364,10 +365,11 @@ Webhook tools use the same administrator-only permission as the dashboard. Deliv
 | `compare_generations` | Guides you through comparing two generation runs to identify performance regressions and module cache changes. |
 | `compare_cache_runs` | Guides you through comparing two cache runs to identify cache effectiveness changes and target-level regressions. |
 | `integrate_gradle_project` | Guides you through integrating Tuist into an existing Gradle project. It includes separate tool and Gradle authentication, account discovery, project creation, remote cache policy, build insights, and read-back verification. |
+| `integrate_bazel_project` | Guides you through creating or selecting a Bazel project, authenticating the command line, configuring the remote cache and build insights, and verifying the integration through Tuist build data. |
 | `integrate_xcode_project` | Guides you through integrating Tuist into an existing Xcode project. Supports Xcode cache, build insights, test insights, and test sharding. |
 | `ask_tuist` | Answers a Tuist question using public material for context and focused implementation and test evidence as the source of truth for current behavior. It requires a `question` and cites revision-pinned evidence. |
 
-Project-data prompts accept `account_handle` and `project_handle` to scope the investigation to a specific project. The comparison prompts also accept `base` and `head` arguments to specify the two items to compare (by ID, dashboard URL, or branch name). `ask_tuist` accepts a `question` instead of project parameters. `integrate_gradle_project` also accepts `features`, a comma-separated list of Gradle integrations to apply: `remote_cache`, `build_insights`, `test_insights`, `flaky_tests`, and `test_sharding`. `integrate_xcode_project` accepts `features` with `xcode_cache`, `build_insights`, `test_insights`, and `test_sharding`.
+Project-data prompts accept `account_handle` and `project_handle` to scope the investigation to a specific project. The comparison prompts also accept `base` and `head` arguments to specify the two items to compare (by ID, dashboard URL, or branch name). `ask_tuist` accepts a `question` instead of project parameters. `integrate_gradle_project` also accepts `features`, a comma-separated list of Gradle integrations to apply: `remote_cache`, `build_insights`, `test_insights`, `flaky_tests`, and `test_sharding`. `integrate_bazel_project` accepts an optional `server_url` for self-hosted or local installations. `integrate_xcode_project` accepts `features` with `xcode_cache`, `build_insights`, `test_insights`, and `test_sharding`.
 
 #### Gradle integration prompt features
 

--- a/server/priv/docs/en/guides/features/cache/bazel-cache.md
+++ b/server/priv/docs/en/guides/features/cache/bazel-cache.md
@@ -17,11 +17,13 @@ Create a project with Bazel as its build system, authenticate the Tuist command-
 tuist bazel setup
 ```
 
-Add the generated file to your repository's `.bazelrc`:
+By default, setup adds the generated file to your repository's `.bazelrc`:
 
 ```text
 try-import %workspace%/.bazelrc.tuist
 ```
+
+Pass `--no-add-bazelrc-import` if you want to manage the import yourself. Setup also leaves `.bazelrc` unchanged when it cannot find a Bazel workspace marker, when the file is a symbolic link, or when the file already configures a remote cache or Build Event Service.
 
 The generated configuration points both Bazel's [Remote Execution API](https://github.com/bazelbuild/remote-apis) cache and Build Event Service at Kura. It uses the existing Tuist credential helper for both connections.
 

--- a/server/test/tuist/mcp/components/prompts/prompts_test.exs
+++ b/server/test/tuist/mcp/components/prompts/prompts_test.exs
@@ -10,6 +10,7 @@ defmodule Tuist.MCP.Components.Prompts.PromptsTest do
   alias Tuist.MCP.Components.Prompts.CompareTestCase
   alias Tuist.MCP.Components.Prompts.CompareTestRuns
   alias Tuist.MCP.Components.Prompts.FixFlakyTest
+  alias Tuist.MCP.Components.Prompts.IntegrateBazelProject
   alias Tuist.MCP.Components.Prompts.IntegrateGradleProject
   alias Tuist.MCP.Components.Prompts.IntegrateXcodeProject
   alias Tuist.Projects
@@ -200,6 +201,43 @@ defmodule Tuist.MCP.Components.Prompts.PromptsTest do
       assert text =~ "CI=1 ./gradlew clean TASK"
       assert text =~ "list_gradle_build_tasks"
       assert text =~ "remote_cache,test_sharding"
+    end
+  end
+
+  describe "integrate_bazel_project" do
+    test "returns prompt messages" do
+      result =
+        IntegrateBazelProject.template(nil, %{
+          "account_handle" => "acme",
+          "project_handle" => "bazel",
+          "server_url" => "https://tuist.dev"
+        })
+
+      assert %{messages: [message]} = result
+      text = message.content.text
+      assert text =~ "Integrate an existing Bazel project with Tuist"
+      assert text =~ "`acme/bazel`"
+      assert text =~ "create_project"
+      assert text =~ "build_system=bazel"
+      assert text =~ "tuist.toml"
+      assert text =~ "tuist bazel setup"
+      assert text =~ "list_bazel_invocations"
+      assert text =~ "sanitized `test.log` artifacts"
+    end
+
+    test "rejects an unsafe server origin before rendering commands" do
+      result =
+        IntegrateBazelProject.template(nil, %{
+          "server_url" => "https://attacker.example;touch"
+        })
+
+      assert %{messages: [message]} = result
+      text = message.content.text
+
+      assert text =~ "could not be generated"
+      assert text =~ "Do not edit files or run authentication commands"
+      refute text =~ "attacker.example"
+      refute text =~ ";touch"
     end
   end
 

--- a/server/test/tuist/mcp/components/tools/create_project_test.exs
+++ b/server/test/tuist/mcp/components/tools/create_project_test.exs
@@ -31,6 +31,26 @@ defmodule Tuist.MCP.Components.Tools.CreateProjectTest do
       assert full_handle == "#{user.account.name}/#{project_handle}"
     end
 
+    test "creates a Bazel project" do
+      user = AccountsFixtures.user_fixture()
+      project_handle = "mcp-bazel-project-#{TuistTestSupport.Utilities.unique_integer()}"
+
+      result =
+        CreateProject.call(%Plug.Conn{assigns: %{current_user: user}}, %{
+          "account_handle" => user.account.name,
+          "project_handle" => project_handle,
+          "build_system" => "bazel"
+        })
+
+      assert %{"content" => [%{"type" => "text", "text" => text}]} = result
+      full_handle = "#{user.account.name}/#{project_handle}"
+
+      assert %{
+               "build_system" => "bazel",
+               "full_handle" => ^full_handle
+             } = JSON.decode!(text)
+    end
+
     test "returns project changeset errors" do
       user = AccountsFixtures.user_fixture()
       project_handle = "mcp-project-#{TuistTestSupport.Utilities.unique_integer()}"

--- a/server/test/tuist/mcp/components/tools/get_bazel_integration_guide_test.exs
+++ b/server/test/tuist/mcp/components/tools/get_bazel_integration_guide_test.exs
@@ -1,0 +1,73 @@
+defmodule Tuist.MCP.Components.Tools.GetBazelIntegrationGuideTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+
+  alias Tuist.MCP.BazelIntegrationGuide
+  alias Tuist.MCP.Components.Tools.GetBazelIntegrationGuide
+
+  describe "get_bazel_integration_guide" do
+    test "returns a local-server workflow with authentication and cache verification" do
+      result =
+        GetBazelIntegrationGuide.call(%Plug.Conn{}, %{
+          "account_handle" => "acme",
+          "project_handle" => "bazel",
+          "server_url" => "http://localhost:8080"
+        })
+
+      assert %{"guide" => guide} = result["structuredContent"]
+      assert guide =~ "`acme/bazel`"
+      assert guide =~ "list_accounts"
+      assert guide =~ "create_project"
+      assert guide =~ "build_system=bazel"
+      assert guide =~ ~s{tuist auth whoami --url "http://localhost:8080"}
+      assert guide =~ ~s{tuist auth login --url "http://localhost:8080"}
+      assert guide =~ ~s{project = "ACCOUNT_HANDLE/PROJECT_HANDLE"}
+      assert guide =~ ~s{url = "http://localhost:8080"}
+      assert guide =~ "Tuist/Config.swift"
+      assert guide =~ "try-import %workspace%/.bazelrc.tuist"
+      assert guide =~ "Confirm that the exact `try-import` line is present and active"
+      assert guide =~ "existing `--remote_cache` or `--bes_backend` options conflict"
+      assert guide =~ ".bazelrc.tuist` contains a machine-local credential-helper path"
+      assert guide =~ "must never be committed"
+      assert guide =~ "--no-build-insights"
+      assert guide =~ "bazel build --bes_upload_mode=wait_for_upload_complete TARGET"
+      assert guide =~ "no more than 60 seconds"
+      assert guide =~ "For a failed `bazel build`"
+      assert guide =~ "For a failed `bazel test`"
+      assert guide =~ "list_bazel_invocation_logs"
+      assert guide =~ "get_bazel_invocation_log"
+      assert guide =~ "When the user chose `--no-build-insights`"
+      assert guide =~ "No invocation is expected in Tuist"
+    end
+
+    test "defaults to the deployment serving the tool" do
+      result = GetBazelIntegrationGuide.call(%Plug.Conn{}, %{})
+
+      assert result["structuredContent"]["guide"] =~ ~s{tuist auth whoami --url "http://localhost:8080"}
+    end
+
+    test "treats a blank server URL as omitted" do
+      result = GetBazelIntegrationGuide.call(%Plug.Conn{}, %{"server_url" => "  "})
+
+      assert result["structuredContent"]["guide"] =~ ~s{tuist auth whoami --url "http://localhost:8080"}
+    end
+
+    test "rejects an invalid server URL" do
+      result =
+        GetBazelIntegrationGuide.call(%Plug.Conn{}, %{
+          "server_url" => "https://attacker.example;touch"
+        })
+
+      assert %{"isError" => true, "content" => [%{"text" => message}]} = result
+      assert message =~ "server_url must be an HTTP or HTTPS origin"
+      refute message =~ "attacker.example"
+    end
+
+    test "trims a valid server origin and quotes IPv6 origins in shell commands" do
+      assert {:ok, guide} =
+               BazelIntegrationGuide.build(%{"server_url" => "  http://[::1]:8080/  "})
+
+      assert guide =~ ~s{tuist auth whoami --url "http://[::1]:8080"}
+      assert guide =~ ~s{url = "http://[::1]:8080"}
+    end
+  end
+end

--- a/server/test/tuist/mcp/components/tools/project_and_automation_alert_tools_test.exs
+++ b/server/test/tuist/mcp/components/tools/project_and_automation_alert_tools_test.exs
@@ -40,6 +40,28 @@ defmodule Tuist.MCP.Components.Tools.ProjectAndAutomationAlertToolsTest do
                "visibility" => "private"
              }
     end
+
+    test "returns a Bazel project with schema-valid structured content" do
+      account = %{id: 1, name: "acme"}
+
+      project = %{
+        id: 2,
+        account: account,
+        name: "app",
+        default_branch: "main",
+        visibility: :private,
+        build_system: :bazel
+      }
+
+      stub(Projects, :get_project_by_account_and_project_handles, fn "acme", "app" -> project end)
+      stub(Tuist.Authorization, :authorize, fn :project_read, :subject, ^project -> :ok end)
+      stub(Projects, :get_repository_url, fn ^project -> "https://github.com/acme/app" end)
+
+      conn = %Plug.Conn{assigns: %{current_subject: :subject}}
+
+      assert %{"structuredContent" => %{"build_system" => "bazel"}} =
+               GetProject.call(conn, %{"account_handle" => "acme", "project_handle" => "app"})
+    end
   end
 
   describe "list_automation_alerts" do

--- a/server/test/tuist/mcp/server_test.exs
+++ b/server/test/tuist/mcp/server_test.exs
@@ -6,6 +6,7 @@ defmodule Tuist.MCP.ServerTest do
   alias Tuist.MCP.Components.Tools.AddOrganizationMember
   alias Tuist.MCP.Components.Tools.CreateOrganization
   alias Tuist.MCP.Components.Tools.CreateProject
+  alias Tuist.MCP.Components.Tools.GetBazelIntegrationGuide
   alias Tuist.MCP.Components.Tools.GetGradleIntegrationGuide
   alias Tuist.MCP.Components.Tools.UpdateTestCase
   alias Tuist.MCP.Server
@@ -18,6 +19,7 @@ defmodule Tuist.MCP.ServerTest do
       tool_names = server.tools |> Map.keys() |> Enum.sort()
 
       assert "get_gradle_integration_guide" in tool_names
+      assert "get_bazel_integration_guide" in tool_names
       assert "list_accounts" in tool_names
       assert "get_organization" in tool_names
       assert "list_account_tokens" in tool_names
@@ -76,14 +78,16 @@ defmodule Tuist.MCP.ServerTest do
       assert "list_previews" in tool_names
       assert "get_preview" in tool_names
       assert "get_latest_preview" in tool_names
-      assert server.version == "1.25.0"
+      assert server.version == "1.26.0"
       assert server.instructions =~ "agent_auth.skill"
       assert server.instructions =~ "identity-assertion exchange"
       assert server.instructions =~ "enter the code on the Tuist page"
       assert server.instructions =~ "explicitly ask the user to confirm the email address"
 
       assert server.instructions =~
-               "get_gradle_integration_guide` tool provides the Gradle and Android integration workflow"
+               "The `get_gradle_integration_guide` and `get_bazel_integration_guide` tools provide the Gradle, Android, and Bazel integration workflows"
+
+      assert server.instructions =~ "Gradle and Bazel require separate `tuist auth whoami --url` authentication"
     end
 
     test "offers search_tuist only on the Tuist-hosted installation" do
@@ -152,6 +156,7 @@ defmodule Tuist.MCP.ServerTest do
       assert CreateOrganization.annotations()[:readOnlyHint] == false
       assert CreateProject.annotations()[:readOnlyHint] == false
       assert GetGradleIntegrationGuide.annotations()[:readOnlyHint] == true
+      assert GetBazelIntegrationGuide.annotations()[:readOnlyHint] == true
       assert AddOrganizationMember.annotations()[:readOnlyHint] == false
       assert AddOrganizationMember.annotations()[:destructiveHint] == true
     end
@@ -169,6 +174,7 @@ defmodule Tuist.MCP.ServerTest do
       assert "compare_generations" in prompt_names
       assert "compare_cache_runs" in prompt_names
       assert "integrate_gradle_project" in prompt_names
+      assert "integrate_bazel_project" in prompt_names
       assert "integrate_xcode_project" in prompt_names
     end
 


### PR DESCRIPTION
## What changed

This adds a shared Bazel integration guide to Tuist's [Model Context Protocol](https://modelcontextprotocol.io/) server and exposes it through both a tool and a prompt. The workflow lets a coding agent discover or create a Bazel project, establish command-line authentication, run `tuist bazel setup`, and verify the integration using Tuist's Bazel invocation and cache data.

The project creation, project listing, and project detail tool schemas now include Bazel consistently. The public agentic-coding guide documents the new tool, prompt, and separate authentication boundary.

This pull request is stacked on #12882, which introduces the `tuist bazel setup` behavior used by the guide.

## Why

Connecting an existing Bazel repository to Tuist should be possible from one prompt. A coding agent needs more than the setup command name to do that safely: it needs to select the right Tuist project, authenticate the command line against the same deployment, handle existing repository configuration, preserve the user's build-insights choice, and prove that the resulting build data reaches Tuist.

Without a source-of-truth workflow, agents can confuse Model Context Protocol authentication with Bazel authentication, commit machine-specific configuration, silently override an existing remote service, or report success before the integration is observable.

## Approach

The prompt and tool render one shared guide so their behavior cannot drift. The guide validates an explicitly supplied server origin before placing it in shell commands, treats an omitted or blank origin as the current deployment, and refuses origins containing credentials, paths, query parameters, or fragments.

The generated Bazel configuration is described explicitly:

- `.bazelrc` receives one stable, repository-safe line: `try-import %workspace%/.bazelrc.tuist`.
- `.bazelrc.tuist` is machine-specific and must be ignored by Git. It configures the remote cache endpoint, account header, project remote-instance name, and installed credential-helper path.
- With build insights enabled, `.bazelrc.tuist` also configures the Build Event Service endpoint, account and project headers, a 30-second upload timeout, and fully asynchronous uploads.
- Neither file contains a Tuist access token. The credential helper obtains credentials outside the repository.

The guide checks whether setup actually added the import, stops on conflicting existing remote-cache or Build Event Service flags, and distinguishes verification with build insights enabled from the `--no-build-insights` path. Test failures are directed to the sanitized `test.log` tools; general build failures stay with local Bazel output and invocation metadata.

## Impact

Coding agents can now take an existing Bazel repository from zero to a verified Tuist integration without wrapping normal `bazel build` or `bazel test` commands. The workflow preserves explicit user choices and avoids checking credentials or machine-local paths into source control.

There are no database migrations, new stored customer data, or user-interface changes in this slice.

## Validation

- `TUIST_SERVER_CLICKHOUSE_HTTP_PORT=49223 TUIST_SERVER_TEST_CLICKHOUSE_DB=tuist_test_476 TUIST_SERVER_TEST_POSTGRES_DB=tuist_test_476 mix test test/tuist/mcp/components/prompts/prompts_test.exs test/tuist/mcp/components/tools/create_project_test.exs test/tuist/mcp/components/tools/get_bazel_integration_guide_test.exs test/tuist/mcp/components/tools/project_and_automation_alert_tools_test.exs test/tuist/mcp/server_test.exs` (37 tests passed)
- `mix credo --strict` for all 12 changed Elixir source and test files
- `git diff --check`
- Three-pass Claude Opus adversarial review at extra-high effort, with all actionable findings addressed and a clean closure pass
