### PR TITLE
chore(infra): point the MDM deploy at the single values file

### DIFF
--- a/.github/workflows/mdm-deployment.yml
+++ b/.github/workflows/mdm-deployment.yml
@@ -1,18 +1,22 @@
 name: MDM Deployment
 
-# Deploys the self-hosted Apple MDM stack (infra/helm/mdm) to the staging
-# cluster.
+# Deploys the self-hosted Apple MDM stack (infra/helm/mdm).
 #
-# The `ref` input exists so a branch can be deployed to staging WITHOUT
+# There is one MDM instance and it owns every Mac we own, whatever
+# cluster that Mac ends up serving — the MDM manages a host before it
+# joins anything. The cluster named below is where the server is hosted,
+# not an environment tier, and there is no per-cluster MDM.
+#
+# The `ref` input exists so a branch can be deployed WITHOUT
 # merging it: the workflow definition is taken from the ref this workflow
 # is dispatched on (normally main), but the code, chart and images all
 # come from `ref`. That is the path used while validating the fleet MDM
 # against physical hardware, where the stack changes far more often than
 # it is ready to land on main.
 #
-# Staging only. The production instance enrolls devices against a
-# different, permanent hostname and gets its own release when the
-# prototype gauntlet passes.
+# The hostname is permanent: the MDM protocol cannot move an enrollment's
+# ServerURL, so changing it means DFU-reprovisioning every enrolled
+# machine.
 
 on:
   workflow_dispatch:
@@ -91,7 +95,7 @@ jobs:
           tags: ${{ env.REGISTRY }}/tuist/scepserver:${{ steps.tag.outputs.image_tag }}
 
   deploy:
-    name: Deploy staging
+    name: Deploy
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -128,7 +132,7 @@ jobs:
         run: |
           helm upgrade --install "$HELM_RELEASE_NAME" "$HELM_CHART_PATH" \
             --namespace "$NAMESPACE" --create-namespace \
-            -f "$HELM_CHART_PATH/values-staging.yaml" \
+            -f "$HELM_CHART_PATH/values-production.yaml" \
             --set images.enroller.tag="$IMAGE_TAG" \
             --set images.scep.tag="$IMAGE_TAG" \
             --atomic --timeout 15m --wait


### PR DESCRIPTION
## What

One-line change: the MDM deploy workflow now reads `values-production.yaml` instead of `values-staging.yaml`, plus the comments that described a staging/production split.

## Why

The MDM chart collapsed to a single instance at `mdm.tuist.dev` (tuist/tuist#12749). `values-staging.yaml` no longer exists, so the workflow on `main` currently points at a missing file and any dispatch fails.

The reasoning for one instance: the MDM manages a host *before* it joins any cluster — which cluster a mini serves is decided later, by the kubeconfig the operator SSH bootstrap installs. So a per-cluster MDM is a category error. And a separate bench would buy nothing while the fleet is being validated, since the only enrolled machine is a disposable prototype, while costing a second APNs push certificate, a second ABM server row, and a migration later. Choosing the permanent hostname now is free because nothing is enrolled yet, and it means the prototype validates the real one.

The cluster the release is hosted in is not an environment tier, and the comment now says so, so nobody later infers that staging-fleet Macs should enroll somewhere separate.

## Validation

`helm template` and `helm lint` pass for the chart against `values-production.yaml` and the CI values; the workflow parses as valid YAML. The dispatch path itself has been exercised repeatedly against the branch, so this is the only thing standing between it and a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)