### PR TITLE
fix(infra): exclude ClickHouse bare-metal nodes from hcloud CSI

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -58,6 +58,7 @@ Cluster API CRs and cluster-scoped manifests for the self-hosted CAPI + caph sta
 - `mgmt/flux-diff-rbac.yaml` — least-privilege `flux-diff` SA/Role for the `flux diff` PR job (`.github/workflows/flux-diff.yml`); dry-run write on `clusters` only.
 - `mgmt/reconciliation-checks.yaml` — CronJob (+ scrape-target Pushgateway) that reports orphan Hetzner servers and stale (removed-from-git) Clusters as metrics; alerts via Pillar 2.
 - `mgmt/bootstrap/` — Helm values for the per-workload bootstrap (Cilium, HCCM, hcloud-csi, ESO `ClusterSecretStore`).
+  The hcloud-csi node affinity excludes both Robot pools (`runners-linux` and `clickhouse`); these nodes lack the provider labels used by the other exclusions. Keep this list aligned when adding Robot pools, since Hetzner Cloud volumes and metadata are unavailable on bare metal.
 - `mgmt/ci-service-account.yaml` — SA + RBAC for the GitHub Actions deployer (applied per workload).
 - `mgmt/preview-mgmt-rbac.yaml` — narrow SA + Role on the mgmt cluster used by the preview-deploy / preview-sweep workflows to scale the preview MachineDeployment.
 - `onboarding.md` — end-to-end runbook for standing up a new workload cluster.

--- a/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
+++ b/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
@@ -43,8 +43,8 @@ node:
   # to a CrashLoopBackOff with "context deadline exceeded" trying to
   # GET /hetzner/v1/metadata/availability-zone.
   hostNetwork: true
-  # Skip Hetzner Robot bare-metal nodes (the `runners-linux` pool in
-  # `cluster-<env>.yaml`). The chart's default tolerations are
+  # Skip Hetzner Robot bare-metal nodes (the `runners-linux` and
+  # `clickhouse` pools). The chart's default tolerations are
   # `operator: Exists`, which swallows the
   # `tuist.dev/runner-tier=bare-metal:NoSchedule` taint and lands the
   # pod on bare metal, where two things go wrong:
@@ -58,13 +58,16 @@ node:
   #      before binding its `:9808` healthz port, so the liveness
   #      probe gets `connection refused` and CrashLoopBackOff kicks
   #      in. Observed on `bm-tuist-staging-runners-linux-*`.
+  # ClickHouse nodes also lack Hetzner Cloud's metadata service, so
+  # the driver exits on an availability-zone lookup timeout. Their
+  # data lives on local storage and needs no Hetzner Cloud CSI driver.
   #
   # Helm replaces (rather than merges) `node.affinity` when set, so
   # the chart's upstream Robot exclusions (`is-root-server`,
   # `provided-by=robot`) are re-declared here alongside our own
   # rules. All match expressions live in one list so they AND
   # together — a node schedules the pod only if it is none of:
-  # Hetzner root server, Robot-provisioned, in `runners-linux`,
+  # Hetzner root server, Robot-provisioned, in `runners-linux` or `clickhouse`,
   # provisioned by the in-house CAPI provider on non-Hetzner infra
   # (OVHcloud / Dedibox / Scaleway), or running darwin. Our CAPI
   # HCCM doesn't set the `is-root-server` / `provided-by` labels
@@ -104,7 +107,7 @@ node:
                 operator: NotIn
                 values:
                   - robot
-              # Hetzner Robot bare metal (the `runners-linux` pool).
+              # Hetzner Robot bare metal (`runners-linux` and `clickhouse`).
               # caph provisions these, so they carry no
               # `node.cluster.x-k8s.io/instance-type` label and the
               # provider rule below can't catch them; exclude by pool.
@@ -113,6 +116,7 @@ node:
                 operator: NotIn
                 values:
                   - runners-linux
+                  - clickhouse
               # Nodes the in-house CAPI provider brings up on
               # non-Hetzner infrastructure (OVHcloud, Dedibox,
               # Scaleway) for the kura cache fleets. hcloud Volumes


### PR DESCRIPTION
The `hcloud-csi-node` DaemonSet currently schedules onto the new Hetzner Robot ClickHouse nodes and repeatedly crashes. Add `clickhouse` to its existing pool exclusions so those nodes no longer run a Cloud-only storage driver, and document the exclusion in the infrastructure guidance.

### Why this is needed

The September 5 investigation of the [Pod CrashLoop / Frequent Restarts alert](https://tuist.grafana.net/alerting/grafana/dfkmrxsh5yz9ce/view?orgId=1) identified three affected pods: `hcloud-csi-node-7m64d` and `hcloud-csi-node-cfzc5` in canary, and `hcloud-csi-node-l9h2s` in staging. Both canary nodes joined at approximately 21:12 UTC after #12814; the staging node had been running since September 3 and had accumulated over 1,300 combined container restarts.

Previous-container logs show the driver exiting with code 1 after its request to `http://169.254.169.254/hetzner/v1/metadata/availability-zone` times out. The registrar then exits because it cannot connect to `unix:///run/csi/socket`. These are startup errors, with no OOM termination recorded.

The live DaemonSet affinity matches the repository, so this is a missing exclusion rather than deployment drift. The Robot nodes carry `node.cluster.x-k8s.io/pool=clickhouse`, but lack the Robot/provider labels checked by the other exclusions. The existing pool exclusion only covers `runners-linux`.

### Approach and impact

Extend the existing `NotIn` pool expression with `clickhouse`. This uses the label already present on every affected node and avoids requiring node relabeling or a broader change to cloud-node selection. All affinity expressions remain in the same selector term, preserving their AND semantics and the existing exclusions.

The bare-metal ClickHouse data volume uses local storage and does not need the Hetzner Cloud CSI driver. CSI pods on actual cloud nodes remain eligible, including those supporting cloud-backed Keeper storage. Production currently has 10 healthy CSI node pods and no ClickHouse nodes; the exclusion prevents the same failure when that pool is enabled.

The existing CSI Node Driver Deployment workflow watches this values file and will reconcile staging, canary, and production after merge. No cluster resources were mutated during implementation. Live recovery must be verified after deployment.

### How to test locally

- Ran `git diff --check` successfully.
- Rendered the upstream chart with `helm template hcloud-csi --repo https://charts.hetzner.cloud hcloud-csi --namespace kube-system -f infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml` (resolved chart: `hcloud-csi-2.23.0`).
- Parsed the rendered YAML and verified that the DaemonSet affinity exactly matches the values and retains `hostNetwork: true`.
- Compared the original and rendered affinity against fresh node-label snapshots from all three environments. Canary eligibility changed from 9 to 7, staging from 8 to 7, and production remained 10. The only excluded nodes were the three affected ClickHouse nodes; all previously eligible cloud nodes remain eligible.
- Confirmed the incident using read-only pod status, previous driver/registrar logs, node labels, DaemonSet status, and persistent-volume configuration.

After merge, verify the CSI deployment workflow succeeds, `hcloud-csi-node` has no pods on the `clickhouse` pool, and its desired and ready counts agree in each environment.
