### PR TITLE
feat(kura): restore per-box page-cache visibility on the cache fleet

### DIFF
--- a/infra/grafana-dashboards/tuist-kura-region-scalability.json
+++ b/infra/grafana-dashboards/tuist-kura-region-scalability.json
@@ -5944,6 +5944,198 @@
             }
           }
         }
+      },
+      "panel-23": {
+        "kind": "Panel",
+        "spec": {
+          "id": 23,
+          "title": "Page cache by node",
+          "description": "Share of each Kura box's RAM held as page cache (`node_memory_Cached_bytes / node_memory_MemTotal_bytes`). This is the quantity ceiling overcommit actually spends: Kura's mmap'd segments live here, so a box that is packed past its real memory reclaims page cache long before it OOM-kills anything, and pays for it in read latency rather than in restarts. **Host memory used** cannot show this, because `MemAvailable` counts reclaimable cache as available: a box with a large working cache and a genuinely idle box both read as ~90% available there.\n\nRead it against **Free memory by node** beside it. Cache high and free low is a box whose spare RAM is already doing work; both low is a box with no slack left. Cache is what a heavier `MemoryCeilingOversubscription` in the CAPI provider (`infra/cluster-api-provider-tuist/controllers/shared/node_memory.go`) consumes once free memory runs out.\n\nDo not drop this query without replacing it. Grafana Cloud Adaptive Metrics auto-applies query-driven recommendations, and it held an aggregation rule on `node_memory_Cached_bytes` and `node_memory_MemFree_bytes` that dropped `cluster` and `instance` for as long as nothing queried them; the series were a single label-less total until September 7, 2026.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, instance) (node_memory_Cached_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region, instance) (node_memory_MemTotal_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"))",
+                        "legendFormat": "{{region}} / {{instance}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "percentunit",
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            }
+          }
+        }
+      },
+      "panel-24": {
+        "kind": "Panel",
+        "spec": {
+          "id": 24,
+          "title": "Free memory by node",
+          "description": "Share of each Kura box's RAM the kernel is holding genuinely free (`node_memory_MemFree_bytes / node_memory_MemTotal_bytes`), doing no work for anyone. Overcommit spends this first and it costs nothing; only once it is gone does packing start evicting the page cache in **Page cache by node**.\n\nFree plus page cache is roughly what **Host memory used** reports as available, split into the half that is free for the taking and the half that is already earning its keep.",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "refId": "A",
+                    "query": {
+                      "datasource": {
+                        "name": "$datasource"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "sum by (cluster, region, instance) (node_memory_MemFree_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\")) / sum by (cluster, region, instance) (node_memory_MemTotal_bytes{env=\"$env\"} * on (cluster, instance) group_left(region) label_replace($node_region, \"instance\", \"$1\", \"node\", \"(.*)\"))",
+                        "legendFormat": "{{region}} / {{instance}}",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    }
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 0,
+                    "showPoints": "never",
+                    "spanNulls": true,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "percentunit",
+                  "min": 0,
+                  "max": 1
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "layout": {
@@ -6074,6 +6266,32 @@
                         },
                         "x": 12,
                         "y": 8,
+                        "width": 12,
+                        "height": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-23"
+                        },
+                        "x": 0,
+                        "y": 16,
+                        "width": 12,
+                        "height": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-24"
+                        },
+                        "x": 12,
+                        "y": 16,
                         "width": 12,
                         "height": 8
                       }

--- a/infra/helm/k8s-monitoring/README.md
+++ b/infra/helm/k8s-monitoring/README.md
@@ -130,6 +130,67 @@ Plus the telemetry services themselves:
 - `kube-state-metrics` Deployment
 - `node-exporter` DaemonSet
 
