### PR TITLE
fix(server): update Kura regions test manifest path

### DIFF
--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -316,7 +316,7 @@ defmodule Tuist.Kura.RegionsTest do
 
     test "keeps managed regions aligned with platform ingress classes and production node pools" do
       platform_values = read_repo_yaml("infra/helm/platform/values.yaml")
-      production_cluster = read_repo_yaml("infra/k8s/clusters/cluster-production.yaml")
+      production_cluster = read_repo_yaml("infra/k8s/clusters/workloads/production/cluster.yaml")
 
       platform_ingress_keys = %{
         "eu-central" => "kura-eu-central-ingress-nginx",


### PR DESCRIPTION
Both server test jobs in [CI run 33980509499](https://github.com/tuist/tuist/actions/runs/33980509499) failed in the Kura region alignment test: each reported 8,134 of 8,135 tests passing, with a `File.Error` when reading `infra/k8s/clusters/cluster-production.yaml`.

The production cluster manifest moved to `infra/k8s/clusters/workloads/production/cluster.yaml` during the Flux infrastructure reorganization, but the test retained the old path. Update the test to read the current manifest so it can again check the region catalog against the platform ingress classes and production node pools. This preserves the existing assertions and fixes the CI regression without changing runtime behavior.

### Validation

- All 53 tests in `Tuist.Kura.RegionsTest` passed in an isolated ExUnit run, compiling this worktree's `Tuist.Environment` and `Tuist.Kura.Regions` modules and using cached dependencies from the local checkout.
- `git diff --check` passed.
- The full server suite was not rerun locally.

### How to test locally

From `server/`, run:

```sh
mix test test/tuist/kura/regions_test.exs
```
