### PR TITLE
feat(infra): alert on Flux failing, and correct the README's claim that we did

### DIFF
--- a/infra/flux/mgmt/README.md
+++ b/infra/flux/mgmt/README.md
@@ -206,10 +206,29 @@ node count — it changes which controller owns it.
 
 ## Health of Flux itself
 
-A down reconciler stops correcting drift, so Flux's controllers are scraped
-and heartbeat-alerted via Pillar 2 (`infra/helm/k8s-monitoring/values-management.yaml`
-+ `infra/helm/k8s-monitoring/alerts.md`). Grafana Cloud evaluates the alerts
-outside this single-node cluster.
+A down reconciler stops correcting drift without breaking anything visible, so
+Flux is watched from Grafana Cloud, which evaluates outside this single-node
+cluster. Two rules are live (`infra/helm/k8s-monitoring/alerts.md`):
+
+- **`Flux - reconciliation has stalled fleet-wide`** on
+  `gotk_reconcile_duration_seconds_count`. A fleet total, so suspending one
+  Kustomization does not page.
+- **`Flux - telemetry missing from the management cluster`**, the paired
+  `absent_over_time` rule. The stall rule compares a counter, so if the
+  controllers vanish the series goes too and that comparison returns No Data,
+  which is Normal here; this rule is what catches Flux not running at all.
+
+Both read metrics collected by pod-annotation autodiscovery, not an explicit
+scrape config.
+
+Neither detects a reconcile that runs and **fails**: the duration histogram
+counts failed reconciles too, and Flux 2.9.5 does not export
+`gotk_reconcile_condition`. That gap is closed by a kube-state-metrics
+custom-resource-state config for Kustomizations in `values-management.yaml`,
+using the same mechanism as the CAPI custom-resource metrics. The rule that
+consumes it is written up in `alerts.md` and is deliberately **not created until
+the series is confirmed flowing**, because a rule whose query matches nothing
+reads as passing.
 
 ## Removing a cluster (explicit destroy flow)
 

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -462,6 +462,99 @@ absent_over_time(
 - Pending period: 0 minutes
 - Summary: `Reconciliation-check telemetry absent entirely (Pushgateway reset or never scraped)`
 
+### Flux reconciliation stalled
+
+**Provisioned** in the `Infrastructure` folder as
+`Flux - reconciliation has stalled fleet-wide` (critical), paired with
+`Flux - telemetry missing from the management cluster`.
+
+Flux reconciles the workload `Cluster` resources from git
+(`infra/flux/mgmt/README.md`). A stalled reconciler breaks nothing at the
+moment it stalls; it stops correcting drift, so the fleet diverges from the
+repository silently and the next real change never lands.
+
+```promql
+sum(increase(gotk_reconcile_duration_seconds_count{cluster="tuist-management"}[1h]))
+```
+
+- Pending period: 10 minutes, firing below 1
+- Summary: `Flux has not completed any reconciliation in the last hour`
+
+Normal is roughly 120 per hour across the seven Kustomizations and the
+GitRepository.
+
+**Fleet total on purpose.** Suspending a single Kustomization is a normal
+operation, so a per-Kustomization version of this rule would page every time
+someone suspends one to fix git. This fires only when *all* reconciliation has
+stopped.
+
+**It cannot see a reconcile that runs and fails**, because the duration
+histogram counts failed reconciles too. That is the separate rule below.
+
+### Flux telemetry missing
+
+```promql
+absent_over_time(gotk_reconcile_duration_seconds_count{cluster="tuist-management"}[30m])
+```
+
+- Pending period: 15 minutes
+- Summary: `Flux controller telemetry has stopped arriving from the management cluster`
+
+The stall rule compares a counter against a threshold, so if the controllers
+disappear the series goes with them, the comparison returns No Data, and No Data
+is Normal here. That leaves the most severe case invisible to it. This rule
+covers it.
+
+Note these metrics are collected by pod-annotation autodiscovery rather than an
+explicit scrape config, so a change to those annotations stops collection
+silently. This rule is what makes that loud.
+
+### Flux Kustomization not Ready
+
+**Not yet provisioned. Do not create it until the metric below exists** - a rule
+whose query matches nothing sits in No Data, renders as Normal, and is
+indistinguishable from a passing rule, which is the failure this whole section
+exists to avoid.
+
+Flux 2.9.5 exports `gotk_reconcile_duration_seconds_*` and `gotk_event_*` but
+**not** `gotk_reconcile_condition`, so nothing off the controllers says whether a
+reconcile *succeeded*. A Kustomization that fetches and then fails to apply on
+every interval is indistinguishable from a healthy one in the metrics above.
+
+The series comes from kube-state-metrics custom-resource-state, the same
+mechanism already producing `kube_customresource_kubeadmcontrolplane_*`,
+configured in `values-management.yaml`. Once it is flowing:
+
+```promql
+max by (namespace, kustomization) (
+  kube_customresource_kustomization_status_condition{
+    cluster="tuist-management", type="Ready"
+  }
+)
+== 0
+unless
+max by (namespace, kustomization) (
+  kube_customresource_kustomization_spec_suspend{cluster="tuist-management"}
+) == 1
+```
+
+- Pending period: 15 minutes
+- Summary: `Flux Kustomization {{ $labels.kustomization }} has not applied cleanly`
+
+The `unless` clause excludes deliberately suspended Kustomizations, which keep
+whatever Ready condition they last had.
+
+Two things to check before creating the rule, both of which have silently killed
+a rule in this document before:
+
+- Confirm the query returns a series. Add `kube_customresource_kustomization_.*`
+  to `metricsTuning.includeMetrics` is already done, but that list is an
+  **allowlist**: anything not matched is dropped before it leaves the cluster.
+- Check the labels survived adaptive metrics. A brand-new metric has no query
+  usage, which is exactly what the recommender aggregates away, and this rule is
+  useless without `kustomization`. Query the bare metric: the error names every
+  aggregated label.
+
 ### Cluster API admission webhook failing (fleet-wide write freeze)
 
 The management cluster serves the CAPI/CAPH admission webhooks with a

--- a/infra/helm/k8s-monitoring/values-management.yaml
+++ b/infra/helm/k8s-monitoring/values-management.yaml
@@ -37,6 +37,7 @@ k8s-monitoring:
         includeMetrics:
           - kube_customresource_kubeadmcontrolplane_.*
           - kube_customresource_machinedeployment_.*
+          - kube_customresource_kustomization_.*
 
   integrations:
     alloy:
@@ -74,6 +75,9 @@ k8s-monitoring:
             verbs: ["list", "watch"]
           - apiGroups: ["cluster.x-k8s.io"]
             resources: ["machinedeployments"]
+            verbs: ["list", "watch"]
+          - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+            resources: ["kustomizations"]
             verbs: ["list", "watch"]
       customResourceState:
         enabled: true
@@ -190,3 +194,42 @@ k8s-monitoring:
                       type: Gauge
                       gauge:
                         path: [status, replicas]
+              # Flux Kustomizations. Flux 2.9.5 exports gotk_reconcile_duration
+              # and gotk_event_* but NOT gotk_reconcile_condition, so nothing
+              # off the controllers themselves says whether a reconcile
+              # SUCCEEDED: the duration histogram counts failures too. A
+              # Kustomization that fetches and then fails to apply every
+              # interval looks identical to a healthy one in those metrics,
+              # which is the state Flux is meant to protect against - drift
+              # stops being corrected while reconciliation appears to run.
+              #
+              # spec.suspend is exported alongside the condition because
+              # suspending is a normal operation (see the suspend and resume
+              # section in infra/flux/mgmt/README.md) and a suspended
+              # Kustomization keeps whatever Ready condition it last had. An
+              # alert that ignores this pages every time someone suspends one
+              # to fix git.
+              - groupVersionKind:
+                  group: kustomize.toolkit.fluxcd.io
+                  version: v1
+                  kind: Kustomization
+                labelsFromPath:
+                  namespace: [metadata, namespace]
+                  kustomization: [metadata, name]
+                metrics:
+                  - name: kustomization_status_condition
+                    help: Flux Kustomization status conditions, 1 when the condition holds.
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [status, conditions]
+                        labelsFromPath:
+                          type: ["type"]
+                        valueFrom: ["status"]
+                  - name: kustomization_spec_suspend
+                    help: 1 when the Kustomization is suspended and not reconciling.
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [spec, suspend]
+                        nilIsZero: true


### PR DESCRIPTION
Closes the last real gap in [hive/specs/72](https://hive.tuist.dev/specs/72) Pillar 2, found while auditing what is actually provisioned in Grafana Cloud rather than what the docs say is.

## The gap

Flux reconciles the workload `Cluster` resources from git, and **nothing alerted if Flux itself stopped**. No provisioned rule referenced `flux` or `gotk`, `alerts.md` documented none, and `values-management.yaml` had no Flux scrape config at all. The metrics arrive only incidentally, through pod-annotation autodiscovery.

That is the one gap that undercuts the premise of Pillar 1. A dead reconciler breaks nothing visible at the moment it dies. It silently stops correcting drift, the fleet diverges from the repository, and the next real change never lands.

Meanwhile [infra/flux/mgmt/README.md](infra/flux/mgmt/README.md) asserted the opposite:

> Flux's controllers are scraped and heartbeat-alerted via Pillar 2

Scraped was true. Heartbeat-alerted was not. That sentence described intent and read as a statement of fact, so it is rewritten to say what exists and what does not.

## What is now live

Two rules, following the house pattern of a threshold rule paired with an absent rule:

- **`Flux - reconciliation has stalled fleet-wide`** on `increase(gotk_reconcile_duration_seconds_count[1h])` below 1. A fleet total on purpose: suspending a single Kustomization is a normal operation, documented in the same README, so a per-Kustomization version would page every time someone suspended one to fix git.
- **`Flux - telemetry missing from the management cluster`**, the paired `absent_over_time` rule. The stall rule compares a counter, so if the controllers vanish the series goes with them and the comparison returns No Data, which the house convention renders as Normal. Without the pair, Flux not running at all is the single case the stall rule cannot see.

## What this still cannot see, and the config that fixes it

Neither rule detects a reconcile that runs and **fails**, because the duration histogram counts failed reconciles too. A Kustomization that fetches and then fails to apply every interval is indistinguishable from a healthy one.

The natural metric for that, `gotk_reconcile_condition`, does not exist. Flux 2.9.5 exports 14 `gotk_` metrics and it is not among them, so nothing off the controllers reports whether a reconcile succeeded.

This adds a kube-state-metrics custom-resource-state config for Kustomizations to close it, using the same mechanism that already produces `kube_customresource_kubeadmcontrolplane_*`. It exports the Ready condition and `spec.suspend`, the latter because a suspended Kustomization keeps whatever Ready condition it last had and an alert that ignores that pages on every deliberate suspend.

Three things the config needs that are easy to miss, all included:

- `metricsTuning.includeMetrics` is an **allowlist**, so the new series is added to it or it is dropped before leaving the cluster.
- kube-state-metrics needs `list`/`watch` RBAC on `kustomizations`.
- The CRD is served at `v1`, matching the Kustomizations in `infra/flux/mgmt/`.

## Why the third rule is not created here

The rule consuming that metric is written up in `alerts.md` but deliberately **not provisioned**. A rule whose query matches nothing sits in No Data, renders as Normal, and is indistinguishable from a passing rule. That is exactly how `CAPI - etcd has no leader` came to be dead on arrival, corrected in [#12909](https://github.com/tuist/tuist/pull/12909).

It gets created once the series is confirmed flowing, and after checking that adaptive metrics has not aggregated the `kustomization` label away, which is the documented risk for a brand-new metric with no query usage.

## Validation

- Flux confirmed reconciling: seven Kustomizations (`cluster-staging`, `cluster-canary`, `cluster-production`, `cluster-hive`, `cluster-once`, `cluster-atlas`, and `flux-system` self-managing) plus the `GitRepository`, at 121 reconciles in the last hour on `tuist-management`.
- The stall rule tracks a real `Normal` alert instance, so it is evaluating a series rather than sitting on No Data.
- The absent rule reads `Normal (NoData)`, which is correct for `absent_over_time` while the series is present.
- `values-management.yaml` parsed with `yq` and the three edits confirmed in the rendered structure.

The kube-state-metrics config takes effect on the next monitoring chart deploy to the management cluster; the verification query and its two traps are in `alerts.md`.