+## Metrics aggregated downstream of this chart
+
+What this chart keeps is not what Grafana Cloud stores. **Adaptive Metrics** sits
+in front of the tenant and rewrites series on ingest, so a metric can be
+allow-listed here, present in the collector's deployed config, and still be
+unqueryable in the shape a dashboard or alert needs. Check it before concluding
+the chart is at fault.
+
+Its rules are query-driven: it proposes aggregating away any label no query has
+touched in the lookback, and **auto-apply is enabled on this stack**, so a
+recommendation becomes a rule on its own. That means a metric nobody queries
+loses its labels, and a query is the only thing that keeps them.
+
+An aggregated metric does not disappear. It survives as a single series with the
+aggregated labels removed, which is why a matcher on one of them silently
+matches nothing:
+
+```
+{__name__="node_memory_Cached_bytes", cluster="tuist-production"}   # no data
+sum(node_memory_Cached_bytes)                                       # a number
+node_memory_Cached_bytes                                            # errors, and names every aggregated label
+```
+
+The bare query is the fastest audit: the error lists exactly which labels are
+gone.
+
+Read and edit the rules through the tenant's own endpoint, authenticated as the
+metrics tenant rather than as the Grafana instance. A Grafana stack
+service-account token is the wrong credential here; the env vault's `LOKI_TOKEN`
+is an access policy token that carries tenant read:
+
+```bash
+TOKEN=$(op read "op://tuist-k8s-production/LOKI_TOKEN/password")
+BASE=https://prometheus-prod-24-prod-eu-west-2.grafana.net
+
+# Current rules, and whether recommendations auto-apply
+curl -s -u "1774467:$TOKEN" $BASE/aggregations/rules > rules.json
+curl -s -u "1774467:$TOKEN" $BASE/aggregations/recommendations/config
+```
+
+`POST /aggregations/rules` replaces the **entire** rule set, so edit the file
+rather than sending a fragment, and pass the `Etag` from the GET as `If-Match`
+so a concurrent change fails instead of being clobbered. Keep the GET response
+as the rollback. Ingest picks the change up within about fifteen minutes;
+already-stored samples stay aggregated, so verify on fresh data.
+
+Deleting a rule is not durable on its own while auto-apply is on. The
+recommendation that produced it stands until a query touches the metric again,
+and the next cycle reapplies it. Pair every deletion with the query that
+protects it, which for Kura page cache is the **Page cache by node** panel in
+`infra/grafana-dashboards/tuist-kura-region-scalability.json`.
+
+`recommendations/config` also carries a global `keep_labels` list: a label named
+there is never proposed for aggregation on any metric. It is empty today.
+Putting `cluster` in it would end this whole class of bug, at the cost of every
+future recommendation that would have dropped `cluster` for real savings.
+
+Restoring a label restores its cardinality. `node_memory_Cached_bytes` and
+`node_memory_MemFree_bytes` are 59 hosts each, so about 120 series and a dollar
+a month at the stack's measured rate.
+
 ## Metrics scrape cadence
 
 Cluster and custom metrics jobs normally use a 60-second scrape interval. The

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -372,6 +372,11 @@ k8s-monitoring:
           - node_cpu_seconds_total
           - node_exporter_build_info
           - node_filesystem.*
+          # `node_memory.*` keeps every member of the family node-exporter
+          # reads out of /proc/meminfo in one pass, so a member missing in
+          # Grafana Cloud was never dropped here; it was aggregated at
+          # ingest by Adaptive Metrics. See "Metrics aggregated downstream
+          # of this chart" in README.md before editing this list.
           - node_memory.*
           - process_cpu_seconds_total
           - process_resident_memory_bytes


### PR DESCRIPTION
## What changed

`node_memory_Cached_bytes` and `node_memory_MemFree_bytes` are now readable per Kura box in production, and the Kura region scalability dashboard has two panels that read them: **Page cache by node** and **Free memory by node**.

- `infra/grafana-dashboards/tuist-kura-region-scalability.json` gains the two panels in the RAM trends row, joined to region through `$node_region` exactly like the rest of that row.
- `infra/helm/k8s-monitoring/README.md` gains a "Metrics aggregated downstream of this chart" section: how to read and edit Adaptive Metrics aggregation rules from the CLI, which credential works, and why deleting a rule is not durable while auto-apply is on.
- `infra/helm/k8s-monitoring/values.yaml` gains a note on the `node_memory.*` allow-list entry so the next person does not chase the chart.

## Why

Kura cache boxes advertise `tuist.dev/memory-ceiling-mib` at twice their allocatable RAM (`MemoryCeilingOversubscription` in `infra/cluster-api-provider-tuist/controllers/shared/node_memory.go`), so a box runs out of schedulable ceiling long before it runs out of real memory. On 2026-09-07 one us-east box was 94.4% committed on that dimension while `MemAvailable`-based utilisation read around 10%, and that is where a cache replica sat Pending for two days.

Raising the multiple is the obvious lever, but the cost of doing so was invisible. `MemAvailable` counts reclaimable page cache as available, so a box holding a large working cache and a box with genuinely free RAM both read as roughly 90% available. Kura leans on page cache for read performance and its mmap'd segments live there, so overcommit evicts cache long before it OOM-kills anything, and it surfaces as read latency rather than as restarts. `kura_container_memory_pressure_bytes` excludes clean file-backed cache by design, so the measurement that says no production pod comes within 3x of its ceiling is measuring OOM headroom and is silent about the cost that would actually be paid. `Cached` is what separates the two cases, and it could not be read per box.

