### PR TITLE
feat(server): place Air by traffic and shorten the Kura relocation window

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -206,17 +206,6 @@ server:
       # an implementation detail behind it (ovhFleet below, replicas 1) —
       # mirroring staging.
       value: eu-central,scw-fr-par-runners,ca-east
-    - name: TUIST_KURA_AIR_REGION
-      # Air is funded on the ca-east OVH validation box, as on staging.
-      # Without this the default names us-east, which this environment does not
-      # serve, so every Air account resolved into a region the lifecycle loop
-      # never iterates and no instance was ever provisioned.
-      value: ca-east
-    - name: TUIST_KURA_AIR_REGIONS
-      # Both public regions carry an Air budget, matching staging, so
-      # traffic-driven placement is observable rather than collapsing onto a
-      # single funded region.
-      value: ca-east,eu-central
     - name: TUIST_KURA_INACTIVE_DAYS
       # Every account this environment provisions comes from an acceptance
       # test run, and a test account never builds again. On the production

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -131,21 +131,6 @@ server:
     # done.
     - name: TUIST_KURA_ROLLOUT_PACING
       value: progressive
-    - name: TUIST_KURA_AIR_REGION
-      # Staging has no `us-east` pool, so every Air account would resolve to a
-      # region whose instances could never schedule, and the Air-only 60-day
-      # pressure rule could not be exercised at all. Run the free tier on the
-      # `ca-east` OVH validation box instead. Production omits this and serves
-      # us-east. Only Air moves: a paid account restricted to Europe or the
-      # USA chose that, and no deployment setting may relocate it.
-      value: ca-east
-    - name: TUIST_KURA_AIR_REGIONS
-      # Both public regions carry an Air budget here, which is what makes
-      # traffic-driven placement observable at all: with one funded region
-      # every Air account resolves to it whatever its traffic says. Production
-      # funds Air in one region and omits this, so the single-region variable
-      # above still decides there.
-      value: ca-east,eu-central
     - name: TUIST_KURA_INACTIVE_DAYS
       # Production reclaims after 90 days, which no environment can wait out,
       # so the archival half of the lifecycle would first run for real against

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -438,54 +438,6 @@ defmodule Tuist.Environment do
   end
 
   @doc """
-  The region Air instances run in for an account's storage region.
-
-  An account that states no storage region ("All regions") has no residency
-  constraint to uphold, so where its free tier runs is a deployment decision:
-  `us-east` unless `TUIST_KURA_AIR_REGION` names another.
-
-  An account that chose Europe has stated one. "Storage region" in account
-  settings names module cache binaries, which is what a Kura instance holds, so
-  such an account is never placed in the United States: it runs in whichever
-  region `TUIST_KURA_AIR_EUROPE_REGION` names, and is refused while nothing
-  names one. That variable is unset everywhere today, which is why those
-  accounts are refused now, and setting it is what turns Air in Europe on.
-
-  Paid regions are not configurable for the opposite reason: a paid account
-  restricted to Europe or the USA chose that, and no deployment setting may
-  move it.
-
-  Staging has no `us-east` pool, so without this every Air account there
-  resolves to a region whose instances can never schedule, and the Air-only
-  pressure rule cannot be exercised at all.
-  """
-  def kura_air_region(:europe), do: air_region_env("TUIST_KURA_AIR_EUROPE_REGION", nil)
-
-  def kura_air_region(storage_region) when storage_region in [:all, :usa],
-    do: air_region_env("TUIST_KURA_AIR_REGION", "us-east")
-
-  @doc """
-  Every region with an Air budget, which is the set Air placement chooses
-  from. Air in a region costs a storage slot on a tier that pays for none, so
-  a region serves Air only once someone funds it; an account whose residency
-  admits no funded region is refused, and the refusal is what quantifies the
-  case for funding one.
-
-  `TUIST_KURA_AIR_REGIONS` names the set. Without it the set is whatever the
-  single-region variables name, so a deployment that has configured neither
-  keeps serving Air exactly where it does today.
-  """
-  def kura_air_region_ids do
-    case System.get_env("TUIST_KURA_AIR_REGIONS") do
-      value when value in [nil, ""] ->
-        Enum.reject([kura_air_region(:all), kura_air_region(:europe)], &is_nil/1)
-
-      value ->
-        value |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == ""))
-    end
-  end
-
-  @doc """
   How many placement proposals the sweep may apply on its own in a day.
 
   Zero unless `TUIST_KURA_PLACEMENT_AUTOMATIC_APPLIES_PER_DAY` names a number,
@@ -503,14 +455,6 @@ defmodule Tuist.Environment do
           {count, _rest} when count >= 0 -> count
           _ -> 0
         end
-    end
-  end
-
-  defp air_region_env(variable, default) do
-    case System.get_env(variable) do
-      nil -> default
-      "" -> default
-      region -> region
     end
   end
 

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -611,7 +611,7 @@ defmodule Tuist.Kura do
   defp permitted_for(%PlacementProposal{account_id: account_id}) do
     account = Repo.get!(Account, account_id)
 
-    AccountPolicies.placeable_regions(account, AccountPolicies.sizing_plan(account))
+    AccountPolicies.placeable_regions(account)
   end
 
   # `put_primary/3` demotes whatever held the role, so the source stays a

--- a/server/lib/tuist/kura/account_policies.ex
+++ b/server/lib/tuist/kura/account_policies.ex
@@ -7,26 +7,37 @@ defmodule Tuist.Kura.AccountPolicies do
   stored. A Kura instance holds exactly those, so an account that named a
   region is served from it and never from another, whatever the plan.
 
-  Air runs in United States East for an account that named no region, and in
-  whichever region the deployment serves Air from in Europe for an account that
-  named Europe. Paid accounts with a country group resolve deterministically to
-  that group's pool. A paid account
-  that allows every region has stated no constraint, so it resolves in this
-  order:
+  Every plan resolves over the same set: the regions the account's residency
+  admits and this deployment serves. Air is not held to a narrower one — what
+  bounds a region is the capacity `Tuist.Kura.Admission` finds there, not the
+  tier of the account asking. Resolution runs in this order:
 
-    1. its explicit versioned assignment, if an operator made one,
-    2. the region its live public instance is already in, so resolution never
-       relocates a running account, and
-    3. United States East, the deterministic default a dormant account
-       receives before its next provisioning demand.
+    1. its explicit versioned assignment, if an operator made one and the
+       account's residency still admits it,
+    2. the region placement decided for it (`PlacerRegions.primary_region/1`),
+    3. the region its live public instance is already in, so resolution never
+       relocates a running account,
+    4. the region nearest where its cache traffic comes from, counted by
+       `Tuist.Kura.Origins` and mapped by `Tuist.Kura.OriginMap`, and
+    5. the residency default, which a dormant account with no attributable
+       traffic receives before its next provisioning demand.
 
-  An assignment is the only route *here* to a region no preference derives to.
-  `accounts.region` is `all | europe | usa`, so nothing resolves to United
-  States West or Asia Pacific Southeast on its own; an account is opted into
-  either per account, for latency. Asia Pacific has no derivation rule for the
-  same reason United States West has none: there is no `accounts.region` value
-  that names it. So an APAC account is pinned there by an operator, or resolves
-  to United States East like any other account that stated no constraint.
+  Steps 2 and 4 are what reach a region no storage-region preference names.
+  `accounts.region` is `all | europe | usa`, so nothing *derives* to United
+  States West or Asia Pacific Southeast from the preference alone — but an
+  account whose traffic comes from Taiwan and whose residency constrains
+  nothing resolves to Asia Pacific Southeast at step 4 with no operator
+  involved.
+
+  An assignment is therefore no longer the only route to those regions. What
+  it is instead is placement's per-account rollback: the sweep skips an
+  account holding one entirely, so pinning an account stops it being placed
+  automatically rather than merely deciding where it sits today.
+
+  Step 4 decides only for an account with nothing already running, because
+  steps 2 and 3 outrank it. Moving an account that is being served is a
+  relocation, which `Tuist.Kura.Placement` decides on a far longer window of
+  evidence and which is applied through the endpoint drain.
 
   Resolution is not the only way an account gets a server in a region, and this
   module is not a gate on that. A customer can also add one directly from
@@ -35,11 +46,11 @@ defmodule Tuist.Kura.AccountPolicies do
   *places* an account — demand, lifecycle, provisioning — not what the customer
   is permitted to pick.
 
-  Step 2 counts only live instances in public regions, and picks one when there
+  Step 3 counts only live instances in public regions, and picks one when there
   are several; `live_service_regions/1` carries the reasoning for both, and for
   why an archive does not hold an account to its region.
 
-  Step 2 is what keeps the default from being a migration. Without it an
+  Step 3 is what keeps the default from being a migration. Without it an
   account already serving from elsewhere would start recording demand against
   the default region, cold-provision a second instance there, and leave the
   original holding its allocation with no reclamation path on the plans that
@@ -246,27 +257,22 @@ defmodule Tuist.Kura.AccountPolicies do
     )
   end
 
-  # Air is funded per region rather than served everywhere, so its candidates
-  # are the funded ones its residency admits. An Air account whose residency
-  # admits no funded region is refused, exactly as an account restricted to
-  # Europe is today, and the refusal is counted: sustained refused demand is
-  # what an Air budget in a new region gets decided from.
   defp effective_service_region(%Account{} = account, :air, lookups) do
-    # Funding is the gate, and the deployment has to serve what it funds.
-    # Funding a region it does not serve is a configuration error, and
-    # resolving into one anyway is silent: demand lands in a region
-    # `Lifecycle.lifecycle_regions/0` never iterates, so the account reports as
-    # provisioning forever while nothing ever provisions it. Refusing surfaces
-    # it on the refusal counter instead, which is what quantifies the case for
-    # funding a region the deployment actually serves.
-    case account |> permitted_regions() |> restrict_to_plan(:air) |> Enum.filter(&Regions.available?/1) do
+    # Air is placed like any other plan: wherever its residency admits and the
+    # deployment serves. It used to be admitted only to regions carrying an
+    # explicit Air budget, which collapsed every Air account onto the one
+    # funded region whatever its traffic said, and refused outright the
+    # accounts whose residency admitted no funded region at all. What bounds a
+    # region is capacity rather than plan: `Tuist.Kura.Admission` refuses an
+    # instance a region cannot hold, which is a decision taken against the
+    # disk that is actually there instead of against a list maintained by
+    # hand.
+    case account |> permitted_regions() |> Enum.filter(&Regions.available?/1) do
       [] ->
         {:error, :service_region_unavailable}
 
       placeable ->
-        # No residency default here: Air is funded region by region, so the
-        # only regions it may land in are the ones on that list.
-        {:ok, place(account, placeable, placeable, lookups) || List.first(placeable)}
+        {:ok, place(account, placeable, placeable, lookups) || default_within(account, placeable)}
     end
   end
 
@@ -305,6 +311,21 @@ defmodule Tuist.Kura.AccountPolicies do
   defp effective_service_region(%Account{}, :open_source, _lookups), do: {:error, :plan_not_supported}
 
   defp effective_service_region(%Account{}, _plan, _lookups), do: {:error, :service_region_unavailable}
+
+  # Where an Air account lands when nothing has decided for it: the residency
+  # default where the deployment serves it, which is where these accounts have
+  # always resolved, and the first region it does serve otherwise.
+  #
+  # The paid plans refuse at this point instead, and Air cannot. A deployment
+  # is free not to serve the default region — staging serves neither American
+  # one — and refusing there would leave the free tier unresolvable in the
+  # environment its lifecycle is exercised in. Ordering decides only among
+  # regions the residency already admits, so falling back breaks no promise.
+  defp default_within(account, placeable) do
+    default = residency_default(account)
+
+    if default in placeable, do: default, else: List.first(placeable)
+  end
 
   # In order: what placement decided, then where the account is already served
   # from, then where its traffic comes from, then the residency default.
@@ -374,23 +395,22 @@ defmodule Tuist.Kura.AccountPolicies do
 
   @doc """
   The regions an account may actually be placed in: the ones its residency
