### PR TITLE
feat(infra): reconcile Cloudflare configuration with Flux

### DIFF
--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -65,6 +65,14 @@ Cluster API CRs and cluster-scoped manifests for the self-hosted CAPI + caph sta
 ### `flux/` — GitOps reconciliation on the mgmt cluster
 Flux (`infra/flux/mgmt/`) is **Pillar 1** of [hive/specs/72](https://hive.tuist.dev/specs/72): it continuously reconciles the workload `Cluster` CRs under `k8s/clusters/workloads/` onto the mgmt cluster, so drift is corrected on an interval instead of only on merge and routine changes need no break-glass. Health alerting is the independent **Pillar 2** (`helm/k8s-monitoring/values-management.yaml` + `alerts.md`), Grafana Cloud, evaluated outside the single-node cluster with a heartbeat. Per-cluster `Kustomization`s never prune `Cluster` objects and use `force: false`; the immutable ClusterClass/bare-metal templates and preview stay on `mgmt-cluster-apply.yml`. See `infra/flux/mgmt/README.md` for bootstrap, the never-prune destroy flow, and the break-glass recovery path.
 
+Flux also installs management-cluster controllers whose desired state
+belongs in this repository. The Cloudflare operator release lives under
+`flux/cloudflare-operator/` and is reached through the
+`flux/mgmt/cloudflare-operator.yaml` Kustomization. Cloudflare resources
+live under `flux/cloudflare-config/`; their separate dependent
+Kustomization ensures the operator and its custom resource definitions
+are ready first.
+
 ### `kura-controller/` — Kura endpoint controller
 Go controller for `KuraInstance` and `KuraGateway` CRs (`kura.tuist.dev/v1alpha1`). It reconciles account-region Kura endpoint intent into Kubernetes workload resources and, when server policy requests it, dedicated ingress-nginx/LB gateway infrastructure on the Hetzner-backed cluster. Keep it separate from CAPI infrastructure providers; it manages product workload lifecycle, not cluster node lifecycle.
 

--- a/infra/cloudflare-operator/AGENTS.md
+++ b/infra/cloudflare-operator/AGENTS.md
@@ -78,9 +78,22 @@ The operator ships as a container image and a Helm chart at
 (not per-workload cluster) because the resources it manages are
 zone-global.
 
-Cloudflare API token lives in a Kubernetes Secret referenced by the
-chart. The token needs `Zone:Read` and `Zone WAF:Edit` scoped to
-the account and zone under management.
+Flux installs the chart through
+`infra/flux/mgmt/cloudflare-operator.yaml`, which points at the local
+Helm release under `infra/flux/cloudflare-operator/`. Managed values pin
+both the source commit tag and the immutable image digest. Cloudflare
+configuration lives under `infra/flux/cloudflare-config/` and is applied
+by a separate Flux Kustomization that depends on `cloudflare-operator`,
+so the custom resource definition and controller are ready before any
+managed resource is applied. Imported resources start in `read_only` and
+must report no proposed changes before a separate pull request switches
+them to `active`.
+
+The Cloudflare [application programming interface](https://developers.cloudflare.com/fundamentals/api/)
+token lives in a Kubernetes Secret referenced by the chart. The token
+needs `Zone:Read` and `Zone WAF:Edit`, where WAF means
+[Web Application Firewall](https://www.cloudflare.com/learning/ddos/glossary/web-application-firewall-waf/),
+scoped to the account and zone under management.
 
 ## Local development
 
@@ -101,6 +114,5 @@ credentials.
 - `server/lib/tuist_web/plugs/public_page_header_plug.ex` — sets the
   `x-tuist-public` response header the sample rate limit rule keys on.
 - Hive spec #72 (GitOps and health monitoring for the workload
-  clusters) — once Flux is running, this operator's CRDs get
-  committed to git and Flux applies them to the management cluster.
-  Until then the deployment workflow does `kubectl apply` directly.
+  clusters) — Flux installs this operator and applies its configuration
+  to the management cluster.

--- a/infra/cloudflare-operator/config/samples/public-pages-rate-limit.yaml
+++ b/infra/cloudflare-operator/config/samples/public-pages-rate-limit.yaml
@@ -1,5 +1,6 @@
-# The rate limit currently live on tuist.dev, codified so future edits
-# happen via PR against this file rather than the Cloudflare dashboard.
+# Example matching the rate limit currently live on tuist.dev. The
+# deployed resource is maintained under infra/flux/cloudflare-config/;
+# future behavior changes belong there rather than in this sample.
 #
 # Counts responses from origin that carry `x-tuist-public: 1` (set by
 # TuistWeb.Plugs.PublicPageHeaderPlug on URLs reachable without sign-in)
@@ -40,9 +41,9 @@ spec:
     # so counting is scoped per edge datacenter. ip.src makes the key
     # per-visitor within a datacenter.
     characteristics:
-      - "cf.colo.id"
       - "ip.src"
+      - "cf.colo.id"
     requestsPerPeriod: 60
     period: 10
-    mitigationTimeoutSeconds: 60
+    mitigationTimeoutSeconds: 0
     countingExpression: "(http.response.headers[\"x-tuist-public\"][0] eq \"1\")"

--- a/infra/cloudflare-operator/controllers/cloudflareratelimit_controller_test.go
+++ b/infra/cloudflare-operator/controllers/cloudflareratelimit_controller_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -244,6 +247,71 @@ func TestReconcile_Adopt_ZeroChangeIsNoop(t *testing.T) {
 	}
 	if cf.addCalls != 0 || cf.updateCalls != 0 {
 		t.Fatalf("adoption of matching rule must be a no-op: add=%d update=%d", cf.addCalls, cf.updateCalls)
+	}
+}
+
+// TestImportedPublicPagesRateLimitMatchesCapturedLiveRule guards the
+// production adoption gate. The expected rule below is the Cloudflare
+// response captured during import; changing the Git-managed manifest
+// makes this test fail until the intended drift is reviewed explicitly.
+func TestImportedPublicPagesRateLimitMatchesCapturedLiveRule(t *testing.T) {
+	manifestPath := filepath.Join("..", "..", "flux", "cloudflare-config", "public-pages-rate-limit.yaml")
+	manifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read imported manifest: %v", err)
+	}
+	manifestJSON, err := utilyaml.ToJSON(manifest)
+	if err != nil {
+		t.Fatalf("convert imported manifest: %v", err)
+	}
+	cr := &cfv1alpha1.CloudflareRateLimit{}
+	if err := json.Unmarshal(manifestJSON, cr); err != nil {
+		t.Fatalf("decode imported manifest: %v", err)
+	}
+	cr.UID = types.UID("captured-live-rule")
+	cr.Finalizers = []string{finalizer}
+
+	live := cloudflare.Rule{
+		ID:          "20a7e7c0f002481baa1b6b91af90e3ba",
+		Ref:         "20a7e7c0f002481baa1b6b91af90e3ba",
+		Version:     "1",
+		Action:      "managed_challenge",
+		Expression:  `(http.request.method eq "GET")`,
+		Description: "Public pages – anti-bombardment",
+		Enabled:     true,
+		LastUpdated: "2026-09-04T11:03:36.413297Z",
+		RateLimit: &cloudflare.RuleRateLimit{
+			Characteristics:    []string{"ip.src", "cf.colo.id"},
+			RequestsPerPeriod:  60,
+			Period:             10,
+			MitigationTimeout:  0,
+			CountingExpression: `(http.response.headers["x-tuist-public"][0] eq "1")`,
+		},
+	}
+
+	scheme := newTestScheme(t)
+	kClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr).WithStatusSubresource(cr).Build()
+	cf := &fakeCF{ruleset: &cloudflare.Ruleset{
+		ID:    "a8873085ecc543edbb509922cc213352",
+		Rules: []cloudflare.Rule{live},
+	}}
+	r := &CloudflareRateLimitReconciler{Client: kClient, Scheme: scheme, CF: cf}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: cr.Name}}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if cf.addCalls != 0 || cf.updateCalls != 0 || cf.createCalls != 0 {
+		t.Fatalf("imported rule must be a no-op: add=%d update=%d create=%d", cf.addCalls, cf.updateCalls, cf.createCalls)
+	}
+	got := &cfv1alpha1.CloudflareRateLimit{}
+	if err := kClient.Get(context.Background(), types.NamespacedName{Name: cr.Name}, got); err != nil {
+		t.Fatalf("get reconciled resource: %v", err)
+	}
+	if got.Status.Message != "read_only: in sync (adopted)" {
+		t.Errorf("status message = %q, want zero-change adoption", got.Status.Message)
+	}
+	if got.Status.ProposedChanges != "" {
+		t.Errorf("unexpected proposed changes: %q", got.Status.ProposedChanges)
 	}
 }
 

