### PR TITLE
fix(infra): size Kata shared memory for runner hosts

### DIFF
--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -335,11 +335,31 @@ property; only `OVHDedicatedMachine` carries a bootstrap-time capability today.
 A repair that cannot complete must stay loud rather than retry quietly. The
 `KataRuntimeReady` condition is marked False the moment the gap is observed,
 before any SSH, and the `capt_node_kata_runtime_ready` gauge (0 = requested but
-missing) is what the **Runner Box Missing Kata Runtime** rule alerts on
+missing or unverified) is what the **Runner Box Missing Kata Runtime** rule alerts on
 (Grafana Cloud, Alerts folder, `Runners` group, `for: 20m`, routed to Slack like
 its siblings). `Machine.Status.Ready` is deliberately left alone: the node is a
 healthy Kubernetes node, and failing it would make CAPI churn a box that needs a
 two-minute in-place fix.
+
+Kata's virtio-fs configuration backs guest RAM with files in `/dev/shm`. The
+Linux default tmpfs ceiling is half of host RAM, below the runner node's
+allocatable memory: concurrent guests can exhaust it while the host still has
+free RAM, causing QEMU `kvm run failed Bad address` failures. The shared-memory
+setup in `controllers/linux/kata_shared_memory.go` grows that ceiling to
+`MemTotal`, preserves larger custom ceilings and mount flags, and verifies the
+result. This changes a ceiling; it does not preallocate memory.
+
+Bootstrap installs `tuist-kata-shared-memory.service`, ordered before containerd,
+and the Ready-path repair installs and runs the same service on existing OVH
+Kata hosts without restarting containerd, kubelet, or guests. Only a successful
+repair stamps `tuist.dev/kata-shared-memory-config` on the Node with the script
+and unit hash plus `status.nodeInfo.bootID`. A changed configuration or boot
+invalidates that proof; it is not continuous detection of manual mount changes
+within the same boot. Missing proof sets `KataSharedMemoryUnverified`; a failed
+repair sets `KataRuntimeRepairFailed`, leaving the machine Ready and the existing
+runtime label intact. Non-Kata fleets are unaffected. The Hetzner worker template
+in `infra/k8s/clusters/bare-metal.yaml` installs identical files for new workers
+(checked by a test); existing Hetzner workers do not use this OVH repair path.
 
 Alerts for this operator are Grafana-managed rules, created in Grafana Cloud
 rather than checked in: managed clusters run no Prometheus Operator, so there is

--- a/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift.go
@@ -17,12 +17,10 @@ import (
 	bootstrap "github.com/tuist/tuist/infra/macos-host-bootstrap"
 )
 
-// KataRuntimeSelectorLabel is the node label the kata-qemu RuntimeClass selects
-// on (infra/helm/tuist/templates/kata-qemu.yaml). It is the single observable
-// that decides whether a runner Pod can land on the box, which is why the drift
-// loop checks it rather than, say, the provider version that bootstrapped the
-// node: it is true by construction that a node carrying this label is one the
-// scheduler will place kata Pods on, and false by construction otherwise.
+// KataRuntimeSelectorLabel is the node label selected by the kata-qemu
+// RuntimeClass (infra/helm/tuist/templates/kata-qemu.yaml). The drift loop checks
+// it to establish schedulability, then checks the shared-memory configuration
+// proof before reporting the runtime ready.
 const KataRuntimeSelectorLabel = "katacontainers.io/kata-runtime"
 
 // KataRuntimeReadyCondition reports whether a machine that asked for
@@ -49,14 +47,18 @@ const (
 	// complete: the box is unreachable, or it refused the runtime (e.g. its
 	// containerd predates the v3 config syntax the handler is written in).
 	KataRuntimeRepairFailedReason = "KataRuntimeRepairFailed"
+
+	// KataSharedMemoryUnverifiedReason also covers labelled hosts that predate
+	// shared-memory sizing or have rebooted since the last successful repair.
+	KataSharedMemoryUnverifiedReason = "KataSharedMemoryUnverified"
 )
 
 // kataRuntimeReadyGauge is the alertable form of the condition. Only machines
 // that asked for kata get a series, so `min_over_time(...) == 0` is a clean
