### PR TITLE
fix(infra): grant the reconciliation checks read on Nodes

### DIFF
--- a/infra/k8s/mgmt/reconciliation-checks.yaml
+++ b/infra/k8s/mgmt/reconciliation-checks.yaml
@@ -37,13 +37,19 @@ metadata:
     app.kubernetes.io/name: reconciliation-checks
     app.kubernetes.io/managed-by: tuist-bootstrap
 ---
-# Read-only across two namespaces (clusters/machines in org-tuist,
-# kustomizations in flux-system), so a cluster-scoped read ClusterRole.
+# Read-only, and cluster-scoped: Nodes are cluster-scoped, and the CAPI objects
+# and Flux Kustomizations live in different namespaces.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: reconciliation-checks
 rules:
+  # This cluster's own Nodes: their providerIDs are what excludes the management
+  # VM from the orphan check (mgmt does not self-manage, so its Hetzner server
+  # has no owning Machine and would be reported every run).
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
   - apiGroups: ["cluster.x-k8s.io"]
     resources: ["clusters", "machines"]
     verbs: ["get", "list"]


### PR DESCRIPTION
One-line RBAC fix, already applied to the management cluster and verified there. This brings git in line.

## Root cause

The orphan check excludes the management cluster's own VM by comparing Hetzner server ids against this cluster's Node providerIDs — mgmt does not self-manage, so its server has no owning CAPI `Machine` and would be reported as an orphan on every run.

That `kubectl get nodes` call was added (addressing an earlier review finding) **without the matching RBAC**, so the CronJob failed on its first real execution:

    nodes is forbidden: User "system:serviceaccount:org-tuist:reconciliation-checks"
    cannot list resource "nodes" in API group "" at the cluster scope

`set -euo pipefail` made it fail loudly rather than silently reporting zero — the right failure mode for a check whose entire purpose is catching what nothing else sees. A check that fails open would be worse than no check.

## Validation (on the live management cluster)

- Job completes: `orphan_servers=0 stale_clusters=0`
- Pushgateway serves `capi_reconciliation_orphan_servers`, `capi_reconciliation_stale_clusters` and `capi_reconciliation_last_success_timestamp_seconds`
- Per-offender series correctly absent (only emitted when there are offenders)

The zero orphan count is itself the evidence the exclusion works: without it, the mgmt VM alone would make it 1.

## Remaining for this check to page

The alert rules in `infra/helm/k8s-monitoring/alerts.md` still need creating by hand in Grafana Cloud — Git Sync does not yet provision alerting.