### PR TITLE
feat(infra): protect crawlable pages with Cloudflare

### DIFF
--- a/.github/workflows/cloudflare-operator-image.yml
+++ b/.github/workflows/cloudflare-operator-image.yml
@@ -3,8 +3,9 @@ name: Cloudflare Operator Image
 # PR validation + ad-hoc image build for cloudflare-operator, the
 # Kubernetes controller that reconciles CRDs under cloudflare.tuist.dev
 # against the Cloudflare API so that zone-level configuration (rate
-# limits today, cache rules / WAF custom rules / AI Crawl Control /
-# zone settings as follow-on CRDs) lives in git.
+# limits and Web Application Firewall custom rules today, with cache rules,
+# crawler controls, and zone settings as possible follow-on resources) lives
+# in git.
 #
 # Steady-state image promotion for the operator will follow the same
 # pattern as the other infra controllers; today this workflow handles

--- a/infra/cloudflare-operator/AGENTS.md
+++ b/infra/cloudflare-operator/AGENTS.md
@@ -5,10 +5,10 @@ against the Cloudflare API. It exists so zone-level Cloudflare
 configuration lives in git and reaches production through a reviewed
 PR, not through the Cloudflare dashboard.
 
-**Scope today: `CloudflareRateLimit` only.** Additional CRDs (cache
-rules, WAF custom rules, zone settings, AI Crawl Control) are
-follow-up work; each is a separate PR so the first production
-deployment has one small reviewable surface.
+**Scope today: `CloudflareRateLimit` and `CloudflareCustomRule`.**
+Additional custom resources, such as cache rules, zone settings, and
+Artificial Intelligence Crawl Control, should remain separate kinds
+rather than overloading either ruleset shape.
 
 ## Why an operator, not Terraform
 
@@ -22,8 +22,8 @@ update the same rule across reconciles with no client-side state.
 
 ## Safe-first-deploy design
 
-The rate-limit CRD is designed so the first deployment against a
-live zone is provably zero-risk:
+Both custom resource definitions are designed so the first deployment
+against a live zone is provably zero-risk:
 
 - **`spec.mode` defaults to `read_only`.** In read_only the operator
   computes the intended diff, logs it, mirrors it into
