### PR TITLE
fix(server): measure Kura ring turnover against the ring, not the claim

### DIFF
--- a/server/lib/tuist/kura/claim_sizing.ex
+++ b/server/lib/tuist/kura/claim_sizing.ex
@@ -107,9 +107,9 @@ defmodule Tuist.Kura.ClaimSizing do
 
       with window when not is_nil(window) <-
              qualifying_window(by_date, context.today, rung.window_days, &grow_day?(&1, threshold_seconds)),
-           true <- ring_turnover(window, current_bytes) >= Map.get(rung, :min_ring_turnover, 0.0) do
+           true <- turnover_cleared?(window, rung) do
         {grow_target_bytes(window, current_bytes, floor_seconds, policy),
-         grow_evidence(window, floor_seconds, threshold_seconds, current_bytes)}
+         grow_evidence(window, floor_seconds, threshold_seconds)}
       else
         _ -> nil
       end
@@ -119,10 +119,34 @@ defmodule Tuist.Kura.ClaimSizing do
   defp shed_age_threshold({:seconds, seconds}, _floor_seconds), do: seconds
   defp shed_age_threshold({:floor_fraction, fraction}, floor_seconds), do: round(floor_seconds * fraction)
 
-  defp ring_turnover(_window, current_bytes) when current_bytes <= 0, do: 0.0
+  # An unmeasured ring is no denominator, so a rung that asks for turnover
+  # goes unproven rather than falling back to the claim: the claim also funds
+  # upload staging, a spare segment and the index, so it is materially larger
+  # than the ring it pays for and would read turnover low on every account.
+  defp turnover_cleared?(window, rung) do
+    case {Map.get(rung, :min_ring_turnover), ring_turnover(window)} do
+      {nil, _turnover} -> true
+      {_minimum, nil} -> false
+      {minimum, turnover} -> turnover >= minimum
+    end
+  end
 
-  defp ring_turnover(window, current_bytes) do
-    window |> Enum.map(& &1.evicted_bytes) |> Enum.sum() |> Kernel./(current_bytes)
+  defp ring_turnover(window) do
+    case ring_budget_bytes(window) do
+      nil -> nil
+      budget_bytes -> window |> Enum.map(& &1.evicted_bytes) |> Enum.sum() |> Kernel./(budget_bytes)
+    end
+  end
+
+  # The ring the nodes reported running, taken at its smallest across the
+  # window. A window never spans a resize, so the days normally agree; when
+  # they do not, every byte in the sum went out against a ring at least this
+  # small.
+  defp ring_budget_bytes(window) do
+    window
+    |> Enum.map(& &1.last_ring_budget_bytes)
+    |> Enum.reject(&(is_nil(&1) or &1 <= 0))
+    |> Enum.min(fn -> nil end)
   end
 
   # Backfill cannot fake this: shed age is measured from the content's own
@@ -223,7 +247,7 @@ defmodule Tuist.Kura.ClaimSizing do
     |> min(current_bytes)
   end
 
-  defp grow_evidence(window, floor_seconds, threshold_seconds, current_bytes) do
+  defp grow_evidence(window, floor_seconds, threshold_seconds) do
     %{
       "signal" => "shed_age_below_retention_floor",
       "window_days" => length(window),
@@ -232,9 +256,13 @@ defmodule Tuist.Kura.ClaimSizing do
       "median_shed_age_seconds" => window |> Enum.map(& &1.median_shed_age_seconds) |> median(),
       "median_ring_span_seconds" => window |> Enum.map(& &1.median_ring_span_seconds) |> median(),
       "evicted_bytes" => window |> Enum.map(& &1.evicted_bytes) |> Enum.sum(),
-      "ring_turnover" => window |> ring_turnover(current_bytes) |> Float.round(1)
+      "ring_budget_bytes" => ring_budget_bytes(window),
+      "ring_turnover" => window |> ring_turnover() |> round_turnover()
     }
   end
