### PR TITLE
feat(noora): support range bar charts

### DIFF
--- a/noora/js/Chart.js
+++ b/noora/js/Chart.js
@@ -282,6 +282,46 @@ export function prepareChartOptions(input, element) {
     }
   }
 
+  if (option.tooltip?.formatter === "fn:rangeBarTooltip") {
+    option.tooltip.formatter = rangeBarTooltipFormatter;
+    option.tooltip.trigger ??= "item";
+  }
+
+  if (Array.isArray(option.series)) {
+    let hasRangeBarSeries = false;
+
+    option.series.forEach((series) => {
+      if (series.renderItem === "fn:rangeBar") {
+        series.renderItem = rangeBarRenderItem;
+        series.encode ??= { x: [1, 2], y: 0 };
+        hasRangeBarSeries = true;
+      }
+    });
+
+    if (hasRangeBarSeries) {
+      const hasMultipleXAxes = Array.isArray(option.xAxis);
+      const hasMultipleYAxes = Array.isArray(option.yAxis);
+      const xAxes = hasMultipleXAxes ? option.xAxis : [option.xAxis];
+      const yAxes = hasMultipleYAxes ? option.yAxis : [option.yAxis];
+      const xAxis = { ...(xAxes[0] ?? {}) };
+      const yAxis = { ...(yAxes[0] ?? {}) };
+
+      if (yAxis.data === undefined && Array.isArray(xAxis.data)) {
+        yAxis.data = xAxis.data;
+        delete xAxis.data;
+      }
+
+      const rangeXAxis = { ...xAxis, type: "value" };
+      const rangeYAxis = { ...yAxis, type: "category" };
+      option.xAxis = hasMultipleXAxes
+        ? [rangeXAxis, ...xAxes.slice(1)]
+        : rangeXAxis;
+      option.yAxis = hasMultipleYAxes
+        ? [rangeYAxis, ...yAxes.slice(1)]
+        : rangeYAxis;
+    }
+  }
+
   if (option.yAxis?.splitLine?.lineStyle?.color) {
     option.yAxis.splitLine.lineStyle.color = processColor(
       option.yAxis.splitLine.lineStyle.color,
@@ -401,6 +441,86 @@ function processItemColor(dataItem) {
       });
     }
   }
