### PR TITLE
fix(registry): tolerate missing Hive DSN during deployment

### DIFF
--- a/infra/helm/AGENTS.md
+++ b/infra/helm/AGENTS.md
@@ -15,6 +15,7 @@ This node covers Helm assets under `infra/helm/`.
 - Model infrastructure dependencies with capability names such as `objectStorage`, not provider names such as `minio`.
 - Support both `embedded` and `external` dependency modes when practical.
 - Keep local validation simple: `helm template` first, then a small-cluster install path such as `kind`.
+- Registry managed secrets select the optional Sentry DSN from the extracted 1Password item, falling back to `SENTRY_DSN_REGISTRY` or an empty DSN. Keep optional telemetry out of required `remoteRef` lookups so it cannot block storage credentials or pod startup.
 
 ## Related Context
 - Parent infra context: `infra/AGENTS.md`

--- a/infra/helm/tuist/templates/registry-external-secrets.yaml
+++ b/infra/helm/tuist/templates/registry-external-secrets.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.registry.enabled .Values.registry.managedSecrets }}
 {{- $secretName := .Values.registry.runtimeSecretName | default (include "tuist.componentName" (dict "root" . "component" "registry-runtime")) -}}
+{{- $sentryDsnField := .Values.registry.externalSecrets.fields.sentryDsn | default "SENTRY_DSN_REGISTRY" -}}
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -22,18 +23,13 @@ spec:
     template:
       engineVersion: v2
       data:
-        SENTRY_DSN_REGISTRY: '{{ `{{ (index . "sentry_dsn" | default (index . "SENTRY_DSN_REGISTRY") | default "") | trim }}` }}'
+        SENTRY_DSN_REGISTRY: {{ printf "{{ (index . %q | default (index . \"SENTRY_DSN_REGISTRY\") | default \"\") | trim }}" $sentryDsnField | squote }}
         S3_REGISTRY_BUCKET: "{{ `{{ .s3_registry_bucket | trim }}` }}"
         S3_HOST: "{{ `{{ .s3_host | trim }}` }}"
         S3_ACCESS_KEY_ID: "{{ `{{ .s3_access_key_id | trim }}` }}"
         S3_SECRET_ACCESS_KEY: "{{ `{{ .s3_secret_access_key | trim }}` }}"
         S3_REGION: "{{ `{{ .s3_region | trim }}` }}"
   data:
-    {{- with .Values.registry.externalSecrets.fields.sentryDsn }}
-    - secretKey: sentry_dsn
-      remoteRef:
-        key: {{ printf "%s/%s" $.Values.registry.externalSecrets.item . | quote }}
-    {{- end }}
     - secretKey: s3_registry_bucket
       remoteRef:
         key: "{{ .Values.registry.externalSecrets.item }}/{{ .Values.registry.externalSecrets.fields.s3RegistryBucket }}"

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -37,12 +37,9 @@ registry:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
-  # Point registry's Sentry envelopes at the Registry domain DSN in the
-  # self-hosted Hive ingest (hive.tuist.dev). Prereq (MUST land before this
-  # merges): add a SENTRY_DSN_REGISTRY_HIVE field to the REGISTRY 1Password
-  # item in `tuist-k8s-canary` holding the Registry-domain Hive DSN;
-  # otherwise the ES sync errors on a missing remoteRef. Rollback is a
-  # revert; the old SENTRY_DSN_REGISTRY field on the same item stays put.
+  # Prefer the Registry-domain Hive DSN when provisioned on the REGISTRY
+  # 1Password item. Until then, use SENTRY_DSN_REGISTRY so a missing telemetry
+  # field cannot block the runtime secret and its required storage credentials.
   externalSecrets:
     fields:
       sentryDsn: SENTRY_DSN_REGISTRY_HIVE

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -52,12 +52,9 @@ registry:
     limits:
       cpu: "4"
       memory: "4Gi"