+
+  defp round_turnover(nil), do: nil
+  defp round_turnover(turnover), do: Float.round(turnover, 1)
 
   defp shrink_evidence(window, policy) do
     %{

--- a/server/lib/tuist_web/live/ops_account_live.ex
+++ b/server/lib/tuist_web/live/ops_account_live.ex
@@ -816,14 +816,27 @@ defmodule TuistWeb.OpsAccountLive do
   # The second line: how much observation stands behind the first. Days are
   # what the measurements are grouped into, so an operator can see whether this
   # is one bad afternoon or a standing pattern.
-  defp kura_claim_proposal_basis(%{direction: :grow, evidence: evidence}) do
+  defp kura_claim_proposal_basis(%{direction: :grow, evidence: %{"ring_turnover" => turnover} = evidence})
+       when not is_nil(turnover) do
     dngettext(
       "dashboard",
       "Seen on %{count} day of measurements (%{bytes} discarded, %{turnover}x the whole cache).",
       "Seen on %{count} consecutive days of measurements (%{bytes} discarded, %{turnover}x the whole cache).",
       evidence["window_days"],
       bytes: ByteFormatter.format_bytes(evidence["evicted_bytes"] || 0),
-      turnover: evidence["ring_turnover"] || 0
+      turnover: turnover
+    )
+  end
+
+  # No node reported the ring it was running, so there is no turnover to
+  # quote and the volume stands on its own.
+  defp kura_claim_proposal_basis(%{direction: :grow, evidence: evidence}) do
+    dngettext(
+      "dashboard",
+      "Seen on %{count} day of measurements (%{bytes} discarded).",
+      "Seen on %{count} consecutive days of measurements (%{bytes} discarded).",
+      evidence["window_days"],
+      bytes: ByteFormatter.format_bytes(evidence["evicted_bytes"] || 0)
     )
   end
 

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -407,8 +407,8 @@ msgstr ""
 #: lib/tuist_web/components/runs/ran_by_badge.ex:104
 #: lib/tuist_web/live/ops_account_helpers.ex:15
 #: lib/tuist_web/live/ops_account_helpers.ex:24
-#: lib/tuist_web/live/ops_account_live.ex:862
-#: lib/tuist_web/live/ops_account_live.ex:891
+#: lib/tuist_web/live/ops_account_live.ex:875
+#: lib/tuist_web/live/ops_account_live.ex:904
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -694,22 +694,22 @@ msgstr ""
 msgid "Air"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:986
+#: lib/tuist_web/live/ops_account_live.ex:999
 #, elixir-autogen, elixir-format
 msgid "Argentina"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:987
+#: lib/tuist_web/live/ops_account_live.ex:1000
 #, elixir-autogen, elixir-format
 msgid "Australia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:988
+#: lib/tuist_web/live/ops_account_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Austria"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:989
+#: lib/tuist_web/live/ops_account_live.ex:1002
 #, elixir-autogen, elixir-format
 msgid "Belgium"
 msgstr ""
@@ -721,17 +721,17 @@ msgstr ""
 msgid "Billing email"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:990
+#: lib/tuist_web/live/ops_account_live.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Brazil"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:991
+#: lib/tuist_web/live/ops_account_live.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Bulgaria"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:992
+#: lib/tuist_web/live/ops_account_live.ex:1005
 #, elixir-autogen, elixir-format
 msgid "Canada"
 msgstr ""
@@ -762,12 +762,12 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:993
+#: lib/tuist_web/live/ops_account_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Chile"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:994
+#: lib/tuist_web/live/ops_account_live.ex:1007
 #, elixir-autogen, elixir-format
 msgid "China"
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:995
+#: lib/tuist_web/live/ops_account_live.ex:1008
 #, elixir-autogen, elixir-format
 msgid "Colombia"
 msgstr ""
@@ -792,7 +792,7 @@ msgstr ""
 msgid "Creates a Stripe customer (if missing), sets the billing address, and starts an invoice-billed Enterprise subscription. The customer receives an invoice by email; no card is collected here."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:996
+#: lib/tuist_web/live/ops_account_live.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Croatia"
 msgstr ""
@@ -802,17 +802,17 @@ msgstr ""
 msgid "Current version"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:997
+#: lib/tuist_web/live/ops_account_live.ex:1010
 #, elixir-autogen, elixir-format
 msgid "Cyprus"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:998
+#: lib/tuist_web/live/ops_account_live.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Czechia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:999
+#: lib/tuist_web/live/ops_account_live.ex:1012
 #, elixir-autogen, elixir-format
 msgid "Denmark"
 msgstr ""
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1000
+#: lib/tuist_web/live/ops_account_live.ex:1013
 #, elixir-autogen, elixir-format
 msgid "Estonia"
 msgstr ""
@@ -849,67 +849,67 @@ msgstr ""
 msgid "Finished"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1001
+#: lib/tuist_web/live/ops_account_live.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Finland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1002
+#: lib/tuist_web/live/ops_account_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "France"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1003
+#: lib/tuist_web/live/ops_account_live.ex:1016
 #, elixir-autogen, elixir-format
 msgid "Germany"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1004
+#: lib/tuist_web/live/ops_account_live.ex:1017
 #, elixir-autogen, elixir-format
 msgid "Greece"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1005
+#: lib/tuist_web/live/ops_account_live.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Hong Kong"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1006
+#: lib/tuist_web/live/ops_account_live.ex:1019
 #, elixir-autogen, elixir-format
 msgid "Hungary"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1007
+#: lib/tuist_web/live/ops_account_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Iceland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1008
+#: lib/tuist_web/live/ops_account_live.ex:1021
 #, elixir-autogen, elixir-format
 msgid "India"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1009
+#: lib/tuist_web/live/ops_account_live.ex:1022
 #, elixir-autogen, elixir-format
 msgid "Indonesia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1010
+#: lib/tuist_web/live/ops_account_live.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Ireland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1011
+#: lib/tuist_web/live/ops_account_live.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Israel"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1012
+#: lib/tuist_web/live/ops_account_live.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Italy"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1013
+#: lib/tuist_web/live/ops_account_live.ex:1026
 #, elixir-autogen, elixir-format
 msgid "Japan"
 msgstr ""
@@ -930,27 +930,27 @@ msgstr ""
 msgid "Latest deployment"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1014
+#: lib/tuist_web/live/ops_account_live.ex:1027
 #, elixir-autogen, elixir-format
 msgid "Latvia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1015
+#: lib/tuist_web/live/ops_account_live.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Lithuania"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1016
+#: lib/tuist_web/live/ops_account_live.ex:1029
 #, elixir-autogen, elixir-format
 msgid "Luxembourg"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1017
+#: lib/tuist_web/live/ops_account_live.ex:1030
 #, elixir-autogen, elixir-format
 msgid "Malaysia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1018
+#: lib/tuist_web/live/ops_account_live.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Malta"
 msgstr ""
@@ -960,7 +960,7 @@ msgstr ""
 msgid "Manage on Stripe"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1019
+#: lib/tuist_web/live/ops_account_live.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Mexico"
 msgstr ""
@@ -977,12 +977,12 @@ msgstr ""
 msgid "Name on invoice"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1020
+#: lib/tuist_web/live/ops_account_live.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Netherlands"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1021
+#: lib/tuist_web/live/ops_account_live.ex:1034
 #, elixir-autogen, elixir-format
 msgid "New Zealand"
 msgstr ""
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1022
+#: lib/tuist_web/live/ops_account_live.ex:1035
 #, elixir-autogen, elixir-format
 msgid "Norway"
 msgstr ""
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Pending"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1023
+#: lib/tuist_web/live/ops_account_live.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Philippines"
 msgstr ""
@@ -1059,12 +1059,12 @@ msgstr ""
 msgid "Plan & billing"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1024
+#: lib/tuist_web/live/ops_account_live.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Poland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1025
+#: lib/tuist_web/live/ops_account_live.ex:1038
 #, elixir-autogen, elixir-format
 msgid "Portugal"
 msgstr ""
@@ -1089,7 +1089,7 @@ msgstr ""
 msgid "Region"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1026
+#: lib/tuist_web/live/ops_account_live.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Romania"
 msgstr ""
@@ -1109,32 +1109,32 @@ msgstr ""
 msgid "Select a country"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1027
+#: lib/tuist_web/live/ops_account_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Singapore"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1028
+#: lib/tuist_web/live/ops_account_live.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Slovakia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1029
+#: lib/tuist_web/live/ops_account_live.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Slovenia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1030
+#: lib/tuist_web/live/ops_account_live.ex:1043
 #, elixir-autogen, elixir-format
 msgid "South Africa"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1031
+#: lib/tuist_web/live/ops_account_live.ex:1044
 #, elixir-autogen, elixir-format
 msgid "South Korea"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1032
+#: lib/tuist_web/live/ops_account_live.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Spain"
 msgstr ""
@@ -1170,22 +1170,22 @@ msgstr ""
 msgid "Succeeded"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1033
+#: lib/tuist_web/live/ops_account_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Sweden"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1034
+#: lib/tuist_web/live/ops_account_live.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Switzerland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1035
+#: lib/tuist_web/live/ops_account_live.ex:1048
 #, elixir-autogen, elixir-format
 msgid "Taiwan"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1036
+#: lib/tuist_web/live/ops_account_live.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Thailand"
 msgstr ""
@@ -1195,7 +1195,7 @@ msgstr ""
 msgid "Trialing"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1037
+#: lib/tuist_web/live/ops_account_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Turkey"
 msgstr ""
@@ -1211,22 +1211,22 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1038
+#: lib/tuist_web/live/ops_account_live.ex:1051
 #, elixir-autogen, elixir-format
 msgid "Ukraine"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1039
+#: lib/tuist_web/live/ops_account_live.ex:1052
 #, elixir-autogen, elixir-format
 msgid "United Arab Emirates"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1040
+#: lib/tuist_web/live/ops_account_live.ex:1053
 #, elixir-autogen, elixir-format
 msgid "United Kingdom"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1041
+#: lib/tuist_web/live/ops_account_live.ex:1054
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
@@ -1242,7 +1242,7 @@ msgstr ""
 msgid "Upgrade to Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1042
+#: lib/tuist_web/live/ops_account_live.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Uruguay"
 msgstr ""
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "User"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1043
+#: lib/tuist_web/live/ops_account_live.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Vietnam"
 msgstr ""
@@ -1957,19 +1957,19 @@ msgstr ""
 msgid "Claim"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:948
+#: lib/tuist_web/live/ops_account_live.ex:961
 #, elixir-autogen, elixir-format
 msgid "Kura disk claim set to %{claim}. No running instance changed; it applies the next time volumes are built."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:956
+#: lib/tuist_web/live/ops_account_live.ex:969
 #, elixir-autogen, elixir-format
 msgid "Kura disk claim lowered to %{claim}. %{count} running instance keeps its cache and evicts down to the new budget."
 msgid_plural "Kura disk claim lowered to %{claim}. %{count} running instances keep their caches and evict down to the new budget."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.ex:971
+#: lib/tuist_web/live/ops_account_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "Kura disk claim raised to %{claim}. Up to %{count} running instance rebuilds its volumes, one replica at a time behind the standby that keeps serving."
 msgid_plural "Kura disk claim raised to %{claim}. Up to %{count} running instances rebuild their volumes, one replica at a time behind the standby that keeps serving."
@@ -2172,7 +2172,7 @@ msgid "Unshaped"
 msgstr ""
 
 #: lib/tuist_web/live/ops_account_live.ex:733
-#: lib/tuist_web/live/ops_account_live.ex:839
+#: lib/tuist_web/live/ops_account_live.ex:852
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "Kura Rollouts"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:843
+#: lib/tuist_web/live/ops_account_live.ex:856
 #, elixir-autogen, elixir-format
 msgid "%{count} days"
 msgstr ""
@@ -2248,17 +2248,17 @@ msgid_plural "%{count} decisions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.ex:844
+#: lib/tuist_web/live/ops_account_live.ex:857
 #, elixir-autogen, elixir-format
 msgid "%{count} hours"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:845
+#: lib/tuist_web/live/ops_account_live.ex:858
 #, elixir-autogen, elixir-format
 msgid "%{count} minutes"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:937
+#: lib/tuist_web/live/ops_account_live.ex:950
 #, elixir-autogen, elixir-format
 msgid "%{used} of %{budget}"
 msgstr ""
@@ -2327,8 +2327,8 @@ msgstr ""
 msgid "No sizing decisions"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:856
-#: lib/tuist_web/live/ops_account_live.ex:885
+#: lib/tuist_web/live/ops_account_live.ex:869
+#: lib/tuist_web/live/ops_account_live.ex:898
 #, elixir-autogen, elixir-format
 msgid "Not resolved yet"
 msgstr ""
@@ -2351,14 +2351,14 @@ msgstr ""
 msgid "Reported"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:820
+#: lib/tuist_web/live/ops_account_live.ex:821
 #, elixir-autogen, elixir-format
 msgid "Seen on %{count} day of measurements (%{bytes} discarded, %{turnover}x the whole cache)."
 msgid_plural "Seen on %{count} consecutive days of measurements (%{bytes} discarded, %{turnover}x the whole cache)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.ex:831
+#: lib/tuist_web/live/ops_account_live.ex:844
 #, elixir-autogen, elixir-format
 msgid "Seen on %{count} day of measurements."
 msgid_plural "Seen on %{count} consecutive days of measurements."
@@ -2371,7 +2371,7 @@ msgid "Segments"
 msgstr ""
 
 #: lib/tuist_web/live/ops_account_kura_sizing_live.ex:24
-#: lib/tuist_web/live/ops_account_live.ex:859
+#: lib/tuist_web/live/ops_account_live.ex:872
 #, elixir-autogen, elixir-format
 msgid "Sizing"
 msgstr ""
@@ -2439,43 +2439,43 @@ msgstr ""
 msgid "Why"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:851
+#: lib/tuist_web/live/ops_account_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "applied"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:867
+#: lib/tuist_web/live/ops_account_live.ex:880
 #, elixir-autogen, elixir-format
 msgid "discarding work after %{shed_age}, target %{floor}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:852
+#: lib/tuist_web/live/ops_account_live.ex:865
 #, elixir-autogen, elixir-format
 msgid "dismissed"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:874
+#: lib/tuist_web/live/ops_account_live.ex:887
 #, elixir-autogen, elixir-format
 msgid "peaked at %{peak}% of its disk"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:853
+#: lib/tuist_web/live/ops_account_live.ex:866
 #, elixir-autogen, elixir-format
 msgid "superseded"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:854
+#: lib/tuist_web/live/ops_account_live.ex:867
 #, elixir-autogen, elixir-format
 msgid "waiting"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:903
-#: lib/tuist_web/live/ops_account_live.ex:910
+#: lib/tuist_web/live/ops_account_live.ex:916
+#: lib/tuist_web/live/ops_account_live.ex:923
 #, elixir-autogen, elixir-format
 msgid "%{rate} runs a day over %{days} days"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:896
+#: lib/tuist_web/live/ops_account_live.ex:909
 #, elixir-autogen, elixir-format
 msgid "%{share}%% of runs over %{days} days"
 msgstr ""
@@ -2491,12 +2491,12 @@ msgid "No placement decisions"
 msgstr ""
 
 #: lib/tuist_web/live/ops_account_kura_placement_live.ex:24
-#: lib/tuist_web/live/ops_account_live.ex:888
+#: lib/tuist_web/live/ops_account_live.ex:901
 #, elixir-autogen, elixir-format
 msgid "Placement"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:929
+#: lib/tuist_web/live/ops_account_live.ex:942
 #, elixir-autogen, elixir-format
 msgid "Placement added %{region}. It is provisioned on the account's next cache demand."
 msgstr ""
@@ -2517,12 +2517,12 @@ msgstr ""
 msgid "Placement has recorded nothing for this account; it is served from wherever its instances already are."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:933
+#: lib/tuist_web/live/ops_account_live.ex:946
 #, elixir-autogen, elixir-format
 msgid "Placement is leaving %{region}. It drains once nothing else is waiting on it."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:920
+#: lib/tuist_web/live/ops_account_live.ex:933
 #, elixir-autogen, elixir-format
 msgid "Placement moved to %{to}. %{from} keeps serving until %{to} is up, then drains."
 msgstr ""
@@ -2562,12 +2562,12 @@ msgstr ""
 msgid "The proposal no longer applies; the next placement sweep re-evaluates the account."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:880
+#: lib/tuist_web/live/ops_account_live.ex:893
 #, elixir-autogen, elixir-format
 msgid "add %{region}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:883
+#: lib/tuist_web/live/ops_account_live.ex:896
 #, elixir-autogen, elixir-format
 msgid "leave %{region}"
 msgstr ""
@@ -2676,3 +2676,10 @@ msgstr ""
 #, elixir-autogen, elixir-format
 msgid "We couldn't load the data. Reload the page and try again."
 msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.ex:834
+#, elixir-autogen, elixir-format
+msgid "Seen on %{count} day of measurements (%{bytes} discarded)."
+msgid_plural "Seen on %{count} consecutive days of measurements (%{bytes} discarded)."
+msgstr[0] ""
+msgstr[1] ""

--- a/server/test/tuist/kura/claim_sizing_test.exs
+++ b/server/test/tuist/kura/claim_sizing_test.exs
@@ -27,6 +27,8 @@ defmodule Tuist.Kura.ClaimSizingTest do
     )
   end
 
