### PR TITLE
fix(hetzner-robot-controller): select releasable commits by path, not by scope

### DIFF
--- a/infra/hetzner-robot-controller/AGENTS.md
+++ b/infra/hetzner-robot-controller/AGENTS.md
@@ -20,8 +20,13 @@ controller does the two things caph deliberately doesn't:
    safety — `spec` is operator intent). The controller watches
    for hosts where `hardwareDetails` is populated but
    `rootDeviceHints` is empty, and patches every discovered WWN
-   into `spec.rootDeviceHints.raid.wwn` (RAID 1 layout matching
-   Hetzner's default for AX-class hardware).
+   into `spec.rootDeviceHints.raid.wwn`. Every disk, not the first
+   pair: a four-disk box whose hints name two of them installs
+   across two and silently leaves the rest out of the array, and
+   the layout is fixed at install. The RAID level is not chosen
+   here at all; it comes from the `statefulRaidLevel` ClusterClass
+   variable, which is 1 on the two-disk AX-class boxes and 10 on
+   production's four-disk EX131.
 
 Net: the operator's bring-up workflow becomes "order in Robot
 panel with `tuist-bm-staging-N` naming → bump replicas." No

--- a/infra/hetzner-robot-controller/AGENTS.md
+++ b/infra/hetzner-robot-controller/AGENTS.md
@@ -226,31 +226,26 @@ Tests use controller-runtime's `fake.Client` and an in-memory
 ## Releasing
 
 `.github/workflows/hetzner-robot-controller-release.yml` cuts the
-tag and publishes the image on push to `main`, and the mgmt
-cluster runs whatever tag `infra/k8s/mgmt/hetzner-robot-controller.yaml`
+tag and publishes the image on push to `main`, and the mgmt cluster
+runs whatever tag `infra/k8s/mgmt/hetzner-robot-controller.yaml`
 pins. Renovate raises the pin once a release exists.
 
-A change here only ships if its commit is **scoped to this
-component**. `cliff.toml` matches
-`<type>(...hetzner-robot-controller...)` and its last parser skips
-every other scoped commit, so a change landing under `fix(infra)`
-or `feat(server)` is invisible to `mise run release:check`: no tag
-is cut, and `if: needs.check.outputs.should-release == 'true'`
-skips the release job.
+What makes a commit releasable is the **paths it touches**, not its
+scope. `include_paths` in `mise/tasks/release/components.json`
+restricts the range to this directory, and `cliff.toml` then accepts
+any conventional commit in it apart from `chore` and `ci`. A change
+landing under `feat(server)` or `fix(infra)` releases exactly as one
+under `fix(hetzner-robot-controller)` does.
 
-Nothing reports that. CI is green, `main` carries the change, and
-the cluster keeps running the old image until someone compares the
-pin against the code. It happened to the WWN four-disk fix, which
-merged under `feat(server)` in
-[#12814](https://github.com/tuist/tuist/pull/12814) and left the
-mgmt cluster on `0.1.0` with a filler that still installed a
-four-disk box across two of its disks.
-
-So scope commits touching this directory
-`<type>(hetzner-robot-controller)`. If one lands under the wrong
-scope, the recovery is another commit here carrying the right one;
-`workflow_dispatch` does not help, because the release job is
-gated on the same check.
+`cliff.toml` used to match on the scope instead, and that is how the
+WWN four-disk fix shipped nowhere. It merged under `feat(server)` in
+[#12814](https://github.com/tuist/tuist/pull/12814), `release:check`
+found nothing releasable, the release job was skipped by
+`if: needs.check.outputs.should-release == 'true'`, and the mgmt
+cluster kept running `0.1.0` with a filler that installs a four-disk
+box across two of its disks. Nothing reported it: CI was green and
+`main` carried the fix, so the drift was visible only by comparing
+the pin against the code.
 
 ## Future work
 

--- a/infra/hetzner-robot-controller/AGENTS.md
+++ b/infra/hetzner-robot-controller/AGENTS.md
@@ -218,6 +218,35 @@ Coverage:
 Tests use controller-runtime's `fake.Client` and an in-memory
 `robot.FakeClient` — no live Robot API or k8s cluster required.
 
+## Releasing
+
+`.github/workflows/hetzner-robot-controller-release.yml` cuts the
+tag and publishes the image on push to `main`, and the mgmt
+cluster runs whatever tag `infra/k8s/mgmt/hetzner-robot-controller.yaml`
+pins. Renovate raises the pin once a release exists.
+
+A change here only ships if its commit is **scoped to this
+component**. `cliff.toml` matches
+`<type>(...hetzner-robot-controller...)` and its last parser skips
+every other scoped commit, so a change landing under `fix(infra)`
+or `feat(server)` is invisible to `mise run release:check`: no tag
+is cut, and `if: needs.check.outputs.should-release == 'true'`
+skips the release job.
+
+Nothing reports that. CI is green, `main` carries the change, and
+the cluster keeps running the old image until someone compares the
+pin against the code. It happened to the WWN four-disk fix, which
+merged under `feat(server)` in
+[#12814](https://github.com/tuist/tuist/pull/12814) and left the
+mgmt cluster on `0.1.0` with a filler that still installed a
+four-disk box across two of its disks.
+
+So scope commits touching this directory
+`<type>(hetzner-robot-controller)`. If one lands under the wrong
+scope, the recovery is another commit here carrying the right one;
+`workflow_dispatch` does not help, because the release job is
+gated on the same check.
+
 ## Future work
 
 - **Webhook on the CR for the deletion gate** (admission rejection

--- a/infra/hetzner-robot-controller/cliff.toml
+++ b/infra/hetzner-robot-controller/cliff.toml
@@ -58,16 +58,22 @@ commit_preprocessors = [
 # hardwareDetails. Distinct from runners-controller (workload-
 # cluster pod scaler).
 commit_parsers = [
-    { message = "^feat\\([^)]*\\bhetzner-robot-controller\\b[^)]*\\)", group = "<!-- 0 -->⛰️  Features" },
-    { message = "^fix\\([^)]*\\bhetzner-robot-controller\\b[^)]*\\)", group = "<!-- 1 -->🐛 Bug Fixes" },
-    { message = "^docs?\\([^)]*\\bhetzner-robot-controller\\b[^)]*\\)", group = "<!-- 3 -->📚 Documentation" },
-    { message = "^perf\\([^)]*\\bhetzner-robot-controller\\b[^)]*\\)", group = "<!-- 4 -->⚡ Performance" },
-    { message = "^refactor\\([^)]*\\bhetzner-robot-controller\\b[^)]*\\)", group = "<!-- 2 -->🚜 Refactor" },
-    { message = "^style\\([^)]*\\bhetzner-robot-controller\\b[^)]*\\)", group = "<!-- 5 -->🎨 Styling" },
-    { message = "^test\\([^)]*\\bhetzner-robot-controller\\b[^)]*\\)", group = "<!-- 6 -->🧪 Testing" },
-    { message = "^chore\\([^)]*\\bhetzner-robot-controller\\b[^)]*\\)", skip = true },
-    { message = "^ci\\([^)]*\\bhetzner-robot-controller\\b[^)]*\\)", skip = true },
-    { message = "^[a-z]+\\([^)]+\\)", skip = true },
+    # `include_paths` in mise/tasks/release/components.json already restricts
+    # this changelog to this controller's files, so accept conventional commits
+    # regardless of their scope, the way infra/helm/cliff.toml does. Matching on
+    # a `hetzner-robot-controller` scope instead is how the four-disk WWN fix
+    # merged under `feat(server)` and never shipped: the check found nothing
+    # releasable, no tag was cut, and the mgmt cluster stayed on 0.1.0 while
+    # main carried the fix.
+    { message = "^feat(\\([^)]*\\))?!?:", group = "<!-- 0 -->⛰️  Features" },
+    { message = "^fix(\\([^)]*\\))?!?:", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^docs?(\\([^)]*\\))?!?:", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf(\\([^)]*\\))?!?:", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor(\\([^)]*\\))?!?:", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style(\\([^)]*\\))?!?:", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test(\\([^)]*\\))?!?:", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore(\\([^)]*\\))?!?:", skip = true },
+    { message = "^ci(\\([^)]*\\))?!?:", skip = true },
 ]
 protect_breaking_commits = false
 filter_commits = true


### PR DESCRIPTION
## What changed

`infra/hetzner-robot-controller/cliff.toml` now selects releasable commits by the **paths they touch** rather than by their scope, matching what `infra/helm/cliff.toml` already does. Plus two documentation corrections in the same directory.

## Why

The WWN four-disk fix merged in [#12814](https://github.com/tuist/tuist/pull/12814) and was never released. The mgmt cluster still runs `ghcr.io/tuist/tuist-hetzner-robot-controller:0.1.0`, pinned in `infra/k8s/mgmt/hetzner-robot-controller.yaml`, which is the version whose filler promotes only the first two WWNs.

That gates the ClickHouse migration's next hardware step. Production's box is an EX131-2-LTD with four NVMe at RAID 10. Under `0.1.0` its `spec.rootDeviceHints.raid.wwn` names two disks, so installimage builds the array across two of four, silently. The layout is fixed at first rescue boot, so the only way back is a reinstall of a machine bought for its disk.

## Root cause

`hetzner-robot-controller-release.yml` gates its release job on `if: needs.check.outputs.should-release == 'true'`, and that output comes from `git cliff --bumped-version` over the component's `include_paths`.

The parsers matched only `<type>(...hetzner-robot-controller...)`, and the last one, `{ message = "^[a-z]+\\([^)]+\\)", skip = true }`, discarded every other scoped commit. With `filter_commits = true`, the only commits in `hetzner-robot-controller@0.1.0..HEAD` touching those paths were `feat(server)`, `chore(deps)` and `ci(infra)`, so nothing survived, cliff returned `0.1.0` unchanged, and the job was skipped.

Nothing reports this. CI was green, `main` carried the fix, and the drift was visible only by comparing the pin against the code. `workflow_dispatch` is not a way out either, since it reaches the same gated job.

## Why path-based rather than a correctly scoped commit

The first version of this PR just added a commit under this component's scope, which would have cut `0.1.1` and shipped the image. That treats the symptom. The scope match was redundant with the path filter and strictly worse than it: `include_paths` already restricts the range to this directory, so requiring the scope as well only adds a way for a real change to go unreleased.

`infra/helm/cliff.toml` reached the same conclusion earlier and says so in a comment: the release workflow already restricts the changelog to chart paths, so it accepts conventional commits regardless of scope, because chart changes often land under broader scopes such as `infra` or `kura`. Controller changes land under broader scopes for exactly the same reason.

`chore` and `ci` stay skipped, so a Dependabot bump touching this directory still does not cut a release.

## Validation

`git cliff` cannot open a partial clone (`unsupported extension name extensions.partialclone`), which silently makes `release:check` fall back to `initial_version` locally. The behaviour was therefore reproduced on a synthetic repository carrying this component's real `cliff.toml`, the same paths and the same commit subjects.

| Commits in range | Old parsers | New parsers |
|---|---|---|
| `feat(server)` touching this directory | `0.1.0`, no release | `0.2.0` |
| plus `feat(kura)` touching nothing here | `0.1.0` | `0.2.0`, no extra bump |
| plus `chore(deps)` touching this directory | `0.1.0` | `0.2.0`, no extra bump |

The old-parser column reproduces the skipped job on [#12814](https://github.com/tuist/tuist/pull/12814)'s merge commit exactly. The new one releases the commit that actually changed the filler, and still ignores both unrelated components and dependency bumps.

## Impact

Merging cuts `hetzner-robot-controller@0.2.0` from the existing `feat(server)` commit, publishes the image, and Renovate then raises the pin. Nothing changes at runtime until that pin moves.

After it moves, a four-disk host reflected from Robot gets every disk in its `rootDeviceHints`, which is the precondition for naming production's EX131 as `tuist-bm-production-ch-*`. Until then those boxes should stay under Hetzner's default name, since `hetzner-robot-controller` ignores any server without the `tuist-bm-` prefix and the rename is what triggers the install.

## Not done here

Fifteen other components still select by scope and carry the same latent bug: `app`, `cache`, `cli`, `gradle`, `grafana-datasource`, `noora`, `server`, `skills`, and the `infra/` set (`cloudflare-operator`, `cluster-api-provider-tuist`, `egress-tree-agent`, `runner-image`, `runners-controller`, `stable-egress-controller`, `xcresult-processor-image`). The `infra/` ones look most exposed, since infra changes routinely land under `feat(infra)` or a product scope. `server` and `cli` deserve separate thought, because a release there cascades into a production deploy. Worth a follow-up rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
