### PR TITLE
fix(server): read the module cache analytics from xcode_targets_by_project

### DIFF
--- a/server/lib/tuist/builds/analytics.ex
+++ b/server/lib/tuist/builds/analytics.ex
@@ -2330,7 +2330,7 @@ defmodule Tuist.Builds.Analytics do
             ) AS own,
             xt.dependencies_hash AS deps,
             xt.external_hash AS ext
-          FROM xcode_targets AS xt
+          FROM xcode_targets_by_project AS xt
           INNER JOIN command_events AS e ON xt.command_event_id = e.id
           WHERE e.project_id = {project_id:Int64}
             AND e.ran_at >= {start:DateTime64(6)}
@@ -2404,7 +2404,7 @@ defmodule Tuist.Builds.Analytics do
         xt.dependencies AS dependencies,
         e.ran_at AS ran_at,
         coalesce(nullIf(e.git_commit_sha, ''), toString(e.id)) AS commit
-      FROM xcode_targets AS xt
+      FROM xcode_targets_by_project AS xt
       INNER JOIN command_events AS e ON xt.command_event_id = e.id
       WHERE e.project_id = {project_id:Int64}
         AND e.ran_at >= {start:DateTime64(6)}
@@ -2413,7 +2413,7 @@ defmodule Tuist.Builds.Analytics do
     )
     WHERE commit = (
       SELECT argMax(coalesce(nullIf(e2.git_commit_sha, ''), toString(e2.id)), e2.ran_at)
-      FROM xcode_targets AS xt2
+      FROM xcode_targets_by_project AS xt2
       INNER JOIN command_events AS e2 ON xt2.command_event_id = e2.id
       WHERE e2.project_id = {project_id:Int64}
         AND e2.ran_at >= {start:DateTime64(6)}
@@ -2617,7 +2617,7 @@ defmodule Tuist.Builds.Analytics do
             ) AS own,
             xt.dependencies_hash AS deps,
             xt.external_hash AS ext
-          FROM xcode_targets AS xt
+          FROM xcode_targets_by_project AS xt
           INNER JOIN command_events AS e ON xt.command_event_id = e.id
           -- Commands that produce an activity log carry the build run they
           -- belong to, which is where the scheme lives. Bounded to the same
@@ -2782,7 +2782,7 @@ defmodule Tuist.Builds.Analytics do
     SELECT
       toDate(e.ran_at) AS day,
       uniqExact(xt.name) AS modules
-    FROM xcode_targets AS xt
+    FROM xcode_targets_by_project AS xt
     INNER JOIN command_events AS e ON xt.command_event_id = e.id
     WHERE e.project_id = {project_id:Int64}
       AND e.ran_at >= {start:DateTime64(6)}
@@ -2844,7 +2844,7 @@ defmodule Tuist.Builds.Analytics do
     SELECT uniqExact(name)
     FROM (
       SELECT xt.name AS name, #{String.replace(commit_key, "%{alias}", "e")} AS commit
-      FROM xcode_targets AS xt
+      FROM xcode_targets_by_project AS xt
       INNER JOIN command_events AS e ON xt.command_event_id = e.id
       WHERE e.project_id = {project_id:Int64}
         AND e.ran_at >= {start:DateTime64(6)}
@@ -2854,7 +2854,7 @@ defmodule Tuist.Builds.Analytics do
     )
     WHERE commit = (
       SELECT argMax(#{String.replace(commit_key, "%{alias}", "e2")}, e2.ran_at)
-      FROM xcode_targets AS xt2
+      FROM xcode_targets_by_project AS xt2
       INNER JOIN command_events AS e2 ON xt2.command_event_id = e2.id
       WHERE e2.project_id = {project_id:Int64}
         AND e2.ran_at >= {start:DateTime64(6)}
@@ -2968,7 +2968,7 @@ defmodule Tuist.Builds.Analytics do
       toDate(e.ran_at) AS day,
       countIf(xt.binary_cache_hit = 'miss') AS invalidations,
       countIf(xt.binary_cache_hit != 'miss') AS reuses
-    FROM xcode_targets AS xt
+    FROM xcode_targets_by_project AS xt
     INNER JOIN command_events AS e ON xt.command_event_id = e.id
     WHERE e.project_id = {project_id:Int64}
       AND e.ran_at >= {start:DateTime64(6)}
@@ -3056,7 +3056,7 @@ defmodule Tuist.Builds.Analytics do
           ) AS own,
           xt.dependencies_hash AS deps,
           xt.external_hash AS ext
-        FROM xcode_targets AS xt
+        FROM xcode_targets_by_project AS xt
         INNER JOIN command_events AS e ON xt.command_event_id = e.id
         WHERE e.project_id = {project_id:Int64}
           AND e.ran_at >= {start:DateTime64(6)}
@@ -3125,7 +3125,7 @@ defmodule Tuist.Builds.Analytics do
       -- a CLI that does not send edges, which would drop this module's edges
       -- for the day while its neighbours keep theirs.
       argMaxIf(xt.dependencies, e.ran_at, notEmpty(xt.dependencies)) AS deps
-    FROM xcode_targets AS xt
+    FROM xcode_targets_by_project AS xt
     INNER JOIN command_events AS e ON xt.command_event_id = e.id
     WHERE e.project_id = {project_id:Int64}
       AND e.ran_at >= {start:DateTime64(6)}


### PR DESCRIPTION
## What changed

The ten module cache analytics queries in `Tuist.Builds.Analytics` now read `xcode_targets_by_project` instead of `xcode_targets`. Nothing else changes: the filters, bounds and joins are the ones #12896 added.

## Root cause

#12896 created `xcode_targets_by_project`, copied every partition into it and described the queries as reading it, but the queries never moved. The substitution that was meant to retarget the `FROM` clauses used a word-boundary escape that BSD sed does not support, so it matched nothing, and the grep run right after it still listed `FROM xcode_targets AS xt` for every clause. I misread that output as the new name. The review, the 143 passing tests and the dev verification all exercised a code path that still read `xcode_targets`, which works, so nothing caught it.

The migration itself deployed fine today. Production has the table with every partition copied (row counts match `xcode_targets` per day, apart from today's live partition and the TTL edge) and the materialized view keeping it current since 09:21 UTC. The page has been scanning the whole `xcode_targets` table since, now failing at the 15 s execution limit #12911 introduced instead of the client timeout.

## Measured in production

The exact daily hits and misses query the page runs, from `system.query_log`, against both tables:

| Table | Rows read | Bytes read | Duration |
|---|---|---|---|
| `xcode_targets` (current) | 898,365,835 | 33 GiB | 4.4 s |
| `xcode_targets_by_project` (this change) | 1,627,946 | 46 MiB | 1.4 s |

The heavier queries on the page (the self-joined reason breakdown and the module list) read 1.8 billion rows today and time out at 15 s; they are the same shape and gain the same reduction.

## Validation

- 125 tests across the module analytics and the three module cache LiveViews pass on this branch; they insert through `xcode_targets` and read through the materialized view, so they now exercise the new table.
- `mix format` and `mix credo` clean.
- No migration, no data change: deploying this flips the page onto data that is already there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
