### PR TITLE
fix(server): improve Gradle cache summary layout

### DIFF
--- a/server/assets/app/css/pages/gradle_build.css
+++ b/server/assets/app/css/pages/gradle_build.css
@@ -174,17 +174,20 @@
     gap: var(--noora-spacing-6);
 
     & [data-part="widgets-card-section"].noora-card__section {
-      flex-direction: row;
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
       gap: var(--noora-spacing-4);
       padding: var(--noora-spacing-8);
 
-      & > * {
-        flex-grow: 1;
+      @media (max-width: 1024px) {
+        & {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
       }
 
       @media (max-width: 768px) {
         & {
-          flex-direction: column;
+          grid-template-columns: minmax(0, 1fr);
         }
       }
     }


### PR DESCRIPTION
## What changed

The Gradle cache summary now presents its eight metrics in a responsive grid: four columns on wide screens, two on medium screens, and one on small screens.

## Why

The summary gained additional cache diagnostics, but its original single-row layout continued treating every metric as a flexible card. At normal desktop widths, labels wrapped heavily and values became difficult to scan.

## Root cause

The container still used the flex layout designed for five metrics. Adding three more metrics forced all eight cards into one row.

## Approach

The summary container now uses a four-column grid with two responsive breakpoints. The change remains scoped to the Gradle cache summary, leaving other widget groups unchanged.

## Impact

Gradle build users can scan cache metrics without narrow, uneven cards. No migration or behavior change is required.

## Validation

- Ran the stylesheet linter on `server/assets/app/css/pages/gradle_build.css`.
- Ran the design-token validation task.
- Started the local server and captured the original and corrected layouts in headless Chrome at a 2,048-pixel viewport.
- Confirmed the corrected layout renders two rows of four cards, with each card measuring 429 pixels wide.
- The focused server test could not run because the local ClickHouse version rejects test transactions before the tests execute.

### How to test locally

1. Start the server with `mise run dev` from `server/`.
2. Open a Gradle build run and select the Gradle Cache tab.
3. Resize the browser and confirm the summary uses four, two, and one columns at wide, medium, and small widths.

## Screenshots

**Before and after**

| Before | After |
|---|---|
| ![Gradle cache summary before](https://github.com/tuist/tuist/blob/c4bdb25820044b9f019f7131139504ac3ec13735/gradle-widgets-before.png?raw=true) | ![Gradle cache summary after](https://github.com/tuist/tuist/blob/c4bdb25820044b9f019f7131139504ac3ec13735/gradle-widgets-after.png?raw=true) |