-// "a runner box has been unable to take jobs" alert with no cache-fleet noise.
+// "a runner box has an unverified Kata configuration" alert with no cache-fleet noise.
 var kataRuntimeReadyGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "capt_node_kata_runtime_ready",
-	Help: "1 when a machine with spec.kataRuntime carries the katacontainers.io/kata-runtime node label the kata-qemu RuntimeClass selects on, 0 when it does not (the node is Ready but no runner Pod can schedule on it). Machines that never asked for kata publish no series.",
+	Help: "1 when a machine with spec.kataRuntime has the runtime label and verified shared-memory configuration for this boot, 0 otherwise. Machines that never asked for kata publish no series.",
 }, []string{"machine", "fleet"})
 
 func init() {
@@ -147,7 +149,8 @@ export DEBIAN_FRONTEND=noninteractive
 
 // labelKataRuntimeNode patches the kata labels onto the live Node, which is the
 // step that actually makes the kata-qemu RuntimeClass select the box. Only
-// reached once the repair script has verified the runtime is installed.
+// reached once the repair script has verified the runtime and shared-memory
+// capacity. The annotation records that proof for this configuration and boot.
 func labelKataRuntimeNode(ctx context.Context, c client.Client, node *corev1.Node) error {
 	helper, err := patch.NewHelper(node, c)
 	if err != nil {
@@ -159,6 +162,10 @@ func labelKataRuntimeNode(ctx context.Context, c client.Client, node *corev1.Nod
 	for _, label := range kataNodeLabels {
 		node.Labels[label.Key] = label.Value
 	}
+	if node.Annotations == nil {
+		node.Annotations = map[string]string{}
+	}
+	node.Annotations[kataSharedMemoryAnnotation] = kataSharedMemoryRevision(node)
 	return helper.Patch(ctx, node)
 }
 
@@ -177,7 +184,7 @@ func labelKataRuntimeNode(ctx context.Context, c client.Client, node *corev1.Nod
 // in-place repair.
 //
 // Returns requeue=true when it did work or deferred, false when there was
-// nothing to do. On a converged node this is one map lookup.
+// nothing to do. Converged nodes need no SSH until the configuration or boot changes.
 //
 // Any future bootstrap-time capability on these kinds needs the same treatment:
 // an observable on the Node, a check here, and a repair that is additive rather
@@ -198,7 +205,8 @@ func reconcileLinuxKataRuntimeDrift(
 		forgetKataRuntimeMetric(machineName)
 		return false, nil
 	}
-	if node.Labels[KataRuntimeSelectorLabel] == "true" {
+	runtimeInstalled := node.Labels[KataRuntimeSelectorLabel] == "true"
+	if runtimeInstalled && node.Annotations[kataSharedMemoryAnnotation] == kataSharedMemoryRevision(node) {
 		conditions.MarkTrue(machine, KataRuntimeReadyCondition)
 		recordKataRuntimeReady(machineName, fleet, true)
 		return false, nil
@@ -207,10 +215,16 @@ func reconcileLinuxKataRuntimeDrift(
 	// Mark before attempting anything. Every path out of here that does not
 	// finish the repair leaves the machine visibly broken, which is the whole
 	// point: the incident's cost was that a node in this state looked healthy.
-	conditions.MarkFalse(machine, KataRuntimeReadyCondition, KataRuntimeMissingReason,
-		clusterv1.ConditionSeverityError,
-		"node carries no %s label, so no runtimeClassName=kata-qemu Pod can schedule on it; repairing in place",
-		KataRuntimeSelectorLabel)
+	if runtimeInstalled {
+		conditions.MarkFalse(machine, KataRuntimeReadyCondition, KataSharedMemoryUnverifiedReason,
+			clusterv1.ConditionSeverityError,
+			"Kata shared-memory capacity has not been verified for this configuration and boot; repairing in place")
+	} else {
+		conditions.MarkFalse(machine, KataRuntimeReadyCondition, KataRuntimeMissingReason,
+			clusterv1.ConditionSeverityError,
+			"node carries no %s label, so no runtimeClassName=kata-qemu Pod can schedule on it; repairing in place",
+			KataRuntimeSelectorLabel)
+	}
 	recordKataRuntimeReady(machineName, fleet, false)
 
 	host := nodeInternalIP(node)
@@ -231,7 +245,11 @@ func reconcileLinuxKataRuntimeDrift(
 	}
 	hostKey := bootstrap.NewHostKeyState(known)
 
-	sshErr := bootstrapOverSSH(ctx, opts.BootstrapUser, host, privateKey, renderKataRuntimeRepairScript(opts), hostKey)
+	script := renderKataSharedMemoryRepairScript(opts)
+	if !runtimeInstalled {
+		script = renderKataRuntimeRepairScript(opts)
+	}
+	sshErr := bootstrapOverSSH(ctx, opts.BootstrapUser, host, privateKey, script, hostKey)
 	// Persist a newly TOFU'd key before anything else, matching the bootstrap and
 	// kubelet-config paths: the key was observed even if the script then failed.
 	if observed := hostKey.Observed(); observed != "" && observed != known {
@@ -242,7 +260,7 @@ func reconcileLinuxKataRuntimeDrift(
 	if sshErr != nil {
 		conditions.MarkFalse(machine, KataRuntimeReadyCondition, KataRuntimeRepairFailedReason,
 			clusterv1.ConditionSeverityError,
-			"could not install the kata runtime on %s, so the node still takes no runner job: %v", host, sshErr)
+			"could not repair the Kata runtime or shared-memory configuration on %s: %v", host, sshErr)
 		return false, fmt.Errorf("repair kata runtime over ssh on %s: %w", host, sshErr)
 	}
 	if labelErr := labelKataRuntimeNode(ctx, c, node); labelErr != nil {
@@ -251,7 +269,7 @@ func reconcileLinuxKataRuntimeDrift(
 
 	conditions.MarkTrue(machine, KataRuntimeReadyCondition)
 	recordKataRuntimeReady(machineName, fleet, true)
-	logger.Info("installed the kata runtime on a node that joined without it and labelled it for the kata-qemu RuntimeClass",
+	logger.Info("verified the Kata runtime and shared-memory configuration",
 		"node", node.Name, "host", host)
 	return true, nil
 }

--- a/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/kata_runtime_drift_test.go
@@ -169,6 +169,10 @@ func TestKataRuntimeMissingIsSurfacedOnTheMachine(t *testing.T) {
 // correctly-bootstrapped runner box looks like, and it must cost nothing.
 func TestKataRuntimeReadyWhenNodeCarriesTheLabel(t *testing.T) {
 	h := newKataHarness(t, true, map[string]string{"katacontainers.io/kata-runtime": "true"})
+	h.node.Annotations[kataSharedMemoryAnnotation] = kataSharedMemoryRevision(h.node)
+	if err := h.client.Update(context.Background(), h.node); err != nil {
+		t.Fatal(err)
+	}
 	h.reconcile()
 
 	cond := conditions.Get(h.machine, clusterv1.ConditionType("KataRuntimeReady"))

--- a/infra/cluster-api-provider-tuist/controllers/linux/kata_shared_memory.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/kata_shared_memory.go
@@ -1,0 +1,72 @@
+package linux
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const kataSharedMemoryAnnotation = "tuist.dev/kata-shared-memory-config"
+
+// Kata's virtio-fs backend puts guest RAM in /dev/shm. Its default half-RAM
+// tmpfs ceiling is invisible to kube-scheduler and can fail KVM_RUN with EFAULT
+// while the host still has ample available memory. Raising the ceiling does
+// not allocate RAM; scheduling still accounts for pod requests and node reservations.
+// Keep the script and unit in sync with the Hetzner worker's cloud-init files.
+const kataSharedMemoryScript = `#!/bin/sh
+set -eu
+
+test "$(findmnt -n -o FSTYPE --mountpoint /dev/shm)" = tmpfs
+memory_kib=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+test "$memory_kib" -gt 0
+target_bytes=$((memory_kib * 1024))
+current_bytes=$(df -B1 --output=size /dev/shm | tail -n 1)
+
+# Grow only, preserving any larger operator-defined ceiling and mount flags.
+if [ "$current_bytes" -lt "$target_bytes" ]; then
+  mount -o "remount,size=${memory_kib}k" /dev/shm
+fi
+test "$(df -B1 --output=size /dev/shm | tail -n 1)" -ge "$target_bytes"
+`
+
+const kataSharedMemoryUnit = `[Unit]
+Description=Size shared memory for Kata guest RAM
+RequiresMountsFor=/dev/shm
+Before=containerd.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/tuist-kata-shared-memory
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+`
+
+func kataSharedMemoryRevision(node *corev1.Node) string {
+	return fmt.Sprintf("%x:%s", sha256.Sum256([]byte(kataSharedMemoryScript+kataSharedMemoryUnit)), node.Status.NodeInfo.BootID)
+}
+
+// Runs at bootstrap and on existing Kata hosts. Restarting this oneshot only
+// verifies/grows the mount; it never restarts containerd, kubelet, or a VM.
+func renderKataSharedMemoryRepairScript(opts linuxCloudInitOptions) string {
+	sudo, _ := escalation(opts.BootstrapUser)
+	return "#!/usr/bin/env bash\nset -euo pipefail\n" + kataSharedMemorySetup(sudo)
+}
+
+func kataSharedMemorySetup(sudo string) string {
+	return fmt.Sprintf(`%sbash -s <<'TUIST_KATA_SHM_ROOT'
+set -euo pipefail
+install -d /usr/local/sbin
+cat > /usr/local/sbin/tuist-kata-shared-memory <<'TUIST_KATA_SHM_SCRIPT'
+%sTUIST_KATA_SHM_SCRIPT
+chmod 0755 /usr/local/sbin/tuist-kata-shared-memory
+cat > /etc/systemd/system/tuist-kata-shared-memory.service <<'TUIST_KATA_SHM_UNIT'
+%sTUIST_KATA_SHM_UNIT
+systemctl daemon-reload
+systemctl enable tuist-kata-shared-memory.service
+systemctl restart tuist-kata-shared-memory.service
+TUIST_KATA_SHM_ROOT
+`, sudo, kataSharedMemoryScript, kataSharedMemoryUnit)
+}

--- a/infra/cluster-api-provider-tuist/controllers/linux/kata_shared_memory_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/kata_shared_memory_test.go
@@ -1,0 +1,204 @@
+package linux
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/yaml"
+)
+
+func TestKataSharedMemoryScript(t *testing.T) {
+	for _, tc := range []struct {
+		name, initial, fs, failure, want string
+		wantError, wantMount             bool
+	}{
+		{name: "grow default ceiling", initial: "65536", fs: "tmpfs", want: "131072", wantMount: true},
+		{name: "already sized", initial: "131072", fs: "tmpfs", want: "131072"},
+		{name: "preserve larger ceiling", initial: "262144", fs: "tmpfs", want: "262144"},
+		{name: "refuse other filesystem", initial: "65536", fs: "ext4", want: "65536", wantError: true},
+		{name: "failed remount", initial: "65536", fs: "tmpfs", failure: "fail", want: "65536", wantError: true, wantMount: true},
+		{name: "verify remount took effect", initial: "65536", fs: "tmpfs", failure: "noop", want: "65536", wantError: true, wantMount: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			// All privileged/host-dependent commands are replaced. Execute the
+			// actual service script, but never mount anything on the test host.
+			shim := `#!/bin/sh
+case "${0##*/}" in
+  findmnt) echo "$TEST_FS" ;;
+  awk) echo 128 ;;
+  df) echo Size; cat "$TEST_DIR/size" ;;
+  mount)
+    printf '%s\n' "$*" >> "$TEST_DIR/mounts"
+    [ "$*" = '-o remount,size=128k /dev/shm' ] || exit 2
+    [ "$TEST_FAILURE" != fail ] || exit 1
+    [ "$TEST_FAILURE" = noop ] || echo 131072 > "$TEST_DIR/size"
+    ;;
+esac
+`
+			for _, name := range []string{"findmnt", "awk", "df", "mount"} {
+				if err := os.WriteFile(filepath.Join(dir, name), []byte(shim), 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.WriteFile(filepath.Join(dir, "size"), []byte(tc.initial), 0600); err != nil {
+				t.Fatal(err)
+			}
+			for attempt := 0; attempt < 2; attempt++ {
+				cmd := exec.Command("/bin/sh", "-s")
+				cmd.Stdin = strings.NewReader(kataSharedMemoryScript)
+				cmd.Env = append(os.Environ(), "PATH="+dir+":/usr/bin:/bin", "TEST_DIR="+dir,
+					"TEST_FS="+tc.fs, "TEST_FAILURE="+tc.failure)
+				out, err := cmd.CombinedOutput()
+				if (err != nil) != tc.wantError {
+					t.Fatalf("attempt %d: err=%v output=%s", attempt, err, out)
+				}
+			}
+			size, err := os.ReadFile(filepath.Join(dir, "size"))
+			if err != nil || strings.TrimSpace(string(size)) != tc.want {
+				t.Fatalf("size=%q err=%v, want %s", size, err, tc.want)
+			}
+			mounts, err := os.ReadFile(filepath.Join(dir, "mounts"))
+			if tc.wantMount != (err == nil) {
+				t.Fatalf("mounts=%q err=%v, wantMount=%v", mounts, err, tc.wantMount)
+			}
+			if !tc.wantError && strings.Count(string(mounts), "\n") > 1 {
+				t.Fatal("second run must not remount a sufficient ceiling")
+			}
+		})
+	}
+}
+
+func TestKataSharedMemoryDriftOnExistingHost(t *testing.T) {
+	for _, revision := range []string{"", "old-configuration", "previous-boot"} {
+		t.Run(revision, func(t *testing.T) {
+			h := newKataHarness(t, true, map[string]string{KataRuntimeSelectorLabel: "true"})
+			h.node.Annotations[kataSharedMemoryAnnotation] = revision
+			if err := h.client.Update(context.Background(), h.node); err != nil {
+				t.Fatal(err)
+			}
+			h.reconcile()
+			cond := conditions.Get(h.machine, KataRuntimeReadyCondition)
+			if cond == nil || cond.Status != corev1.ConditionFalse || cond.Reason != KataSharedMemoryUnverifiedReason {
+				t.Fatalf("unverified shared memory must be surfaced: %v", cond)
+			}
+			if h.liveNode().Annotations[kataSharedMemoryAnnotation] != revision {
+				t.Fatal("a deferred repair must not stamp the node")
+			}
+			if !h.machine.Status.Ready {
+				t.Fatal("shared-memory drift must not cause CAPI to replace a healthy node")
+			}
+		})
+	}
+}
+
+func TestKataSharedMemoryRepairFailureNeverRecordsProof(t *testing.T) {
+	h := newKataHarness(t, true, map[string]string{KataRuntimeSelectorLabel: "true"})
+	h.node.Status.Addresses = []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "127.0.0.1"}}
+	if err := h.client.Status().Update(context.Background(), h.node); err != nil {
+		t.Fatal(err)
+	}
+	_, err := reconcileLinuxKataRuntimeDrift(context.Background(), h.client, h.r.CredentialsManager,
+		h.machine, h.machine.Name, h.machine.Spec.FleetName, h.r.hostOptions(h.machine), h.liveNode())
+	if err == nil {
+		t.Fatal("expected repair to fail against an unreachable host")
+	}
+	node := h.liveNode()
+	if node.Annotations[kataSharedMemoryAnnotation] != "" {
+		t.Fatal("failed repair must not record proof")
+	}
+	if node.Labels[KataRuntimeSelectorLabel] != "true" {
+		t.Fatal("failed repair must preserve the runtime label")
+	}
+	cond := conditions.Get(h.machine, KataRuntimeReadyCondition)
+	if cond == nil || cond.Status != corev1.ConditionFalse || cond.Reason != KataRuntimeRepairFailedReason {
+		t.Fatalf("failed repair must remain visible: %v", cond)
+	}
+}
+
+func TestKataSharedMemoryProofPreservesNodeMetadataAndExpiresAfterBoot(t *testing.T) {
+	h := newKataHarness(t, true, map[string]string{KataRuntimeSelectorLabel: "true", "keep": "label"})
+	h.node.Annotations["keep"] = "annotation"
+	if err := h.client.Update(context.Background(), h.node); err != nil {
+		t.Fatal(err)
+	}
+	if err := labelKataRuntimeNode(context.Background(), h.client, h.liveNode()); err != nil {
+		t.Fatal(err)
+	}
+	node := h.liveNode()
+	proof := node.Annotations[kataSharedMemoryAnnotation]
+	if proof != kataSharedMemoryRevision(node) || node.Annotations["keep"] != "annotation" || node.Labels["keep"] != "label" {
+		t.Fatalf("invalid proof or lost metadata: %v", node.ObjectMeta)
+	}
+	node.Status.NodeInfo.BootID = "new-boot"
+	if proof == kataSharedMemoryRevision(node) {
+		t.Fatal("a new boot must invalidate the previous verification")
+	}
+}
+
+func TestKataSharedMemoryRepairDoesNotRestartRuntime(t *testing.T) {
+	for _, user := range []string{"root", "ubuntu"} {
+		script := renderKataSharedMemoryRepairScript(linuxCloudInitOptions{BootstrapUser: user})
+		cmd := exec.Command("/bin/bash", "-n")
+		cmd.Stdin = strings.NewReader(script)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("invalid repair script: %v: %s", err, out)
+		}
+		for _, banned := range []string{"apt-get", "restart containerd", "restart kubelet", "reboot", "umount"} {
+			if strings.Contains(script, banned) {
+				t.Fatalf("shared-memory-only repair contains %q", banned)
+			}
+		}
+	}
+}
+
+func TestHetznerKataSharedMemoryMatchesProvider(t *testing.T) {
+	data, err := os.ReadFile("../../../k8s/clusters/bare-metal.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"/usr/local/sbin/tuist-kata-shared-memory":             kataSharedMemoryScript,
+		"/etc/systemd/system/tuist-kata-shared-memory.service": kataSharedMemoryUnit,
+	}
+	for _, document := range strings.Split(string(data), "\n---") {
+		var template struct {
+			Spec struct {
+				Template struct {
+					Spec struct {
+						Files              []struct{ Path, Content string }
+						PreKubeadmCommands []string
+					}
+				}
+			}
+		}
+		if err := yaml.Unmarshal([]byte(document), &template); err != nil {
+			t.Fatal(err)
+		}
+		for _, file := range template.Spec.Template.Spec.Files {
+			if expected, ok := want[file.Path]; ok {
+				if file.Content != expected {
+					t.Fatalf("Hetzner %s differs from the provider", file.Path)
+				}
+				delete(want, file.Path)
+			}
+		}
+		commands := strings.Join(template.Spec.Template.Spec.PreKubeadmCommands, "\n")
+		if commands != "" {
+			start := strings.Index(commands, "systemctl start tuist-kata-shared-memory.service")
+			containerd := strings.Index(commands, "systemctl enable --now containerd")
+			if start < 0 || start > containerd {
+				t.Fatal("shared-memory service must run before containerd")
+			}
+		}
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing Hetzner files: %v", want)
+	}
+}

--- a/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit.go
@@ -899,6 +899,7 @@ func kataSetup(sudo, sudoE string, enabled bool) string {
 # written in: registering it against a v2 config is silently ignored, and the
 # node then reports Ready while every runtimeClassName=kata-qemu Pod hangs.
 %[1]sgrep -q '^version = 3' /etc/containerd/config.toml || { echo "tuist: containerd config is not version 3; the kata-qemu handler would be ignored. Refusing to join a runner node that cannot run microVM Pods." >&2; exit 1; }
+%[5]s
 %[2]sapt-get install -y zstd
 # kata-static expands with a top-level opt/, so extracting at / lands the shim
 # and its bundled qemu under /opt/kata/{bin,libexec,share}. Guarded on a version
@@ -932,7 +933,7 @@ ConfigPath = "/opt/kata/share/defaults/kata-containers/configuration-qemu.toml"
 # same block in infra/k8s/clusters/bare-metal.yaml for the measured detail.
 SystemdCgroup = true
 TUIST_KATA_EOF
-`, sudo, sudoE, kataVersion, kataVersionStampPath)
+`, sudo, sudoE, kataVersion, kataVersionStampPath, kataSharedMemorySetup(sudo))
 }
 
 // kataNodeLabels are appended to the kubelet's --node-labels when the fleet runs

--- a/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit_test.go
+++ b/infra/cluster-api-provider-tuist/controllers/linux/linux_cloudinit_test.go
@@ -466,6 +466,8 @@ func TestRenderLinux_KataRuntime(t *testing.T) {
 		"runtime_path = \"/opt/kata/bin/containerd-shim-kata-v2\"",
 		"katacontainers.io/kata-runtime=true",
 		"tuist.dev/kata-runtime=true",
+		kataSharedMemoryScript,
+		kataSharedMemoryUnit,
 		// Set on the handler itself: the earlier rewrite only touches what the
 		// generated default emitted, and this block is appended after it.
 		"SystemdCgroup = true",
@@ -496,9 +498,14 @@ func TestRenderLinux_KataRuntime(t *testing.T) {
 		t.Errorf("expected the kata block before the containerd restart (kata=%d restart=%d)", kataIdx, restartIdx)
 	}
 
+	shmIdx := strings.Index(withKata, "systemctl restart tuist-kata-shared-memory.service")
+	if shmIdx < 0 || shmIdx > restartIdx {
+		t.Fatal("shared memory must be sized before containerd restarts")
+	}
+
 	// Cache fleets: nothing kata anywhere, including the node labels.
 	withoutKata := renderLinuxBootstrapScript(opts)
-	for _, unwanted := range []string{"kata-static", "kata-qemu", "katacontainers.io/kata-runtime"} {
+	for _, unwanted := range []string{"kata-static", "kata-qemu", "katacontainers.io/kata-runtime", "tuist-kata-shared-memory"} {
 		if strings.Contains(withoutKata, unwanted) {
 			t.Errorf("cache-fleet render must not contain %q", unwanted)
 		}

--- a/infra/k8s/clusters/bare-metal.yaml
+++ b/infra/k8s/clusters/bare-metal.yaml
@@ -366,6 +366,42 @@ spec:
   template:
     spec:
       files:
+        # Keep these in sync with controllers/linux/kata_shared_memory.go.
+        # Kata guest RAM must not hit tmpfs's default half-RAM ceiling.
+        - content: |
+            #!/bin/sh
+            set -eu
+
+            test "$(findmnt -n -o FSTYPE --mountpoint /dev/shm)" = tmpfs
+            memory_kib=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+            test "$memory_kib" -gt 0
+            target_bytes=$((memory_kib * 1024))
+            current_bytes=$(df -B1 --output=size /dev/shm | tail -n 1)
+
+            # Grow only, preserving any larger operator-defined ceiling and mount flags.
+            if [ "$current_bytes" -lt "$target_bytes" ]; then
+              mount -o "remount,size=${memory_kib}k" /dev/shm
+            fi
+            test "$(df -B1 --output=size /dev/shm | tail -n 1)" -ge "$target_bytes"
+          owner: root:root
+          path: /usr/local/sbin/tuist-kata-shared-memory
+          permissions: "0755"
+        - content: |
+            [Unit]
+            Description=Size shared memory for Kata guest RAM
+            RequiresMountsFor=/dev/shm
+            Before=containerd.service
+
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/local/sbin/tuist-kata-shared-memory
+            RemainAfterExit=yes
+
+            [Install]
+            WantedBy=multi-user.target
+          owner: root:root
+          path: /etc/systemd/system/tuist-kata-shared-memory.service
+          permissions: "0644"
         # containerd's GitHub-released tarball does NOT ship a
         # systemd unit (the older cri-containerd-cni- bundle did,
         # the plain `containerd-` tarball does not). Without this,
@@ -499,6 +535,8 @@ spec:
         # on disk, systemd just hasn't scanned it yet. Same call
         # the cloud worker template makes for the same reason.
         - systemctl daemon-reload
+        - systemctl enable tuist-kata-shared-memory.service
+        - systemctl start tuist-kata-shared-memory.service
         - systemctl enable --now containerd
         - systemctl enable kubelet
       postKubeadmCommands:


### PR DESCRIPTION
## Problem and evidence

The [Server run on main](https://github.com/tuist/tuist/actions/runs/34041541651) lost both its Test and Docker build runners. Both pods were on `tuist-tuist-ovh-fleet-runners-linux-wxhhv-2c6zk`. The Docker sandbox logged `kvm run failed Bad address` at 15:16:56 UTC on September 6, followed by QEMU `guest failure: internal-error` and exit 255. The Test sandbox subsequently lost its agent connection and also exited 255. Rerunning the failed jobs succeeded on attempt 2.

Inspection found a concrete capacity mismatch on all four production OVH runner hosts: `/dev/shm` was approximately 62.7 GiB (the default half of physical RAM), while Kubernetes advertised approximately 117 GiB of allocatable memory. Live Kata 3.30.0 QEMU processes use `memory-backend-file` with `mem-path=/dev/shm` and `share=on`; the pinned runtime defaults virtio-fs guest memory to that path. Host memory availability remained around 60 GiB and the OOM-kill counter stayed at zero during the incident.

This matches the [upstream Kata report of full `/dev/shm` causing KVM “Bad address” failures](https://github.com/kata-containers/kata-containers/issues/12919). Six such errors appeared across three production hosts in the inspected 24-hour window. We did not capture historical `/dev/shm` usage at the crash timestamps, so exhaustion is a strongly supported diagnosis rather than a proven explanation for every runner loss. The undersized ceiling itself was verified directly.

## Change and rationale

- Install a boot service that grows `/dev/shm` to at least `MemTotal`, preserves larger custom ceilings and mount flags, and verifies the resulting size. Raising the ceiling does not preallocate RAM.
- Run the service before containerd during Kata bootstrap. Keep the Hetzner worker template's script and unit identical to the provider's, enforced by a test.
- Extend the existing OVH Ready-path reconciliation to repair hosts that already advertise Kata. This path installs and runs only the shared-memory service; it does not restart containerd, kubelet, or guests. Bootstrap-only changes would leave the existing `OnDelete` fleet untouched.
- Record successful verification using a Node annotation containing the script/unit hash and boot ID. Configuration changes and reboots invalidate the proof. Failed or deferred repairs remain visible through `KataRuntimeReady` and its existing metric without making CAPI replace the node. Non-Kata provider fleets are unaffected.

## Validation and rollout

- `go test ./...` and `go build ./...` passed in `infra/cluster-api-provider-tuist`.
- Regression tests execute the actual shell script with mocked host commands: growth, idempotence, larger limits, unexpected filesystems, remount errors, and ineffective remounts. Controller tests cover existing-host drift, failed-repair proof handling, metadata preservation, and boot invalidation. Rendering checks cover shell syntax, bootstrap ordering, and the absence of runtime restarts in the shared-memory-only repair.
- `git diff --check` passed.

No production remount or deployment was performed. Deploying the updated provider will repair existing OVH Kata hosts; the Hetzner template applies to newly bootstrapped workers and does not repair existing Hetzner workers. The verification annotation is not continuous detection of manual mount changes within a boot. Actual Linux remount and reboot behavior still need validation during rollout.