## Root cause

Not the chart. The deployed `k8s-monitoring-alloy-metrics` ConfigMap in `tuist-production` keeps `node_memory.*` through the scrape keep-list, the `extraMetricProcessingRules` trims, and the remote_write `write_relabel_config` chain. `MemAvailable` and `MemTotal` arriving through that same keep rule already proves the collector path works, because no rule anywhere distinguishes members of the family, and node-exporter reads them all out of a single pass over `/proc/meminfo`.

The cause was Grafana Cloud Adaptive Metrics. It held an aggregation rule on `node_memory_Cached_bytes`, `node_memory_MemFree_bytes` and `node_memory_Buffers_bytes` dropping `app, cluster, component, container, env, instance, k8s_cluster_name, namespace, pod, source, workload`.

The metrics were never missing. They were ingested the whole time as one label-less series each, which is why the diagnostic query looked like a total drop:

```
{__name__="node_memory_Cached_bytes", cluster="tuist-production"}   # no data, cluster is aggregated away
sum(node_memory_Cached_bytes)                                       # 666915147776
node_memory_Cached_bytes                                            # errors, and names every aggregated label
```

Its recommendations are query-driven, so the two `node_memory_*` metrics that dashboards and alerts already read kept their labels and the rest lost theirs. The same failure mode is on record for `tart_kubelet_*` and for the CAPI control-plane metrics.

## Why this shape of fix

The rule deletion alone is not durable. Auto-apply is enabled on this stack (`/aggregations/recommendations/config` returns `{"keep_labels": [], "auto_apply": {"enabled": true}}`) and the recommendation for both metrics still stands after the deletion, so it comes back on the next cycle unless a live query protects the metric. That is what makes the dashboard panels part of the fix rather than a follow-up, and it is why the panel description says not to drop the query.

The blunter alternative is to put `cluster` in the global `keep_labels`, which would end this class of bug for every metric at once. It is called out in the README as an option rather than taken here, because it also gives up every future recommendation that would have dropped `cluster` for real savings, and metrics is effectively the whole Grafana Cloud bill.

`Buffers` was deliberately left aggregated. Nothing needs it, and on these boxes it is a rounding error against `Cached`.

## Applied out of band

Adaptive Metrics rules are Grafana Cloud configuration and are not in this repository, so this part is not in the diff:

- `POST /aggregations/rules` on the metrics tenant with an `If-Match` guard, removing the `node_memory_Cached_bytes` and `node_memory_MemFree_bytes` entries. 1,564 rules to 1,562.
- The pre-change rule set was captured first, and the result was fetched back and diffed by `(metric, match_type)`: exactly two removals, nothing added, nothing changed.

Rollback is re-adding the two entries, each `{"metric": "<name>", "drop_labels": ["app","cluster","component","container","env","instance","k8s_cluster_name","namespace","pod","source","workload"], "aggregations": ["count","sum","sum:counter"]}`.

No Grafana alert rule was created or modified.

## Validation

Both panel expressions were run against production Prometheus, not inspected as config. Coverage is complete, 21 of 21 Linux nodes:

```
node_memory_Cached_bytes         21
node_memory_MemAvailable_bytes   21
node_memory_MemFree_bytes        21
node_memory_MemTotal_bytes       21
```

Page cache and free memory per Kura box, first reading after the change:

| Region | Page cache | Free |
|---|---|---|
| us-east (94.4% ceiling-committed box) | 80.3% | 2.6% |
| us-east (second box, added recently) | 13.5% | 77.1% |
| eu-central | 85.1% | 2.1% |
| us-west | 53.4% | 13.8% |
| scw-fr-par-runners | 59.9% | 35.2% |

The first row is the point of the change. That box reads about 89% available on `MemAvailable`, which is what made 2x look conservative, but almost all of that headroom is page cache doing work rather than idle memory.

## Impact

Developer-facing only. No customer's memory ceiling changed, no pod spec changed, and nothing about scheduling changed. Restoring the two labels costs about 120 active series, roughly a dollar a month at this stack's measured rate.

## Follow-ups, not in this PR

- The measurement itself. One instant reading is not a busy-period measurement, and there is no history for these series before today. The panels need a weekday CI peak before the ceiling multiple is worth touching.
- Raising `MemoryCeilingOversubscription`, which stays at 2 here.
- If the multiple does move materially, Kura's per-pod memory pressure controller is sized from the pod's own ceiling, so it defends the instance and not the box. A pod can sit comfortably inside its ceiling with the controller quiet while the box is exhausted, and today the only box-level signal is the `Kura cache box out of memory` alert, which fires after the fact rather than shedding before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
