### PR TITLE
fix(infra): pin md-processor replicas again after it scaled below its floor

### DIFF
--- a/infra/k8s/clusters/workloads/production/cluster.yaml
+++ b/infra/k8s/clusters/workloads/production/cluster.yaml
@@ -154,19 +154,23 @@ spec:
         # without the autoscaler bounds, dropping cluster-autoscaler's
         # node-group registration mid-flight.
         #
-        # `replicas` is deliberately UNSET on this pool (spec/72 footgun):
-        # it is autoscaled between the min/max annotations below, and CAPI's
-        # topology controller only manages replicas when the field is
-        # present. Under Flux (10-min reconcile) a pinned `replicas` would
-        # be re-asserted on every sync and fight cluster-autoscaler; leaving
-        # it unset lets CAPI default within [min,max] and hands replica
-        # control to the autoscaler (see the CAPI Autoscaling docs). Before
-        # enabling the production Flux Kustomization, confirm the live MD's
-        # replicas are preserved:
-        #   kubectl -n org-tuist get md tuist-md-processor \
-        #     -o jsonpath='{.spec.replicas}{"\n"}{.metadata.annotations}'
+        # `replicas` is pinned here, NOT omitted. Omitting it is CAPI's
+        # documented autoscaler pattern — the Cluster CRD says a nil value means
+        # "an external entity (like cluster autoscaler) is responsible" — but the
+        # same sentence says the MachineDeployment is then "created without the
+        # number of Replicas (defaulting to 1)". Applying nil to an MD that
+        # already ran 2 therefore dropped it to 1: a running processor node was
+        # deleted and the pool sat below its own autoscaler minimum until it was
+        # restored by hand. Moving this pool to autoscaler-owned replicas is a
+        # deliberate change needing a window, not something to carry along in an
+        # unrelated migration.
+        #
+        # Consequence while pinned: Flux re-asserts 2 on its interval, so a
+        # cluster-autoscaler scale-up is reverted within one reconcile. That is
+        # the trade being made knowingly — capacity floor over elasticity.
         - class: hcloud-worker
           name: md-processor
+          replicas: 2
           failureDomain: fsn1
           rollout:
             strategy:


### PR DESCRIPTION
**Production capacity incident, already mitigated. Merge to make the mitigation durable.**

## What happened

Bootstrapping Flux (spec/72, #11652) applied the production Cluster CR with `replicas` omitted on `md-processor`. CAPI's Cluster CRD documents nil as the autoscaler pattern — *"an external entity (like cluster autoscaler) is responsible for the management of this value"* — but the same sentence continues: *"the MachineDeployment is created without the number of Replicas (defaulting to 1)"*.

Applied to an MD already running 2, that defaulting fired. CAPI scaled the pool to 1 and started deleting a running node, putting production xcactivitylog parsing **below the pool's own autoscaler minimum of 2**.

## Mitigation (already applied)

1. Suspended the `cluster-production` Flux Kustomization so Flux could not re-assert the omission.
2. Restored `replicas: 2` on the live Cluster CR; the topology controller scaled back up.

Pool is back at **2/2 Running**. `kubectl diff` of this branch against live is now clean.

## Why pin rather than pursue the autoscaler pattern

Omission is still the right end state, but the **transition** is destructive on an existing pool: it costs a node and a dip below the floor before the autoscaler reacts. That belongs in a deliberate window with someone watching, not carried along in a GitOps migration.

The trade while pinned is stated in the manifest: Flux re-asserts 2 on its interval, so an autoscaler scale-up is reverted within one reconcile. Capacity floor over elasticity, chosen knowingly.

## After merge

Un-suspend the Kustomization — until then Flux would re-apply the omission and repeat the scale-down:

    kubectl -n flux-system patch kustomization cluster-production --type=merge -p '{"spec":{"suspend":false}}'

## Follow-up worth scheduling

Moving `md-processor` to autoscaler-owned replicas deliberately: omit `replicas`, expect one node of churn, confirm cluster-autoscaler restores to min=2, and verify CAPI then leaves the field alone across reconciles.