+  # The budget is the ring a 16Gi claim funds once upload staging, a spare
+  # segment and the index are reserved, matching the default context's claim.
   defp churn_days(count, end_day, attrs \\ []) do
     for offset <- (count - 1)..0//-1 do
       rollup(
@@ -36,7 +38,8 @@ defmodule Tuist.Kura.ClaimSizingTest do
             eviction_count: 40,
             evicted_bytes: 10 * @gibibyte,
             median_shed_age_seconds: 12 * 3_600,
-            median_ring_span_seconds: div(3 * @day_seconds, 2)
+            median_ring_span_seconds: div(3 * @day_seconds, 2),
+            last_ring_budget_bytes: 13 * @gibibyte
           ],
           attrs
         )
@@ -141,7 +144,7 @@ defmodule Tuist.Kura.ClaimSizingTest do
     test "severe shedding acts on two days instead of serving out the long window" do
       # 30 minutes against a 3-day floor: the ring is churning artifacts it
       # just stored, and every further day of confirmation is a day the
-      # account rebuilds what it already built. Turnover here is 1.25 rings a
+      # account rebuilds what it already built. Turnover here is 0.8 rings a
       # day, short of the single-day rung.
       context = context(rollups: severe_churn(2, @today))
 
@@ -156,17 +159,18 @@ defmodule Tuist.Kura.ClaimSizingTest do
       # where eight-hour shedding would have to prove two. Because a ring
       # turns over about once per span it holds, that is also roughly an
       # hour of real time rather than two.