-  admits, that this deployment serves, and that carry a budget for its plan.
+  admits and this deployment serves.
 
   The constraint resolver the placer consumes. `resolve/1` decides where an
   account goes; this says where it is allowed to go, and the difference
   between the two is what a placement decision is.
+
+  Plan-blind, because the two things that narrow this are the account's
+  residency promise and what the deployment runs, and neither is bought. What
+  a plan decides is how large an instance is and how many regions it may hold
+  at once (`Tuist.Kura.Placement`), not which regions are eligible.
   """
-  def placeable_regions(%Account{} = account, plan) do
+  def placeable_regions(%Account{} = account) do
     account
     |> permitted_regions()
     |> Enum.filter(&Regions.available?/1)
-    |> restrict_to_plan(plan)
   end
-
-  # Air is funded per region; the paid plans are served wherever the
-  # deployment serves.
-  defp restrict_to_plan(regions, :air), do: Enum.filter(regions, &(&1 in Environment.kura_air_region_ids()))
-  defp restrict_to_plan(regions, _plan), do: regions
 
   defp permitted_regions(%Account{region: residency}) do
     Regions.admitted_by_residency(residency)

--- a/server/lib/tuist/kura/placement.ex
+++ b/server/lib/tuist/kura/placement.ex
@@ -96,7 +96,16 @@ defmodule Tuist.Kura.Placement do
         min_runs_per_day: 10,
         min_active_days: 5
       },
-      expand: %{window_days: 14, min_runs_per_day: 50, min_active_days: 7},
+      # Pro's floor, not a higher one. The ladder is ordered by how many
+      # instances a plan funds — Air 2, Pro 3, Enterprise 5 — so the plan that
+      # funds the most regions cannot be the one that demands the most traffic
+      # to open one; at 50 it was stricter than Pro while being entitled to two
+      # more instances. What the floor has to be is an absolute rate a real
+      # second site clears and a handful of stragglers does not, and 25 a day
+      # is that rate whatever the plan. Measured against the fleet on
+      # 2026-09-07: it opens a region for the accounts whose second site runs
+      # 30-40 builds a day, and still refuses the 5-runs-a-day tails.
+      expand: %{window_days: 14, min_runs_per_day: 25, min_active_days: 7},
       retire: %{window_days: 90, max_runs_per_day: 10},
       relocation_window_days: 90,
       max_relocations_per_window: 1

--- a/server/lib/tuist/kura/placement.ex
+++ b/server/lib/tuist/kura/placement.ex
@@ -17,6 +17,17 @@ defmodule Tuist.Kura.Placement do
   weekend would never fire for a normal team. Volume is therefore read as a
   total across the span, with a separate count of the days that saw traffic
   so a single burst cannot pass for a durable move.
+
+  Relocation reads a fortnight. What it has to be sure of is that the majority
+  genuinely moved, which is a question about rate and spread rather than about
+  elapsed time: 140 runs at a 60% majority spread over five separate days
+  demands the same daily rate a month-long window did, and a slightly wider
+  share of the window's days, so shortening the span tightens the evidence
+  rather than weakening it. The month was also longer than the origin history
+  it reads, which meant every account whose placement predated origin
+  attribution had to wait out a window it could not yet fill before anything
+  could move it — the accounts most likely to be in the wrong region were the
+  ones the rung reached last.
   """
 
   alias Tuist.Kura.OriginMap