+}
+
+function rangeBarRenderItem(params, api) {
+  const lane = api.value(0);
+  const start = api.value(1);
+  const end = api.value(2);
+
+  if (
+    !Number.isFinite(lane) ||
+    !Number.isFinite(start) ||
+    !Number.isFinite(end) ||
+    end < start
+  ) {
+    return null;
+  }
+
+  const startCoordinate = api.coord([start, lane]);
+  const endCoordinate = api.coord([end, lane]);
+  const height = api.size([0, 1])[1] * 0.62;
+  const shape = echarts.graphic.clipRectByRect(
+    {
+      x: startCoordinate[0],
+      y: startCoordinate[1] - height / 2,
+      width: Math.max(endCoordinate[0] - startCoordinate[0], 1),
+      height,
+    },
+    {
+      x: params.coordSys.x,
+      y: params.coordSys.y,
+      width: params.coordSys.width,
+      height: params.coordSys.height,
+    },
+  );
+
+  if (!shape) return null;
+
+  return {
+    type: "rect",
+    shape,
+    style: api.style(),
+  };
+}
+
+export function rangeBarTooltipFormatter(params) {
+  const param = Array.isArray(params) ? params[0] : params;
+  if (!param) return "";
+
+  const [, start, end] = Array.isArray(param.value) ? param.value : [];
+  const duration =
+    Number.isFinite(start) && Number.isFinite(end) && end >= start
+      ? end - start
+      : null;
+  const data = param.data && typeof param.data === "object" ? param.data : {};
+  const description = data.name || param.name;
+  const rows = [
+    rangeBarTooltipRow(data.durationLabel, duration),
+    rangeBarTooltipRow(data.startLabel, start),
+  ].filter(Boolean);
+  const title = description
+    ? `<span data-part="title">${escapeHtml(description)}</span>`
+    : "";
+  const divider =
+    description && rows.length > 0
+      ? '<div class="noora-line-divider"><div data-part="line"></div></div>'
+      : "";
+
+  if (!title && rows.length === 0) return "";
+
+  return `<div class="noora-chart-tooltip">${title}${divider}${rows.join("")}</div>`;
+}
+
+function rangeBarTooltipRow(label, value) {
+  if (!label) return "";
+
+  const formattedValue = Number.isFinite(value)
+    ? formatMilliseconds(value)
+    : "\u2014";
+  const labelElement = `<span data-part="label">${escapeHtml(label)}</span>`;
+
+  return `<div data-part="series-item">${labelElement}<span data-part="value">${escapeHtml(formattedValue)}</span></div>`;
 }
 
 function transformColorProperty(colorProp) {

--- a/noora/js/Chart.test.js
+++ b/noora/js/Chart.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { tooltipSeries } from "./Chart.js";
+import {
+  prepareChartOptions,
+  rangeBarTooltipFormatter,
+  tooltipSeries,
+} from "./Chart.js";
 
 describe("tooltipSeries", () => {
   it("formats a value with the configured formatter", () => {
@@ -19,5 +23,174 @@ describe("tooltipSeries", () => {
 
     expect(html).not.toContain("0ms");
     expect(html).toContain("—");
+  });
+});
+
+describe("range bars", () => {
+  const chartElement = { setAttribute: () => {} };
+
+  it("replaces range-bar callbacks and supplies the required axes and encoding", () => {
+    const option = prepareChartOptions(
+      {
+        tooltip: { formatter: "fn:rangeBarTooltip" },
+        xAxis: { type: "category" },
+        yAxis: { type: "value" },
+        series: [{ type: "custom", renderItem: "fn:rangeBar" }],
+      },
+      chartElement,
+    );
+
+    expect(option.tooltip.formatter).toBe(rangeBarTooltipFormatter);
+    expect(option.tooltip.trigger).toBe("item");
+    expect(option.series[0].renderItem).toBeTypeOf("function");
+    expect(option.series[0].encode).toEqual({ x: [1, 2], y: 0 });
+    expect(option.xAxis.type).toBe("value");
+    expect(option.yAxis.type).toBe("category");
+  });
+
+  it("moves component labels to the range-bar category axis", () => {
+    const option = prepareChartOptions(
+      {
+        xAxis: { type: "category", data: ["Worker 1"] },
+        yAxis: { type: "value" },
+        series: [{ type: "custom", renderItem: "fn:rangeBar" }],
+      },
+      chartElement,
+    );
+
+    expect(option.xAxis.data).toBeUndefined();
+    expect(option.yAxis.data).toEqual(["Worker 1"]);
+  });
+
+  it("preserves secondary axes while configuring the range-bar axes", () => {
+    const option = prepareChartOptions(
+      {
+        xAxis: [
+          { type: "category", data: ["Worker 1"] },
+          { type: "value", name: "Secondary time" },
+        ],
+        yAxis: [{ type: "value" }, { type: "value", name: "Cumulative work" }],
+        series: [{ type: "custom", renderItem: "fn:rangeBar" }],
+      },
+      chartElement,
+    );
+
+    expect(option.xAxis).toHaveLength(2);
+    expect(option.xAxis[1].name).toBe("Secondary time");
+    expect(option.yAxis).toHaveLength(2);
+    expect(option.yAxis[1].name).toBe("Cumulative work");
+    expect(option.yAxis[0].data).toEqual(["Worker 1"]);
+  });
+
+  it("preserves an explicitly configured tooltip trigger and encoding", () => {
+    const option = prepareChartOptions(
+      {
+        tooltip: { trigger: "axis", formatter: "fn:rangeBarTooltip" },
+        series: [
+          {
+            type: "custom",
+            renderItem: "fn:rangeBar",
+            encode: { x: [2, 1], y: 0 },
+          },
+        ],
+      },
+      chartElement,
+    );
+
+    expect(option.tooltip.trigger).toBe("axis");
+    expect(option.series[0].encode).toEqual({ x: [2, 1], y: 0 });
+  });
+
+  it("formats an axis-trigger parameter and escapes caller-provided labels", () => {
+    const html = rangeBarTooltipFormatter([
+      {
+        name: "fallback",
+        value: [0, 250, 1750],
+        data: {
+          name: "<Compile>",
+          durationLabel: "Execution & analysis",
+          startLabel: 'Worker "1"',
+        },
+      },
+    ]);
+
+    expect(html).toContain("&lt;Compile&gt;");
+    expect(html).toContain("Execution &amp; analysis");
+    expect(html).toContain("Worker &quot;1&quot;");
+    expect(html).toContain("1.5s");
+    expect(html).toContain("250ms");
+    expect(html).toContain('data-part="series-item"');
+    expect(html).not.toContain("<Compile>");
+  });
+
+  it("renders missing timing values as unavailable without inventing labels", () => {
+    const html = rangeBarTooltipFormatter({
+      value: [0, null, undefined],
+      data: {
+        name: "Pending",
+        durationLabel: "Execution",
+        startLabel: "Worker 1",
+      },
+    });
+
+    expect(html).toContain("—");
+    expect(html).not.toContain("NaN");
+    expect(html).not.toContain("Build activity");
+    expect(html).not.toContain("Other");
+    expect(html).not.toContain("starts");
+  });
+
+  it("omits ambiguous values when tooltip labels are not supplied", () => {
+    const html = rangeBarTooltipFormatter({
+      value: [0, 100, 300],
+      data: { name: "Task" },
+    });
+
+    expect(html).toContain("Task");
+    expect(html).not.toContain("100ms");
+    expect(html).not.toContain("200ms");
+  });
+
+  it("does not render an empty tooltip for an unlabeled data point", () => {
+    const html = rangeBarTooltipFormatter({
+      value: [0, 100, 300],
+      data: [0, 100, 300],
+    });
+
+    expect(html).toBe("");
+  });
+
+  it("does not render a range bar with invalid dimensions", () => {
+    const option = prepareChartOptions(
+      { series: [{ type: "custom", renderItem: "fn:rangeBar" }] },
+      chartElement,
+    );
+
+    const api = {
+      value: () => undefined,
+    };
+
+    expect(option.series[0].renderItem({}, api)).toBeNull();
+  });
+
+  it("uses the start and end dimensions to render the range geometry", () => {
+    const option = prepareChartOptions(
+      { series: [{ type: "custom", renderItem: "fn:rangeBar" }] },
+      chartElement,
+    );
+    const api = {
+      value: (dimension) => [1, 200, 700][dimension],
+      coord: ([x, y]) => [x * 0.5, 100 + y * 40],
+      size: () => [0, 40],
+      style: () => ({ fill: "#000" }),
+    };
+    const params = {
+      coordSys: { x: 0, y: 0, width: 800, height: 300 },
+    };
+
+    const result = option.series[0].renderItem(params, api);
+
+    expect(result.shape.x).toBe(100);
+    expect(result.shape.width).toBe(250);
   });
 });

--- a/noora/lib/noora/chart.ex
+++ b/noora/lib/noora/chart.ex
@@ -51,7 +51,41 @@ defmodule Noora.Chart do
         }
       }
     }