-      rollups = 1 |> churn_at(@today, 20 * 60, 30 * 60) |> Enum.map(&Map.put(&1, :evicted_bytes, 18 * @gibibyte))
+      rollups = 1 |> churn_at(@today, 20 * 60, 30 * 60) |> Enum.map(&Map.put(&1, :evicted_bytes, 14 * @gibibyte))
 
       assert {:grow, "32Gi", evidence} = ClaimSizing.evaluate(context(rollups: rollups))
       assert evidence["window_days"] == 1
+      assert evidence["ring_budget_bytes"] == 13 * @gibibyte
       assert evidence["ring_turnover"] == 1.1
       assert evidence["qualifying_threshold_seconds"] == 3_600
     end
 
     test "catastrophic shedding still needs a whole ring lost" do
       # Half a ring under an hour old is a burst, not a verdict.
-      rollups = 1 |> churn_at(@today, 20 * 60, 30 * 60) |> Enum.map(&Map.put(&1, :evicted_bytes, 8 * @gibibyte))
+      rollups = 1 |> churn_at(@today, 20 * 60, 30 * 60) |> Enum.map(&Map.put(&1, :evicted_bytes, 6 * @gibibyte))
 
       assert ClaimSizing.evaluate(context(rollups: rollups)) == :none
     end
