### PR TITLE
feat(infra): add a second Kura box to the us-east region

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -847,7 +847,7 @@ ovhFleet:
 ovhFleets:
   us-east:
     enabled: true
-    replicas: 1
+    replicas: 2
     endpoint: ovh-us
     nodePool: kura-us-east
     machine:


### PR DESCRIPTION
> [!IMPORTANT]
> The box is installed and verified. Merging is now unblocked. Merging *before* the box was installed would have parked the MachineDeployment at 1/2 and wedged `helm --wait` into an `--atomic` rollback; that risk is cleared.

## What changed

`ovhFleets.us-east.replicas` goes from 1 to 2 in the production values. That is the whole diff.

## Why

us-east has run on a single OVH Advance-1 since the region was created, and it is now full: **10940m of 11000m allocatable CPU is reserved**, with **13 cache pods across 8 accounts Pending** on `Insufficient cpu`. Two of those Pending pods are the second replicas of live tenants, so those instances are currently running single-replica, against the gapless-deploy invariant that `replicas: 2` exists for.

This is specific to us-east, not a fleet-wide shortage. us-west sits at 28% CPU on the identical shape, and eu-central has a second box carrying no cache pods at all.

| dimension | us-east node | of allocatable |
|---|---|---|
| cpu | 10940m | 11000m (99.5%) |
| `tuist.dev/memory-ceiling-mib` | 47360 | 56138 (84%) |
| `ephemeral-storage` | 514 GiB | 789 GiB (65%) |

The 13 Pending pods need roughly 6500m; the new box offers about 10560m after per-box system overhead, so it absorbs all of them.

## Why this box

`ns1035315.ip-40-160-23.us`, service 10281061, Vint Hill. Its `commercialRange` is `ADVANCE-1 | AMD EPYC 4245P`, which the fleet's existing `offer: advance-1` substring matcher adopts unchanged, so the replica count is the only thing that had to change.

It is the same 32 GB / 2x960 NVMe shape as the box already in the pool, which keeps the region uniformly sized. Being a 2-disk box it installs as RAID 1 and does not exercise the RAID 10 path in `DiskGroup.raidLevel()`, which no box in the fleet has run on real hardware yet.

A larger box was considered and rejected. Every Advance-1 has 12 threads whatever RAM and disk are bolted on, so at the flat 500m request the region gains the same ~10 tenant slots either way, and the 4x960 variant would have left most of its extra disk unreachable behind the CPU wall. Bandwidth is not the constraint it appears to be either: the existing box NIC peaks at 2096 Mbps of 3 Gbit/s, but that is one tenant, and the four Air tenants on the box move 0.04 Mbps each.

## What this is not

This is capacity and failure isolation. It is not a fix for the reservation model. The CPU wall is over-reservation rather than load: the box peaks at **1.04 cores of 11** over 14 days, and the per-pod spread inside a single plan is 75x. Sizing `requests.cpu` from observed usage is https://github.com/tuist/tuist/pull/12910, and that is the change that stops this recurring.

## Validation

Rendered the production chart before and after with `helm template` and diffed the full output. The only functional change is `replicas: 1` to `replicas: 2` on the `tuist-tuist-ovh-fleet-us-east` MachineDeployment; the remaining diff lines are the per-render random self-host secrets, which managed environments source from ESO.

Box verified on the hardware itself before enabling:

- Hardware `diskGroups`: a single group of 2 x NVMe 960 GB, so RAID 1 rather than the untested RAID 10 path.
- `md4` is RAID 1 across both NVMe, 828.6 GB, **xfs, mounted at `/data`**; `md3` is the capped 64 GiB ext4 root; every array reports `[2/2] [UU]`.
- `/etc/fstab` carries a `/data xfs` entry, which is what `dataProjectQuotaScript` needs in order to add `prjquota` and remount at join. The mount currently reads `noquota`, which that script fixes; it hard-fails only when `/data` is not xfs or has no fstab entry, and neither applies.

## Checklist

- [x] Box ordered, prepped, and displayName marked `tuist-kura-ovh-production-us-east`
- [x] OS install finished (`os: ubuntu2404-server_64`, all install steps done, no errors)
- [x] `/data` confirmed as xfs on the RAID 1 NVMe array, with the fstab entry `prjquota` needs
- [ ] After merge: box adopted, Node `Ready` with the `tuist.dev/kura-cache` taint
- [ ] After merge: the 13 Pending pods schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)
