### PR TITLE
fix(server): stop collecting browser telemetry from automated browsers

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -4826,6 +4826,80 @@ is an interruption policy that should be reassessed with more history. It
 delays detection of low-volume regressions; the lower-percentile rules remain
 independent.
 
+**First firing above the floor, 2026-09-07: p99 14.56s, 1043 samples, D=13 — and
+not a regression.** p75 was 1.67s and flat over the preceding three days
+(1.17 -> 1.67), so the site was healthy for typical visitors the whole time.
+**Check p75 before investigating a p99 page.** The 13 sessions were spread over
+12 pages, 11 of them with a single session, and broke down as:
+
+- **Seven were one automated client.** Chrome on Linux X11, viewport exactly
+  1919x992, `browser_os="Linux unknown"`, one LCP sample per session, 47 such
+  sessions in 24h. Their origin timings were fast — `requestTime` 258-675ms,
+  `responseTime` 6-213ms, `pageLoadTime` 642ms — while `ttfb` read 12-31s,
+  because the wait sits before `fetchStart` with `dnsLookupTime`,
+  `tcpHandshakeTime`, `tlsNegotiationTime`, `redirectTime` and
+  `serviceWorkerTime` all zero. That gap is the crawler's own request queue, not
+  this service. It reached nothing private: 43 of its 47 samples were
+  `/users/log_in`, which carries `view_name=dashboard` and so looks like
+  dashboard traffic in a `view_name` breakdown. It was crawling public localized
+  docs and following the docs header's log-in link, ignoring `Disallow: /users/`.
+- **Two were restored documents.** Navigation entries with `ttfb`,
+  `requestTime`, `responseTime` and `tcpHandshakeTime` all zero but `duration`
+  53.0s and 7.4s. The 53s session's other navigation was normal (TTFB 567ms,
+  page load 1.38s). No one waited 53 seconds; these are not user-perceived
+  latency.
+- **Four were genuine**, one of them network distance (zh-CN client, 3.7s TCP
+  plus 3.4s TLS).
+
+Two rules of thumb fall out. `ttfb` far exceeding `requestTime + responseTime`
+with every connection phase at zero means client-side queueing. Every network
+phase at zero under a large `duration` means a restored document.
+
+Automated browsers are no longer instrumented: `shared/js/analytics.js` skips
+Faro entirely when `navigator.webdriver` is set, so these samples stop at the
+source rather than being filtered per rule. That flag only catches automation
+that does not hide itself. To check whether it worked, watch the fingerprint
+directly — it should fall to roughly zero:
+
+```logql
+count(sum by (session_id) (
+  count_over_time(
+    {service_name="tuist-web"}
+      | logfmt
+      | kind="measurement"
+      | type="web-vitals"
+      | app_environment="prod"
+      | lcp!=""
+      | browser_os="Linux unknown"
+      | browser_viewportWidth="1919"
+      | browser_viewportHeight="992"
+      | session_id!=""
+      | __error__="" [24h]
+  )
+))
+```
+
+**D scales with traffic**, which is worth remembering before reading a rise as a
+regression. It is an absolute count over 24h and it tracked the weekly cycle
+across these three days: 2-3 sessions at about 410 samples over the weekend, 13
+at about 1026 on the Monday. The poor-session *rate* did roughly double
+(0.5% -> 1.3%), so volume was not the whole story, but a rate would be a truer
+signal than a raw count.
+
+**The finding worth acting on was document weight, not the tail.** Dashboard
+navigations carry a p99 of 1.88 MB decoded HTML and a 24h peak of 8.26 MB
+(230 KB gzipped), against 610 KB for docs and 454 KB for marketing; the
+bundle-size-analysis pages serve 1.88 MB every time. The origin renders them
+quickly (TTFB 0.8-5.0s, `responseTime` 23-338ms), so this is invisible in server
+latency, but the size is a multiplier at both ends: the worst sample in the
+window (58.4s) spent 49.1s in the response phase moving that body, and a large
+DOM inflates `element_render_delay` directly — one real-user sample paired a
+249ms TTFB with 15.1s of element render delay. Image weight was not involved
+(`mise run marketing:image-budget` passed; `resource_load_duration` was
+122-153ms wherever present), and HTTP/1.1 is a client property rather than a
+route misconfiguration, appearing on 9-13% of navigations across every
+`view_name`.
+
 For per-page investigation, group the inner sum by
 `(app_environment, page_url, session_id)` and the outer count by
 `(app_environment, page_url)`. Three affected sessions on the same page is a