@@ -174,20 +178,74 @@ defmodule Tuist.Kura.ClaimSizingTest do
     test "an hour-old ring does not get the relaxed volume once it is merely severe" do
       # Ninety minutes clears the catastrophic rung, so the account falls to
       # the eight-hour rung and owes the full two rings again.
-      rollups = 1 |> churn_at(@today, 90 * 60, 2 * 3_600) |> Enum.map(&Map.put(&1, :evicted_bytes, 18 * @gibibyte))
+      rollups = 1 |> churn_at(@today, 90 * 60, 2 * 3_600) |> Enum.map(&Map.put(&1, :evicted_bytes, 14 * @gibibyte))
 
       assert ClaimSizing.evaluate(context(rollups: rollups)) == :none
     end
 
     test "a single severe day acts when the account cycled its whole ring twice over" do
-      # Volume replaces elapsed time on the shortest rung: 40Gi evicted
-      # against a 16Gi claim is two and a half rings lost in a day, while the
+      # Volume replaces elapsed time on the shortest rung: 33Gi evicted
+      # against a 13Gi ring is two and a half rings lost in a day, while the
       # content going out is younger than a working day.
-      rollups = 1 |> severe_churn(@today) |> Enum.map(&Map.put(&1, :evicted_bytes, 40 * @gibibyte))
+      rollups = 1 |> severe_churn(@today) |> Enum.map(&Map.put(&1, :evicted_bytes, 33 * @gibibyte))
 
       assert {:grow, "32Gi", evidence} = ClaimSizing.evaluate(context(rollups: rollups))
       assert evidence["window_days"] == 1
       assert evidence["ring_turnover"] == 2.5