+  }
   ```
+
+  ## Range bars
+
+  Custom series can use Noora's built-in range-bar renderer and tooltip. Each
+  point contains `[lane, start_in_milliseconds, end_in_milliseconds]`.
+  Noora configures the value and category axes and the required encoding when
+  it encounters `renderItem: "fn:rangeBar"`.
+
+  ```elixir
+  <.chart
+    id="timeline"
+    type="custom"
+    series={[
+      %{
+        type: "custom",
+        renderItem: "fn:rangeBar",
+        data: [
+          %{
+            value: [0, 125, 575],
+            name: "Compile Sources",
+            durationLabel: "Execution duration",
+            startLabel: "Started after"
+          }
+        ]
+      }
+    ]}
+    labels={["Worker 1"]}
+    extra_options={%{tooltip: %{formatter: "fn:rangeBarTooltip"}}}
+  />
+  ```
+
+  The optional `name`, `durationLabel`, and `startLabel` values are rendered in the
+  tooltip exactly as supplied, allowing callers to localize them.
   """
   use Phoenix.Component
 
@@ -59,10 +93,16 @@ defmodule Noora.Chart do
 
   attr(:type, :string,
     default: "bar",
-    values: ["bar", "line", "pie", "scatter", "radar"],
+    values: ["bar", "line", "pie", "scatter", "radar", "custom"],
     doc: """
     The type of chart to render. Defaults to "bar".
-    Available types: bar, line, pie, scatter, radar
+    Available types: bar, line, pie, scatter, radar, custom.
+
+    The custom type passes the provided series through to Apache ECharts. Use
+    `renderItem: "fn:rangeBar"` and `tooltip.formatter:
+    "fn:rangeBarTooltip"` for a range-bar timeline. Range-bar points use
+    `[lane, start_in_milliseconds, end_in_milliseconds]`; Noora supplies
+    the required value x-axis, category y-axis, and series encoding.
     """
   )
 
@@ -83,6 +123,11 @@ defmodule Noora.Chart do
     For scatter charts:
       - A list of [x, y] points: [[10, 20], [30, 40]]
       - A list of maps with series: [%{name: "Series 1", data: [[10, 20], [30, 40]]}]
+
+    For custom range-bar charts:
+      - A custom series with `renderItem: "fn:rangeBar"`
+      - Data points with `[lane, start_in_milliseconds, end_in_milliseconds]`
+      - Optional `name`, `durationLabel`, and `startLabel` fields for tooltip content
     """
   )
 
@@ -388,9 +433,9 @@ defmodule Noora.Chart do
     end
   end
 
-  # Sets tooltip trigger based on chart type (item for pie, axis for others)
+  # Sets tooltip trigger based on chart type (item for pie/custom, axis for others)
   defp add_tooltip_options(options, chart_type) do
-    trigger_value = if chart_type == "pie", do: "item", else: "axis"
+    trigger_value = if chart_type in ["pie", "custom"], do: "item", else: "axis"
 
     tooltip = %{
       trigger: trigger_value

--- a/noora/storybook/storybook/chart.story.exs
+++ b/noora/storybook/storybook/chart.story.exs
@@ -125,6 +125,56 @@ defmodule TuistWeb.Storybook.Chart do
         }
       },
       %Variation{
+        id: :range_bar_timeline,
+        description: "Range-bar timeline with overlapping work",
+        attributes: %{
+          id: "range-bar-timeline",
+          style: "width: 800px; height: 320px;",
+          type: "custom",
+          show_legend: false,
+          grid_lines: true,
+          labels: ["Loading and analysis", "Execution lane 1", "Execution lane 2"],
+          series: [
+            %{
+              type: "custom",
+              renderItem: "fn:rangeBar",
+              data: [
+                %{
+                  value: [0, 0, 980],
+                  name: "Analyze dependencies",
+                  durationLabel: "Analysis duration",
+                  startLabel: "Started after",
+                  itemStyle: %{color: "var:noora-chart-secondary"}
+                },
+                %{
+                  value: [1, 820, 2_270],
+                  name: "Compile sources",
+                  durationLabel: "Execution duration",
+                  startLabel: "Started after",
+                  itemStyle: %{color: "var:noora-chart-primary"}
+                },
+                %{
+                  value: [2, 1_150, 1_930],
+                  name: "Link executable",
+                  durationLabel: "Execution duration",
+                  startLabel: "Started after",
+                  itemStyle: %{color: "var:noora-chart-tertiary"}
+                }
+              ]
+            }
+          ],
+          extra_options: %{
+            grid: %{left: 150, right: 24, top: 24, bottom: 40},
+            tooltip: %{formatter: "fn:rangeBarTooltip"},
+            xAxis: %{
+              axisLabel: %{formatter: "fn:formatMilliseconds"},
+              splitLine: %{show: true, lineStyle: %{type: "dashed"}}
+            },
+            yAxis: %{axisTick: %{show: false}}
+          }
+        }
+      },
+      %Variation{
         id: :test_run_duration,
         description: "Test run duration chart showing pass/fail status",
         attributes: %{

--- a/noora/test/noora/chart_test.exs
+++ b/noora/test/noora/chart_test.exs
@@ -1,0 +1,21 @@
+defmodule Noora.ChartTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Noora.Chart
+
+  test "uses item tooltips for custom charts" do
+    html =
+      render_component(&Chart.chart/1, %{
+        id: "timeline",
+        type: "custom",
+        series: [%{type: "custom", renderItem: "fn:rangeBar", data: []}],
+        extra_options: %{tooltip: %{formatter: "fn:rangeBarTooltip"}}
+      })
+
+    assert html =~ ~s(&quot;trigger&quot;:&quot;item&quot;)
+    assert html =~ ~s(&quot;formatter&quot;:&quot;fn:rangeBarTooltip&quot;)
+    assert html =~ ~s(&quot;renderItem&quot;:&quot;fn:rangeBar&quot;)
+  end
+end


### PR DESCRIPTION
## What changed

Noora charts can now render horizontal range bars through an [Apache ECharts custom series](https://echarts.apache.org/handbook/en/how-to/custom-series/). The component translates declarative formatter and renderer tokens after the chart options cross the server-rendered boundary, configures the range axes and encoding, and preserves any secondary axes supplied by the caller.

Range points use `[lane, start, end]` values. Their tooltips derive the duration, escape uploaded labels, omit ambiguous unlabeled values, and leave all user-facing copy to the caller for localization. A Storybook example documents the complete contract, and focused JavaScript and Elixir tests cover option preparation, geometry, malformed input, tooltip safety, and rendered configuration.

## Why

The Bazel build timeline needs to show overlapping analysis and execution spans. A reusable Noora primitive keeps that rendering behavior in the design system instead of embedding chart callbacks and styling in the Bazel page.

## Approach

The public component accepts `type="custom"` and two explicit tokens: `fn:rangeBar` for geometry and `fn:rangeBarTooltip` for tooltip content. The browser hook replaces only those known tokens with functions, supplies safe defaults, and keeps caller overrides intact. The start and end dimensions match the range-bar convention used by Apache ECharts, which also gives the chart enough information to calculate its extent correctly.

## Impact

Existing bar, line, pie, scatter, and radar charts keep their current behavior. Callers can now build range timelines without shipping page-specific JavaScript or hardcoded English copy.

## Validation

- `mise run noora:test` (204 tests passed)
- `mix test` in `noora/` (12 tests passed)
- `mise run noora:lint`
- `mise run noora:build`
- Rendered the new range-bar variation in Storybook and verified it with headless Chrome

### Storybook verification

![Noora Storybook rendering a three-lane range-bar timeline](https://github.com/user-attachments/assets/7d368884-d468-4ae8-9d36-e164eed00e57)

### How to test locally

From `noora/storybook`, run `mix setup` and `mix phx.server`, then open `http://localhost:4000/chart?tab=playground&variation_id=range_bar_timeline`.