--- a/infra/flux/cloudflare-config/kustomization.yaml
+++ b/infra/flux/cloudflare-config/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - public-pages-rate-limit.yaml

--- a/infra/flux/cloudflare-config/public-pages-rate-limit.yaml
+++ b/infra/flux/cloudflare-config/public-pages-rate-limit.yaml
@@ -1,0 +1,25 @@
+# Imported from the live tuist.dev http_ratelimit entry-point ruleset on
+# 2026-09-05. Keep this resource in read_only until its status reports no
+# proposed changes, then switch mode to active in a separate pull request.
+apiVersion: cloudflare.tuist.dev/v1alpha1
+kind: CloudflareRateLimit
+metadata:
+  name: public-pages-anti-bombardment
+spec:
+  zoneId: 4421110085237b867a891bd0a40da106
+  description: "Public pages – anti-bombardment"
+  expression: "(http.request.method eq \"GET\")"
+  action: managed_challenge
+  enabled: true
+  mode: read_only
+  adopt:
+    ruleId: 20a7e7c0f002481baa1b6b91af90e3ba
+  retainOnDelete: true
+  ratelimit:
+    characteristics:
+      - "ip.src"
+      - "cf.colo.id"
+    requestsPerPeriod: 60
+    period: 10
+    mitigationTimeoutSeconds: 0
+    countingExpression: "(http.response.headers[\"x-tuist-public\"][0] eq \"1\")"