+    end
+
+    test "turnover is measured against the ring the nodes ran, not the claim funding it" do
+      # A claim also funds upload staging, a spare segment and the index, so
+      # an 8Gi claim runs a 5Gi ring. 11Gi shed in a day is 2.2 rings of what
+      # the account actually cycled and only 1.4 of the claim, so measuring
+      # the claim would hold the eight-hour rung shut while the ring turned
+      # over twice.
+      rollups =
+        1
+        |> churn_at(@today, 6 * 3_600, 12 * 3_600)
+        |> Enum.map(&Map.merge(&1, %{evicted_bytes: 11 * @gibibyte, last_ring_budget_bytes: 5 * @gibibyte}))
+
+      context = context(plan: :air, current_claim_size: "8Gi", rollups: rollups)
+
+      assert {:grow, "16Gi", evidence} = ClaimSizing.evaluate(context)
+      assert evidence["window_days"] == 1
+      assert evidence["ring_budget_bytes"] == 5 * @gibibyte
+      assert evidence["ring_turnover"] == 2.2
+    end
+
+    test "a window with no measured ring withholds the rungs that gate on turnover" do
+      # Nothing reported a ring budget, so there is no honest denominator and
+      # the volume rungs stay shut rather than falling back to the claim. The
+      # reading waits for the two-day rung, which buys its confirmation with
+      # elapsed time instead.
+      rollups =
+        2
+        |> churn_at(@today, 20 * 60, 30 * 60)
+        |> Enum.map(&Map.merge(&1, %{evicted_bytes: 40 * @gibibyte, last_ring_budget_bytes: nil}))
+
+      assert ClaimSizing.evaluate(context(rollups: Enum.take(rollups, -1))) == :none
+
+      assert {:grow, "32Gi", evidence} = ClaimSizing.evaluate(context(rollups: rollups))
+      assert evidence["window_days"] == 2
+      assert evidence["ring_budget_bytes"] == nil
+      assert evidence["ring_turnover"] == nil
+    end
+
+    test "a window whose days disagree is measured against the smallest ring it ran" do
+      # Days normally agree, because a window never spans a resize. When they
+      # do not, every byte in the sum went out against a ring at least this
+      # small, so the smaller of the two is the denominator.
+      [older, newer] = churn_at(2, @today, 20 * 60, 30 * 60)
+
+      rollups = [
+        Map.put(older, :last_ring_budget_bytes, 5 * @gibibyte),
+        Map.put(newer, :last_ring_budget_bytes, 13 * @gibibyte)
+      ]
+
+      assert {:grow, "32Gi", evidence} = ClaimSizing.evaluate(context(rollups: rollups))
+      assert evidence["window_days"] == 2
+      assert evidence["ring_budget_bytes"] == 5 * @gibibyte
+      assert evidence["ring_turnover"] == 4.0
     end
 
     test "a single severe day without the volume waits for a second day" do


