### PR TITLE
fix(server): restore provisioned Kura Sentry secret reference

### DIFF
--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -1404,6 +1404,8 @@ jobs:
           echo "::group::external secrets"
           kubectl -n "$NAMESPACE" get externalsecret,secretstore 2>&1 || true
           kubectl -n "$NAMESPACE" describe externalsecret 2>&1 || true
+          kubectl -n "$KURA_CONTROLLER_NAMESPACE" get externalsecret,secretstore 2>&1 || true
+          kubectl -n "$KURA_CONTROLLER_NAMESPACE" describe externalsecret 2>&1 || true
           echo "::endgroup::"
       - name: Post-deploy smoke test
         run: |

--- a/infra/helm/AGENTS.md
+++ b/infra/helm/AGENTS.md
@@ -15,6 +15,7 @@ This node covers Helm assets under `infra/helm/`.
 - Model infrastructure dependencies with capability names such as `objectStorage`, not provider names such as `minio`.
 - Support both `embedded` and `external` dependency modes when practical.
 - Keep local validation simple: `helm template` first, then a small-cluster install path such as `kind`.
+- Provision replacement external-secret items and fields in each environment before changing managed values. Helm waits for `ExternalSecret` readiness, including Kura resources in the separate `kura` namespace; an unreadable telemetry secret can roll back the whole server release.
 - Grafana-managed alert queries and their operational rationale live in
   `k8s-monitoring/alerts.md`. Keep that runbook aligned with live rule changes;
   browser LCP p99 also requires distinct affected sessions, not just total samples.

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -356,14 +356,10 @@ kuraController:
   sentry:
     externalSecret:
       enabled: true
-      # Points at the self-hosted Hive ingest (../hive) so Kura errors land in
-      # the Kura project on hive.tuist.dev. The `kura-sentry-hive` 1P item in
-      # `tuist-k8s-canary` holds the Hive DSN under the default
-      # `KURA_SENTRY_DSN` field and MUST exist before this merges; a
-      # remoteRef whose item is missing fails the whole `kura-shared-secrets`
-      # sync. The prior `kura-sentry` item is kept in the vault as a rollback:
-      # flip this back to `kura-sentry` and reroll.
-      item: kura-sentry-hive
+      # Keep the provisioned item until kura-sentry-hive/KURA_SENTRY_DSN
+      # is available in tuist-k8s-canary. An unreadable remoteRef leaves
+      # kura-sentry-secrets unready and rolls back the whole server deploy.
+      item: kura-sentry
 
 # Only the shared mesh cache pools are listed. The runner-cache pool
 # (kura-scw-fr-par) is intentionally excluded: it advertises no egress budget,

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -341,14 +341,10 @@ kuraController:
   sentry:
     externalSecret:
       enabled: true
-      # Points at the self-hosted Hive ingest (../hive) so Kura errors land in
-      # the Kura project on hive.tuist.dev. The `kura-sentry-hive` 1P item in
-      # `tuist-k8s-production` holds the Hive DSN under the default
-      # `KURA_SENTRY_DSN` field and MUST exist before this merges; a
-      # remoteRef whose item is missing fails the whole `kura-shared-secrets`
-      # sync. The prior `kura-sentry` item is kept in the vault as a rollback:
-      # flip this back to `kura-sentry` and reroll.
-      item: kura-sentry-hive
+      # Keep the provisioned item until kura-sentry-hive/KURA_SENTRY_DSN
+      # is available in tuist-k8s-production. An unreadable remoteRef leaves
+      # kura-sentry-secrets unready and rolls back the whole server deploy.
+      item: kura-sentry
 
 # Only the shared mesh cache pools are listed. The runner-cache pool
 # (kura-scw-fr-par) is intentionally excluded: it advertises no egress budget,


### PR DESCRIPTION
Fixes the [failed canary server deployment](https://github.com/tuist/tuist/actions/runs/34046173494/job/101532325901), which waited an hour for `ExternalSecret/kura/kura-sentry-secrets` and then rolled back the entire release.

### Cause and approach

#12881 changed the Kura Sentry reference from `kura-sentry/KURA_SENTRY_DSN` to `kura-sentry-hive/KURA_SENTRY_DSN` before the replacement item was available to the canary secret provider. External Secrets operator logs confirm `no item matched the secret reference query`. Several consecutive deployment attempts hit the same blocker. After rollback, canary successfully synced the original reference; production also reports `Ready=True` with that reference.

Restore the provisioned `kura-sentry` item in both managed overlays so the canary-to-production cascade uses the working secret source. This defers Kura's Hive DSN migration until the replacement item and field are available in each environment. Keeping the existing reference preserves error reporting and Helm readiness checks without increasing the timeout or ignoring failed secret synchronization.

Add ExternalSecret and SecretStore failure diagnostics for the Kura controller namespace. Previously, diagnostics only inspected the server namespace and omitted the resource that blocked this deployment. Document the provisioning prerequisite in the Helm guidance and adjacent values comments.

### How to test locally

Render each environment with Helm 4.2.0, supplying the image values normally resolved by the deploy workflow:

```sh
for env in canary production; do
  namespace=tuist
  if [ "$env" = canary ]; then namespace=tuist-canary; fi
  helm template tuist infra/helm/tuist --namespace "$namespace" \
    -f infra/helm/tuist/values-managed-common.yaml \
    -f "infra/helm/tuist/values-managed-$env.yaml" \
    --set runnersFleet.runnerImageSemver=0.0.0 \
    --set runnersFleetLinux.shapeRunnerImage=ghcr.io/tuist/runner:validation \
    --set registry.image.tag=validation \
    --set kuraController.image.tag=validation \
    --set egressTreeAgent.image.tag=validation \
    --set codebaseSearch.image.tag=validation > "/tmp/tuist-$env.yaml"
done
```

Validation completed:

- Both full managed charts render successfully. Comparing before and after confirms that the only manifest change is the Kura secret reference, excluding randomly generated placeholder secrets from offline rendering.
- `actionlint -shellcheck= -ignore 'label "tuist-linux" is unknown' .github/workflows/server-deployment.yml` passes; the ignore covers the existing custom runner label.
- `git diff --check` passes.
- Read-only live checks confirm that both environments successfully sync `kura-sentry/KURA_SENTRY_DSN`.
- `helm lint` reports an existing `templates/dedibox-fleet.yaml` document-separator error, reproduced with the original values. Full chart rendering passes despite this lint limitation.

No deployment has been triggered for this change.