--- a/infra/flux/cloudflare-operator/helm-release.yaml
+++ b/infra/flux/cloudflare-operator/helm-release.yaml
@@ -1,0 +1,30 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cloudflare-operator
+  namespace: flux-system
+spec:
+  interval: 10m
+  releaseName: cloudflare-operator
+  targetNamespace: cloudflare-operator
+  storageNamespace: cloudflare-operator
+  chart:
+    spec:
+      chart: ./infra/helm/cloudflare-operator
+      interval: 10m
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      valuesFiles:
+        - values.yaml
+        - values-mgmt.yaml
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      strategy: rollback

--- a/infra/flux/cloudflare-operator/kustomization.yaml
+++ b/infra/flux/cloudflare-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml

--- a/infra/flux/mgmt/README.md
+++ b/infra/flux/mgmt/README.md
@@ -1,6 +1,6 @@
 # Flux on the management cluster
 
-Flux reconciles the workload `Cluster` resources from git onto the
+Flux reconciles management-cluster desired state from git onto the
 self-hosted CAPI + caph **management cluster** (single-node Talos). This is
 **Pillar 1** of [hive/specs/72](https://hive.tuist.dev/specs/72): continuous
 GitOps reconciliation, so drift is corrected on an interval instead of only
@@ -13,11 +13,11 @@ mechanism; a degraded control plane pages via Grafana Cloud.
 
 ## What Flux owns (and deliberately does not)
 
-| Owned by Flux (`infra/k8s/clusters/workloads/`) | Kept on `mgmt-cluster-apply.yml` |
+| Owned by Flux | Kept on `mgmt-cluster-apply.yml` |
 |---|---|
 | `tuist-staging`, `tuist-canary`, `tuist` (production) | `clusterclass-tuist.yaml`, `bare-metal*.yaml` (immutable templates — the delete-and-apply fallback for `field is immutable` can't be reproduced by a Kustomization) |
 | tenants `hive-production`, `once-production`, `atlas-production` | `cluster-preview.yaml` (replicas mutated out-of-band by the preview workflows; Flux would fight them every interval) and `cluster-pentest.yaml` (isolated security-assessment cluster) |
-| | the mgmt-side workloads (etcd-snapshot, tailscale, autoscaler, hetzner-robot-controller) |
+| Cloudflare operator Helm release and `tuist.dev` rate-limit configuration | the other mgmt-side workloads (etcd-snapshot, tailscale, autoscaler, hetzner-robot-controller) |
 
 One Flux `Kustomization` per cluster (`cluster-*.yaml` here), each `path`
 scoped to a single `workloads/<cluster>/` subdir. Key invariants:
@@ -27,6 +27,29 @@ scoped to a single `workloads/<cluster>/` subdir. Key invariants:
   controller, Flux halts and reports instead of stomping it.
 - **`healthCheckExprs`** gate each Kustomization on the `Cluster`'s v1beta2
   `Available` rollup (a sync gate, not health alerting).
+
+`cloudflare-operator.yaml` follows the same child-Kustomization pattern,
+but points at a local Helm release and waits for it to become ready. Its
+managed values pin the operator image by digest. `cloudflare-config.yaml`
+depends on that release and applies the Cloudflare resources under
+`infra/flux/cloudflare-config/`, preventing Flux from applying a custom
+resource before its definition exists.
+
+The adopted rate-limit resource starts in `read_only`. That mode deliberately
+reports `Ready=False`, so the configuration Kustomization does not wait on
+resource health. Before changing it to `active`, inspect the proposed change:
+
+```bash
+kubectl get cloudflareratelimit public-pages-anti-bombardment \
+  -o jsonpath='{.status.message}{"\n"}{.status.proposedChanges}{"\n"}'
+```
+
+Only an empty `status.proposedChanges` and an `in sync (adopted)` message are
+safe to activate. The `cloudflare-operator/token` field in the
+`tuist-k8s-mgmt` 1Password vault should be read-only for this adoption pass;
+replace it with a zone-scoped token carrying `Zone WAF:Edit`, where WAF means
+[Web Application Firewall](https://www.cloudflare.com/learning/ddos/glossary/web-application-firewall-waf/),
+only when the resource is switched to `active`.
 
 ## Install (one-time, break-glass)
 
@@ -88,7 +111,7 @@ kubectl kustomize flux-system \
   | kubectl apply -f -
 ```
 
-Verify — expect seven Kustomizations Ready and the provider set:
+Verify — expect nine Kustomizations Ready and the provider set:
 
 ```bash
 kubectl -n flux-system get kustomizations

--- a/infra/flux/mgmt/cloudflare-config.yaml
+++ b/infra/flux/mgmt/cloudflare-config.yaml
@@ -1,0 +1,22 @@
+# Applies the Cloudflare desired state only after the operator Helm release
+# is healthy. Read-only Cloudflare resources deliberately report Ready=False,
+# so this Kustomization does not wait on their health while adoption is being
+# verified. The resource status remains the rollout gate before active mode.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudflare-config
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: cloudflare-operator
+  interval: 10m
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infra/flux/cloudflare-config
+  prune: true
+  wait: false
+  force: false

--- a/infra/flux/mgmt/cloudflare-operator.yaml
+++ b/infra/flux/mgmt/cloudflare-operator.yaml
@@ -1,0 +1,20 @@
+# Installs the Cloudflare operator into the management cluster from the
+# chart in this repository. The child Kustomization waits for the Helm
+# release so Cloudflare configuration can depend on the controller and
+# its custom resource definition being ready.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudflare-operator
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infra/flux/cloudflare-operator
+  prune: true
+  wait: true
+  force: false

--- a/infra/helm/cloudflare-operator/Chart.yaml
+++ b/infra/helm/cloudflare-operator/Chart.yaml
@@ -7,11 +7,15 @@ description: >
   syncs the Cloudflare API token from 1Password via
   external-secrets-operator.
 
+  The installer must create the target namespace. Flux does this through
+  HelmRelease.spec.install.createNamespace; direct Helm installs must pass
+  --create-namespace.
+
   Runs one replica with leader election so `--replicaCount` can be
   bumped without racing rules. The reconciler is stateless (it finds
   its rules on Cloudflare by a stable `ref` it sets), so there is no
   local state volume to attach.
 
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"

--- a/infra/helm/cloudflare-operator/templates/deployment.yaml
+++ b/infra/helm/cloudflare-operator/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
         - name: manager
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ with .Values.image.digest }}@{{ . }}{{ end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --resync-interval={{ .Values.resyncInterval }}

--- a/infra/helm/cloudflare-operator/templates/namespace.yaml
+++ b/infra/helm/cloudflare-operator/templates/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.namespace }}

--- a/infra/helm/cloudflare-operator/values-mgmt.yaml
+++ b/infra/helm/cloudflare-operator/values-mgmt.yaml
@@ -3,6 +3,8 @@
 # configuration is global, not per-env.
 
 image:
-  # Set at deploy time by the release workflow (defaults to the
-  # chart's appVersion).
-  tag: ""
+  # Built from f13d662ff12b, the commit that introduced the operator.
+  # Keep the human-readable tag and immutable multi-platform digest
+  # together so reviewers can trace both the source and deployed bytes.
+  tag: sha-f13d662ff12b
+  digest: sha256:dcd9825f51b6d0521fe5ccb69aa0594a2149c6a53fcb42bea12d67c11953e685

--- a/infra/helm/cloudflare-operator/values.yaml
+++ b/infra/helm/cloudflare-operator/values.yaml
@@ -9,6 +9,10 @@ image:
   # tag today, so falling back to it would land in ErrImagePull.
   # Override to :sha-<git-sha> at install time for reproducible deploys.
   tag: latest
+  # Set together with tag in managed environments. Kubernetes verifies
+  # this content digest before starting the container, so a mutable tag
+  # cannot move the deployed operator to an unreviewed build.
+  digest: ""
   pullPolicy: IfNotPresent
 
 replicaCount: 1


### PR DESCRIPTION
Moves the Cloudflare operator and the existing `tuist.dev` public-pages rate limit into the management cluster's Flux reconciliation path, while keeping the imported rule unable to mutate Cloudflare during adoption.

## What changed

- Added a Flux Helm release for the Cloudflare operator with an immutable container image digest.
- Added a dependent Flux configuration reconciliation for Cloudflare resources.
- Imported the existing public-pages rate-limit rule by its Cloudflare identifier in `read_only` mode with deletion retention enabled.
- Added a regression test that compares the Git-managed manifest with the captured live rule and requires zero proposed changes.
- Documented the deployment order, 1Password credential, adoption check, and separate activation step.

## Why

Cloudflare configuration was still managed outside the repository even though Flux now reconciles management-cluster state. Importing the live rule gives configuration changes the same review and reconciliation workflow as the rest of the managed infrastructure.

## Approach

The operator is installed first through a local Helm chart. A second Flux reconciliation depends on that release before applying Cloudflare resources. The live rule is adopted explicitly rather than recreated, and remains read-only so this pull request cannot change Cloudflare behavior. Activation requires a separate reviewed pull request after the operator reports that the imported configuration is already in sync.

## Impact

After merge, Flux will install the operator and continuously compare the committed rate-limit resource with Cloudflare. The existing rule remains unchanged during the adoption phase. Future edits can be proposed through Git, with activation controlled independently.

### How to test locally

From `infra/cloudflare-operator`:

```bash
go test ./...
go vet ./...
go build ./...
```

From the repository root:

```bash
helm lint infra/helm/cloudflare-operator -f infra/helm/cloudflare-operator/values-mgmt.yaml
helm template cloudflare-operator infra/helm/cloudflare-operator -f infra/helm/cloudflare-operator/values-mgmt.yaml | kubeconform -strict -summary -ignore-missing-schemas
flux build kustomization flux-system --path ./infra/flux/mgmt --kustomization-file ./infra/flux/mgmt/flux-system/gotk-sync.yaml --dry-run --recursive --local-sources GitRepository/flux-system/flux-system=.
```

The operator tests, static analysis, build, Helm lint, recursive Flux render, and schema validation completed successfully. The rendered Helm resources reported no invalid resources, and the recursive Flux output contained the operator release, dependent configuration reconciliation, and imported rate-limit resource.