@@ -40,10 +51,10 @@ defmodule Tuist.Kura.Placement do
         within_days: 14
       },
       relocate: %{
-        window_days: 30,
+        window_days: 14,
         majority_share: 0.6,
         min_runs_per_day: 10,
-        min_active_days: 10
+        min_active_days: 5
       },
       expand: %{window_days: 14, min_runs_per_day: 100, min_active_days: 7},
       retire: %{window_days: 90, max_runs_per_day: 20},
@@ -60,10 +71,10 @@ defmodule Tuist.Kura.Placement do
         within_days: 14
       },
       relocate: %{
-        window_days: 30,
+        window_days: 14,
         majority_share: 0.6,
         min_runs_per_day: 10,
-        min_active_days: 10
+        min_active_days: 5
       },
       expand: %{window_days: 14, min_runs_per_day: 25, min_active_days: 7},
       retire: %{window_days: 90, max_runs_per_day: 5},
@@ -80,10 +91,10 @@ defmodule Tuist.Kura.Placement do
         within_days: 14
       },
       relocate: %{
-        window_days: 30,
+        window_days: 14,
         majority_share: 0.6,
         min_runs_per_day: 10,
-        min_active_days: 10
+        min_active_days: 5
       },
       expand: %{window_days: 14, min_runs_per_day: 50, min_active_days: 7},
       retire: %{window_days: 90, max_runs_per_day: 10},
