### PR TITLE
feat(cli): support per-target Build For settings in schemes

### DIFF
--- a/cli/Sources/ProjectDescription/BuildAction.swift
+++ b/cli/Sources/ProjectDescription/BuildAction.swift
@@ -4,6 +4,8 @@
 public struct BuildAction: Equatable, Codable, Sendable {
     /// A list of targets to build, which are defined in the project.
     public var targets: [TargetReference]
+    /// The build purposes enabled for each target. Targets absent from this dictionary are built for all purposes.
+    public var buildFor: [TargetReference: Set<BuildActionTarget.BuildFor>]
     /// A list of actions that are executed before starting the build process.
     public var preActions: [ExecutionAction]
     /// A list of actions that are executed after the build process.
@@ -34,11 +36,61 @@ public struct BuildAction: Equatable, Codable, Sendable {
     ) -> BuildAction {
         BuildAction(
             targets: targets,
+            buildFor: [:],
             preActions: preActions,
             postActions: postActions,
             buildOrder: buildOrder,
             runPostActionsOnFailure: runPostActionsOnFailure,
             findImplicitDependencies: findImplicitDependencies
         )
+    }
+
+    /// Returns a build action with independently configurable build purposes for each target.
+    public static func buildAction(
+        buildActionTargets: [BuildActionTarget],
+        preActions: [ExecutionAction] = [],
+        postActions: [ExecutionAction] = [],
+        buildOrder: BuildOrder = .dependency,
+        runPostActionsOnFailure: Bool = false,
+        findImplicitDependencies: Bool = true
+    ) -> BuildAction {
+        BuildAction(
+            targets: buildActionTargets.map(\.target),
+            buildFor: Dictionary(uniqueKeysWithValues: buildActionTargets.map { ($0.target, $0.buildFor) }),
+            preActions: preActions,
+            postActions: postActions,
+            buildOrder: buildOrder,
+            runPostActionsOnFailure: runPostActionsOnFailure,
+            findImplicitDependencies: findImplicitDependencies
+        )
+    }
+}
+
+/// A target in a scheme's build action and the purposes for which Xcode should build it.
+public struct BuildActionTarget: Equatable, Codable, Sendable {
+    public enum BuildFor: String, Codable, CaseIterable, Sendable {
+        case analyzing
+        case archiving
+        case profiling
+        case running
+        case testing
+    }
+
+    public var target: TargetReference
+    public var buildFor: Set<BuildFor>
+
+    public static func target(
+        _ name: String,
+        buildFor: Set<BuildFor> = Set(BuildFor.allCases)
+    ) -> BuildActionTarget {
+        .init(target: .target(name), buildFor: buildFor)
+    }
+
+    public static func project(
+        path: Path,
+        target: String,
+        buildFor: Set<BuildFor> = Set(BuildFor.allCases)
+    ) -> BuildActionTarget {
+        .init(target: .project(path: path, target: target), buildFor: buildFor)
     }
 }

--- a/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
+++ b/cli/Sources/TuistGenerator/Generator/SchemeDescriptorsGenerator.swift
@@ -244,10 +244,6 @@ struct SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
     ) throws -> XCScheme.BuildAction? {
         guard let buildAction = scheme.buildAction else { return nil }
 
-        let buildFor: [XCScheme.BuildAction.Entry.BuildFor] = [
-            .analyzing, .archiving, .profiling, .running, .testing,
-        ]
-
         var entries: [XCScheme.BuildAction.Entry] = []
         var preActions: [XCScheme.ExecutionAction] = []
         var postActions: [XCScheme.ExecutionAction] = []
@@ -266,6 +262,15 @@ struct SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             else {
                 continue
             }
+            let buildFor: [XCScheme.BuildAction.Entry.BuildFor]
+            if let selectedBuildForOptions = buildAction.buildFor[buildActionTarget] {
+                buildFor = BuildAction.BuildFor.allCases
+                    .filter(selectedBuildForOptions.contains)
+                    .map(\.xcodeProjBuildFor)
+            } else {
+                buildFor = BuildAction.BuildFor.allCases.map(\.xcodeProjBuildFor)
+            }
+
             entries.append(
                 XCScheme.BuildAction.Entry(
                     buildableReference: buildableReference, buildFor: buildFor
@@ -1173,6 +1178,23 @@ struct SchemeDescriptorsGenerator: SchemeDescriptorsGenerating {
             return true
         default:
             return nil
+        }
+    }
+}
+
+private extension BuildAction.BuildFor {
+    var xcodeProjBuildFor: XCScheme.BuildAction.Entry.BuildFor {
+        switch self {
+        case .analyzing:
+            return .analyzing
+        case .archiving:
+            return .archiving
+        case .profiling:
+            return .profiling
+        case .running:
+            return .running
+        case .testing:
+            return .testing
         }
     }
 }

--- a/cli/Sources/TuistLoader/Models+ManifestMappers/BuildAction+ManifestMapper.swift
+++ b/cli/Sources/TuistLoader/Models+ManifestMappers/BuildAction+ManifestMapper.swift
@@ -27,13 +27,54 @@ extension XcodeGraph.BuildAction {
                 name: $0.targetName
             )
         }