--- a/server/assets/AGENTS.md
+++ b/server/assets/AGENTS.md
@@ -18,6 +18,8 @@ This directory contains frontend assets for the Phoenix app (LiveView, marketing
   JavaScript rather than a script from a CDN, so the page loads no third-party
   origin and the Content Security Policy stays on `'self'`. Web vitals feed the
   LCP alerts documented in `infra/helm/k8s-monitoring/alerts.md`.
+  Browsers reporting `navigator.webdriver` are not instrumented at all, so
+  crawlers and headless test runners neither emit web vitals nor page views.
 
 ## Related Context
 

--- a/server/assets/shared/js/analytics.js
+++ b/server/assets/shared/js/analytics.js
@@ -13,6 +13,13 @@ export function initAnalytics() {
     return null;
   }
 
+  // Automated browsers report `navigator.webdriver`. Their web vitals measure
+  // the crawler's own request queue rather than the site, so they are not
+  // collected: the percentile alerts describe real visitors.
+  if (navigator.webdriver) {
+    return null;
+  }
+
   const faro = initializeFaro({
     url: config.collector_url,
     app: {


### PR DESCRIPTION
The `Web - LCP p99 pathological tail` alert fired on 2026-09-07 with p99 14.56s over 1043 samples and 13 affected sessions, the first crossing above the `D >= 10` affected-session floor added the day before. This makes the crawler traffic behind it stop reaching the percentiles at all, and records the investigation in the runbook.

### It was not a regression

p75 was 1.67s and flat across the preceding three days (1.17s to 1.67s), inside the 1.2 to 1.8s target and far under the 2.5s Core Web Vitals threshold. Typical visitors were unaffected the whole time. A healthy p75 under a blown p99 means tail composition rather than a regression, so the first triage step for this alert is to read p75, not to go looking for a deploy.

The 13 affected sessions were spread over 12 pages, 11 of them with a single session, and broke down as:

- **Seven were one automated client.** Chrome on Linux X11, viewport exactly 1919x992, one LCP sample per session, 47 such sessions in 24h. Their origin timings were fast (`requestTime` 258 to 675ms, `responseTime` 6 to 213ms, `pageLoadTime` 642ms) while `ttfb` read 12 to 31s, because the wait sits before `fetchStart` with `dnsLookupTime`, `tcpHandshakeTime`, `tlsNegotiationTime`, `redirectTime` and `serviceWorkerTime` all zero. That gap is the crawler's own request queue, not this service.
- **Two were restored documents.** Navigation entries with `ttfb`, `requestTime`, `responseTime` and `tcpHandshakeTime` all zero under a `duration` of 53.0s and 7.4s. The 53s session's other navigation was normal (TTFB 567ms, page load 1.38s), so nobody waited 53 seconds.
- **Four were genuine**, one of those network distance (3.7s TCP plus 3.4s TLS).

### Root cause of the noise

Faro instruments automated browsers exactly as it instruments people, so a crawler's internal queueing is recorded as if it were this site being slow. Roughly 70% of the tail describes the measuring client rather than the thing being measured.

### The fix, and why this one

`server/assets/shared/js/analytics.js` now skips Faro initialization entirely when `navigator.webdriver` is set.

The obvious alternative was filtering inside the five LCP alert rules. That was rejected: it needs a new field to filter on, and a filter that silently matches nothing is precisely the failure mode this pipeline has already shipped three times (all three presented as every rule green with no data behind any of it, documented in the same runbook section). Dropping at the source needs no new field, so there is no name to get wrong, and it also keeps crawler page views and resource timings out of the stream rather than only the vitals.

The honest limit: `navigator.webdriver` only catches automation that does not conceal itself. Because of that the change is verifiable by prediction rather than assumed correct, and the runbook carries the fingerprint query to confirm the population actually falls away.

### The crawler reached nothing private

Worth stating explicitly, because a `view_name` breakdown makes this look worse than it is: 43 of the crawler's 47 samples were `/users/log_in`, which renders in the app layout and therefore carries `view_name=dashboard`. It read as dashboard traffic and was not. Zero bundles, builds, tests, module-cache, runs or settings page views from that fingerprint in 24h.

It was crawling public localized documentation and following the log-in link in the docs header (`/docs/login?return_to=<current_path>` in `server/lib/tuist_web/docs/layouts/root.html.heex`), ignoring `Disallow: /users/`. Those documentation URLs were confirmed to return 200 anonymously, so nothing was redirecting it to login. Project pages stay covered by the generated `Disallow: /*/bundles` family in `server/lib/tuist_web/utilities/robots_txt.ex` (built from router metadata and defaulting to disallow, so new dashboard routes are private by construction) and by `require_authenticated_user_for_private_projects`.

### Impact

Browser telemetry now describes real visitors. Alert thresholds are unchanged, so the effect is on the input rather than the rule. `D` should fall on its own once crawler samples stop arriving, which is worth re-measuring before anyone reworks it into a rate. Ingest volume drops a little too, since automated sessions stop emitting resource timings.

No change for real users: `navigator.webdriver` is false in ordinary browsers.

### Also recorded, not fixed here

The finding that outlived the alert is document weight. Dashboard navigations carry a p99 of 1.88 MB decoded HTML and a 24h peak of 8.26 MB (230 KB gzipped), against 610 KB for docs and 454 KB for marketing. The origin renders these quickly, so it is invisible in server-side latency, but the weight is a multiplier at both ends of the LCP budget: the worst sample in the window spent 49.1s in the response phase, and one real-user sample paired a 249ms TTFB with 15.1s of element render delay. That is tracked separately and is not part of this change.

Two hypotheses were ruled out rather than left open. Image weight is not involved (`mise run marketing:image-budget` passes at 73.5 MB, and `resource_load_duration` was 122 to 153ms wherever present), and HTTP/1.1 is a client property rather than a route misconfiguration, appearing on 9 to 13% of navigations across every `view_name`.

### How to test locally

The change is five lines and is best checked by exercising both branches, since the whole point is that one population stops reporting.

1. Run the server with analytics enabled so `globalThis.analytics` carries `enabled: true` and a `collector_url`.
2. In an ordinary browser, load any page and confirm `POST` requests to `/-/faro/collect` still happen and that `navigator.webdriver` is `false` in the console. Telemetry must be unaffected for real visitors.
3. Simulate automation. Either drive the same page with a WebDriver or CDP session (Playwright and Puppeteer both set the flag by default), or in the console of a normal browser run `Object.defineProperty(navigator, "webdriver", { get: () => true })` before the bundle initializes and reload. No `/-/faro/collect` requests should be sent, and no page view event either.

In production, confirm the population actually falls away rather than assuming the flag caught it. Against the `grafanacloud-logs` datasource, this fingerprint returned 47 sessions in the 24h before the change and should approach zero after it deploys:

```logql
count(sum by (session_id) (
  count_over_time(
    {service_name="tuist-web"}
      | logfmt
      | kind="measurement"
      | type="web-vitals"
      | app_environment="prod"
      | lcp!=""
      | browser_os="Linux unknown"
      | browser_viewportWidth="1919"
      | browser_viewportHeight="992"
      | session_id!=""
      | __error__="" [24h]
  )
))
```

If it does not fall, the crawler is patching the flag and a different lever is needed.

### Validation already run

24h of production Loki was queried directly: per-page p99, per-page affected sessions, per-sample LCP phase attribution, and the correlated `faro.performance.navigation` timings for every one of the 13 affected sessions, which is what separated client-side queueing from origin latency. Three day trends were pulled for p75, p99, affected sessions and sample volume. `mise run marketing:image-budget` was run, and the four public localized documentation URLs the crawler was bounced from were confirmed to return 200 anonymously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
