### PR TITLE
fix(server): bound xcode target backfill memory

### DIFF
--- a/server/priv/AGENTS.md
+++ b/server/priv/AGENTS.md
@@ -13,6 +13,9 @@ This directory contains database migrations and other private assets.
 ## Guardrails
 - If you change stored customer data, update `server/data-export.md`.
 - Use `:timestamptz` for migration timestamps (per Credo rules).
+- Bound ClickHouse `INSERT SELECT` backfills with explicit read/insert thread,
+  block-size, and query-memory settings, including catch-up passes. Copying
+  one partition at a time alone does not bound their peak memory usage.
 - Add marketing changelog entries only for customer-facing product changes that are ready to announce.
 - Do not add product changelog entries for ops-only, admin-only, internal rollout, infrastructure-only, or otherwise unannounced functionality.
 

--- a/server/priv/ingest_repo/migrations/20260905120000_add_project_id_to_xcode_targets.exs
+++ b/server/priv/ingest_repo/migrations/20260905120000_add_project_id_to_xcode_targets.exs
@@ -55,6 +55,18 @@ defmodule Tuist.IngestRepo.Migrations.AddProjectIdToXcodeTargets do
   @buffer_margin_seconds 300
   @settle_ms 15_000
 
+  # Partitioning bounds the rows scanned, but not the parallel read pipelines
+  # or the insert buffers used to sort these wide rows into the new key order.
+  # The defaults exhausted production's 18 GiB ClickHouse memory budget.
+  @backfill_settings [
+    max_threads: 1,
+    max_insert_threads: 1,
+    max_block_size: 65_536,
+    min_insert_block_size_rows: 65_536,
+    min_insert_block_size_bytes: 64 * 1024 * 1024,
+    max_memory_usage: 2 * 1024 * 1024 * 1024
+  ]
+
   @columns ~w(
     project_id inserted_at command_event_id name product binary_cache_hash binary_cache_hit
     sources_hash resources_hash copy_files_hash core_data_models_hash target_scripts_hash
@@ -202,7 +214,8 @@ defmodule Tuist.IngestRepo.Migrations.AddProjectIdToXcodeTargets do
           WHERE toYYYYMMDD(inserted_at) = {partition:UInt32} AND #{@project_id_expr} != 0
           """,
           %{partition: partition},
-          timeout: 1_200_000
+          timeout: 1_200_000,
+          settings: @backfill_settings
         )
       end)
     end
@@ -235,7 +248,8 @@ defmodule Tuist.IngestRepo.Migrations.AddProjectIdToXcodeTargets do
           )
         """,
         %{gap_start: gap_start, gap_end: gap_end},
-        timeout: 1_200_000
+        timeout: 1_200_000,
+        settings: @backfill_settings
       )
     end)
   end


### PR DESCRIPTION
## Problem

[Production deployment 34095831552](https://github.com/tuist/tuist/actions/runs/34095831552/job/101672239114) failed in the pre-upgrade migration job while `20260905120000_add_project_id_to_xcode_targets` copied partition `20260811`. ClickHouse rejected the query with `MEMORY_LIMIT_EXCEEDED`: it would use 18.01 GiB against an 18.00 GiB server limit. The migration job exhausted its retries and Helm rolled the application release back.

The migration already copies one daily partition at a time, but its `INSERT SELECT` queries inherited the server's read parallelism and insert block sizes. Partitioning bounds how much data is scanned; it does not bound the concurrent pipelines and buffers sorting the wide target rows into the destination's project-based key order.

## Change

Apply the same explicit settings to both the partition copies and the final catch-up query:

- One read thread and one insert thread.
- 65,536-row read/insert blocks and a 64 MiB insert-buffer threshold.
- A 2 GiB query memory limit to leave headroom for live workloads.

This reduces the backfill's working set instead of raising production's memory limit or retrying the same oversized query. Existing partition cleanup, dictionary resolution, advisory locking, materialized-view creation, and gap deduplication remain intact. The existing migration must be repaired because a later migration cannot run past its failure. Already-migrated environments will skip it.

Document the memory constraint in the migration guidance. No stored fields, retention, or export behavior changes.

## Validation

- Parsed the changed migration and checked formatting with Elixir 1.20.2; `git diff --check` passed.
- Invoked the actual migration in an isolated ClickHouse 26.1.2.11 instance with a temporary Elixir harness. The harness supplied the repo adapter and PostgreSQL transaction/migrator shims; it executed the ClickHouse statements against real tables.
- Copied two million synthetic wide target rows across two daily partitions, covering dictionary-resolved and existing project IDs.
- Injected a failure after the first partition and verified that rerunning recovered all rows without duplicates.
- Inserted a row between the partition copy and materialized-view creation and verified catch-up resolved and copied it.
- Verified a completed migration can rerun without duplicates, new inserts flow through the materialized view, and the temporary dictionary is removed.
- Successful partition copies peaked at 363,195,507 bytes (about 346 MiB); the gap copies used under 4 MiB.

The full Mix suite was not run because this fresh worktree has no server dependencies. The local check uses the repository's installed ClickHouse version; production reports 26.4.1.2212. These synthetic results are not a production-scale benchmark. Production has not been redeployed by this PR.