### PR DESCRIPTION
## What changed

`Tuist.Kura.ClaimSizing` divided a window's evicted bytes by the account's **storage claim** to get `ring_turnover`. It now divides by the **ring the nodes reported running**, read from `last_ring_budget_bytes` on the rollup row.

## Why

"Ring turnover" is meant to say how many times the account rewrote its CAS segment ring. The claim is not the ring. `cas_capacity_bytes/1` in `Tuist.Kura.Provisioner.KubernetesController` reserves upload staging, one spare segment for rotation and 3% for the RocksDB index out of the claim, then Kura rounds the remainder down to whole 512 MiB segments:

- `usable = storage_bytes - staging_bytes - 512Mi`, where `staging = storage/8`, capped at 8 GiB and floored at 2 GiB
- `budget = usable * 97 / 100`, then floored to whole segments

For an 8Gi claim that is staging 2 GiB, usable 5.5 GiB, x0.97 = 5,728,412,631, which is 10 whole segments = 5 GiB. Dividing by 8 GiB where the real ring is 5 GiB reads turnover **37.5% low**, and the same shape of gap exists at every claim size.

Two grow rungs are gated on the ratio:

```elixir
%{shed_age_under: {:seconds, 3_600},  window_days: 1, min_ring_turnover: 1.0},
%{shed_age_under: {:seconds, 28_800}, window_days: 1, min_ring_turnover: 2.0},
```