@@ -105,7 +105,7 @@ go build ./...
 go test ./...
 ```
 
-The reconciler is tested with a scripted fake implementing the
+The reconcilers are tested with a scripted fake implementing the
 narrow `RulesetAPI` interface, so tests don't need real Cloudflare
 credentials.
 

--- a/infra/cloudflare-operator/api/v1alpha1/cloudflarecustomrule_types.go
+++ b/infra/cloudflare-operator/api/v1alpha1/cloudflarecustomrule_types.go
@@ -1,0 +1,171 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// CloudflareCustomRuleSpec describes one rule in a zone's
+// http_request_firewall_custom entry-point ruleset.
+//
+// +kubebuilder:validation:XValidation:rule="self.zoneId == oldSelf.zoneId",message="zoneId is immutable"
+// +kubebuilder:validation:XValidation:rule="has(self.adopt) || self.createNewRule == true",message="either adopt.ruleId or createNewRule=true must be set"
+type CloudflareCustomRuleSpec struct {
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="zoneId is immutable"
+	ZoneID string `json:"zoneId"`
+
+	Description string `json:"description"`
+	Expression  string `json:"expression"`
+
+	// +kubebuilder:validation:Enum=block;managed_challenge;js_challenge;log
+	Action string `json:"action"`
+
+	// +kubebuilder:default=read_only
+	Mode ReconcileMode `json:"mode,omitempty"`
+
+	// +kubebuilder:default=false
+	Paused bool `json:"paused,omitempty"`
+
+	// +kubebuilder:default=true
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// +kubebuilder:validation:XValidation:rule="!has(oldSelf) || self == oldSelf",message="adopt is immutable once set"
+	Adopt *AdoptRule `json:"adopt,omitempty"`
+
+	// +kubebuilder:default=false
+	CreateNewRule bool `json:"createNewRule,omitempty"`
+
+	// +kubebuilder:default=true
+	RetainOnDelete bool `json:"retainOnDelete,omitempty"`
+}
+
+func (s *CloudflareCustomRuleSpec) IsEnabled() bool {
+	return s.Enabled == nil || *s.Enabled
+}
+
+func (s *CloudflareCustomRuleSpec) EffectiveMode() ReconcileMode {
+	if s.Mode == "" {
+		return ReconcileModeReadOnly
+	}
+	return s.Mode
+}
+
+type CloudflareCustomRuleStatus struct {
+	Conditions         []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+	Ref                string             `json:"ref,omitempty"`
+	RuleID             string             `json:"ruleId,omitempty"`
+	RulesetID          string             `json:"rulesetId,omitempty"`
+	ManagedZoneID      string             `json:"managedZoneId,omitempty"`
+	ObservedGeneration int64              `json:"observedGeneration,omitempty"`
+	Mode               ReconcileMode      `json:"mode,omitempty"`
+	ProposedChanges    string             `json:"proposedChanges,omitempty"`
+	Message            string             `json:"message,omitempty"`
+	LastReconciledAt   *metav1.Time       `json:"lastReconciledAt,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster,shortName=cfcustom
+// +kubebuilder:printcolumn:name="Zone",type="string",JSONPath=".spec.zoneId"
+// +kubebuilder:printcolumn:name="Mode",type="string",JSONPath=".spec.mode"
+// +kubebuilder:printcolumn:name="Action",type="string",JSONPath=".spec.action"
+// +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.message"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+type CloudflareCustomRule struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   CloudflareCustomRuleSpec   `json:"spec,omitempty"`
+	Status CloudflareCustomRuleStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+type CloudflareCustomRuleList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []CloudflareCustomRule `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&CloudflareCustomRule{}, &CloudflareCustomRuleList{})
+}
+
+func (in *CloudflareCustomRuleSpec) DeepCopyInto(out *CloudflareCustomRuleSpec) {
+	*out = *in
+	if in.Enabled != nil {
+		in, out := &in.Enabled, &out.Enabled
+		*out = new(bool)
+		**out = **in
+	}
+	if in.Adopt != nil {
+		in, out := &in.Adopt, &out.Adopt
+		*out = new(AdoptRule)
+		**out = **in
+	}
+}
+
+func (in *CloudflareCustomRule) DeepCopyInto(out *CloudflareCustomRule) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.Spec.DeepCopyInto(&out.Spec)
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+func (in *CloudflareCustomRule) DeepCopy() *CloudflareCustomRule {
+	if in == nil {
+		return nil
+	}
+	out := new(CloudflareCustomRule)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *CloudflareCustomRule) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+func (in *CloudflareCustomRuleList) DeepCopyInto(out *CloudflareCustomRuleList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]CloudflareCustomRule, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+func (in *CloudflareCustomRuleList) DeepCopy() *CloudflareCustomRuleList {
+	if in == nil {
+		return nil
+	}
+	out := new(CloudflareCustomRuleList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *CloudflareCustomRuleList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+func (in *CloudflareCustomRuleStatus) DeepCopyInto(out *CloudflareCustomRuleStatus) {
+	*out = *in
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]metav1.Condition, len(*in))
+		copy(*out, *in)
+	}
+	if in.LastReconciledAt != nil {
+		in, out := &in.LastReconciledAt, &out.LastReconciledAt
+		*out = (*in).DeepCopy()
+	}
+}

--- a/infra/cloudflare-operator/cmd/manager/main.go
+++ b/infra/cloudflare-operator/cmd/manager/main.go
@@ -102,6 +102,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := (&controllers.CloudflareCustomRuleReconciler{
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		CF:             cf,
+		ResyncInterval: resyncInterval,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "setup CloudflareCustomRuleReconciler")
+		os.Exit(1)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "set up health check")
 		os.Exit(1)

--- a/infra/cloudflare-operator/config/crd/cloudflare.tuist.dev_cloudflarecustomrules.yaml
+++ b/infra/cloudflare-operator/config/crd/cloudflare.tuist.dev_cloudflarecustomrules.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cloudflarecustomrules.cloudflare.tuist.dev
+spec:
+  group: cloudflare.tuist.dev
+  scope: Cluster
+  names:
+    plural: cloudflarecustomrules
+    singular: cloudflarecustomrule
+    kind: CloudflareCustomRule
+    shortNames: [cfcustom]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - {name: Zone, type: string, jsonPath: .spec.zoneId}
+        - {name: Mode, type: string, jsonPath: .spec.mode}
+        - {name: Action, type: string, jsonPath: .spec.action}
+        - {name: Message, type: string, jsonPath: .status.message}
+        - {name: Age, type: date, jsonPath: .metadata.creationTimestamp}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            apiVersion: {type: string}
+            kind: {type: string}
+            metadata: {type: object}
+            spec:
+              type: object
+              required: [zoneId, description, expression, action]
+              x-kubernetes-validations:
+                - rule: "self.zoneId == oldSelf.zoneId"
+                  message: "spec.zoneId is immutable"
+                - rule: "has(self.adopt) || self.createNewRule == true"
+                  message: "either spec.adopt.ruleId or spec.createNewRule=true must be set"
+                - rule: "!has(oldSelf.adopt) || (has(self.adopt) && self.adopt.ruleId == oldSelf.adopt.ruleId)"
+                  message: "spec.adopt is immutable once set"
+              properties:
+                zoneId: {type: string}
+                description: {type: string}
+                expression: {type: string}
+                action:
+                  type: string
+                  enum: [block, managed_challenge, js_challenge, log]
+                enabled: {type: boolean, default: true}
+                mode:
+                  type: string
+                  enum: [read_only, active]
+                  default: read_only
+                paused: {type: boolean, default: false}
+                createNewRule: {type: boolean, default: false}
+                retainOnDelete: {type: boolean, default: true}
+                adopt:
+                  type: object
+                  required: [ruleId]
+                  properties:
+                    ruleId: {type: string}
+            status:
+              type: object
+              properties:
+                ref: {type: string}
+                ruleId: {type: string}
+                rulesetId: {type: string}
+                managedZoneId: {type: string}
+                mode: {type: string}
+                proposedChanges: {type: string}
+                observedGeneration: {type: integer, format: int64}
+                message: {type: string}
+                lastReconciledAt: {type: string, format: date-time}
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status, lastTransitionTime, reason]
+                    properties:
+                      type: {type: string, maxLength: 316}
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      observedGeneration: {type: integer, format: int64, minimum: 0}
+                      lastTransitionTime: {type: string, format: date-time}
+                      reason: {type: string, maxLength: 1024}
+                      message: {type: string, maxLength: 32768}
+

--- a/infra/cloudflare-operator/config/rbac/role.yaml
+++ b/infra/cloudflare-operator/config/rbac/role.yaml
@@ -4,13 +4,13 @@ metadata:
   name: cloudflare-operator-manager
 rules:
   - apiGroups: ["cloudflare.tuist.dev"]
-    resources: [cloudflareratelimits]
+    resources: [cloudflareratelimits, cloudflarecustomrules]
     verbs: [get, list, watch, update, patch]
   - apiGroups: ["cloudflare.tuist.dev"]
-    resources: [cloudflareratelimits/status]
+    resources: [cloudflareratelimits/status, cloudflarecustomrules/status]
     verbs: [get, update, patch]
   - apiGroups: ["cloudflare.tuist.dev"]
-    resources: [cloudflareratelimits/finalizers]
+    resources: [cloudflareratelimits/finalizers, cloudflarecustomrules/finalizers]
     verbs: [update]
   - apiGroups: ["coordination.k8s.io"]
     resources: [leases]

--- a/infra/cloudflare-operator/controllers/cloudflarecustomrule_controller.go
+++ b/infra/cloudflare-operator/controllers/cloudflarecustomrule_controller.go
@@ -1,0 +1,253 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	cfv1alpha1 "github.com/tuist/tuist/infra/cloudflare-operator/api/v1alpha1"
+	"github.com/tuist/tuist/infra/cloudflare-operator/internal/cloudflare"
+)
+
+// +kubebuilder:rbac:groups=cloudflare.tuist.dev,resources=cloudflarecustomrules,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=cloudflare.tuist.dev,resources=cloudflarecustomrules/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=cloudflare.tuist.dev,resources=cloudflarecustomrules/finalizers,verbs=update
+
+type CloudflareCustomRuleReconciler struct {
+	client.Client
+	Scheme         *runtime.Scheme
+	CF             RulesetAPI
+	ResyncInterval time.Duration
+}
+
+type customRulePlan struct {
+	operation string
+	action    string
+	summary   string
+	rulesetID string
+	ruleID    string
+	existing  *cloudflare.Rule
+}
+
+func (r *CloudflareCustomRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("cloudflarecustomrule", req.Name)
+	cr := &cfv1alpha1.CloudflareCustomRule{}
+	if err := r.Get(ctx, req.NamespacedName, cr); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if cr.Spec.Paused {
+		message := "paused"
+		if !cr.DeletionTimestamp.IsZero() {
+			message = "paused: delete held"
+		}
+		return ctrl.Result{RequeueAfter: resyncOrDefault(r.ResyncInterval)}, r.writeStatus(
+			ctx, cr, cr.Status.Ref, cr.Status.RulesetID, cr.Status.RuleID, message, "",
+			cfv1alpha1.ReasonPaused, metav1.ConditionFalse, cr.Status.ObservedGeneration,
+		)
+	}
+
+	ref := customRuleRef(cr)
+	if !cr.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, logger, cr, ref)
+	}
+	added, err := ensureFinalizer(ctx, r.Client, cr)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if added {
+		return ctrl.Result{}, nil
+	}
+
+	desired := renderCustomRule(cr, ref)
+	plan, err := r.planReconcile(ctx, cr, desired)
+	if err != nil {
+		_ = r.writeStatus(ctx, cr, ref, plan.rulesetID, plan.ruleID, err.Error(), "", cfv1alpha1.ReasonReconcileError, metav1.ConditionFalse, cr.Status.ObservedGeneration)
+		return ctrl.Result{}, err
+	}
+
+	if cr.Spec.EffectiveMode() == cfv1alpha1.ReconcileModeReadOnly {
+		logger.Info("read_only: would "+plan.action, "rulesetId", plan.rulesetID, "ruleId", plan.ruleID, "ref", ref)
+		if err := r.writeStatus(ctx, cr, ref, plan.rulesetID, plan.ruleID, "read_only: "+plan.action, plan.summary, cfv1alpha1.ReasonReadOnly, metav1.ConditionFalse, cr.Status.ObservedGeneration); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: resyncOrDefault(r.ResyncInterval)}, nil
+	}
+
+	if err := r.applyPlan(ctx, logger, cr, desired, plan); err != nil {
+		_ = r.writeStatus(ctx, cr, ref, plan.rulesetID, plan.ruleID, err.Error(), "", cfv1alpha1.ReasonReconcileError, metav1.ConditionFalse, cr.Status.ObservedGeneration)
+		return ctrl.Result{}, err
+	}
+	if err := r.writeStatus(ctx, cr, ref, plan.rulesetID, plan.ruleID, plan.action, "", cfv1alpha1.ReasonReconciled, metav1.ConditionTrue, cr.Generation); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: resyncOrDefault(r.ResyncInterval)}, nil
+}
+
+func (r *CloudflareCustomRuleReconciler) planReconcile(ctx context.Context, cr *cfv1alpha1.CloudflareCustomRule, desired cloudflare.Rule) (customRulePlan, error) {
+	plan := customRulePlan{}
+	rs, err := r.CF.GetPhaseRuleset(ctx, cr.Spec.ZoneID, cloudflare.CustomFirewallPhase)
+	if err != nil {
+		return plan, fmt.Errorf("get ruleset: %w", err)
+	}
+
+	if cr.Spec.Adopt != nil {
+		if rs == nil {
+			plan.action = fmt.Sprintf("adoption target %q not found: zone has no custom firewall ruleset", cr.Spec.Adopt.RuleID)
+			return plan, errors.New(plan.action)
+		}
+		plan.rulesetID = rs.ID
+		plan.existing = cloudflare.FindRuleByID(rs, cr.Spec.Adopt.RuleID)
+		if plan.existing == nil {
+			plan.action = fmt.Sprintf("adoption target %q not found in ruleset %s", cr.Spec.Adopt.RuleID, rs.ID)
+			return plan, errors.New(plan.action)
+		}
+		plan.ruleID = plan.existing.ID
+		merged := mergeCustomRule(*plan.existing, desired)
+		if rulesetRuleDiffers(plan.existing, &merged) {
+			plan.operation = "adopt-update"
+			plan.action = "would update adopted rule"
+			plan.summary = summariseDiff(plan.existing, &merged)
+		} else {
+			plan.operation = "adopt-noop"
+			plan.action = "in sync (adopted)"
+		}
+		return plan, nil
+	}
+
+	if rs == nil {
+		if !cr.Spec.CreateNewRule {
+			plan.action = "refusing to create: set spec.createNewRule=true or spec.adopt.ruleId"
+			return plan, errors.New(plan.action)
+		}
+		plan.operation = "create-ruleset-and-rule"
+		plan.action = "would create ruleset + rule"
+		plan.summary = "phase ruleset absent; would POST ruleset then POST rule"
+		return plan, nil
+	}
+	plan.rulesetID = rs.ID
+	plan.existing = cloudflare.FindRuleByRef(rs, desired.Ref)
+	if plan.existing == nil {
+		if !cr.Spec.CreateNewRule {
+			plan.action = "refusing to create: set spec.createNewRule=true or spec.adopt.ruleId"
+			return plan, errors.New(plan.action)
+		}
+		plan.operation = "create"
+		plan.action = "would create"
+		plan.summary = "no rule with ref " + desired.Ref
+		return plan, nil
+	}
+	plan.ruleID = plan.existing.ID
+	if rulesetRuleDiffers(plan.existing, &desired) {
+		plan.operation = "update"
+		plan.action = "would update"
+		plan.summary = summariseDiff(plan.existing, &desired)
+	} else {
+		plan.operation = "in-sync"
+		plan.action = "in sync"
+	}
+	return plan, nil
+}
+
+func (r *CloudflareCustomRuleReconciler) applyPlan(ctx context.Context, logger logr.Logger, cr *cfv1alpha1.CloudflareCustomRule, desired cloudflare.Rule, plan customRulePlan) error {
+	rulesetID := plan.rulesetID
+	if rulesetID == "" {
+		rs, err := r.CF.CreatePhaseRuleset(ctx, cr.Spec.ZoneID, cloudflare.CustomFirewallPhase)
+		if err != nil {
+			return fmt.Errorf("create ruleset: %w", err)
+		}
+		rulesetID = rs.ID
+	}
+
+	switch plan.operation {
+	case "create", "create-ruleset-and-rule":
+		if _, err := r.CF.AddRule(ctx, cr.Spec.ZoneID, rulesetID, desired); err != nil {
+			return fmt.Errorf("add rule: %w", err)
+		}
+		logger.Info("created custom firewall rule", "rulesetId", rulesetID, "ref", desired.Ref)
+	case "update":
+		if _, err := r.CF.UpdateRule(ctx, cr.Spec.ZoneID, rulesetID, plan.existing.ID, desired); err != nil {
+			return fmt.Errorf("update rule: %w", err)
+		}
+	case "adopt-update":
+		merged := mergeCustomRule(*plan.existing, desired)
+		if _, err := r.CF.UpdateRule(ctx, cr.Spec.ZoneID, rulesetID, plan.existing.ID, merged); err != nil {
+			return fmt.Errorf("update adopted rule: %w", err)
+		}
+	case "in-sync", "adopt-noop":
+	default:
+		return fmt.Errorf("planReconcile produced unhandled operation %q", plan.operation)
+	}
+	return nil
+}
+
+func (r *CloudflareCustomRuleReconciler) reconcileDelete(ctx context.Context, logger logr.Logger, cr *cfv1alpha1.CloudflareCustomRule, ref string) (ctrl.Result, error) {
+	zone := cr.Status.ManagedZoneID
+	if zone == "" {
+		zone = cr.Spec.ZoneID
+	}
+	if cr.Spec.RetainOnDelete || cr.Spec.EffectiveMode() == cfv1alpha1.ReconcileModeReadOnly {
+		return ctrl.Result{}, removeFinalizerAndPersist(ctx, r.Client, cr)
+	}
+	if err := driveRulesetDelete(ctx, r.CF, logger, zone, cloudflare.CustomFirewallPhase, "custom firewall rule", ref); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, removeFinalizerAndPersist(ctx, r.Client, cr)
+}
+
+func (r *CloudflareCustomRuleReconciler) writeStatus(ctx context.Context, cr *cfv1alpha1.CloudflareCustomRule, ref, rulesetID, ruleID, message, proposed, reason string, readyStatus metav1.ConditionStatus, observedGeneration int64) error {
+	patch := client.MergeFrom(cr.DeepCopy())
+	cr.Status.Ref = ref
+	cr.Status.RulesetID = rulesetID
+	cr.Status.RuleID = ruleID
+	cr.Status.Message = message
+	cr.Status.ProposedChanges = proposed
+	cr.Status.Mode = cr.Spec.EffectiveMode()
+	cr.Status.ObservedGeneration = observedGeneration
+	if cr.Status.ManagedZoneID == "" && readyStatus == metav1.ConditionTrue {
+		cr.Status.ManagedZoneID = cr.Spec.ZoneID
+	}
+	now := metav1Now()
+	setCondition(&cr.Status.Conditions, metav1.Condition{Type: cfv1alpha1.ConditionTypeReady, Status: readyStatus, Reason: reason, Message: message, LastTransitionTime: now, ObservedGeneration: observedGeneration})
+	cr.Status.LastReconciledAt = &now
+	return r.Status().Patch(ctx, cr, patch)
+}
+
+func mergeCustomRule(base, desired cloudflare.Rule) cloudflare.Rule {
+	out := base
+	out.Action = desired.Action
+	out.Expression = desired.Expression
+	out.Description = desired.Description
+	out.Enabled = desired.Enabled
+	return out
+}
+
+func customRuleRef(cr *cfv1alpha1.CloudflareCustomRule) string {
+	return makeRef(customRuleRefPrefix, cr.Name, string(cr.UID))
+}
+
+func renderCustomRule(cr *cfv1alpha1.CloudflareCustomRule, ref string) cloudflare.Rule {
+	return cloudflare.Rule{
+		Action:      cr.Spec.Action,
+		Expression:  cr.Spec.Expression,
+		Description: cr.Spec.Description,
+		Enabled:     cr.Spec.IsEnabled(),
+		Ref:         ref,
+	}
+}
+
+func (r *CloudflareCustomRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&cfv1alpha1.CloudflareCustomRule{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, annotationOrDeletionChanged()))).
+		Complete(r)
+}

--- a/infra/cloudflare-operator/controllers/cloudflarecustomrule_controller_test.go
+++ b/infra/cloudflare-operator/controllers/cloudflarecustomrule_controller_test.go
@@ -1,0 +1,82 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	cfv1alpha1 "github.com/tuist/tuist/infra/cloudflare-operator/api/v1alpha1"
+	"github.com/tuist/tuist/infra/cloudflare-operator/internal/cloudflare"
+)
+
+func sampleCustomRule(uid string) *cfv1alpha1.CloudflareCustomRule {
+	enabled := true
+	return &cfv1alpha1.CloudflareCustomRule{
+		ObjectMeta: metaWithUID("bot-protection", uid),
+		Spec: cfv1alpha1.CloudflareCustomRuleSpec{
+			ZoneID:         "zone-abc",
+			Description:    "Bot protection",
+			Expression:     `starts_with(http.request.uri.path, "/public") and not cf.client.bot`,
+			Action:         "managed_challenge",
+			Enabled:        &enabled,
+			Mode:           cfv1alpha1.ReconcileModeActive,
+			CreateNewRule:  true,
+			RetainOnDelete: false,
+		},
+	}
+}
+
+func TestCustomRuleReconcileReadOnlyDoesNotWrite(t *testing.T) {
+	cr := sampleCustomRule("uid-read-only")
+	cr.Spec.Mode = cfv1alpha1.ReconcileModeReadOnly
+	cr.Finalizers = []string{finalizer}
+
+	scheme := newTestScheme(t)
+	kClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr).WithStatusSubresource(cr).Build()
+	cf := &fakeCF{ruleset: &cloudflare.Ruleset{ID: "custom-ruleset"}}
+	reconciler := &CloudflareCustomRuleReconciler{Client: kClient, Scheme: scheme, CF: cf}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: cr.Name}}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if cf.addCalls != 0 || cf.updateCalls != 0 || cf.createCalls != 0 {
+		t.Fatalf("read_only must not write: add=%d update=%d create=%d", cf.addCalls, cf.updateCalls, cf.createCalls)
+	}
+}
+
+func TestCustomRuleReconcileUpdatesAdoptedRuleAndPreservesRef(t *testing.T) {
+	cr := sampleCustomRule("uid-adopt")
+	cr.Spec.Adopt = &cfv1alpha1.AdoptRule{RuleID: "dashboard-rule"}
+	cr.Spec.CreateNewRule = false
+	cr.Finalizers = []string{finalizer}
+
+	live := cloudflare.Rule{
+		ID:          "dashboard-rule",
+		Ref:         "dashboard-rule",
+		Description: "Bot protection",
+		Expression:  `starts_with(http.request.uri.path, "/public")`,
+		Action:      "managed_challenge",
+		Enabled:     true,
+	}
+	scheme := newTestScheme(t)
+	kClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr).WithStatusSubresource(cr).Build()
+	cf := &fakeCF{ruleset: &cloudflare.Ruleset{ID: "custom-ruleset", Rules: []cloudflare.Rule{live}}}
+	reconciler := &CloudflareCustomRuleReconciler{Client: kClient, Scheme: scheme, CF: cf}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: cr.Name}}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if cf.updateCalls != 1 {
+		t.Fatalf("update calls = %d, want 1", cf.updateCalls)
+	}
+	got := cf.ruleset.Rules[0]
+	if got.Ref != "dashboard-rule" {
+		t.Errorf("adopted ref = %q, want dashboard-rule", got.Ref)
+	}
+	if got.Expression != cr.Spec.Expression {
+		t.Errorf("expression = %q, want %q", got.Expression, cr.Spec.Expression)
+	}
+}

--- a/infra/cloudflare-operator/controllers/cloudflareratelimit_controller_test.go
+++ b/infra/cloudflare-operator/controllers/cloudflareratelimit_controller_test.go
@@ -250,11 +250,9 @@ func TestReconcile_Adopt_ZeroChangeIsNoop(t *testing.T) {
 	}
 }
 
-// TestImportedPublicPagesRateLimitMatchesCapturedLiveRule guards the
-// production adoption gate. The expected rule below is the Cloudflare
-// response captured during import; changing the Git-managed manifest
-// makes this test fail until the intended drift is reviewed explicitly.
-func TestImportedPublicPagesRateLimitMatchesCapturedLiveRule(t *testing.T) {
+// TestPublicPagesRateLimitExcludesVerifiedBots guards the handoff between
+// the human-facing challenge rule and the separate crawler rule.
+func TestPublicPagesRateLimitExcludesVerifiedBots(t *testing.T) {
 	manifestPath := filepath.Join("..", "..", "flux", "cloudflare-config", "public-pages-rate-limit.yaml")
 	manifest, err := os.ReadFile(manifestPath)
 	if err != nil {
@@ -300,15 +298,18 @@ func TestImportedPublicPagesRateLimitMatchesCapturedLiveRule(t *testing.T) {
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: cr.Name}}); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
-	if cf.addCalls != 0 || cf.updateCalls != 0 || cf.createCalls != 0 {
-		t.Fatalf("imported rule must be a no-op: add=%d update=%d create=%d", cf.addCalls, cf.updateCalls, cf.createCalls)
+	if cf.addCalls != 0 || cf.updateCalls != 1 || cf.createCalls != 0 {
+		t.Fatalf("expected one reviewed adoption update: add=%d update=%d create=%d", cf.addCalls, cf.updateCalls, cf.createCalls)
+	}
+	if gotRule := cf.ruleset.Rules[0]; gotRule.Expression != `(http.request.method eq "GET" and not cf.client.bot)` {
+		t.Errorf("updated expression = %q", gotRule.Expression)
 	}
 	got := &cfv1alpha1.CloudflareRateLimit{}
 	if err := kClient.Get(context.Background(), types.NamespacedName{Name: cr.Name}, got); err != nil {
 		t.Fatalf("get reconciled resource: %v", err)
 	}
-	if got.Status.Message != "read_only: in sync (adopted)" {
-		t.Errorf("status message = %q, want zero-change adoption", got.Status.Message)
+	if got.Status.Message != "would update adopted rule" {
+		t.Errorf("status message = %q, want adopted update", got.Status.Message)
 	}
 	if got.Status.ProposedChanges != "" {
 		t.Errorf("unexpected proposed changes: %q", got.Status.ProposedChanges)

--- a/infra/cloudflare-operator/controllers/ref.go
+++ b/infra/cloudflare-operator/controllers/ref.go
@@ -24,7 +24,8 @@ func makeRef(kindPrefix, name, uid string) string {
 // String constants callers pass as kindPrefix. Keep short — refs are
 // capped at 32 chars total by Cloudflare and the hash suffix eats 20.
 const (
-	rateLimitRefPrefix = "cfrl_"
+	rateLimitRefPrefix  = "cfrl_"
+	customRuleRefPrefix = "cfcustom_"
 )
 
 // sanityRef panics if the produced ref would violate Cloudflare's

--- a/infra/flux/cloudflare-config/custom-firewall-rules.yaml
+++ b/infra/flux/cloudflare-config/custom-firewall-rules.yaml
@@ -1,0 +1,53 @@
+# Imported from the live tuist.dev custom firewall entry-point ruleset on
+# 2026-09-06. The public dashboard rule excludes Cloudflare-verified crawlers,
+# which are bounded separately by the verified crawler rate-limit rule.
+apiVersion: cloudflare.tuist.dev/v1alpha1
+kind: CloudflareCustomRule
+metadata:
+  name: public-dashboard-bot-protection
+spec:
+  zoneId: 4421110085237b867a891bd0a40da106
+  description: "Bot protection"
+  expression: |-
+    (
+      http.request.uri.path eq "/tuist" or
+      starts_with(http.request.uri.path, "/tuist/projects") or
+      starts_with(http.request.uri.path, "/tuist/runners") or
+      starts_with(http.request.uri.path, "/tuist/usage") or
+      starts_with(http.request.uri.path, "/tuist/tuist") or
+      starts_with(http.request.uri.path, "/tuist/gradle-plugin") or
+      starts_with(http.request.uri.path, "/tuist/ios_app_with_frameworks") or
+      starts_with(http.request.uri.path, "/tuist/android")
+    ) and not (
+      ends_with(http.request.uri.path, "/manifest.plist") or
+      ends_with(http.request.uri.path, "/app.ipa") or
+      ends_with(http.request.uri.path, "/app.apk") or
+      ends_with(http.request.uri.path, "/qr-code.svg") or
+      ends_with(http.request.uri.path, "/qr-code.png") or
+      ends_with(http.request.uri.path, "/icon.png") or
+      (
+        ends_with(http.request.uri.path, "/download") and
+        not starts_with(http.request.uri.path, "/tuist/runners/")
+      )
+    ) and not cf.client.bot
+  action: managed_challenge
+  enabled: true
+  mode: active
+  adopt:
+    ruleId: 6d023cf1e6b24525af4c727a4ebe730f
+  retainOnDelete: true
+---
+apiVersion: cloudflare.tuist.dev/v1alpha1
+kind: CloudflareCustomRule
+metadata:
+  name: leaked-credentials-challenge
+spec:
+  zoneId: 4421110085237b867a891bd0a40da106
+  description: "Leaked credentials detected - managed challenge"
+  expression: "cf.waf.credential_check.password_leaked"
+  action: managed_challenge
+  enabled: true
+  mode: active
+  adopt:
+    ruleId: b7afe460a4a241cbabe975d698397da9
+  retainOnDelete: true

--- a/infra/flux/cloudflare-config/kustomization.yaml
+++ b/infra/flux/cloudflare-config/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - custom-firewall-rules.yaml
   - public-pages-rate-limit.yaml
+  - verified-crawlers-rate-limit.yaml

--- a/infra/flux/cloudflare-config/public-pages-rate-limit.yaml
+++ b/infra/flux/cloudflare-config/public-pages-rate-limit.yaml
@@ -1,6 +1,6 @@
-# Imported from the live tuist.dev http_ratelimit entry-point ruleset on
-# 2026-09-05. Keep this resource in read_only until its status reports no
-# proposed changes, then switch mode to active in a separate pull request.
+# Imported from the live tuist.dev rate-limiting entry-point ruleset on
+# 2026-09-05. Its read-only adoption reconciled without proposed changes
+# before active management was enabled.
 apiVersion: cloudflare.tuist.dev/v1alpha1
 kind: CloudflareRateLimit
 metadata:
@@ -8,10 +8,10 @@ metadata:
 spec:
   zoneId: 4421110085237b867a891bd0a40da106
   description: "Public pages – anti-bombardment"
-  expression: "(http.request.method eq \"GET\")"
+  expression: "(http.request.method eq \"GET\" and not cf.client.bot)"
   action: managed_challenge
   enabled: true
-  mode: read_only
+  mode: active
   adopt:
     ruleId: 20a7e7c0f002481baa1b6b91af90e3ba
   retainOnDelete: true

--- a/infra/flux/cloudflare-config/verified-crawlers-rate-limit.yaml
+++ b/infra/flux/cloudflare-config/verified-crawlers-rate-limit.yaml
@@ -1,0 +1,25 @@
+# Cloudflare-verified crawlers can index public pages without solving a
+# browser challenge. This separate rule still places a hard ceiling on the
+# database-backed requests from each crawler address and returns HTTP 429 so
+# compliant crawlers back off.
+apiVersion: cloudflare.tuist.dev/v1alpha1
+kind: CloudflareRateLimit
+metadata:
+  name: verified-crawlers-public-pages
+spec:
+  zoneId: 4421110085237b867a891bd0a40da106
+  description: "Verified crawlers - public pages"
+  expression: "(http.request.method eq \"GET\" and cf.client.bot)"
+  action: block
+  enabled: true
+  mode: active
+  createNewRule: true
+  retainOnDelete: false
+  ratelimit:
+    characteristics:
+      - "ip.src"
+      - "cf.colo.id"
+    requestsPerPeriod: 60
+    period: 10
+    mitigationTimeoutSeconds: 10
+    countingExpression: "(http.response.headers[\"x-tuist-public\"][0] eq \"1\")"

--- a/infra/helm/cloudflare-operator/Chart.yaml
+++ b/infra/helm/cloudflare-operator/Chart.yaml
@@ -17,5 +17,5 @@ description: >
   local state volume to attach.
 
 type: application
-version: 0.1.1
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"

--- a/infra/helm/cloudflare-operator/templates/crd-cloudflarecustomrule.yaml
+++ b/infra/helm/cloudflare-operator/templates/crd-cloudflarecustomrule.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.installCRDs -}}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cloudflarecustomrules.cloudflare.tuist.dev
+spec:
+  group: cloudflare.tuist.dev
+  scope: Cluster
+  names:
+    plural: cloudflarecustomrules
+    singular: cloudflarecustomrule
+    kind: CloudflareCustomRule
+    shortNames: [cfcustom]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - {name: Zone, type: string, jsonPath: .spec.zoneId}
+        - {name: Mode, type: string, jsonPath: .spec.mode}
+        - {name: Action, type: string, jsonPath: .spec.action}
+        - {name: Message, type: string, jsonPath: .status.message}
+        - {name: Age, type: date, jsonPath: .metadata.creationTimestamp}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            apiVersion: {type: string}
+            kind: {type: string}
+            metadata: {type: object}
+            spec:
+              type: object
+              required: [zoneId, description, expression, action]
+              x-kubernetes-validations:
+                - rule: "self.zoneId == oldSelf.zoneId"
+                  message: "spec.zoneId is immutable"
+                - rule: "has(self.adopt) || self.createNewRule == true"
+                  message: "either spec.adopt.ruleId or spec.createNewRule=true must be set"
+                - rule: "!has(oldSelf.adopt) || (has(self.adopt) && self.adopt.ruleId == oldSelf.adopt.ruleId)"
+                  message: "spec.adopt is immutable once set"
+              properties:
+                zoneId: {type: string}
+                description: {type: string}
+                expression: {type: string}
+                action:
+                  type: string
+                  enum: [block, managed_challenge, js_challenge, log]
+                enabled: {type: boolean, default: true}
+                mode:
+                  type: string
+                  enum: [read_only, active]
+                  default: read_only
+                paused: {type: boolean, default: false}
+                createNewRule: {type: boolean, default: false}
+                retainOnDelete: {type: boolean, default: true}
+                adopt:
+                  type: object
+                  required: [ruleId]
+                  properties:
+                    ruleId: {type: string}
+            status:
+              type: object
+              properties:
+                ref: {type: string}
+                ruleId: {type: string}
+                rulesetId: {type: string}
+                managedZoneId: {type: string}
+                mode: {type: string}
+                proposedChanges: {type: string}
+                observedGeneration: {type: integer, format: int64}
+                message: {type: string}
+                lastReconciledAt: {type: string, format: date-time}
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type, status, lastTransitionTime, reason]
+                    properties:
+                      type: {type: string, maxLength: 316}
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      observedGeneration: {type: integer, format: int64, minimum: 0}
+                      lastTransitionTime: {type: string, format: date-time}
+                      reason: {type: string, maxLength: 1024}
+                      message: {type: string, maxLength: 32768}
+{{- end -}}
+

--- a/infra/helm/cloudflare-operator/templates/rbac.yaml
+++ b/infra/helm/cloudflare-operator/templates/rbac.yaml
@@ -4,13 +4,13 @@ metadata:
   name: cloudflare-operator-manager
 rules:
   - apiGroups: ["cloudflare.tuist.dev"]
-    resources: [cloudflareratelimits]
+    resources: [cloudflareratelimits, cloudflarecustomrules]
     verbs: [get, list, watch, update, patch]
   - apiGroups: ["cloudflare.tuist.dev"]
-    resources: [cloudflareratelimits/status]
+    resources: [cloudflareratelimits/status, cloudflarecustomrules/status]
     verbs: [get, update, patch]
   - apiGroups: ["cloudflare.tuist.dev"]
-    resources: [cloudflareratelimits/finalizers]
+    resources: [cloudflareratelimits/finalizers, cloudflarecustomrules/finalizers]
     verbs: [update]
   - apiGroups: ["coordination.k8s.io"]
     resources: [leases]

--- a/infra/helm/cloudflare-operator/values-mgmt.yaml
+++ b/infra/helm/cloudflare-operator/values-mgmt.yaml
@@ -3,8 +3,8 @@
 # configuration is global, not per-env.
 
 image:
-  # Built from f13d662ff12b, the commit that introduced the operator.
+  # Built from fff611d7d7d9, the commit that added crawler protection.
   # Keep the human-readable tag and immutable multi-platform digest
   # together so reviewers can trace both the source and deployed bytes.
-  tag: sha-f13d662ff12b
-  digest: sha256:dcd9825f51b6d0521fe5ccb69aa0594a2149c6a53fcb42bea12d67c11953e685
+  tag: sha-fff611d7d7d9
+  digest: sha256:51298683de6c24666b4e2b1a6d788782a40cdfc9f2075a8cd1bbd4e1e5302b55

--- a/infra/helm/cloudflare-operator/values.yaml
+++ b/infra/helm/cloudflare-operator/values.yaml
@@ -29,7 +29,7 @@ namespace: cloudflare-operator
 # ExternalSecret pulling the Cloudflare API token from 1Password. The
 # item must expose a field named `token` scoped with:
 #   - Zone:Read
-#   - Zone WAF:Edit
+#   - Zone WAF:Edit (rate limits and custom firewall rules)
 #   - (once cache-rules land) Cache Rules:Edit
 externalSecret:
   enabled: true

--- a/server/lib/tuist_web/plugs/public_page_header_plug.ex
+++ b/server/lib/tuist_web/plugs/public_page_header_plug.ex
@@ -1,9 +1,9 @@
 defmodule TuistWeb.Plugs.PublicPageHeaderPlug do
   @moduledoc ~S"""
   Marks responses whose URL is reachable without sign-in by setting the
-  `x-tuist-public: 1` response header. A page is public when the project or
-  account it lives under has `visibility: :public`, or when a preview is
-  itself public.
+  `x-tuist-public: 1` response header. A page is public when it belongs to
+  the marketing site, when the project or account it lives under has
+  `visibility: :public`, or when a preview is itself public.
 
   Cloudflare's Advanced Rate Limiting rule keys its counter on this header
   (counting expression `http.response.headers["x-tuist-public"][0] eq "1"`),
@@ -31,12 +31,14 @@ defmodule TuistWeb.Plugs.PublicPageHeaderPlug do
 
   @header "x-tuist-public"
 
+  def mark_public_marketing_page(conn, _opts), do: put_public_header(conn)
+
   def mark_public_project_page(
         %{path_params: %{"account_handle" => account_handle, "project_handle" => project_handle}} = conn,
         _opts
       ) do
     case Projects.get_project_by_account_and_project_handles(account_handle, project_handle) do
-      %{visibility: :public} -> put_public_header(conn)
+      %{visibility: :public} -> conn |> put_public_header() |> enable_robot_indexing()
       _ -> conn
     end
   end
@@ -45,7 +47,7 @@ defmodule TuistWeb.Plugs.PublicPageHeaderPlug do
 
   def mark_public_account_page(%{path_params: %{"account_handle" => account_handle}} = conn, _opts) do
     case Accounts.get_account_by_handle(account_handle) do
-      %{visibility: :public} -> put_public_header(conn)
+      %{visibility: :public} -> conn |> put_public_header() |> enable_robot_indexing()
       _ -> conn
     end
   end
@@ -69,4 +71,12 @@ defmodule TuistWeb.Plugs.PublicPageHeaderPlug do
   def mark_public_preview_page(conn, _opts), do: conn
 
   defp put_public_header(conn), do: put_resp_header(conn, @header, "1")
+
+  defp enable_robot_indexing(conn) do
+    if Tuist.Environment.prod?() and Tuist.Environment.tuist_hosted?() do
+      put_resp_header(conn, "x-robots-tag", "index, follow")
+    else
+      conn
+    end
+  end
 end

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -163,6 +163,7 @@ defmodule TuistWeb.Router do
     plug MarkdownNegotiationPlug
     plug :accepts, ["html"]
     plug :enable_robot_indexing
+    plug :mark_public_marketing_page
     plug LegacyRedirectsPlug
     plug :fetch_session
     plug :fetch_live_flash
@@ -1301,8 +1302,6 @@ defmodule TuistWeb.Router do
 
   defp enable_robot_indexing(conn, params) do
     if Tuist.Environment.prod?() and Tuist.Environment.tuist_hosted?() do
-      # Once we iterate on the open-graph tags of the dashboard pages for public projects
-      # we should iterate on this to enable indexing for public projects
       put_resp_header(conn, "x-robots-tag", "index, follow")
     else
       disable_robot_indexing(conn, params)

--- a/server/test/tuist_web/plugs/public_page_header_plug_test.exs
+++ b/server/test/tuist_web/plugs/public_page_header_plug_test.exs
@@ -1,5 +1,6 @@
 defmodule TuistWeb.Plugs.PublicPageHeaderPlugTest do
   use TuistTestSupport.Cases.ConnCase, async: true
+  use Mimic
 
   alias Tuist.Accounts
   alias Tuist.Repo
@@ -32,6 +33,31 @@ defmodule TuistWeb.Plugs.PublicPageHeaderPlugTest do
       conn = PublicPageHeaderPlug.mark_public_project_page(conn, [])
 
       assert Plug.Conn.get_resp_header(conn, @header) == ["1"]
+    end
+
+    test "allows indexing for a public project on the hosted production site", %{conn: conn} do
+      stub(Tuist.Environment, :prod?, fn -> true end)
+      stub(Tuist.Environment, :tuist_hosted?, fn -> true end)
+
+      project =
+        [visibility: :public]
+        |> ProjectsFixtures.project_fixture()
+        |> Repo.preload(:account)
+
+      conn = %{
+        conn
+        | path_params: %{
+            "account_handle" => project.account.name,
+            "project_handle" => project.name
+          }
+      }
+
+      conn =
+        conn
+        |> Plug.Conn.put_resp_header("x-robots-tag", "noindex, nofollow")
+        |> PublicPageHeaderPlug.mark_public_project_page([])
+
+      assert Plug.Conn.get_resp_header(conn, "x-robots-tag") == ["index, follow"]
     end
 
     test "does not set the header when the project is private", %{conn: conn} do
@@ -87,6 +113,18 @@ defmodule TuistWeb.Plugs.PublicPageHeaderPlugTest do
       conn = PublicPageHeaderPlug.mark_public_project_page(conn, [])
 
       assert Plug.Conn.get_resp_header(conn, @header) == []
+    end
+  end
+
+  describe "mark_public_marketing_page/2" do
+    test "marks a marketing response as public without changing its indexing policy", %{conn: conn} do
+      conn =
+        conn
+        |> Plug.Conn.put_resp_header("x-robots-tag", "index, follow")
+        |> PublicPageHeaderPlug.mark_public_marketing_page([])
+
+      assert Plug.Conn.get_resp_header(conn, @header) == ["1"]
+      assert Plug.Conn.get_resp_header(conn, "x-robots-tag") == ["index, follow"]
     end
   end
 

--- a/server/test/tuist_web/router_test.exs
+++ b/server/test/tuist_web/router_test.exs
@@ -31,7 +31,9 @@ defmodule TuistWeb.RouterTest do
     stub(Environment, :prod?, fn -> true end)
 
     for route <- [~p"/blog", ~p"/about", ~p"/pricing", ~p"/terms", ~p"/blog"] do
-      assert conn |> get(route) |> get_resp_header("x-robots-tag") == ["index, follow"]
+      response_conn = get(conn, route)
+      assert get_resp_header(response_conn, "x-robots-tag") == ["index, follow"]
+      assert get_resp_header(response_conn, "x-tuist-public") == ["1"]
     end
   end
 


### PR DESCRIPTION
## What changed

Public marketing pages now emit the same `x-tuist-public` response marker as public account, project, and preview pages. Public account and project pages also become indexable on the hosted production site.

The Cloudflare operator now reconciles custom firewall rules in addition to rate-limiting rules. The configuration imports both live custom firewall rules, exempts Cloudflare-verified crawlers from the existing browser challenge, and adds a separate crawler rate limit of 60 database-backed public responses per 10 seconds for each source address and Cloudflare data center. Exceeding that ceiling returns [Hypertext Transfer Protocol status 429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/429), which gives compliant crawlers a standard backoff signal.

The exact multi-platform operator image built from this branch is pinned by digest so the management-cluster deployment can reconcile the new resources as soon as this change lands.

## Why

Public projects and marketing pages should be discoverable by search engines without giving a crawler an unbounded path to database-backed rendering. The previous setup protected the origin by challenging every matching request, including verified search crawlers, and did not classify marketing responses for the existing response-aware rate limit.

## Root cause

The existing rate-limiting rule treated human and verified-crawler traffic identically. A separate live custom firewall rule also challenged the public dashboard paths without a verified-crawler exemption. Public dashboard routes were still explicitly marked `noindex`, and the operator could only represent rate-limiting rules, so the complete live policy could not be maintained from the repository.

## Approach

Cloudflare's `cf.client.bot` field provides the verified-crawler classification on the current plan. Human traffic keeps the managed challenge after crossing the existing threshold. Verified crawlers bypass that challenge but have their own hard rate ceiling and standard 429 response.

The rule continues to count only responses carrying `x-tuist-public`, which lets application visibility remain authoritative without maintaining a Cloudflare path allowlist for dynamic project and account handles.

Full-page caching is intentionally not enabled. These pages share session-aware rendering paths, so caching their complete Hypertext Markup Language responses could expose signed-in state or break session behavior. A cache layer would be safe only after introducing a distinct anonymous rendering contract.

## Impact

Verified search crawlers can index public marketing, account, and project pages without solving a browser challenge. Their database-backed traffic remains bounded at the edge. Human protection is unchanged, private pages stay non-indexable, and the current live custom firewall configuration becomes continuously reconciled by Flux after deployment.

## Validation

- `mise x go@1.25.10 -- go test ./...`
- `mise x go@1.25.10 -- go vet ./...`
- The [Cloudflare operator image workflow](https://github.com/tuist/tuist/actions/runs/34044994048) passed its real Kubernetes application programming interface admission tests, static checks, and multi-platform image build.
- `helm lint infra/helm/cloudflare-operator`
- Rendered the Helm chart with management-cluster values and confirmed the pinned image tag and digest.
- `kubectl kustomize infra/flux/cloudflare-config`
- Validated all three changed Cloudflare expressions through Cloudflare's expression validation endpoint.
- Started the application locally and confirmed `/pricing` returns status 200 with `x-tuist-public: 1`; a headless Chrome load completed successfully.
- The focused server tests compiled successfully but could not execute locally because the shared setup attempted a transaction unsupported by the available ClickHouse instance.
