### PR TITLE
fix(infra): resolve Cloudflare Helm values from source root

### DIFF
--- a/infra/flux/cloudflare-operator/helm-release.yaml
+++ b/infra/flux/cloudflare-operator/helm-release.yaml
@@ -17,9 +17,11 @@ spec:
         kind: GitRepository
         name: flux-system
         namespace: flux-system
+      # GitRepository-backed value files are resolved from the source root,
+      # not from the chart directory.
       valuesFiles:
-        - values.yaml
-        - values-mgmt.yaml
+        - ./infra/helm/cloudflare-operator/values.yaml
+        - ./infra/helm/cloudflare-operator/values-mgmt.yaml
   install:
     createNamespace: true
     remediation:


### PR DESCRIPTION
Restores the Cloudflare operator reconciliation that stalled immediately after the initial Flux adoption merged.

## What changed

The Cloudflare operator Helm release now references both value files from the root of the Flux Git repository source. An adjacent comment records the path-resolution rule that caused the failure.

## Why

The management cluster fetched the merged revision successfully, but it could not package the operator chart. As a result, the operator namespace and custom resource definition were never created, and the Cloudflare configuration remained blocked on its dependency.

## Root cause

The release listed `values.yaml` and `values-mgmt.yaml` as if Flux resolved them relative to the chart directory. For a `GitRepository` source, Flux resolves value-file paths relative to the source root, so it searched for `/values.yaml` and reported `ValuesFilesError`.

## Approach

Both entries now use their complete repository-relative paths under `infra/helm/cloudflare-operator`. This follows the [Flux Helm chart source behavior](https://fluxcd.io/flux/components/source/helmcharts/) and keeps the existing value precedence unchanged.

## Impact

After merge, Flux can package and install the Cloudflare operator, then unblock the dependent Cloudflare configuration reconciliation. The imported Cloudflare rule remains in `read_only` mode, so this fix does not authorize configuration mutations.

### How to test locally

```bash
helm lint infra/helm/cloudflare-operator -f infra/helm/cloudflare-operator/values-mgmt.yaml
helm template cloudflare-operator infra/helm/cloudflare-operator -f infra/helm/cloudflare-operator/values-mgmt.yaml | kubeconform -strict -summary -ignore-missing-schemas
flux build kustomization flux-system --path ./infra/flux/mgmt --kustomization-file ./infra/flux/mgmt/flux-system/gotk-sync.yaml --dry-run --recursive --local-sources GitRepository/flux-system/flux-system=.
```

Helm lint passed. Schema validation found four valid resources, no invalid resources, no errors, and two resources without local schemas. The recursive Flux render produced both corrected paths, and both resolve to files in the repository.