Those are the fast rungs, the ones that exist to catch an account thrashing its cache inside a single day. Understating turnover makes them fire late exactly where speed is the point.

Observed in production on 2026-09-07: an instance was shedding artifacts at a median age of roughly six hours against a 5 GiB ring. The 2.0 rung wanted 17.2 GB evicted (2 x the 8 GiB claim) before it would trip; against the ring the instance actually ran, 2.0 turnover was reached at 10.7 GB, hours earlier. The account sat under a day of retention the whole time.

## How

The denominator comes off the rollup row rather than from a second copy of the provisioner's formula. `kura_storage_snapshots.ring_budget_bytes` is what the nodes themselves report, `Tuist.Kura.StorageTelemetry` aggregates it per day, and `Tuist.Kura.StorageRollups` carries it as `last_ring_budget_bytes`. Production rows for an 8Gi-claim account read exactly `5_368_709_120`, matching the derivation above. Re-deriving the formula in claim sizing would give a second place to drift when the reserves change.

Points that needed settling:

**Which value across a multi-day window.** The smallest measured budget in the window. `reject_pre_resize/2` already drops every day up to and including a resize, so a window never spans a claim change and the days normally agree. When they do not, every byte in the summed eviction total went out against a ring at least that small, so the smallest is the one the sum is honest against.

**Nil handling.** `last_ring_budget_bytes` is nullable. When no day in the window measured a ring there is no honest denominator, so a rung that asks for turnover goes unproven and the reading falls through to a longer rung that buys its confirmation with elapsed time instead. Falling back to the claim was rejected: that reintroduces exactly the understatement this fixes, on every account the telemetry has not reached yet. This also matches how the module already treats missing telemetry on the shrink side, where a day without snapshots breaks the idle streak rather than counting as quiet. Rungs with no `min_ring_turnover` are unaffected, so nothing that used to grow on elapsed time alone stops growing.

**`grow_target_bytes/4` is untouched.** It scales `current_bytes` by `floor_seconds / span_seconds` and its output is a claim, so the claim is the right basis there. Only the ratio was wrong.

**Evidence explains itself.** `grow_evidence` records `ring_budget_bytes` alongside `ring_turnover`, so a stored proposal in `kura_claim_proposals.evidence` says what it divided by. `ring_turnover` is now nullable in that map, so the ops proposal line drops the turnover clause instead of rendering a false "0x the whole cache" when nothing measured a ring. That adds one `dashboard` msgid to the `.pot`; no `.po` files are touched.

## Impact

Accounts thrashing a ring materially smaller than their claim reach the one-day grow rungs at the volume they actually cycled, hours rather than a day earlier in the production case above. Nothing grows on less evidence than before in absolute terms; the bar is now measured against the right thing. Accounts whose nodes have not reported a ring budget keep growing on the elapsed-time rungs exactly as they do today.

## Validation

- New test, confirmed red against the old denominator before the fix: a one-day window whose evicted bytes clear 2.0 turnover against the measured 5 GiB ring but only reach 1.4 against the 8Gi claim, asserting it grows. Under the old code it returned `:none`.
- New test for the nil case, also confirmed red: a single day of catastrophic shedding with 40Gi evicted and no measured ring used to grow on the one-day rung by dividing into the claim, and now waits for the two-day rung.
- New test pinning the multi-day choice: a window whose two days report different budgets is measured against the smaller.
- Existing turnover fixtures now carry the ring a 16Gi claim funds (13 GiB) and their evicted volumes were rescaled so each case still sits on the rung its name describes.
- `mix test test/tuist/kura/ test/tuist_web/live/ops_account_live_test.exs` : 754 passing.
- `mix format --check-formatted` clean, `mix credo --strict` reports nothing new in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
