### PR TITLE
fix(server): respect ClickHouse logging policy in dictionary migrations

### DIFF
--- a/server/lib/tuist/AGENTS.md
+++ b/server/lib/tuist/AGENTS.md
@@ -10,6 +10,10 @@ This directory contains the core business logic and domain modules for the serve
 
 ## Boundaries
 
+- `ClickHouseDictionarySource` builds escaped local dictionary sources for migrations.
+  Its query options suppress application SQL logging without overriding managed
+  ClickHouse logging policy; server password masking requires valid dictionary DDL.
+
 - Web controllers and LiveView code live in `server/lib/tuist_web`.
 - Data migrations live in `server/priv`.
 

--- a/server/lib/tuist/clickhouse_dictionary_source.ex
+++ b/server/lib/tuist/clickhouse_dictionary_source.ex
@@ -15,19 +15,20 @@ defmodule Tuist.ClickHouseDictionarySource do
   server's own address and native port, which is what a same-instance lookup
   wants; the repo's port is the HTTP one the source would not dial anyway.
 
-  Issue the resulting statement with `query_opts/0`, which keeps the credential
-  out of both logs that would otherwise receive it.
+  Issue the resulting statement with `query_opts/0` to suppress application SQL
+  logging. ClickHouse masks the parsed dictionary source password in its query log.
   """
 
   @doc """
-  Query options for a statement rendered with `local_table/2`.
+  Query options for a statement rendered with `local_table/2` or `local_query/2`.
 
-  `log: false` keeps the credential out of the application log. `log_queries: 0`
-  keeps the whole statement out of `system.query_log`: ClickHouse masks
-  dictionary source passwords there on its own, but it does so from the parsed
-  statement, so anything that fails to parse is logged verbatim instead.
+  `log: false` keeps the credential out of the application log. Leave server
+  query logging settings alone: managed ClickHouse forbids changing
+  `log_queries`, so overriding it prevents dictionary creation and blocks deploys.
+  Server-side password masking relies on a successfully parsed statement; callers
+  must use valid dictionary DDL and the escaped source clauses built here.
   """
-  def query_opts, do: [log: false, settings: [log_queries: 0]]
+  def query_opts, do: [log: false]
 
   def local_table(repo, table) do
     config = repo.config()

--- a/server/test/tuist/clickhouse_dictionary_source_test.exs
+++ b/server/test/tuist/clickhouse_dictionary_source_test.exs
@@ -23,6 +23,13 @@ defmodule Tuist.ClickHouseDictionarySourceTest do
     def config, do: [username: "tuist"]
   end
 
+  test "query options suppress application logging without overriding server logging policy" do
+    opts = ClickHouseDictionarySource.query_opts()
+
+    assert opts[:log] == false
+    refute Keyword.has_key?(Keyword.get(opts, :settings, []), :log_queries)
+  end
+
   describe "local_query/2" do
     test "carries the credentials the repo itself connects with" do
       assert ClickHouseDictionarySource.local_query(AuthenticatedRepo, "SELECT id, project_id FROM command_events") ==

--- a/server/test/tuist/ingest_repo/dictionary_source_credentials_test.exs
+++ b/server/test/tuist/ingest_repo/dictionary_source_credentials_test.exs
@@ -42,7 +42,7 @@ defmodule Tuist.IngestRepo.DictionarySourceCredentialsTest do
       |> Enum.filter(fn path ->
         source = File.read!(path)
 
-        String.contains?(source, "ClickHouseDictionarySource.local_table(") and
+        String.contains?(source, ["ClickHouseDictionarySource.local_table(", "ClickHouseDictionarySource.local_query("]) and
           not String.contains?(source, "ClickHouseDictionarySource.query_opts()")
       end)
       |> Enum.map(&Path.basename/1)
@@ -51,8 +51,8 @@ defmodule Tuist.IngestRepo.DictionarySourceCredentialsTest do
     assert unredacted == [],
            """
            These migrations render a dictionary source carrying a password but do not issue \
-           the statement with `Tuist.ClickHouseDictionarySource.query_opts/0`, so a statement \
-           that fails to parse reaches `system.query_log` verbatim:
+           the statement with `Tuist.ClickHouseDictionarySource.query_opts/0`, so the \
+           credential can reach application SQL logs:
 
            #{Enum.map_join(unredacted, "\n", &("  " <> &1))}
            """


### PR DESCRIPTION
The [canary deployment](https://github.com/tuist/tuist/actions/runs/33991669382/job/101376412321) failed in `20260905120000_add_project_id_to_xcode_targets`: creating its dictionary raised `SETTING_CONSTRAINT_VIOLATION: Setting log_queries should not be changed`. The migration job exhausted its retries and Helm rolled back the release.

The shared dictionary source helper unconditionally supplied `settings: [log_queries: 0]` to keep credential-bearing statements out of ClickHouse query logs. Managed ClickHouse prohibits that override, so dictionary creation failed before the backfill could proceed.

Remove the server logging override from the shared helper while retaining `log: false` to suppress application SQL logging. This fixes every migration using the helper without changing database policy or the migration's backfill behavior. ClickHouse masks dictionary source passwords in successfully parsed statements; the helper documentation now explicitly records that malformed DDL does not have that guarantee. Keeping the escaped source construction and validating password masking avoids weakening the database's logging policy to accommodate the migration.

Add a regression assertion for the query options and extend the existing credential-log guard to cover `local_query/2`, which the failing migration uses, as well as `local_table/2`. Update the business-logic intent node to document the constraint.

### How to test locally

- Ran both focused ExUnit files directly with Elixir because this worktree has no installed server dependencies: **9 tests passed**.
  ```sh
  elixir -r server/lib/tuist/clickhouse_dictionary_source.ex -e 'ExUnit.start(); Code.require_file("server/test/tuist/clickhouse_dictionary_source_test.exs"); Code.require_file("server/test/tuist/ingest_repo/dictionary_source_credentials_test.exs")'
  ```
- Started an isolated local ClickHouse **26.1.2.11** instance with `log_queries = 1` constrained as readonly. Confirmed the old override reproduces `SETTING_CONSTRAINT_VIOLATION`, dictionary creation succeeds without it, and the successful DDL in `system.query_log` contains `[HIDDEN]` instead of the dummy password. The failing managed instance runs **26.4.1.2212**; the full migration and deployment have not been rerun.
- Checked formatting with Elixir's formatter and ran `git diff --check`; both passed. The full dependency-backed formatter/test suite was not run.