+        let buildFor = try mapBuildFor(
+            manifest.buildFor,
+            generatorPaths: generatorPaths
+        )
         return XcodeGraph.BuildAction(
             targets: targets,
+            buildFor: buildFor,
             preActions: preActions,
             postActions: postActions,
             parallelizeBuild: parallelizeBuild,
             runPostActionsOnFailure: manifest.runPostActionsOnFailure,
             findImplicitDependencies: manifest.findImplicitDependencies
         )
+    }
+}
+
+private extension XcodeGraph.BuildAction {
+    static func mapBuildFor(
+        _ buildFor: [ProjectDescription.TargetReference: Set<ProjectDescription.BuildActionTarget.BuildFor>],
+        generatorPaths: GeneratorPaths
+    ) throws -> [XcodeGraph.TargetReference: Set<XcodeGraph.BuildAction.BuildFor>] {
+        let keyValuePairs = try buildFor.map { targetReference, buildForOptions in
+            let graphTargetReference = XcodeGraph.TargetReference(
+                projectPath: try generatorPaths.resolveSchemeActionProjectPath(targetReference.projectPath),
+                name: targetReference.targetName
+            )
+            let graphBuildForOptions = Set(buildForOptions.map(\.graphBuildFor))
+
+            return (graphTargetReference, graphBuildForOptions)
+        }
+
+        return Dictionary(uniqueKeysWithValues: keyValuePairs)
+    }
+}
+
+private extension ProjectDescription.BuildActionTarget.BuildFor {
+    var graphBuildFor: XcodeGraph.BuildAction.BuildFor {
+        switch self {
+        case .analyzing:
+            return .analyzing
+        case .archiving:
+            return .archiving
+        case .profiling:
+            return .profiling
+        case .running:
+            return .running
+        case .testing:
+            return .testing
+        }
     }
 }

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/BuildAction.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraph/Models/BuildAction.swift
@@ -2,9 +2,18 @@ import Foundation
 import Path
 
 public struct BuildAction: Equatable, Codable, Sendable {
+    public enum BuildFor: String, Codable, CaseIterable, Sendable {
+        case analyzing
+        case archiving
+        case profiling
+        case running
+        case testing
+    }
+
     // MARK: - Attributes
 
     public var targets: [TargetReference]
+    public var buildFor: [TargetReference: Set<BuildFor>]
     public var preActions: [ExecutionAction]
     public var postActions: [ExecutionAction]
     public var parallelizeBuild: Bool
@@ -15,6 +24,7 @@ public struct BuildAction: Equatable, Codable, Sendable {
 
     public init(
         targets: [TargetReference] = [],
+        buildFor: [TargetReference: Set<BuildFor>] = [:],
         preActions: [ExecutionAction] = [],
         postActions: [ExecutionAction] = [],
         parallelizeBuild: Bool = true,
@@ -22,6 +32,7 @@ public struct BuildAction: Equatable, Codable, Sendable {
         findImplicitDependencies: Bool = true
     ) {
         self.targets = targets
+        self.buildFor = buildFor
         self.preActions = preActions
         self.postActions = postActions
         self.parallelizeBuild = parallelizeBuild

--- a/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Schemes/XCSchemeMapper.swift
+++ b/cli/Sources/XcodeGraph/Sources/XcodeGraphMapper/Mappers/Schemes/XCSchemeMapper.swift
@@ -67,18 +67,44 @@ struct XCSchemeMapper: SchemeMapping {
     ) throws -> BuildAction? {
         guard let action else { return nil }
 
-        let targets = try action.buildActionEntries.compactMap {
-            try mapTargetReference(buildableReference: $0.buildableReference, graphType: graphType)
+        let entries = try action.buildActionEntries.map { entry -> (target: TargetReference, buildFor: Set<BuildAction.BuildFor>) in
+            let target = try mapTargetReference(buildableReference: entry.buildableReference, graphType: graphType)
+            let buildFor = mapBuildFor(entry.buildFor)
+            return (target, buildFor)
         }
+        let targets = entries.map(\.target)
+        let defaultBuildFor = Set(BuildAction.BuildFor.allCases)
+        let nonDefaultBuildForEntries = entries.filter { $0.buildFor != defaultBuildFor }
+        let buildFor = Dictionary(uniqueKeysWithValues: nonDefaultBuildForEntries)
 
         return BuildAction(
             targets: targets,
+            buildFor: buildFor,
             preActions: [],
             postActions: [],
             parallelizeBuild: action.parallelizeBuild,
             runPostActionsOnFailure: action.runPostActionsOnFailure ?? false,
             findImplicitDependencies: action.buildImplicitDependencies
         )
+    }
+
+    private func mapBuildFor(
+        _ buildFor: [XCScheme.BuildAction.Entry.BuildFor]
+    ) -> Set<BuildAction.BuildFor> {
+        Set(buildFor.map {
+            switch $0 {
+            case .analyzing:
+                BuildAction.BuildFor.analyzing
+            case .archiving:
+                BuildAction.BuildFor.archiving
+            case .profiling:
+                BuildAction.BuildFor.profiling
+            case .running:
+                BuildAction.BuildFor.running
+            case .testing:
+                BuildAction.BuildFor.testing
+            }
+        })
     }
 
     /// Maps the optional test action into a domain `TestAction`, or returns `nil` if not present.

--- a/cli/Tests/ProjectDescriptionTests/BuildActionTests.swift
+++ b/cli/Tests/ProjectDescriptionTests/BuildActionTests.swift
@@ -1,0 +1,41 @@
+import Path
+import Testing
+
+@testable import ProjectDescription
+
+struct BuildActionTests {
+    @Test func buildAction_withPerTargetBuildForOptions() {
+        let subject = BuildAction.buildAction(
+            buildActionTargets: [
+                .target("App", buildFor: [.analyzing, .archiving, .profiling, .running]),
+                .target("AppTests", buildFor: [.testing]),
+            ]
+        )
+
+        #expect(subject.targets == [.target("App"), .target("AppTests")])
+        #expect(subject.buildFor[.target("App")] == [.analyzing, .archiving, .profiling, .running])
+        #expect(subject.buildFor[.target("AppTests")] == [.testing])
+    }
+
+    @Test func targetDefaultsToAllBuildForOptions() {
+        let subject = BuildActionTarget.target("App")
+
+        #expect(subject.target == .target("App"))
+        #expect(subject.buildFor == Set(BuildActionTarget.BuildFor.allCases))
+    }
+
+    @Test func projectTargetDefaultsToAllBuildForOptions() {
+        let projectPath = Path.relativeToManifest("../Feature")
+        let subject = BuildActionTarget.project(path: projectPath, target: "Feature")
+
+        #expect(subject.target == .project(path: projectPath, target: "Feature"))
+        #expect(subject.buildFor == Set(BuildActionTarget.BuildFor.allCases))
+    }
+
+    @Test func existingBuildActionAPIUsesDefaultBuildForBehavior() {
+        let subject = BuildAction.buildAction(targets: [.target("App")])
+
+        #expect(subject.targets == [.target("App")])
+        #expect(subject.buildFor.isEmpty)
+    }
+}

--- a/cli/Tests/ProjectDescriptionTests/SchemeTests.swift
+++ b/cli/Tests/ProjectDescriptionTests/SchemeTests.swift
@@ -5,19 +5,6 @@ import XCTest
 @testable import ProjectDescription
 
 final class SchemeTests: XCTestCase {
-    func test_buildAction_withPerTargetBuildForOptions() {
-        let subject = BuildAction.buildAction(
-            buildActionTargets: [
-                .target("App", buildFor: [.analyzing, .archiving, .profiling, .running]),
-                .target("AppTests", buildFor: [.testing]),
-            ]
-        )
-
-        XCTAssertEqual(subject.targets, [.target("App"), .target("AppTests")])
-        XCTAssertEqual(subject.buildFor[.target("App")], [.analyzing, .archiving, .profiling, .running])
-        XCTAssertEqual(subject.buildFor[.target("AppTests")], [.testing])
-    }
-
     private var encoder = JSONEncoder()
     private var decoder = JSONDecoder()
 

--- a/cli/Tests/ProjectDescriptionTests/SchemeTests.swift
+++ b/cli/Tests/ProjectDescriptionTests/SchemeTests.swift
@@ -5,6 +5,19 @@ import XCTest
 @testable import ProjectDescription
 
 final class SchemeTests: XCTestCase {
+    func test_buildAction_withPerTargetBuildForOptions() {
+        let subject = BuildAction.buildAction(
+            buildActionTargets: [
+                .target("App", buildFor: [.analyzing, .archiving, .profiling, .running]),
+                .target("AppTests", buildFor: [.testing]),
+            ]
+        )
+
+        XCTAssertEqual(subject.targets, [.target("App"), .target("AppTests")])
+        XCTAssertEqual(subject.buildFor[.target("App")], [.analyzing, .archiving, .profiling, .running])
+        XCTAssertEqual(subject.buildFor[.target("AppTests")], [.testing])
+    }
+
     private var encoder = JSONEncoder()
     private var decoder = JSONDecoder()
 

--- a/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -70,6 +70,35 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         XCTAssertEqual(result.buildImplicitDependencies, true)
     }
 
+    func test_schemeBuildAction_withPerTargetBuildForOptions() throws {
+        let projectPath = try AbsolutePath(validating: "/somepath/Workspace/Projects/Project")
+        let xcodeProjPath = projectPath.appending(component: "Project.xcodeproj")
+        let targetReference = TargetReference(projectPath: projectPath, name: "App")
+        let scheme = Scheme.test(
+            buildAction: BuildAction(
+                targets: [targetReference],
+                buildFor: [targetReference: [.analyzing, .archiving, .profiling, .running]]
+            )
+        )
+        let app = Target.test(name: "App", product: .app)
+        let project = Project.test(path: projectPath, xcodeProjPath: xcodeProjPath, targets: [app])
+        let graphTraverser = GraphTraverser(graph: .test(projects: [project.path: project]))
+
+        let got = try subject.schemeBuildAction(
+            scheme: scheme,
+            graphTraverser: graphTraverser,
+            rootPath: try AbsolutePath(validating: "/somepath/Workspace"),
+            generatedProjects: [
+                xcodeProjPath: generatedProject(targets: [app], projectPath: "\(xcodeProjPath)"),
+            ]
+        )
+
+        XCTAssertEqual(
+            try XCTUnwrap(got).buildActionEntries.first?.buildFor,
+            [.analyzing, .archiving, .profiling, .running]
+        )
+    }
+
     func test_schemeBuildAction_findImplicitDependenciesFalse() throws {
         // Given
         let projectPath = try AbsolutePath(validating: "/somepath/Workspace/Projects/Project")

--- a/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Generator/SchemeDescriptorsGeneratorTests.swift
@@ -99,6 +99,32 @@ final class SchemeDescriptorsGeneratorTests: XCTestCase {
         )
     }
 
+    func test_schemeBuildAction_withExplicitlyEmptyBuildForOptions() throws {
+        let projectPath = try AbsolutePath(validating: "/somepath/Workspace/Projects/Project")
+        let xcodeProjPath = projectPath.appending(component: "Project.xcodeproj")
+        let targetReference = TargetReference(projectPath: projectPath, name: "App")
+        let scheme = Scheme.test(
+            buildAction: BuildAction(
+                targets: [targetReference],
+                buildFor: [targetReference: []]
+            )
+        )
+        let app = Target.test(name: "App", product: .app)
+        let project = Project.test(path: projectPath, xcodeProjPath: xcodeProjPath, targets: [app])
+        let graphTraverser = GraphTraverser(graph: .test(projects: [project.path: project]))
+
+        let got = try subject.schemeBuildAction(
+            scheme: scheme,
+            graphTraverser: graphTraverser,
+            rootPath: try AbsolutePath(validating: "/somepath/Workspace"),
+            generatedProjects: [
+                xcodeProjPath: generatedProject(targets: [app], projectPath: "\(xcodeProjPath)"),
+            ]
+        )
+
+        XCTAssertEqual(try XCTUnwrap(got).buildActionEntries.first?.buildFor, [])
+    }
+
     func test_schemeBuildAction_findImplicitDependenciesFalse() throws {
         // Given
         let projectPath = try AbsolutePath(validating: "/somepath/Workspace/Projects/Project")

--- a/cli/Tests/TuistLoaderTests/Models+ManifestMappers/BuildAction+ManifestMapperTests.swift
+++ b/cli/Tests/TuistLoaderTests/Models+ManifestMappers/BuildAction+ManifestMapperTests.swift
@@ -1,0 +1,44 @@
+import FileSystem
+import FileSystemTesting
+import Path
+import ProjectDescription
+import Testing
+import XcodeGraph
+
+@testable import TuistLoader
+
+struct BuildActionManifestMapperTests {
+    @Test(.inTemporaryDirectory)
+    func mapsBuildForOptionsAndResolvesProjectPaths() throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let manifestDirectory = temporaryDirectory.appending(component: "App")
+        let generatorPaths = GeneratorPaths(
+            manifestDirectory: manifestDirectory,
+            rootDirectory: temporaryDirectory
+        )
+        let manifest = ProjectDescription.BuildAction.buildAction(
+            buildActionTargets: [
+                .target("App", buildFor: [.running]),
+                .project(
+                    path: .relativeToManifest("../Feature"),
+                    target: "Feature",
+                    buildFor: [.testing]
+                ),
+            ]
+        )
+
+        let subject = try XcodeGraph.BuildAction.from(
+            manifest: manifest,
+            generatorPaths: generatorPaths
+        )
+
+        let appTarget = XcodeGraph.TargetReference(projectPath: manifestDirectory, name: "App")
+        let featureTarget = XcodeGraph.TargetReference(
+            projectPath: temporaryDirectory.appending(component: "Feature"),
+            name: "Feature"
+        )
+        #expect(subject.targets == [appTarget, featureTarget])
+        #expect(subject.buildFor[appTarget] == [.running])
+        #expect(subject.buildFor[featureTarget] == [.testing])
+    }
+}

--- a/cli/Tests/XcodeGraphMapperTests/MapperTests/Schemes/XCSchemeMapperTests.swift
+++ b/cli/Tests/XcodeGraphMapperTests/MapperTests/Schemes/XCSchemeMapperTests.swift
@@ -72,6 +72,8 @@ struct XCSchemeMapperTests {
         #expect(mappedAction != nil)
         #expect(mappedAction?.targets.count == 1)
         #expect(mappedAction?.targets[0].name == "App")
+        let mappedTarget = try #require(mappedAction?.targets[0])
+        #expect(mappedAction?.buildFor[mappedTarget] == [.running, .testing])
         #expect(mappedAction?.parallelizeBuild == false)
         #expect(mappedAction?.runPostActionsOnFailure == true)
         #expect(mappedAction?.findImplicitDependencies == true)

--- a/cli/Tests/XcodeGraphMapperTests/MapperTests/Schemes/XCSchemeMapperTests.swift
+++ b/cli/Tests/XcodeGraphMapperTests/MapperTests/Schemes/XCSchemeMapperTests.swift
@@ -79,6 +79,35 @@ struct XCSchemeMapperTests {
         #expect(mappedAction?.findImplicitDependencies == true)
     }
 
+    @Test("Omits default Build For options when mapping a build action")
+    func mapBuildActionWithDefaultBuildForOptions() async throws {
+        let targetReference = XCScheme.BuildableReference(
+            referencedContainer: "container:App.xcodeproj",
+            blueprintIdentifier: "123",
+            buildableName: "App.app",
+            blueprintName: "App"
+        )
+        let buildActionEntry = XCScheme.BuildAction.Entry(
+            buildableReference: targetReference,
+            buildFor: [.analyzing, .archiving, .profiling, .running, .testing]
+        )
+        let xcscheme = XCScheme.test(
+            name: "UserScheme",
+            buildAction: XCScheme.BuildAction(
+                buildActionEntries: [buildActionEntry],
+                parallelizeBuild: true,
+                buildImplicitDependencies: true
+            )
+        )
+
+        let mapped = try await mapper.map(xcscheme, shared: false, graphType: graphType)
+        let mappedAction = try #require(mapped.buildAction)
+        let mappedTarget = try #require(mappedAction.targets.first)
+
+        #expect(mappedAction.buildFor[mappedTarget] == nil)
+        #expect(mappedAction.buildFor.isEmpty)
+    }
+
     @Test("Maps a test action with testable references, coverage, and environment")
     func mapTestAction() async throws {
         // Given

--- a/cli/Tests/XcodeGraphTests/Models/BuildActionBuildForTests.swift
+++ b/cli/Tests/XcodeGraphTests/Models/BuildActionBuildForTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Path
+import Testing
+
+@testable import XcodeGraph
+
+struct BuildActionBuildForTests {
+    @Test func codableWithBuildForOptions() throws {
+        let target = TargetReference(
+            projectPath: try AbsolutePath(validating: "/path/to/project"),
+            name: "name"
+        )
+        let subject = BuildAction(
+            targets: [target],
+            buildFor: [target: [.running, .testing]]
+        )
+
+        let encoded = try JSONEncoder().encode(subject)
+        let decoded = try JSONDecoder().decode(BuildAction.self, from: encoded)
+
+        #expect(decoded == subject)
+    }
+}

--- a/examples/xcode/generated_app_with_per_target_build_for/Project.swift
+++ b/examples/xcode/generated_app_with_per_target_build_for/Project.swift
@@ -3,15 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "ExampleLibrary",
     options: .options(
-        automaticSchemesOptions: .enabled(
-            targetSchemesGrouping: .byNameSuffix(
-                build: [],
-                test: ["Tests"],
-                run: ["App"]
-            ),
-            testLanguage: SchemeLanguage(identifier: "en"),
-            testRegion: "US"
-        )
+        automaticSchemesOptions: .disabled
     ),
     targets: [
         .target(
@@ -41,6 +33,27 @@ let project = Project(
             infoPlist: .default,
             sources: ["Sources/ExampleLibraryApp/**"],
             dependencies: [.target(name: "ExampleLibrary")]
+        ),
+    ],
+    schemes: [
+        .scheme(
+            name: "ExampleLibrary",
+            shared: true,
+            buildAction: .buildAction(
+                buildActionTargets: [
+                    .target("ExampleLibrary"),
+                    .target("ExampleLibraryTests", buildFor: [.testing]),
+                    .target(
+                        "ExampleLibraryApp",
+                        buildFor: [.analyzing, .archiving, .profiling, .running]
+                    ),
+                ]
+            ),
+            testAction: .targets(
+                ["ExampleLibraryTests"],
+                options: .options(language: "en", region: "US")
+            ),
+            runAction: .runAction(executable: "ExampleLibraryApp")
         ),
     ]
 )

--- a/examples/xcode/generated_app_with_per_target_build_for/Project.swift
+++ b/examples/xcode/generated_app_with_per_target_build_for/Project.swift
@@ -1,0 +1,46 @@
+import ProjectDescription
+
+let project = Project(
+    name: "ExampleLibrary",
+    options: .options(
+        automaticSchemesOptions: .enabled(
+            targetSchemesGrouping: .byNameSuffix(
+                build: [],
+                test: ["Tests"],
+                run: ["App"]
+            ),
+            testLanguage: SchemeLanguage(identifier: "en"),
+            testRegion: "US"
+        )
+    ),
+    targets: [
+        .target(
+            name: "ExampleLibrary",
+            destinations: .iOS,
+            product: .framework,
+            bundleId: "dev.tuist.example-library",
+            deploymentTargets: .iOS("17.0"),
+            sources: ["Sources/ExampleLibrary/**"]
+        ),
+        .target(
+            name: "ExampleLibraryTests",
+            destinations: .iOS,
+            product: .unitTests,
+            bundleId: "dev.tuist.example-library-tests",
+            deploymentTargets: .iOS("17.0"),
+            infoPlist: .default,
+            sources: ["Tests/ExampleLibraryTests/**"],
+            dependencies: [.target(name: "ExampleLibrary")]
+        ),
+        .target(
+            name: "ExampleLibraryApp",
+            destinations: .iOS,
+            product: .app,
+            bundleId: "dev.tuist.example-library-app",
+            deploymentTargets: .iOS("17.0"),
+            infoPlist: .default,
+            sources: ["Sources/ExampleLibraryApp/**"],
+            dependencies: [.target(name: "ExampleLibrary")]
+        ),
+    ]
+)

--- a/examples/xcode/generated_app_with_per_target_build_for/README.md
+++ b/examples/xcode/generated_app_with_per_target_build_for/README.md
@@ -1,0 +1,41 @@
+# Per-target scheme build purposes
+
+This fixture reproduces the inability to disable one Build tab column for one target.
+
+Generate it with the Tuist version being tested:
+
+```sh
+cd examples/xcode/generated_app_with_per_target_build_for
+tuist generate
+```
+
+The fixture contains three targets:
+
+- `ExampleLibrary`, which contains the reusable code.
+- `ExampleLibraryTests`, which imports and tests `ExampleLibrary`.
+- `ExampleLibraryApp`, which imports and displays a value from `ExampleLibrary`.
+
+Open `ExampleLibrary.xcworkspace`, edit the `ExampleLibrary` scheme, and inspect its Build tab. The baseline manifest uses the existing `targets:` API, so all three targets are enabled for Analyze, Test, Run, Profile, and Archive.
+
+The generated XML can also be inspected without Xcode:
+
+```sh
+grep -A8 BuildActionEntry ExampleLibrary.xcodeproj/xcshareddata/xcschemes/ExampleLibrary.xcscheme
+```
+
+After adding per-target build-purpose support, change the build action to:
+
+```swift
+buildAction: .buildAction(
+    buildActionTargets: [
+        .target("ExampleLibrary"),
+        .target("ExampleLibraryTests"),
+        .target(
+            "ExampleLibraryApp",
+            buildFor: [.analyzing, .archiving, .profiling, .running]
+        ),
+    ]
+)
+```
+
+Regenerate the project. `ExampleLibraryApp` should then have `buildForTesting = "NO"`, while its other four values remain `"YES"`.

--- a/examples/xcode/generated_app_with_per_target_build_for/README.md
+++ b/examples/xcode/generated_app_with_per_target_build_for/README.md
@@ -15,7 +15,13 @@ The fixture contains three targets:
 - `ExampleLibraryTests`, which imports and tests `ExampleLibrary`.
 - `ExampleLibraryApp`, which imports and displays a value from `ExampleLibrary`.
 
-Open `ExampleLibrary.xcworkspace`, edit the `ExampleLibrary` scheme, and inspect its Build tab. The baseline manifest uses the existing `targets:` API, so all three targets are enabled for Analyze, Test, Run, Profile, and Archive.
+Open `ExampleLibrary.xcworkspace`, edit the `ExampleLibrary` scheme, and inspect its Build tab. The explicit scheme uses the per-target Build-action API to produce:
+
+| Target | Analyze | Test | Run | Profile | Archive |
+| --- | --- | --- | --- | --- | --- |
+| `ExampleLibrary` | Yes | Yes | Yes | Yes | Yes |
+| `ExampleLibraryTests` | No | Yes | No | No | No |
+| `ExampleLibraryApp` | Yes | No | Yes | Yes | Yes |
 
 The generated XML can also be inspected without Xcode:
 
@@ -23,19 +29,4 @@ The generated XML can also be inspected without Xcode:
 grep -A8 BuildActionEntry ExampleLibrary.xcodeproj/xcshareddata/xcschemes/ExampleLibrary.xcscheme
 ```
 
-After adding per-target build-purpose support, change the build action to:
-
-```swift
-buildAction: .buildAction(
-    buildActionTargets: [
-        .target("ExampleLibrary"),
-        .target("ExampleLibraryTests"),
-        .target(
-            "ExampleLibraryApp",
-            buildFor: [.analyzing, .archiving, .profiling, .running]
-        ),
-    ]
-)
-```
-
-Regenerate the project. `ExampleLibraryApp` should then have `buildForTesting = "NO"`, while its other four values remain `"YES"`.
+After regenerating, `ExampleLibraryApp` should have `buildForTesting = "NO"`, `ExampleLibraryTests` should have only `buildForTesting = "YES"`, and `ExampleLibrary` should have all five values set to `"YES"`.

--- a/examples/xcode/generated_app_with_per_target_build_for/Sources/ExampleLibrary/Greeting.swift
+++ b/examples/xcode/generated_app_with_per_target_build_for/Sources/ExampleLibrary/Greeting.swift
@@ -1,0 +1,3 @@
+public enum Greeting {
+    public static let message = "Hello from ExampleLibrary"
+}

--- a/examples/xcode/generated_app_with_per_target_build_for/Sources/ExampleLibraryApp/AppDelegate.swift
+++ b/examples/xcode/generated_app_with_per_target_build_for/Sources/ExampleLibraryApp/AppDelegate.swift
@@ -1,0 +1,20 @@
+import ExampleLibrary
+import UIKit
+
+@main
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _: UIApplication,
+        didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = UIViewController()
+        viewController.title = Greeting.message
+        viewController.view.backgroundColor = .white
+        window?.rootViewController = UINavigationController(rootViewController: viewController)
+        window?.makeKeyAndVisible()
+        return true
+    }
+}

--- a/examples/xcode/generated_app_with_per_target_build_for/Tests/ExampleLibraryTests/ExampleLibraryTests.swift
+++ b/examples/xcode/generated_app_with_per_target_build_for/Tests/ExampleLibraryTests/ExampleLibraryTests.swift
@@ -1,0 +1,8 @@
+import ExampleLibrary
+import XCTest
+
+final class ExampleLibraryTests: XCTestCase {
+    func test_greeting() {
+        XCTAssertEqual(Greeting.message, "Hello from ExampleLibrary")
+    }
+}

--- a/examples/xcode/generated_app_with_per_target_build_for/Tuist.swift
+++ b/examples/xcode/generated_app_with_per_target_build_for/Tuist.swift
@@ -1,0 +1,3 @@
+import ProjectDescription
+
+let tuist = Tuist(project: .tuist())


### PR DESCRIPTION

## Why

Tuist schemes previously accepted only a list of target references for a Build action. The generator consequently enabled `Analyze`, `Test`, `Run`, `Profile`, and `Archive` for every listed target. Users could not reproduce an Xcode scheme where, for example, an app target is enabled for every purpose except `Test`.


## Demo
Before | After
--|--
<img width="2067"  alt="before" src="https://github.com/user-attachments/assets/5cd4eb77-64ea-4bc3-a989-cdf659443d3c" /> | <img width="2064" alt="after" src="https://github.com/user-attachments/assets/a0923cd6-6b15-49e5-9b24-b0b4869f6827" />

## Root cause

`ProjectDescription.BuildAction` stored target identity but no per-target Build For configuration. `SchemeDescriptorsGenerator` therefore used one hard-coded set of all five purposes for every generated build-action entry.

## Solution

The new overload accepts richer `BuildActionTarget` values without changing the existing API:

```swift
.buildAction(
    buildActionTargets: [
        .target("ExampleLibrary"),
        .target("ExampleLibraryTests", buildFor: [.testing]),
        .target(
            "ExampleLibraryApp",
            buildFor: [.analyzing, .archiving, .profiling, .running]
        ),
    ]
)
```

Targets absent from the internal overrides dictionary continue to use all five purposes. Explicit empty sets remain distinct and disable every purpose for that target. Enum conversions are exhaustive at the ProjectDescription, XcodeGraph, and XcodeProj boundaries.

Automatic scheme generation remains unchanged. This keeps the feature opt-in and avoids silently changing generated schemes for existing users.


## What changed

- Added `BuildActionTarget`, which pairs a target reference with its enabled Xcode Build For purposes: `Analyze`, `Archive`, `Profile`, `Run`, and `Test`.
- Added a `BuildAction.buildAction(buildActionTargets:)` overload for configuring those purposes independently for each target.
- Preserved the existing `BuildAction.buildAction(targets:)` API and its current all-actions behavior.
- Carried the configuration through the ProjectDescription-to-XcodeGraph manifest mapper and scheme generator.
- Added reverse mapping from XcodeProj scheme entries into XcodeGraph while omitting all-actions entries from the overrides dictionary.
- Added a sample project containing a framework, its unit tests, and an application that imports the framework.
- Added coverage for public API defaults, manifest path resolution, scheme generation, explicitly empty option sets, reverse mapping, and Codable round trips.


## Impact

Existing manifests continue to compile and generate the same schemes. Users who opt into the new overload can control the five Build For checkboxes independently for each target.


