### PR TITLE
fix(kura): stabilize metric identity across pod replacements

### DIFF
--- a/infra/helm/AGENTS.md
+++ b/infra/helm/AGENTS.md
@@ -18,6 +18,9 @@ This node covers Helm assets under `infra/helm/`.
 - Grafana-managed alert queries and their operational rationale live in
   `k8s-monitoring/alerts.md`. Keep that runbook aligned with live rule changes;
   browser LCP p99 also requires distinct affected sessions, not just total samples.
+- Kura metrics use `instance=<namespace>/<pod>` at the metrics destination so
+  pod IP changes do not multiply series. Preserve the cluster label and the
+  unready scrape's `ready="false"` label when changing either scrape path.
 
 ## Related Context
 - Parent infra context: `infra/AGENTS.md`

--- a/infra/helm/k8s-monitoring/README.md
+++ b/infra/helm/k8s-monitoring/README.md
@@ -204,6 +204,29 @@ In Grafana Cloud: **Observability → Kubernetes → Cluster navigation** and pi
 
 Server-level labels (`namespace`, `pod`, `container`, deployment/statefulset names) are attached automatically by the upstream chart's k8s attribute processor from pod metadata.
 
+### Kura metric identity across rollouts
+
+For `job="kura"` with nonempty `namespace` and `pod` labels, the metrics
+destination rewrites `instance` to `<namespace>/<pod>`. The existing `cluster`
+label separates environments, and the StatefulSet pod name separates replicas
+while surviving pod replacement. Scraping still uses the pod IP; only the
+stored metric label changes.
+
+This applies to both Ready annotation-autodiscovery and the custom unready
+scrape, including `up` and `scrape_*`. Keep `ready="false"` on the unready path:
+it prevents those samples from colliding with Ready samples during discovery
+handoff. Targets without a complete pod identity and other jobs are unchanged.
+
+Using the IP as `instance` previously created a new set of series on every
+replacement. During the September 7, 2026 production rollout, repeated Kura
+replacements drove active series from roughly 142,000 to 216,000 while old
+series remained active for Grafana Cloud's 20-minute window. The first deploy
+of this rule also creates a one-time identity transition; later replacements
+reuse the stable identity. Counter resets remain visible to `rate`/`increase`.
+The Kura dashboard discovers instance values from metrics, so it picks up the
+new identities automatically. Queries pinned to an IP must use the pod identity
+instead.
+
 ## RBAC — what access does this chart get?
 
 - `alloy-metrics` — cluster-wide `get/list/watch` on nodes/pods/services/endpoints for target discovery, plus `/metrics/cadvisor` on kubelets.

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -4750,7 +4750,7 @@ Kura cannot make its scrape fail: coincident timestamps mean the failure is
 collection-side and no Kura investigation is warranted.
 
 ```promql
-up{cluster="tuist-production", job="kura", instance="<podIP>:4000"} == 0
+up{cluster="tuist-production", job="kura", instance="<namespace>/<pod>"} == 0
 ```
 
 ```promql

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -95,6 +95,17 @@ k8s-monitoring:
       # Kubernetes identifiers that multiply otherwise equivalent series and
       # are not used by dashboards in this repo.
       metricProcessingRules: |
+        // StatefulSet pod names survive replacement, but their IPs do not.
+        // Normalize both Ready autodiscovery and unready Kura scrapes here,
+        // including up/scrape_*; keep cluster and ready labels distinct.
+        write_relabel_config {
+          source_labels = ["job", "namespace", "pod"]
+          separator = ";"
+          regex = "kura;([^;]+);([^;]+)"
+          target_label = "instance"
+          replacement = "$1/$2"
+          action = "replace"
+        }
         write_relabel_config {
           action = "labeldrop"
           regex = "container_id|uid|pod_ip|image_id|image_spec|k8s_pod_uid"


### PR DESCRIPTION
Kura pod replacements now retain `instance=<namespace>/<pod>` in Grafana Cloud metrics instead of creating another set of series for each replacement pod IP. The existing `cluster` label separates environments, and the StatefulSet ordinal keeps replicas distinct.

### Why this change

The September 7 [cardinality-growth alert](https://tuist.grafana.net/alerting/grafana/efoqc5q9vs934a/view?orgId=1) fired during the [production rollout](https://github.com/tuist/tuist/actions/runs/34099137814). Active series rose from roughly 142,000 to 216,000; 98 of 106 pods in the Kura namespace were recreated around 09:21–09:28 UTC. One sampled StatefulSet pod appeared under four different IP-based `instance` values within seven minutes. Kura histograms dominated the changed series.

Grafana Cloud considers a series active for 20 minutes after its last sample, so multiple generations overlapped even after the currently queryable series count returned to approximately 142,000. Existing write relabeling removed `pod_ip` and pod UIDs, but the changing IP survived inside `instance`.

### Approach

- Normalize `instance` once at the Prometheus destination for `job="kura"` with nonempty namespace and pod labels. This covers both Ready annotation-autodiscovery and the custom unready scrape, including `up` and `scrape_*`.
- Preserve `cluster`, namespace, pod, histogram dimensions, and the unready path's `ready="false"` label. The readiness label keeps transiently overlapping Ready/unready scrapes distinct.
- Keep other jobs and targets without a complete pod identity unchanged. Scraping continues to connect to the actual pod IP.
- Document the identity contract and update the failed-scrape runbook example. The Kura dashboard discovers instance values dynamically and needs no query changes.

Destination-level normalization avoids duplicating the policy across the two discovery implementations. It addresses the series multiplication caused by IP changes without changing the secret-refresh or CPU-resource rollout behavior observed during the incident.

The first deployment causes a one-time transition from IP identities to pod identities. Subsequent replacements reuse the stable identity; queries explicitly pinned to an IP need to adopt the new value. Readiness transitions and other changing metric dimensions can still create distinct series.

### Validation

- Built the locked Grafana Kubernetes Monitoring 4.0.3 dependency.
- `helm lint` and `helm template` passed with staging, canary, production, management, and pentest overlays.
- Tested the rule extracted from all four rendered production metrics writers using a temporary Go harness and the Prometheus relabel engine. Verified identical identities across the four observed replacement IPs; distinct replicas, namespaces, clusters, readiness states, buckets, routes, and tenants; stable unready identities; correct handling of `up`/`scrape_*`; and unchanged unrelated jobs or incomplete identities.
- `git diff --check` passed. No live deployment or alert change was made.

### How to test locally

```sh
helm dependency build infra/helm/k8s-monitoring
for env in staging canary production management pentest; do
  helm lint infra/helm/k8s-monitoring -f infra/helm/k8s-monitoring/values-$env.yaml
  helm template k8s-monitoring infra/helm/k8s-monitoring -n observability \
    -f infra/helm/k8s-monitoring/values-$env.yaml > /tmp/k8s-monitoring-$env.yaml
done
```

After deployment, inspect `count by (cluster, namespace, pod, instance, ready) (up{job="kura"})`. For newly ingested samples, `instance` should be `<namespace>/<pod>` and remain stable when a pod is replaced with a different IP. Inspect the active-series trend after the one-time 20-minute transition window.
