### PR TITLE
perf(kura): raise the node memory ceiling oversubscription to 4

### DIFF
--- a/infra/cluster-api-provider-tuist/controllers/shared/node_memory.go
+++ b/infra/cluster-api-provider-tuist/controllers/shared/node_memory.go
@@ -28,10 +28,12 @@ const MemoryCeilingMibResource corev1.ResourceName = "tuist.dev/memory-ceiling-m
 //
 // The factor bounds how badly they may overlap. Too low and the box is packed
 // no denser than it would be with request == limit; too high and reclaim has
-// more to claw back than it can, and the OOM killer arrives instead. Two keeps
-// the worst case within what reclaim can absorb on the current fleet, whose
-// nodes peak near a fifth of their physical memory.
-const MemoryCeilingOversubscription = 2
+// more to claw back than it can, and the OOM killer arrives instead. At four
+// the native requests.memory pack binds first on the current fleet, so
+// admission is decided by the guaranteed floors rather than by this bound.
+// Reclaim has room for it: the densest node peaks at 15% of physical memory,
+// and none has dropped below 71% MemAvailable.
+const MemoryCeilingOversubscription = 4
 
 // ReconcileNodeMemoryCeilingCapacity advertises the node's memory ceiling
 // budget as tuist.dev/memory-ceiling-mib capacity, idempotently.


### PR DESCRIPTION
## What changed

`MemoryCeilingOversubscription` in the CAPI provider goes from 2 to 4, so a shared bare-metal node advertises `tuist.dev/memory-ceiling-mib` capacity at four times its allocatable memory instead of twice.

Capacity side only. `ReconcileNodeMemoryCeilingCapacity` re-applies on every reconcile as a node status patch, so no pod spec, StatefulSet template or tenant entitlement changes and nothing rolls.

## Why

`tuist.dev/memory-ceiling-mib` had become the binding placement constraint in every bin-packed region, well ahead of the constraint that reflects a real guarantee. Measured on production, 2026-09-07:

| region | ceiling reserved | headroom by `ceiling` | headroom by `memory` |
|---|---|---|---|
| us-east | 88% | 1 instance | 12 instances |
| us-west | 55% | 3 instances | 9 instances |
| eu-central | 43% | 6 instances | 20 instances |

us-east is two OVH boxes, 30.96 GiB physical and 27.4 GiB allocatable each:

- ceiling reserved 52992/56138 MiB (94%) and 45824/56138 MiB (82%)
- `requests.memory` 14702/28069 MiB (52%) on both
- coincident 14-day peak working set 8.7 GiB and 0.7 GiB
- minimum `MemAvailable` over 14 days 85% and 90% of physical

The busier node reserves 51.8 GiB of ceilings against a 4.6 GiB observed peak. Across the whole kura fleet no node has dropped below 71% `MemAvailable` in 14 days, and there are no OOM events. The alert was asking for another box in a region using 15% of its RAM.

## Root cause

The factor was chosen as a bound on how far best-effort regions above each pod's floor may overlap, sized when the fleet was small and the tenant mix unmeasured. It is not a statement about memory anyone is entitled to: `limits.memory` is per pod and unchanged by this, so no tenant's admission pools or burst capacity move. The factor only decides how many entitlements we are willing to sell against one box, and at 2 it was refusing tenants the hardware could hold several times over.

## Why 4

4 is the point where the native `requests.memory` pack binds first, which hands admission back to the reservation that is actually guaranteed rather than to a synthetic bound. Making `memory` bind on both us-east nodes needs at least 49152 MiB of free ceiling per node, which is a factor of 3.64 on the busier node and 3.38 on the other.

3 was the obvious alternative and was rejected: it moves us-east from 1 slot to 7 but leaves the same wrong constraint in charge, so the next sign-up wave repeats this conversation.

Safety at 4 does not rest on the factor alone:

- each pod is still capped by its own `limits.memory`, and Kura sheds with 503 at 85% of that before the kernel is involved, so a node-level OOM needs many pods concurrently in the 60-85% band
- the floors pack then refuses admission at 12 more instances in us-east
- *Kura region host memory low* already alerts on measured host memory, which is the right signal to be conservative with

The distribution is what makes the density safe. Per-pod 14-day peak against its own ceiling in us-east: 3 pods at 73-87% (the write primaries of the three largest tenants), 3 at 15-21%, and the remaining 56 at or below 11%, most near 1.9%.

Known limit, stated rather than fixed here: the extended resource is a flat sum and does not model tenant mix. A pathological run of admissions all shaped like the heaviest account in the fleet (about 3.9 GiB per instance across both replicas) would reach roughly 28 GiB on a 31 GiB box before the floors pack stops it.

## Considered and rejected

Shrinking the standby replica's ceiling. [instancePodAffinity](https://github.com/tuist/tuist/blob/main/infra/kura-controller/controllers/kurainstance_controller.go#L3741) co-locates both replicas of an instance, and the standby is close to idle: 362 MiB peak against 4096 reserved for `carousell`, 109 MiB for `pinterest`, 606 MiB for `turo`, against primaries at 3566, 3013 and 2992 MiB. Half of every enterprise instance's ceiling reservation is therefore for a pod that never uses it, on the same box as the primary. Asymmetric ceilings are not safe: replicas are always 2 for gapless deploys, roles swap during a rolling deploy, and Kura sizes its admission pools from the cgroup limit at startup, so a promoted standby would shed early.

## Impact

us-east goes from 1 to 12 placeable enterprise instances, bounded by floors. us-west and eu-central gain the same headroom. No tenant-visible change and no rollout.

## Validation

- `go build ./...` and `go test ./...` in `infra/cluster-api-provider-tuist`, all passing
- `TestReconcileNodeMemoryCeilingCapacity` asserts the budget symbolically and re-checks the budget-exceeds-allocatable invariant, which still holds at 4
- every other reference to the constant (`kura-controller/AGENTS.md`, `kurainstance_controller.go`, `cluster-api-provider-tuist/AGENTS.md`) is symbolic, so no docs hardcode the old factor
- the production numbers above were read from `grafanacloud-prom` with the placement expressions from the *Kura region cannot place another instance* rule in `infra/helm/k8s-monitoring/alerts.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
