### PR TITLE
feat(infra): point Registry's Sentry DSN at the self-hosted Hive ingest

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -37,6 +37,15 @@ registry:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
+  # Point registry's Sentry envelopes at the Registry domain DSN in the
+  # self-hosted Hive ingest (hive.tuist.dev). Prereq (MUST land before this
+  # merges): add a SENTRY_DSN_REGISTRY_HIVE field to the REGISTRY 1Password
+  # item in `tuist-k8s-canary` holding the Registry-domain Hive DSN;
+  # otherwise the ES sync errors on a missing remoteRef. Rollback is a
+  # revert; the old SENTRY_DSN_REGISTRY field on the same item stays put.
+  externalSecrets:
+    fields:
+      sentryDsn: SENTRY_DSN_REGISTRY_HIVE
 
 server:
   replicaCount: 1

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -52,6 +52,15 @@ registry:
     limits:
       cpu: "4"
       memory: "4Gi"
+  # Point registry's Sentry envelopes at the Registry domain DSN in the
+  # self-hosted Hive ingest (hive.tuist.dev). Prereq (MUST land before this
+  # merges): add a SENTRY_DSN_REGISTRY_HIVE field to the REGISTRY 1Password
+  # item in `tuist-k8s-production` holding the Registry-domain Hive DSN;
+  # otherwise the ES sync errors on a missing remoteRef. Rollback is a
+  # revert; the old SENTRY_DSN_REGISTRY field on the same item stays put.
+  externalSecrets:
+    fields:
+      sentryDsn: SENTRY_DSN_REGISTRY_HIVE
 
 server:
   replicaCount: 2

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -54,6 +54,15 @@ registry:
   ingress:
     host: registry-staging.tuist.dev
     tlsSecretName: registry-staging-tls
+  # Point registry's Sentry envelopes at the Registry domain DSN in the
+  # self-hosted Hive ingest (hive.tuist.dev). Prereq (MUST land before this
+  # merges): add a SENTRY_DSN_REGISTRY_HIVE field to the REGISTRY 1Password
+  # item in `tuist-k8s-staging` holding the Registry-domain Hive DSN;
+  # otherwise the ES sync errors on a missing remoteRef. Rollback is a
+  # revert; the old SENTRY_DSN_REGISTRY field on the same item stays put.
+  externalSecrets:
+    fields:
+      sentryDsn: SENTRY_DSN_REGISTRY_HIVE
 
 server:
   kuraCapacityAdmission:


### PR DESCRIPTION
## What

Points the Registry service's Sentry DSN at the self-hosted Hive ingest
(`hive.tuist.dev`) in all three managed envs (staging, canary, production).
Each `values-managed-<env>.yaml` overrides `registry.externalSecrets.fields.sentryDsn`
to `SENTRY_DSN_REGISTRY_HIVE`, a new field on the existing shared `REGISTRY`
1Password item.

## Why

Same motivation as the Kura cutover (#12881): move the Registry away from
Sentry.io and onto our own Hive so error events stay on infrastructure we
control, and can be filtered per domain in the Hive UI.

Hive now supports domain-scoped DSNs, so events sent to this DSN land at
ingest tagged as the Registry domain under the Tuist project. That is what
`get_domain_error_dsn` returned on 2026-09-05 for
`(project=Tuist, domain=Registry)`:

    https://b30ad5e4…@hive.tuist.dev/5

No caller-side (SDK) change is needed: the DSN URL is Sentry-compatible;
Hive resolves the public key server-side to `(project_id, domain_id)`.

## Approach

Two shapes were on the table:

1. **New 1P item** (a `REGISTRY_SENTRY_HIVE` mirror), matching Kura's
   `kura-sentry-hive` shape exactly.
2. **New field on the existing `REGISTRY` 1P item** (`SENTRY_DSN_REGISTRY_HIVE`),
   flipped in via `fields.sentryDsn`.

Chose (2) because the Registry 1P item is a multi-purpose blob (S3
credentials + a Sentry DSN field), and creating a parallel item just for
the DSN would duplicate every S3 field. Adding a field to the same item
preserves the same rollback story with less surface area: revert the
values change and ESO falls back to the untouched `SENTRY_DSN_REGISTRY`
field via the template's precedence rule
(`sentry_dsn || SENTRY_DSN_REGISTRY`).

The chart's `registry-external-secrets.yaml` template already supports this
override without any template change: when `fields.sentryDsn` is non-empty
it emits an explicit `remoteRef` for `sentry_dsn`, which the template's
`data` mapping resolves to `SENTRY_DSN_REGISTRY` in the runtime Secret.

## Prereq: 1Password (MUST land before merge)

Add a `SENTRY_DSN_REGISTRY_HIVE` field to the existing `REGISTRY` 1Password
item in each of these vaults, holding the Hive DSN above:

- `tuist-k8s-staging`
- `tuist-k8s-canary`
- `tuist-k8s-production`

If any is missing at merge time, the ESO reconciler for that env fails to
sync `registry-runtime` because the new remoteRef points at a non-existent
1P field, and the Registry Pods will refuse to start on the next rollout.

## Rollback

Revert this commit. The old `SENTRY_DSN_REGISTRY` field on each `REGISTRY`
1P item is untouched, so the template falls back to it and the runtime
Secret re-syncs to the old Sentry.io DSN on the next ESO refresh.

## Verification

- Diff is three identical overrides (one per env), matching the Kura
  cutover's shape.
- Chart template `registry-external-secrets.yaml` already handles
  `fields.sentryDsn` non-empty via `{{- with .Values.registry.externalSecrets.fields.sentryDsn }}`
  and resolves `sentry_dsn` into `SENTRY_DSN_REGISTRY` in the runtime Secret,
  so no template change is needed.
- Hive DSN minted via `mcp__Hive__get_domain_error_dsn` on 2026-09-05 for the
  linked `(Tuist, Registry)` pair.
- Post-merge: on each env, ESO refresh (up to 1h) or a `kubectl annotate es
  registry-runtime force-sync=$(date +%s)`, then rollout restart the
  registry Deployment.

## Not in scope

- `cache/` service (outdated per Pedro; not being extended).
- Tuist server / processor / xcresult_processor: those cut over via the
  `hive_error_tracking_enabled` FunWithFlags flag flipped in `/ops/flags`,
  independent of this PR.
- Kura: covered by #12881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GzpY4nUjXbuddJJY1yEMp