### PR TITLE
fix(server): restore module cache filter layout

### DIFF
--- a/server/assets/app/css/pages/module_cache.css
+++ b/server/assets/app/css/pages/module_cache.css
@@ -4,6 +4,14 @@
   gap: var(--noora-spacing-6);
   padding: var(--noora-spacing-7) var(--noora-spacing-5);
 
+  & > [data-part="filters"] {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    align-items: center;
+    gap: var(--noora-spacing-4);
+  }
+
   & > [data-part="analytics-card"] {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## What changed

- Restored the flex layout for the filters at the top of the Module Cache dashboard.
- Kept the controls right-aligned while allowing them to wrap on narrower viewports.

## Why

The Module Cache page's Environment, Branch, and date controls were rendering as separate block-level rows, causing the dropdowns to stretch across the page instead of appearing as a compact filter group.

## Root cause

The page-specific filter layout rule was accidentally removed when module invalidation analytics and the Branch filter were added. Without that rule, the dropdown components fell back to their block layout and occupied the full available width.

Restoring the existing rule is preferable to changing the shared dropdown component because the shared behavior is correct elsewhere, and the equivalent Xcode Cache and Gradle Cache pages already use this page-level layout.

## Impact

The Module Cache dashboard filters once again appear together at the top-right and wrap cleanly when horizontal space is limited. Filter behavior and query parameters are unchanged.

## Validation

- `node_modules/.bin/prettier --check assets/app/css/pages/module_cache.css`
- `git diff --check`
