### PR TITLE
docs(server): document LCP p99 affected-session minimum

### DIFF
--- a/infra/helm/AGENTS.md
+++ b/infra/helm/AGENTS.md
@@ -15,6 +15,9 @@ This node covers Helm assets under `infra/helm/`.
 - Model infrastructure dependencies with capability names such as `objectStorage`, not provider names such as `minio`.
 - Support both `embedded` and `external` dependency modes when practical.
 - Keep local validation simple: `helm template` first, then a small-cluster install path such as `kind`.
+- Grafana-managed alert queries and their operational rationale live in
+  `k8s-monitoring/alerts.md`. Keep that runbook aligned with live rule changes;
+  browser LCP p99 also requires distinct affected sessions, not just total samples.
 
 ## Related Context
 - Parent infra context: `infra/AGENTS.md`

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -4336,13 +4336,77 @@ measurement context is prefixed `context_` (`context_rating`,
 | **LCP p75 failing Core Web Vitals** | **0.75** | **6h** | **> 2.5s** | **100** | **30m** |
 | LCP p90 in the Core Web Vitals poor band | 0.90 | 6h | > 4.0s | 100 | 30m |
 | LCP p95 sustained slow tail | 0.95 | 24h | > 5.0s | 300 | 30m |
-| LCP p99 pathological tail | 0.99 | 24h | > 10.0s | 300 | 30m |
+| LCP p99 pathological tail | 0.99 | 24h | > 10.0s and ≥ 10 affected sessions | 300 | 30m |
 
-Each pairs the percentile with a sample-count query and fires only when both the
-threshold is crossed and enough samples exist, so a handful of overnight
-visitors cannot manufacture a percentile. At 32 samples an hour a 6h window
-holds roughly 190 and a 24h window roughly 770; p95 and p99 need the wider one
-because a stable estimate takes about ten times `1/(1-q)` samples.
+Each pairs the percentile with a sample-count query and requires more than the
+listed minimum samples. That prevents evaluating a percentile over very little
+traffic, but does not stop a few outliers from determining p99. At the baseline
+rate of 32 samples an hour a 6h window holds roughly 190 and a 24h window roughly
+770; the wider window helps, but does not guarantee a stable tail estimate.
+
+**p99 also requires at least ten affected sessions.** Rule
+`efx5a3mn2fwg0c` keeps A (p99 in seconds), B (total LCP samples), and the 30-minute
+pending period. D counts distinct non-empty `session_id` values with at least
+one LCP above 10,000 milliseconds in the same 24 hours. Multiple slow page loads
+or reloads within one session count once; a session is not a unique person.
+Its C math expression is `$A > 10.0 && $B > 300 && $D >= 10`.
+
+Use this instant Loki query for D:
+
+```logql
+count by (app_environment) (
+  sum by (app_environment, session_id) (
+    count_over_time(
+      {service_name="tuist-web"}
+        | logfmt
+        | kind="measurement"
+        | type="web-vitals"
+        | app_environment="prod"
+        | lcp!=""
+        | session_id!=""
+        | lcp > 10000
+        | __error__="" [24h]
+    )
+  )
+) or on (app_environment) (
+  0 * sum by (app_environment) (
+    count_over_time(
+      {service_name="tuist-web"}
+        | logfmt
+        | kind="measurement"
+        | type="web-vitals"
+        | app_environment="prod"
+        | lcp!="" [24h]
+    )
+  )
+)
+```
+
+The fallback preserves the `app_environment` label and returns zero when LCP
+telemetry exists but no sessions qualify. It leaves missing telemetry absent;
+the separate browser-vitals telemetry rule covers that case. Missing session
+IDs do not establish distinct affected sessions and are excluded from D.
+
+**Why ten, and validation on 2026-09-06.** The investigated window ending
+2026-09-05 21:46 UTC had p99 13.58s, 477 samples, and only six affected sessions
+on different pages. A 14-day lookback returned LCP data only from September 4.
+At 55 hourly evaluation points from September 4 09:00 UTC through September 6
+15:00 UTC, the old A/B condition crossed its thresholds 19 times; adding D
+suppressed all 19. D ranged from zero to eight. These are sampled condition
+results, not a replay of the 30-minute pending state. The zero-session fallback
+was also verified against live Loki. This short history does not establish a
+statistical cutoff or show sensitivity to a known widespread regression: ten
+is an interruption policy that should be reassessed with more history. It
+delays detection of low-volume regressions; the lower-percentile rules remain
+independent.
+
+For per-page investigation, group the inner sum by
+`(app_environment, page_url, session_id)` and the outer count by
+`(app_environment, page_url)`. Three affected sessions on the same page is a
+candidate complementary signal, not an enabled rule. The six-hour backtest
+snapshots found at most one affected session per page. Before enabling it,
+validate it with more history and normalize URLs so query strings do not split
+one page into multiple groups.
 
 **p75 is the only one of these that measures a standard.** Core Web Vitals
 assesses LCP at the 75th percentile — at or below 2.5s is good, above 4.0s is
@@ -4377,8 +4441,20 @@ quantile_over_time(0.75,
 ```
 
 Swap `resource_load_duration` for `time_to_first_byte`, `resource_load_delay` or
-`element_render_delay`. A large `resource_load_duration` is image weight; a large
-`time_to_first_byte` is the origin.
+`element_render_delay`. A large `resource_load_duration` can mean a heavy image
+or a slow transfer. A large `time_to_first_byte` includes delays before the
+request reaches the origin, including connection establishment. Correlate the
+session and `context_navigation_entry_id` with the `faro.performance.navigation`
+event's `event_data_faroNavigationId`, then inspect `event_data_requestTime`,
+`event_data_dnsLookupTime`, `event_data_tcpHandshakeTime` and
+`event_data_tlsNegotiationTime` before attributing it to the server. The
+September 5 blog outlier spent 35.51s establishing the connection and only 0.57s
+loading its LCP image.
+
+Run `mise run marketing:image-budget` when investigating image weight, but note
+that it only checks `server/priv/static/marketing/images`. Dashboard assets,
+including the signup images under `server/priv/static/app/images`, are outside
+that budget.
 
 These rules are warnings and carry no `affected_service` label. A slow marketing
 page is not a customer-visible outage and must not open a status-page incident.


### PR DESCRIPTION
The LCP p99 alert fired on a small number of unrelated slow visits despite its existing total-sample minimum. In the window ending September 5 at 21:46 UTC, p99 was 13.58s across 477 samples, but only six distinct sessions exceeded 10s. Several outliers were dominated by connection establishment rather than LCP image transfer.

This PR documents the affected-session minimum already applied to the [Grafana-managed alert](https://tuist.grafana.net/alerting/grafana/efx5a3mn2fwg0c/view?orgId=1). The live configuration changed on September 6; merging this documentation does not provision or deploy the alert.

### Approach and impact

The rule now requires `$A > 10.0 && $B > 300 && $D >= 10`: p99 above 10 seconds, more than 300 LCP samples, and at least ten distinct sessions with LCP above 10 seconds in the same 24-hour window. The 30-minute pending period remains unchanged.

The runbook includes the exact Loki query for D. It counts each non-empty session ID once, so repeated slow loads within one browser session cannot satisfy the minimum. A fallback returns an environment-labeled zero when LCP telemetry exists without qualifying sessions, while preserving absent telemetry for the separate telemetry-missing alert.

A larger total-sample floor alone would not establish how many sessions were affected, and a longer pending period would keep reevaluating the same outliers in the rolling 24-hour window. The new floor instead expresses the minimum impact worth an interruption. It can delay detection on low-traffic pages, so ten remains a policy choice to revisit with more history. The lower-percentile alerts remain independent.

The documentation also corrects the assumption that long TTFB proves a slow origin, explains the marketing image budget's exclusion of app assets, and records a per-page repeat-session signal as a diagnostic candidate rather than an enabled alert.

### Validation

- Queried a 14-day lookback; available LCP history covered only about 54 hours.
- Compared 55 hourly evaluation points from September 4 09:00 UTC through September 6 15:00 UTC. The old condition crossed its thresholds 19 times; the new session floor suppressed all 19. Affected-session counts ranged from zero to eight.
- Reproduced six affected sessions for the investigated window.
- Verified the zero-session fallback and absent-telemetry behavior against live Loki.
- Read back the saved rule and verified its first post-update evaluation at September 6 15:26 UTC: health OK, state Normal, p99 9.77s, 406 samples, and four affected sessions.
- `git diff --check` passed.

These backtest results are sampled condition checks, not a replay of the pending state or proof of sensitivity to a known widespread regression.

### How to test locally

Run `git diff --check`. To validate the operational query, run the documented D expression as an instant query against `grafanacloud-logs` in Grafana Explore with an explicit evaluation timestamp. The September 5 21:46 UTC window returned six affected sessions during validation.