-  # Point registry's Sentry envelopes at the Registry domain DSN in the
-  # self-hosted Hive ingest (hive.tuist.dev). Prereq (MUST land before this
-  # merges): add a SENTRY_DSN_REGISTRY_HIVE field to the REGISTRY 1Password
-  # item in `tuist-k8s-production` holding the Registry-domain Hive DSN;
-  # otherwise the ES sync errors on a missing remoteRef. Rollback is a
-  # revert; the old SENTRY_DSN_REGISTRY field on the same item stays put.
+  # Prefer the Registry-domain Hive DSN when provisioned on the REGISTRY
+  # 1Password item. Until then, use SENTRY_DSN_REGISTRY so a missing telemetry
+  # field cannot block the runtime secret and its required storage credentials.
   externalSecrets:
     fields:
       sentryDsn: SENTRY_DSN_REGISTRY_HIVE

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -54,12 +54,9 @@ registry:
   ingress:
     host: registry-staging.tuist.dev
     tlsSecretName: registry-staging-tls
-  # Point registry's Sentry envelopes at the Registry domain DSN in the
-  # self-hosted Hive ingest (hive.tuist.dev). Prereq (MUST land before this
-  # merges): add a SENTRY_DSN_REGISTRY_HIVE field to the REGISTRY 1Password
-  # item in `tuist-k8s-staging` holding the Registry-domain Hive DSN;
-  # otherwise the ES sync errors on a missing remoteRef. Rollback is a
-  # revert; the old SENTRY_DSN_REGISTRY field on the same item stays put.
+  # Prefer the Registry-domain Hive DSN when provisioned on the REGISTRY
+  # 1Password item. Until then, use SENTRY_DSN_REGISTRY so a missing telemetry
+  # field cannot block the runtime secret and its required storage credentials.
   externalSecrets:
     fields:
       sentryDsn: SENTRY_DSN_REGISTRY_HIVE


### PR DESCRIPTION
The [canary deployment](https://github.com/tuist/tuist/actions/runs/33974976574/job/101341316429) timed out after 70 minutes because the registry runtime ExternalSecret could not resolve `REGISTRY/SENTRY_DSN_REGISTRY_HIVE`. Neither the registry nor the new server pods could start without that secret, which also supplies required registry storage credentials.

The managed overlays selected the Hive DSN before its 1Password field was available. Although the secret template already had a legacy DSN fallback, the explicit `remoteRef` failed during provider lookup, before that fallback could run.

This change selects the configured DSN from the existing whole-item extraction instead of requiring a separate field lookup. It prefers the Hive DSN when present, falls back to `SENTRY_DSN_REGISTRY`, and emits an empty DSN if neither exists. Required S3 credential lookups remain mandatory. This allows the Hive migration to take effect when provisioned without making optional telemetry a prerequisite for server and registry startup. The managed overlay comments and Helm agent guidance document the behavior.

### How to test locally

Render each managed environment with its common, environment, and CI placeholder values:

```sh
for env in staging canary production; do
  helm template tuist infra/helm/tuist \
    -f infra/helm/tuist/values-managed-common.yaml \
    -f "infra/helm/tuist/values-managed-${env}.yaml" \
    -f infra/helm/tuist/values-ci.yaml > "/tmp/tuist-${env}.yaml"
done
helm lint infra/helm/tuist \
  -f infra/helm/tuist/values-self-hosted-ci.yaml \
  -f infra/helm/tuist/values-ci.yaml
```

Validation completed with Helm 4.2.3:

- All three managed environment charts rendered successfully; their registry secrets retain required S3 references and omit the required Hive DSN reference.
- A temporary Helm fixture evaluated the rendered DSN expression in 12 cases covering configured Hive/custom fields, legacy fallback, empty overrides, and absent DSNs; all passed.
- Self-hosted inline registry secret rendering and self-hosted chart lint passed.
- `git diff --check` passed.
- Managed chart lint reports an invalid YAML document separator in `templates/dedibox-fleet.yaml`; the same failure was reproduced against an unchanged HEAD archive before this commit.

The fix has not yet been deployed or verified against the live secret provider.
