### PR TITLE
fix(server): avoid nonce-dependent scope assertions

### DIFF
--- a/server/test/tuist_web/live/account_tokens_live_test.exs
+++ b/server/test/tuist_web/live/account_tokens_live_test.exs
@@ -51,9 +51,8 @@ defmodule TuistWeb.AccountTokensLiveTest do
     assert html =~ "Select all project scopes"
     refute html =~ "Project handles"
     refute html =~ "Specific projects"
-    refute html =~ "MCP"
-    refute html =~ "SCIM write"
-    refute html =~ "account:scim:write"
+    refute scope_present?(html, AccountToken.mcp_scope())
+    refute scope_present?(html, AccountToken.scim_scope())
     refute html =~ "#{account.name}/ios-app"
     assert account_tokens_table_headers(html) == ["Name", "Token", "Last used", "Created"]
     assert scope_checked?(html, "ci")
@@ -89,9 +88,8 @@ defmodule TuistWeb.AccountTokensLiveTest do
     assert html =~ "Select all project scopes"
     refute html =~ "Project handles"
     refute html =~ "Specific projects"
-    refute html =~ "MCP"
-    refute html =~ "SCIM write"
-    refute html =~ "account:scim:write"
+    refute scope_present?(html, AccountToken.mcp_scope())
+    refute scope_present?(html, AccountToken.scim_scope())
   end
 
   test "lists tokens beyond the first account-token page", %{conn: conn, account: account} do
@@ -519,12 +517,21 @@ defmodule TuistWeb.AccountTokensLiveTest do
   end
 
   defp scope_checked?(html, scope) do
-    id = "#account-token-scope-#{String.replace(scope, ":", "-")}"
-
     html
     |> Floki.parse_fragment!()
-    |> Floki.find("#{id} .noora-checkbox-control")
+    |> Floki.find("#{scope_selector(scope)} .noora-checkbox-control")
     |> Floki.attribute("data-state")
     |> Kernel.==(["checked"])
+  end
+
+  defp scope_present?(html, scope) do
+    html
+    |> Floki.parse_fragment!()
+    |> Floki.find(scope_selector(scope))
+    |> Enum.any?()
+  end
+
+  defp scope_selector(scope) do
+    "#account-token-scope-#{String.replace(scope, ":", "-")}"
   end
 end


### PR DESCRIPTION
## Motivation

The server workflow on `main` failed in `TuistWeb.AccountTokensLiveTest` even though the account-token page correctly excluded the MCP scope. The test refuted the string `MCP` across the entire rendered HTML document. A randomly generated CSP nonce happened to contain those characters, causing an unrelated piece of page metadata to fail the scope-visibility assertion.

This made the test probabilistically flaky and could fail any change that happened to receive the unlucky nonce.

## Approach

- Replace document-wide string checks for the MCP and SCIM scopes with checks for their actual scope-control DOM IDs.
- Reuse the same scope selector when checking whether a scope is selected.
- Reference the scope values through `AccountToken.mcp_scope/0` and `AccountToken.scim_scope/0` instead of duplicating their string values in the test.

The assertions still verify that neither privileged scope is available in the generic account-token creator, but random CSP values and unrelated page content can no longer affect the result.

## Validation

- `mix test test/tuist_web/live/account_tokens_live_test.exs:32 test/tuist_web/live/account_tokens_live_test.exs:71` — 2 passed
- `MIX_ENV=test mix format --check-formatted test/tuist_web/live/account_tokens_live_test.exs`
- `git diff --check`

The other failure in the linked workflow's `esbuild` job was an independent transient DNS lookup failure for `builds.hex.pm`; the same setup action completed successfully in the other jobs.
