### PR TITLE
chore(server): point the /ops Errors sidebar link at Hive

### DIFF
--- a/server/lib/tuist_web/components/app_layout_components.ex
+++ b/server/lib/tuist_web/components/app_layout_components.ex
@@ -586,7 +586,7 @@ defmodule TuistWeb.AppLayoutComponents do
       <.sidebar_item
         label={dgettext("dashboard", "Errors")}
         icon="alert_triangle"
-        href="https://sentry.io/organizations/tuist/issues/"
+        href="https://hive.tuist.dev/errors"
         target="_blank"
         rel="noopener noreferrer"
         external


### PR DESCRIPTION
## What

Swaps the /ops sidebar's Errors link from
\`sentry.io/organizations/tuist/issues/\` to \`hive.tuist.dev/errors\`.

## Why

Sentry.io is being retired for the services we control. Kura (#12881) and
Registry (#12889) are cutting over to the self-hosted Hive ingest at
\`hive.tuist.dev\`, and the Tuist server + processor + xcresult_processor
have the runtime reroute wired already behind the
\`hive_error_tracking_enabled\` flag. The /ops sidebar link was the last
Sentry.io pointer in the app shell; leaving it would send whoever clicks
\"Errors\" from /ops to an increasingly empty Sentry dashboard while the
real events flow into Hive.

## Approach

Replaced the hard-coded URL. The target scheme matches what Hive returns
today from \`list_error_issues\` — individual issues live at
\`hive.tuist.dev/errors/<id>\`, so \`/errors\` is the natural browser root.

Kept the tab \`target=\"_blank\"\` and \`rel=\"noopener noreferrer\"\` and the
existing \`alert_triangle\` icon so the sidebar behaves exactly the same way,
only the destination changes.

## Not in scope

- Cache continues to point at Sentry.io because the service is outdated
  (Pedro's call). The sidebar link is a shared shell, not per-service, so
  it should track where the majority of events land.
- Server / processor / xcresult_processor envelope cutover; that flips via
  \`hive_error_tracking_enabled\` in \`/ops/flags\` independent of this PR.

## Verification

- \`grep\` for \`sentry.io\` in server code returns only tests and unrelated
  strings after this change.
- Manually confirmed with \`mcp__Hive__list_error_issues\` that Hive is
  ingesting Tuist project events today (7 unresolved issues at time of
  writing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GzpY4nUjXbuddJJY1yEMp