### PR TITLE
chore(infra): add dispatchable MDM staging deployment workflow

### DIFF
--- a/.github/workflows/mdm-deployment.yml
+++ b/.github/workflows/mdm-deployment.yml
@@ -1,0 +1,150 @@
+name: MDM Deployment
+
+# Deploys the self-hosted Apple MDM stack (infra/helm/mdm) to the staging
+# cluster.
+#
+# The `ref` input exists so a branch can be deployed to staging WITHOUT
+# merging it: the workflow definition is taken from the ref this workflow
+# is dispatched on (normally main), but the code, chart and images all
+# come from `ref`. That is the path used while validating the fleet MDM
+# against physical hardware, where the stack changes far more often than
+# it is ready to land on main.
+#
+# Staging only. The production instance enrolls devices against a
+# different, permanent hostname and gets its own release when the
+# prototype gauntlet passes.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch or SHA to build and deploy (defaults to main)
+        required: false
+        default: main
+  push:
+    branches:
+      - main
+    paths:
+      - infra/mdm/**
+      - infra/helm/mdm/**
+      - .github/workflows/mdm-deployment.yml
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: mdm-deploy-staging
+  cancel-in-progress: false
+
+env:
+  MISE_VERSION: "2026.5.15"
+  MISE_GITHUB_TOKEN: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
+  REGISTRY: ghcr.io
+  HELM_CHART_PATH: infra/helm/mdm
+  HELM_RELEASE_NAME: mdm
+  NAMESPACE: mdm
+  DEPLOY_REF: ${{ inputs.ref || github.sha }}
+
+jobs:
+  build:
+    name: Build and push MDM images
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_REF }}
+          submodules: false
+          persist-credentials: false
+      # Tag from the resolved commit of DEPLOY_REF, not from the ref the
+      # workflow was dispatched on, so a redeploy of the same branch head
+      # is idempotent and the running image is traceable to a commit.
+      - id: tag
+        run: echo "image_tag=sha-$(git rev-parse HEAD | cut -c1-12)" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: infra/mdm/enroller/go.mod
+          cache-dependency-path: infra/mdm/enroller/go.sum
+      - name: Test enroller
+        working-directory: infra/mdm/enroller
+        run: go test ./...
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        name: Build and push mdm-enroller image
+        with:
+          context: ./infra/mdm/enroller
+          push: true
+          tags: ${{ env.REGISTRY }}/tuist/mdm-enroller:${{ steps.tag.outputs.image_tag }}
+      - uses: docker/build-push-action@v6
+        name: Build and push scepserver image
+        with:
+          context: ./infra/mdm/scep
+          push: true
+          tags: ${{ env.REGISTRY }}/tuist/scepserver:${{ steps.tag.outputs.image_tag }}
+
+  deploy:
+    name: Deploy staging
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: server-k8s-staging
+    env:
+      KUBECONFIG: ${{ github.workspace }}/.kube/config
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_REF }}
+          persist-credentials: false
+      - uses: jdx/mise-action@v4.0.1
+        with:
+          version: ${{ env.MISE_VERSION }}
+          install_args: "--locked helm kubectl"
+          cache: "false"
+      - uses: 1password/install-cli-action@v2
+      - name: Load kubeconfig from 1Password
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          mkdir -p "$(dirname "$KUBECONFIG")"
+          op document get "kubeconfig: tuist-staging" \
+            --vault "tuist-k8s-staging" --output "$KUBECONFIG"
+          chmod 600 "$KUBECONFIG"
+      - name: Verify cluster reachability
+        run: |
+          set -euo pipefail
+          kubectl --request-timeout=10s get --raw /version >/dev/null
+      - name: helm upgrade --install
+        env:
+          IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
+        run: |
+          helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
+            --namespace "$NAMESPACE" --create-namespace \
+            -f "$HELM_CHART_PATH/values-staging.yaml" \
+            --set images.enroller.tag="$IMAGE_TAG" \
+            --set images.scep.tag="$IMAGE_TAG" \
+            --atomic --timeout 15m --wait
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          set +e
+          echo "::group::helm history"
+          helm history "$HELM_RELEASE_NAME" -n "$NAMESPACE" --max 10 || true
+          echo "::endgroup::"
+          echo "::group::workload resources"
+          kubectl -n "$NAMESPACE" get deploy,svc,ingress,pvc,externalsecret,cluster.postgresql.cnpg.io,pods -o wide || true
+          echo "::endgroup::"
+          echo "::group::pods"
+          kubectl -n "$NAMESPACE" describe pods || true
+          echo "::endgroup::"
+          echo "::group::events"
+          kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp 2>&1 | tail -100 || true
+          echo "::endgroup::"


### PR DESCRIPTION
## What

Adds `.github/workflows/mdm-deployment.yml` and nothing else. It builds the two MDM images and deploys `infra/helm/mdm` to the staging cluster (namespace `mdm`).

The important part is the `ref` input: the workflow definition comes from whatever ref it is dispatched on (normally `main`), but the code, chart and images all come from `ref`. That makes it possible to deploy a branch to staging **without merging it**.

## Why this is its own PR

`workflow_dispatch` only registers once the workflow file exists on the default branch. That is a chicken-and-egg: the MDM stack cannot be deployed to staging from its own branch until the deploy workflow has already landed on `main`.

The alternative was deploying by hand from a laptop, which was attempted and does not work cleanly — it fights the cluster's permission model rather than using it. Namespace creation and `postgresql.cnpg.io/Cluster` writes are denied to every team identity through the kubectl gateway (the only cnpg grant is *delete*, for decommissioning) and granted solely to the pipeline's kubeconfig. That is deliberate: deploys are supposed to go through CI. A hand-run `helm upgrade` gets partway and leaves a release no git ref describes.

Splitting the workflow out keeps the merge boundary honest: what lands on `main` here is deployment machinery, not MDM behavior. The stack itself stays unmerged in tuist/tuist#12749 until it has been validated against a physical Mac mini.

## Notes

- Staging only. The production instance enrolls devices against a different, permanent hostname (an enrollment's ServerURL cannot be changed afterwards) and will get its own release once the prototype gauntlet passes.
- The image tag is derived from the resolved commit of `ref`, not from the dispatch ref, so redeploying the same branch head is idempotent and a running image is traceable to a commit.
- The `push` trigger is inert until `infra/mdm/**` and `infra/helm/mdm/**` exist on `main`, so merging this changes no existing behavior.
- The build job runs `go test ./...` for the enroller before pushing images.

## Validation

- `helm lint` / `helm template` of the chart (on the tuist/tuist#12749 branch) pass for both the CI and staging values, and the enroller's tests pass locally.
- The prerequisites this workflow depends on are already in place and verified: the `MDM` item exists in the `tuist-k8s-staging` vault, and a partial hand-deploy confirmed all three ExternalSecrets reach `SecretSynced=True`, the SCEP depot PVC binds, and the Ingress gets an address on both hostnames.
- Not yet exercised: a full green run, which is the point of merging this — the first dispatch will target the tuist/tuist#12749 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)