@@ -162,12 +173,12 @@ defmodule Tuist.Kura.Placement do
   #
   # An account's first region is chosen the moment a build first asks where to
   # send cache traffic, from whatever origin history exists then — for a new
-  # account, often a single day of it. `relocate` needs 300 runs over 30 days
-  # at a 60% majority and fires once a quarter, so a guess made on a week of
-  # evidence would otherwise stand for months. What justifies that slowness is
-  # the cost of being wrong, and that cost is not constant: moving an account
-  # whose cache is days old and nearly cold is cheap, moving one with a warm
-  # working set is not.
+  # account, often a single day of it. `relocate` needs 140 runs over a
+  # fortnight at a 60% majority and fires once a quarter, so a guess made on a
+  # day of evidence would otherwise stand for weeks. What justifies that
+  # slowness is the cost of being wrong, and that cost is not constant: moving
+  # an account whose cache is days old and nearly cold is cheap, moving one
+  # with a warm working set is not.
   #
   # So this is narrow rather than slow. It reads the same short window the guess
   # itself read, and it only ever runs while the primary is young AND was never

--- a/server/lib/tuist/kura/placement_proposals.ex
+++ b/server/lib/tuist/kura/placement_proposals.ex
@@ -202,7 +202,7 @@ defmodule Tuist.Kura.PlacementProposals do
     context = %{
       plan: plan,
       rollups: Map.get(inputs.rollups, account.id, []),
-      permitted: AccountPolicies.placeable_regions(account, plan),
+      permitted: AccountPolicies.placeable_regions(account),
       primary: primary_from(placer_rows, live),
       # A primary with no placement row behind it was never decided: it came
       # from the resolution chain, which is a guess. Applying anything records

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -302,19 +302,20 @@ defmodule Tuist.Kura.Regions do
     # fleet's `cache-ap-southeast.tuist.dev` endpoint, so an account moved off
     # the legacy lane keeps the region name it already knows.
     #
-    # Nothing DERIVES here, and nothing is meant to. `accounts.region` is
-    # `all | europe | usa`: `europe` derives to eu-central, `usa` derives to
-    # us-east, and `all` defaults to us-east, so no storage-region preference
-    # resolves to Asia Pacific. Do not go looking for the rule that places
-    # accounts here; there is none. Air in particular can never land here,
-    # because Air resolves from the storage-region preference alone.
+    # No storage-region preference names this region: `accounts.region` is
+    # `all | europe | usa`, and none of the three derives to Asia Pacific. What
+    # places accounts here is where their traffic comes from — `Tuist.Kura.Origins`
+    # counts the origin, `Tuist.Kura.OriginMap` maps APAC to this region first,
+    # and an account whose residency constrains nothing resolves here without an
+    # operator. Air reaches it on the same rule as every other plan: what bounds
+    # a region is the disk `Tuist.Kura.Admission` can actually find there, not
+    # the tier of the account asking.
     #
-    # Two things do reach it, exactly as they reach us-west: an operator pinning
-    # an account's resolved region with `AccountPolicies.assign_service_region/4`,
-    # which carries plan checks, audit and versioning; and a customer picking the
-    # region in account settings, which goes through `selectable/0` and never
-    # consults AccountPolicies. The second is deliberate — this is a public
-    # region — so "assignment-only" describes derivation, not access.
+    # Two further routes reach it, exactly as they reach us-west: an operator
+    # pinning an account's resolved region with
+    # `AccountPolicies.assign_service_region/4`, which carries plan checks, audit
+    # and versioning; and a customer picking the region in account settings, which
+    # goes through `selectable/0` and never consults AccountPolicies.
     %{
       id: "ap-southeast",
       display_name: "Asia Pacific Southeast",

--- a/server/test/tuist/kura/account_policies_test.exs
+++ b/server/test/tuist/kura/account_policies_test.exs
@@ -823,7 +823,11 @@ defmodule Tuist.Kura.AccountPoliciesTest do
 
       assert {:ok, %{plan: :air}} = AccountPolicies.resolve(account)
 
-      refute_receive {_event_name, ^event_ref, _measurements, _metadata}
+      # `refute_received` rather than `refute_receive`: the handler is global,
+      # so its 100ms wait is a window for any async test file that refuses a
+      # resolution to deliver into this mailbox. `resolve/1` emits
+      # synchronously, so an event from this call is already here.
+      refute_received {_event_name, ^event_ref, _measurements, _metadata}
     end
   end
 end

--- a/server/test/tuist/kura/account_policies_test.exs
+++ b/server/test/tuist/kura/account_policies_test.exs
@@ -187,10 +187,13 @@ defmodule Tuist.Kura.AccountPoliciesTest do
                {:ok, %{plan: :air, service_region: "us-east"}}
     end
 
-    test "refuses a Europe-restricted Air account until a deployment serves Air in Europe" do
+    test "resolves a Europe-restricted Air account into the European region" do
+      # Refused outright while Air was funded per region: nothing funded Air in
+      # Europe, so the account's residency admitted no region it was allowed
+      # into and resolution had nothing to answer with.
       account = update_region!(organization_account(), :europe)
 
-      assert AccountPolicies.resolve(account) == {:error, :service_region_unavailable}
+      assert AccountPolicies.resolve(account) == {:ok, %{plan: :air, service_region: "eu-central"}}
     end
 
     test "does not include open-source accounts in the first rollout" do
@@ -360,11 +363,13 @@ defmodule Tuist.Kura.AccountPoliciesTest do
     end
   end
 
-  describe "Asia Pacific Southeast is assignment-only" do
+  describe "no storage-region preference names Asia Pacific Southeast" do
     test "no storage-region preference derives to it on any plan" do
-      # The point of the region: nothing places an account there implicitly, so
-      # a reader looking for a derivation rule finds this instead. Every
-      # accounts.region value crossed with every plan that resolves at all.
+      # `accounts.region` is `all | europe | usa`, and none of the three names
+      # this region, so nothing here reaches it. What does reach it is where an
+      # account's traffic comes from — see "placement by origin" — and an
+      # operator assignment. Every accounts.region value crossed with every
+      # plan that resolves at all.
       for region <- [:all, :europe, :usa],
           plan <- [:air, :pro, :enterprise] do
         account = update_region!(organization_account(), region)
@@ -531,29 +536,31 @@ defmodule Tuist.Kura.AccountPoliciesTest do
     end
   end
 
-  describe "Air funded in a region the deployment does not serve" do
-    test "refuses rather than resolving into an unserved funded region" do
-      # What canary was doing for 63 days: Air is funded in `us-east` by
-      # default, canary serves `eu-central`/`ca-east`, and resolution handed
-      # back `us-east` anyway. Demand landed in a region the lifecycle loop
-      # never iterates, no instance was ever created, and the endpoints API
+  describe "Air where the deployment does not serve the residency default" do
+    test "resolves into a region the deployment does serve" do
+      # What canary was doing for 63 days, seen from the other side: Air used
+      # to be admitted only to regions carrying an explicit budget, that budget
+      # named `us-east` by default, and a deployment serving `eu-central` and
+      # `ca-east` resolved every Air account into a region the lifecycle loop
+      # never iterates. No instance was ever created, and the endpoints API
       # reported the account as provisioning on every poll.
       account = organization_account()
       account = update_region!(account, :all)
       serving(["eu-central", "ca-east"])
-      stub(Environment, :kura_air_region_ids, fn -> ["us-east"] end)
-
-      assert AccountPolicies.resolve(account) == {:error, :service_region_unavailable}
-    end
-
-    test "places Air in a funded region the deployment serves" do
-      account = organization_account()
-      account = update_region!(account, :all)
-      serving(["eu-central", "ca-east"])
-      stub(Environment, :kura_air_region_ids, fn -> ["ca-east", "eu-central"] end)
 
       assert {:ok, %{plan: :air, service_region: service_region}} = AccountPolicies.resolve(account)
       assert service_region in ["ca-east", "eu-central"]
+    end
+
+    test "prefers the residency default where the deployment serves it" do
+      # Not merely the first region the deployment serves: `ca-east` sorts
+      # ahead of `us-east` among the regions this account is admitted to, and
+      # the default is still what an account with nothing else to go on gets.
+      account = organization_account()
+      account = update_region!(account, :all)
+      serving(["ca-east", "eu-central", "us-east"])
+
+      assert AccountPolicies.resolve(account) == {:ok, %{plan: :air, service_region: "us-east"}}
     end
   end
 
@@ -720,65 +727,43 @@ defmodule Tuist.Kura.AccountPoliciesTest do
     end
   end
 
-  describe "the Air region" do
-    test "is United States East for an account that states no storage region" do
-      assert Environment.kura_air_region(:all) == "us-east"
-      assert Environment.kura_air_region(:usa) == "us-east"
+  describe "Air is placed on the same rule as every other plan" do
+    test "follows the origin its traffic comes from" do
+      # The point of dropping the per-region Air budget. This account used to
+      # resolve to `us-east` whatever its traffic said, because `us-east` was
+      # the only region Air was admitted to.
+      account = update_region!(organization_account(), :all)
+      serving(["us-east", "eu-central"])
+      seed_origin(account, "PL")
+
+      assert AccountPolicies.resolve(account) == {:ok, %{plan: :air, service_region: "eu-central"}}
     end
 
-    test "is unnamed for Europe until a deployment serves Air from there" do
-      assert Environment.kura_air_region(:europe) == nil
-    end
-
-    test "is where an Air account resolves" do
+    test "resolves into the only region the deployment serves" do
       user = AccountsFixtures.user_fixture()
       account = Accounts.get_account_from_user(user)
 
-      stub(Environment, :kura_air_region_ids, fn -> ["ca-east"] end)
       serving(["ca-east"])
 
       assert {:ok, %{plan: :air, service_region: "ca-east"}} = AccountPolicies.resolve(account)
     end
 
-    test "does not move a paid account restricted to a storage region" do
-      # Where the free tier runs is a deployment decision. A paid account that
-      # chose Europe or the USA chose it, and no deployment setting relocates
-      # it.
-      account = update_region!(organization_account(), :europe)
-      BillingFixtures.subscription_fixture(account_id: account.id, plan: :pro)
-
-      stub(Environment, :kura_air_region, fn :europe -> "ca-east" end)
-
-      assert AccountPolicies.resolve(account) == {:ok, %{plan: :pro, service_region: "eu-central"}}
-    end
-
-    test "keeps a Europe-restricted Air account in Europe once a deployment serves it" do
-      account = update_region!(organization_account(), :europe)
-
-      stub(Environment, :kura_air_region_ids, fn -> ["us-east", "eu-central"] end)
-      deploy_regions(["us-east", "eu-central"])
-
-      assert AccountPolicies.resolve(account) == {:ok, %{plan: :air, service_region: "eu-central"}}
-    end
-
-    test "refuses a Europe-restricted Air account while no deployment serves Air in Europe" do
+    test "refuses a Europe-restricted Air account where no European region is served" do
       # "Storage region" names module cache binaries, which is what a Kura
       # instance holds, so an account that chose Europe is refused rather than
-      # served from the United States pool the rest of Air runs in.
+      # served from the United States.
       account = update_region!(organization_account(), :europe)
 
-      deploy_regions(["us-east", "eu-central"])
-
-      assert AccountPolicies.resolve(account) == {:error, :service_region_unavailable}
-    end
-
-    test "refuses a Europe-restricted Air account when the named region is not served here" do
-      account = update_region!(organization_account(), :europe)
-
-      stub(Environment, :kura_air_region, fn :europe -> "eu-central" end)
       deploy_regions(["us-east"])
 
       assert AccountPolicies.resolve(account) == {:error, :service_region_unavailable}
+    end
+
+    test "does not move a paid account restricted to a storage region" do
+      account = update_region!(organization_account(), :europe)
+      BillingFixtures.subscription_fixture(account_id: account.id, plan: :pro)
+
+      assert AccountPolicies.resolve(account) == {:ok, %{plan: :pro, service_region: "eu-central"}}
     end
   end
 

--- a/server/test/tuist/kura/placement_proposals_test.exs
+++ b/server/test/tuist/kura/placement_proposals_test.exs
@@ -57,13 +57,16 @@ defmodule Tuist.Kura.PlacementProposalsTest do
 
     test "leaves a settled placement to the slower rung" do
       # Past the correction window the account has a cache worth keeping, so
-      # the decision belongs to the rung that reads a month.
+      # the decision belongs to the relocation rung instead — which reaches the
+      # same answer, against its own floors and its own once-a-quarter budget.
       account = paid_account()
       insert_server!(account, "us-east", held_for_days: 30)
       seed_runs(account, "FR", 7, 20)
 
-      assert {:ok, %{evaluated: 1, open: 0}} = PlacementProposals.sweep(@today)
-      assert PlacementProposals.open_proposal_for(account) == nil
+      assert {:ok, %{evaluated: 1, open: 1}} = PlacementProposals.sweep(@today)
+
+      assert %PlacementProposal{kind: :relocate, from_region: "us-east", to_region: "eu-central", status: :open} =
+               PlacementProposals.open_proposal_for(account)
     end
 
     test "corrects a guess once and never again" do

--- a/server/test/tuist/kura/placement_test.exs
+++ b/server/test/tuist/kura/placement_test.exs
@@ -18,7 +18,8 @@ defmodule Tuist.Kura.PlacementTest do
       assert {:relocate, "us-east", "eu-central", evidence} = Placement.evaluate(context)
       assert evidence["signal"] == "majority_of_runs_moved"
       assert evidence["share"] >= 0.6
-      assert evidence["active_days"] == 30
+      # The account built on all 30 days; the rung reads the last 14 of them.
+      assert evidence["active_days"] == 14
     end
 
     test "leaves an account alone below the majority" do

--- a/server/test/tuist/kura/placement_test.exs
+++ b/server/test/tuist/kura/placement_test.exs
@@ -327,13 +327,21 @@ defmodule Tuist.Kura.PlacementTest do
       assert Placement.evaluate(context) == :none
     end
 
-    test "asks Enterprise for more than Pro before opening a region" do
+    test "asks Air for more than the paid plans before opening a region" do
+      # The ladder is ordered by how many regions a plan funds — Air 2, Pro 3,
+      # Enterprise 5 — so Air, which funds the fewest, is the one that has to
+      # see the most traffic before spending a slot. Pro and Enterprise share a
+      # floor: a second site earning a region is the same amount of traffic
+      # whichever paid plan it is on.
       rollups = daily("US-VA", 14, 500) ++ daily("FR", 14, 30)
 
       assert {:expand, "eu-central", _evidence} =
                Placement.evaluate(context(plan: :pro, primary: "us-east", serving: ["us-east"], rollups: rollups))
 
-      assert Placement.evaluate(context(plan: :enterprise, primary: "us-east", serving: ["us-east"], rollups: rollups)) ==
+      assert {:expand, "eu-central", _evidence} =
+               Placement.evaluate(context(plan: :enterprise, primary: "us-east", serving: ["us-east"], rollups: rollups))
+
+      assert Placement.evaluate(context(plan: :air, primary: "us-east", serving: ["us-east"], rollups: rollups)) ==
                :none
     end
 


### PR DESCRIPTION
Kura already places accounts by where their cache traffic comes from — `Tuist.Kura.Origins` counts the origin at the request boundary, `Tuist.Kura.OriginMap` maps it to a region, and `Tuist.Kura.Placement` decides relocations and expansions. That shipped in #12645 and #12734. This PR fixes the two things that stop it producing the placements the evidence asks for, and corrects the documentation that made the whole mechanism look like it did not exist.

### Air is no longer funded per region

Air was admitted only to regions carrying an explicit Air budget (`TUIST_KURA_AIR_REGIONS`, `TUIST_KURA_AIR_REGION`, `TUIST_KURA_AIR_EUROPE_REGION`). Production sets none of them, so `kura_air_region_ids/0` resolved to `["us-east"]` alone. Two consequences, both measured on the production Prometheus tenant on 2026-09-07:

- Every Air account resolved to `us-east` whatever its traffic said. `tuist_kura_lifecycle_placement_preference_unmet_count` — the counter that exists to record exactly this — showed, over seven days, `UA → eu-central` 2259, `NL` 1388, `PL` 1251, `CZ` 1050, and `TW → ap-southeast` 1328, `KR` 258, all served from `us-east`.
- A Europe-residency Air account was placeable **nowhere**: its residency admits only European regions, none of which carried an Air budget, so resolution refused it outright. `tuist_kura_lifecycle_resolution_refused_count{plan="air", reason="service_region_unavailable"}` stood at 43.

The gate is removed. Air now resolves over the same set as every other plan — the regions the account's residency admits and the deployment serves. `AccountPolicies.placeable_regions/2` loses its plan argument and becomes `/1`.

The reason this is safe is that plan was never the right bound. What bounds a region is capacity, and `Tuist.Kura.Admission` already enforces it: `TUIST_KURA_CAPACITY_ADMISSION_ENABLED=1` in production, so a region that cannot hold an instance refuses it, against the disk that is actually there rather than a list maintained by hand.

The obvious alternative was to widen the funded list instead (`TUIST_KURA_AIR_REGIONS=us-east,eu-central,ap-southeast`). That fixes today's counters and leaves the mechanism in place to produce the same class of bug the next time a region is added — a region is served, is selectable by customers, and silently places nobody.

**One trap this opens, and how it is closed.** Without the funding list the natural fallback for an Air account nothing has decided for is the first admitted region, and `Regions.admitted_by_residency/1` returns them sorted. In production that first entry is `ap-southeast`, so every unplaced Air account would have landed in Singapore. `default_within/2` takes the residency default where the deployment serves it — which is where these accounts have always resolved — and only falls through to the first served region otherwise. That fallback is what lets staging and canary, which serve neither American region, keep resolving Air at all; it is the job `TUIST_KURA_AIR_REGION=ca-east` was doing in their values, which is why those entries are removed here rather than left behind.

### The relocation rung reads a fortnight rather than a month

`relocate` required 10 active days inside a 30-day window. Origin history only begins 2026-08-31 (the table was created with #12645), so the rung could not fire for any account before ~2026-09-10 whatever its traffic said — and the accounts most likely to be in the wrong region are precisely the ones whose placement predates origin attribution, so the window they had to wait out was one they could not yet fill.

`window_days` 30 → 14 and `min_active_days` 10 → 5. `min_runs_per_day` stays at 10 and `majority_share` stays at 0.6, so the rung still demands the same daily rate and the same clear majority; five days out of fourteen is a slightly *wider* share of the window than ten out of thirty, so shortening the span tightens the evidence rather than weakening it. `max_relocations_per_window: 1` per 90 days is untouched, so per-account churn is bounded exactly as before.

### Documentation that described the opposite of the code

The `AccountPolicies` moduledoc listed a three-step resolution chain that is actually five, omitting both the placer row and the origin, and claimed an operator assignment was "the only route here to a region no preference derives to". The `ap-southeast` entry in `regions.ex` said "Nothing DERIVES here, and nothing is meant to... Do not go looking for the rule that places accounts here; there is none." Both predate #12645 and are now false — an APAC-origin account whose residency constrains nothing resolves to `ap-southeast` with no operator involved. This is not cosmetic: those two blocks are why the work in this PR was initially scoped as building a placement system that already existed.

The moduledoc also now records that pinning an account with `assign_service_region/4` removes it from `PlacementProposals.placeable_accounts/0` entirely. Pinning is placement's per-account rollback, not a way to repin a managed account — a distinction that is easy to get backwards and expensive to get backwards.

### Impact

- Air accounts are placed by their traffic. The 43 Europe-residency refusals resolve to `eu-central`; APAC Air traffic becomes eligible for `ap-southeast`, which currently runs zero instances.
- Relocation proposals can open for accounts placed before origin attribution existed, roughly two weeks earlier than they otherwise would.
- **Nothing moves unattended.** `TUIST_KURA_PLACEMENT_AUTOMATIC_APPLIES_PER_DAY` is still absent from production, so the apply budget remains 0: the sweep opens proposals and an operator applies them in the ops UI. This PR deliberately does not change that — lowering the floors and enabling unattended applies in the same change would move the fleet on evidence nobody has reviewed yet. Raising the budget is a values change once the first proposals have been looked at.
- Staging and canary lose their `TUIST_KURA_AIR_REGION(S)` entries and keep resolving Air on `ca-east`/`eu-central` through the new fallback.

### The Enterprise expansion floor drops to Pro's

`expand` opens a *second* region alongside the primary, which is the rung that decides "this account's CI is in Virginia but its developers are in London". Enterprise asked 50 runs/day there against Pro's 25, inverting the ladder the floors follow: they are ordered by how many regions a plan funds (Air 2, Pro 3, Enterprise 5), so the plan entitled to the most regions was demanding the most traffic to open one. Air stays at 100 — that end of the ladder was always right.

Measured against the production fleet on 2026-09-07 by running the real `Placement.evaluate/2` over `kura_origin_rollups`:

| # | plan | live | region | runs / 14d | at floor 50 | at floor 25 |
|---|---|---|---|---|---|---|
| 1 | enterprise | us-east | eu-central | 576 (8 days) | `:none` | **expand** |
| 2 | enterprise | us-east | ap-southeast | 577 (8 days) | `:none` | **expand** |
| 3 | enterprise | us-east | eu-central | 262 (~33/day) | `:none` | `:none`, clears as the window fills |
| 4 | enterprise | us-east | eu-central | 284 (~35/day) | `:none` | `:none`, clears as the window fills |
| 5 | enterprise | eu-central | us-east | 1355 | expand | expand |
| 6 | enterprise | us-east+us-west | us-west | 360 | **retire us-west** | `:none` |

Account 2 is the first `ap-southeast` has ever earned from its own traffic.

Account 6 is the interesting one, and it is the straddle working as designed rather than a side effect to worry about: at 50 its 360 us-west runs did not earn the region, so `earns_its_place?` let the retire rung propose giving it up. Lowering the floor gives the rung that would reopen a region the last word on abandoning it, which is what stops a destroy-and-cold-refill cycle.

### A correction to the premise this PR started from

The work was scoped around relocating two specific enterprise accounts, one to `ap-southeast` and one to `eu-central`. The rollups do not support either move — these are accounts 3 and 1 from the table above:

| # | us-east | eu-central | ap-southeast | us-west |
|---|---|---|---|---|
| 3 | **607 (66%)** | 262 (29%) | **47 (5%)** | 1 |
| 1 | **3552 (78%)** | 576 (13%) | — | 433 (9%) |

Both are already primary in the region carrying the majority of their runs, and neither relocates — correctly. The one assumed to belong in APAC has its entire APAC footprint in three origins totalling 47 runs. What both actually have is a *secondary* case, which is why the expansion floor rather than the relocation floor is what moves them.

The relocation change still earns its place, for a population that was not on the list: it is what lets the four Air accounts below move at all, on evidence that exists today rather than in three weeks.

### What the Air change actually unblocks

Before it, an Air account's `placeable_regions` was `["us-east"]`, so `OriginMap.preferred(origin, ["us-east"])` collapsed every origin onto `us-east`. `relocate` rejects the primary from its candidate list, leaving it permanently empty: **no Air account could relocate at any threshold.** Verified through `Placement.evaluate/2` with the before and after permitted sets:

| # | live | eu-central runs | share | active days | before | after |
|---|---|---|---|---|---|---|
| A | us-east | 1676 | 99.5% | 7 | `:none` | relocate → eu-central |
| B | us-east | 423 | 100% | 8 | `:none` | relocate → eu-central |
| C | us-east | 403 | 100% | 8 | `:none` | relocate → eu-central |
| D | us-east | 207 | 100% | 8 | `:none` | relocate → eu-central |

Four accounts serving ~100% European traffic out of Virginia.

### Known, not addressed here

The `retire` rung reads a 90-day window against 8 days of origin history, so every secondary region currently looks quiet against a floor sized for a full quarter. `held_long_enough?` protects regions held under 90 days and the `total == 0` guard protects accounts with no attribution at all, but an account with a long-held secondary and partial history is exposed — account 6 above was, until the expansion floor incidentally covered it. Nothing moves unattended while the apply budget is 0; worth closing before it is raised.

### How to test locally

```bash
mix test test/tuist/kura/ test/tuist/environment_test.exs test/tuist/kura_test.exs
```

Validation run for this change:

- `mix test test/tuist/kura/ test/tuist/environment_test.exs test/tuist/kura_test.exs` — 835 passed
- `mix test test/tuist/accounts_test.exs test/tuist_web/live/ops_account_live_test.exs` — 377 passed
- `mix format --check-formatted` clean; `mix credo --strict` clean on every changed file (the two findings it reports in `regions.ex` and `environment.ex` are on untouched lines, shifted by this diff)

Run across seeds 1, 42 and 7331 (835 passed each) after the expansion change reordered execution.

Test expectations changed as direct consequences of the behaviour change, rather than being adjusted to make the suite pass:

- a Europe-restricted Air account now resolves to `eu-central` instead of being refused
- an account past the correction window now reaches the relocation rung rather than falling through to nothing
- `evidence["active_days"]` reads 14 of a 30-day fixture, because the rung now reads a fortnight
- the Enterprise expansion test asserted the inverted ordering directly, so it is rewritten around the property that survives: Air, funding the fewest regions, is the plan that has to see the most traffic

One pre-existing flake is fixed alongside. `leaves a resolved account uncounted` attaches a `:telemetry_test` handler, which is global, then waits 100ms on `refute_receive`. Several modules emit `resolution_refused`, and the async files exercising them deliver into that mailbox. `resolve/1` emits synchronously, so the wait buys nothing `refute_received` does not already have, and it is the entire interference window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


