### PR TITLE
perf(server): derive the module list and miss reasons from one breakdown query

### DIFF
--- a/server/lib/tuist/builds/analytics.ex
+++ b/server/lib/tuist/builds/analytics.ex
@@ -2278,77 +2278,113 @@ defmodule Tuist.Builds.Analytics do
     build: first-seen / cold / evicted).
   """
   def module_invalidations(opts \\ []) do
+    opts
+    |> module_invalidation_breakdown()
+    |> module_invalidations_from_breakdown(opts)
+  end
+
+  @doc """
+  Returns, per module and day, how often it was built and why it missed:
+  `appearances`, `misses`, `changed` (its own content differed from its previous
+  build) and `upstream` (only a dependency differed). One pass over the window
+  that `module_invalidations/1` and `module_miss_reasons_timeseries/1` both
+  derive from, so a page that needs both runs it once.
+
+  Takes the same options as `module_invalidations/1`, without `:limit`.
+  """
+  def module_invalidation_breakdown(opts) do
     project_id = Keyword.fetch!(opts, :project_id)
 
     start_datetime =
       Keyword.get(opts, :start_datetime, DateTime.add(DateTime.utc_now(), -30, :day))
 
     end_datetime = Keyword.get(opts, :end_datetime, DateTime.utc_now())
-    limit = Keyword.get(opts, :limit, 30)
 
     {filter_sql, filter_params} = module_invalidation_filters(opts)
     {name_sql, name_params} = module_name_filter(opts)
 
     params =
-      %{project_id: project_id, start: start_datetime, end: end_datetime, limit: limit}
+      %{project_id: project_id, start: start_datetime, end: end_datetime}
       |> Map.merge(filter_params)
       |> Map.merge(name_params)
       |> Map.merge(xcode_target_pruning_params(start_datetime, end_datetime))
 
     query = """
-    SELECT name, product, appearances, invalidations, self_changes, dependency_induced
+    SELECT
+      day,
+      name,
+      product,
+      count() AS appearances,
+      countIf(hit = 'miss') AS misses,
+      countIf(hit = 'miss' AND rn > 1 AND own != prev_own) AS changed,
+      countIf(
+        hit = 'miss' AND rn > 1 AND own = prev_own AND (deps != prev_deps OR ext != prev_ext)
+      ) AS upstream
     FROM (
       SELECT
-        name,
-        product,
-        count() AS appearances,
-        countIf(hit = 'miss') AS invalidations,
-        countIf(hit = 'miss' AND rn > 1 AND own != prev_own) AS self_changes,
-        countIf(
-          hit = 'miss' AND rn > 1 AND own = prev_own AND (deps != prev_deps OR ext != prev_ext)
-        ) AS dependency_induced
+        day, name, product, hit, own, deps, ext,
+        row_number() OVER w AS rn,
+        lagInFrame(own, 1) OVER w AS prev_own,
+        lagInFrame(deps, 1) OVER w AS prev_deps,
+        lagInFrame(ext, 1) OVER w AS prev_ext
       FROM (
         SELECT
-          name, product, hit, own, deps, ext,
-          row_number() OVER w AS rn,
-          lagInFrame(own, 1) OVER w AS prev_own,
-          lagInFrame(deps, 1) OVER w AS prev_deps,
-          lagInFrame(ext, 1) OVER w AS prev_ext
-        FROM (
-          SELECT
-            xt.name AS name,
-            xt.product AS product,
-            xt.binary_cache_hit AS hit,
-            e.ran_at AS ran_at,
-            coalesce(e.git_branch, '') AS branch,
-            xt.own_hash AS own,
-            cityHash64(xt.dependencies_hash) AS deps,
-            cityHash64(xt.external_hash) AS ext
-          FROM xcode_targets_by_project AS xt
-          INNER JOIN command_events AS e ON xt.command_event_id = e.id
-          WHERE e.project_id = {project_id:Int64}
-            AND e.ran_at >= {start:DateTime64(6)}
-            AND e.ran_at <= {end:DateTime64(6)}
-            AND xt.binary_cache_hash IS NOT NULL#{filter_sql}#{name_sql}#{xcode_target_pruning()}
-        )
-        WINDOW w AS (
-          PARTITION BY name, product, branch
-          ORDER BY ran_at ASC
-          ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
-        )
+          toDate(e.ran_at) AS day,
+          e.ran_at AS ran_at,
+          coalesce(e.git_branch, '') AS branch,
+          xt.name AS name,
+          xt.product AS product,
+          xt.binary_cache_hit AS hit,
+          xt.own_hash AS own,
+          cityHash64(xt.dependencies_hash) AS deps,
+          cityHash64(xt.external_hash) AS ext
+        FROM xcode_targets_by_project AS xt
+        INNER JOIN command_events AS e ON xt.command_event_id = e.id
+        WHERE e.project_id = {project_id:Int64}
+          AND e.ran_at >= {start:DateTime64(6)}
+          AND e.ran_at <= {end:DateTime64(6)}
+          AND xt.binary_cache_hash IS NOT NULL#{filter_sql}#{name_sql}#{xcode_target_pruning()}
       )
-      GROUP BY name, product
-      HAVING invalidations > 0
+      WINDOW w AS (
+        PARTITION BY name, product, branch
+        ORDER BY ran_at ASC
+        ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
+      )
     )
-    ORDER BY invalidations DESC, appearances DESC
-    LIMIT {limit:UInt32}
+    GROUP BY day, name, product
     """
 
     %{rows: rows} = ClickHouseRepo.query!(query, params)
 
+    Enum.map(rows, fn [day, name, product, appearances, misses, changed, upstream] ->
+      %{
+        day: normalize_date(day),
+        name: name,
+        product: product,
+        appearances: appearances,
+        misses: misses,
+        changed: changed,
+        upstream: upstream
+      }
+    end)
+  end
+
+  @doc """
+  The module list `module_invalidations/1` returns, derived from a breakdown from
+  `module_invalidation_breakdown/1` for the same options.
+  """
+  def module_invalidations_from_breakdown(breakdown, opts) do
+    limit = Keyword.get(opts, :limit, 30)
     radii = opts |> latest_graph_dependencies() |> blast_radii()
 
-    Enum.map(rows, fn [name, product, appearances, invalidations, self_changes, dependency_induced] ->
+    breakdown
+    |> Enum.group_by(&{&1.name, &1.product})
+    |> Enum.map(fn {{name, product}, rows} ->
+      appearances = rows |> Enum.map(& &1.appearances) |> Enum.sum()
+      invalidations = rows |> Enum.map(& &1.misses) |> Enum.sum()
+      self_changes = rows |> Enum.map(& &1.changed) |> Enum.sum()
+      dependency_induced = rows |> Enum.map(& &1.upstream) |> Enum.sum()
+
       %{
         name: name,
         product: product,
@@ -2364,6 +2400,43 @@ defmodule Tuist.Builds.Analytics do
         blast_radius: Map.get(radii, name)
       }
     end)
+    |> Enum.filter(&(&1.invalidations > 0))
+    |> Enum.sort_by(&{-&1.invalidations, -&1.appearances})
+    |> Enum.take(limit)
+  end
+
+  @doc """
+  The daily series `module_miss_reasons_timeseries/1` returns, derived from a
+  breakdown from `module_invalidation_breakdown/1` for the same options.
+  """
+  def miss_reasons_timeseries_from_breakdown(breakdown, opts) do
+    start_datetime =
+      Keyword.get(opts, :start_datetime, DateTime.add(DateTime.utc_now(), -30, :day))
+
+    end_datetime = Keyword.get(opts, :end_datetime, DateTime.utc_now())
+
+    by_day =
+      breakdown
+      |> Enum.group_by(& &1.day)
+      |> Map.new(fn {day, rows} ->
+        misses = rows |> Enum.map(& &1.misses) |> Enum.sum()
+        changed = rows |> Enum.map(& &1.changed) |> Enum.sum()
+        upstream = rows |> Enum.map(& &1.upstream) |> Enum.sum()
+        {day, %{changed: changed, upstream: upstream, cold: max(misses - changed - upstream, 0)}}
+      end)
+
+    dates =
+      start_datetime
+      |> DateTime.to_date()
+      |> Date.range(DateTime.to_date(end_datetime))
+      |> Enum.to_list()
+
+    %{
+      dates: Enum.map(dates, &Date.to_iso8601/1),
+      changed: Enum.map(dates, fn d -> get_in(by_day, [d, :changed]) || 0 end),
+      upstream: Enum.map(dates, fn d -> get_in(by_day, [d, :upstream]) || 0 end),
+      cold: Enum.map(dates, fn d -> get_in(by_day, [d, :cold]) || 0 end)
+    }
   end
 
   # Returns each module's most recent dependency edges (in the window/filters) as a
@@ -2997,83 +3070,9 @@ defmodule Tuist.Builds.Analytics do
   Without `:name` it covers every module in the project.
   """
   def module_miss_reasons_timeseries(opts) do
-    project_id = Keyword.fetch!(opts, :project_id)
-    {name_sql, name_params} = module_name_filter(opts)
-
-    start_datetime =
-      Keyword.get(opts, :start_datetime, DateTime.add(DateTime.utc_now(), -30, :day))
-
-    end_datetime = Keyword.get(opts, :end_datetime, DateTime.utc_now())
-    {filter_sql, filter_params} = module_invalidation_filters(opts)
-
-    params =
-      %{project_id: project_id, start: start_datetime, end: end_datetime}
-      |> Map.merge(filter_params)
-      |> Map.merge(name_params)
-      |> Map.merge(xcode_target_pruning_params(start_datetime, end_datetime))
-
-    query = """
-    SELECT
-      day,
-      countIf(hit = 'miss' AND rn > 1 AND own != prev_own) AS changed,
-      countIf(
-        hit = 'miss' AND rn > 1 AND own = prev_own AND (deps != prev_deps OR ext != prev_ext)
-      ) AS upstream,
-      countIf(hit = 'miss') AS misses
-    FROM (
-      SELECT
-        day, name, product, hit, own, deps, ext,
-        row_number() OVER w AS rn,
-        lagInFrame(own, 1) OVER w AS prev_own,
-        lagInFrame(deps, 1) OVER w AS prev_deps,
-        lagInFrame(ext, 1) OVER w AS prev_ext
-      FROM (
-        SELECT
-          toDate(e.ran_at) AS day,
-          e.ran_at AS ran_at,
-          coalesce(e.git_branch, '') AS branch,
-          xt.name AS name,
-          xt.product AS product,
-          xt.binary_cache_hit AS hit,
-          xt.own_hash AS own,
-          cityHash64(xt.dependencies_hash) AS deps,
-          cityHash64(xt.external_hash) AS ext
-        FROM xcode_targets_by_project AS xt
-        INNER JOIN command_events AS e ON xt.command_event_id = e.id
-        WHERE e.project_id = {project_id:Int64}
-          AND e.ran_at >= {start:DateTime64(6)}
-          AND e.ran_at <= {end:DateTime64(6)}
-          AND xt.binary_cache_hash IS NOT NULL#{filter_sql}#{name_sql}#{xcode_target_pruning()}
-      )
-      WINDOW w AS (
-        PARTITION BY name, product, branch
-        ORDER BY ran_at ASC
-        ROWS BETWEEN 1 PRECEDING AND CURRENT ROW
-      )
-    )
-    GROUP BY day
-    ORDER BY day
-    """
-
-    %{rows: rows} = ClickHouseRepo.query!(query, params)
-
-    by_day =
-      Map.new(rows, fn [day, changed, upstream, misses] ->
-        {normalize_date(day), %{changed: changed, upstream: upstream, cold: max(misses - changed - upstream, 0)}}
-      end)
-
-    dates =
-      start_datetime
-      |> DateTime.to_date()
-      |> Date.range(DateTime.to_date(end_datetime))
-      |> Enum.to_list()
-
-    %{
-      dates: Enum.map(dates, &Date.to_iso8601/1),
-      changed: Enum.map(dates, fn d -> get_in(by_day, [d, :changed]) || 0 end),
-      upstream: Enum.map(dates, fn d -> get_in(by_day, [d, :upstream]) || 0 end),
-      cold: Enum.map(dates, fn d -> get_in(by_day, [d, :cold]) || 0 end)
-    }
+    opts
+    |> module_invalidation_breakdown()
+    |> miss_reasons_timeseries_from_breakdown(opts)
   end
 
   @doc """

--- a/server/lib/tuist_web/live/modules_live.ex
+++ b/server/lib/tuist_web/live/modules_live.ex
@@ -147,11 +147,14 @@ defmodule TuistWeb.ModulesLive do
     else
       socket
       |> assign(:modules_opts, opts)
-      |> assign_async([:modules], fn ->
-        {:ok, %{modules: opts |> Keyword.put(:limit, @max_modules) |> Analytics.module_invalidations()}}
-      end)
-      |> assign_async([:miss_reasons_series], fn ->
-        {:ok, %{miss_reasons_series: Analytics.module_miss_reasons_timeseries(opts)}}
+      |> assign_async([:modules, :miss_reasons_series], fn ->
+        breakdown = Analytics.module_invalidation_breakdown(opts)
+
+        {:ok,
+         %{
+           modules: Analytics.module_invalidations_from_breakdown(breakdown, Keyword.put(opts, :limit, @max_modules)),
+           miss_reasons_series: Analytics.miss_reasons_timeseries_from_breakdown(breakdown, opts)
+         }}
       end)
       |> assign_async([:timeseries, :modules_series, :module_count], fn ->
         {:ok,

--- a/server/priv/gettext/dashboard_cache.pot
+++ b/server/priv/gettext/dashboard_cache.pot
@@ -87,7 +87,7 @@ msgstr ""
 #: lib/tuist_web/live/module_cache_module_live.ex:331
 #: lib/tuist_web/live/module_cache_module_live.html.heex:41
 #: lib/tuist_web/live/module_cache_module_live.html.heex:443
-#: lib/tuist_web/live/modules_live.ex:322
+#: lib/tuist_web/live/modules_live.ex:325
 #: lib/tuist_web/live/modules_live.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Any"
@@ -197,7 +197,7 @@ msgstr ""
 #: lib/tuist_web/live/module_cache_live.html.heex:26
 #: lib/tuist_web/live/module_cache_module_live.ex:330
 #: lib/tuist_web/live/module_cache_module_live.html.heex:43
-#: lib/tuist_web/live/modules_live.ex:321
+#: lib/tuist_web/live/modules_live.ex:324
 #: lib/tuist_web/live/modules_live.html.heex:13
 #: lib/tuist_web/live/xcode_cache_live.ex:425
 #, elixir-autogen, elixir-format
@@ -222,7 +222,7 @@ msgstr ""
 #: lib/tuist_web/live/module_cache_live.html.heex:669
 #: lib/tuist_web/live/module_cache_module_live.html.heex:130
 #: lib/tuist_web/live/module_cache_module_live.html.heex:296
-#: lib/tuist_web/live/modules_live.ex:316
+#: lib/tuist_web/live/modules_live.ex:319
 #: lib/tuist_web/live/xcode_cache_live.ex:304
 #: lib/tuist_web/live/xcode_cache_live.html.heex:109
 #: lib/tuist_web/live/xcode_cache_live.html.heex:786
@@ -444,7 +444,7 @@ msgstr ""
 #: lib/tuist_web/live/module_cache_module_live.ex:329
 #: lib/tuist_web/live/module_cache_module_live.html.heex:42
 #: lib/tuist_web/live/module_cache_module_live.html.heex:522
-#: lib/tuist_web/live/modules_live.ex:320
+#: lib/tuist_web/live/modules_live.ex:323
 #: lib/tuist_web/live/modules_live.html.heex:12
 #: lib/tuist_web/live/xcode_cache_live.ex:426
 #, elixir-autogen, elixir-format
@@ -465,8 +465,8 @@ msgstr ""
 #: lib/tuist_web/components/module_invalidations_table.ex:33
 #: lib/tuist_web/live/module_cache_live.html.heex:249
 #: lib/tuist_web/live/module_cache_module_live.ex:310
-#: lib/tuist_web/live/modules_live.ex:207
-#: lib/tuist_web/live/modules_live.ex:318
+#: lib/tuist_web/live/modules_live.ex:210
+#: lib/tuist_web/live/modules_live.ex:321
 #, elixir-autogen, elixir-format
 msgid "Misses"
 msgstr ""
@@ -1057,7 +1057,7 @@ msgid "Cold"
 msgstr ""
 
 #: lib/tuist_web/live/module_cache_module_live.ex:309
-#: lib/tuist_web/live/modules_live.ex:206
+#: lib/tuist_web/live/modules_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Cold misses"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 #: lib/tuist_web/components/module_invalidations_table.ex:49
 #: lib/tuist_web/live/module_cache_module_live.html.heex:149
 #: lib/tuist_web/live/module_cache_module_live.html.heex:343
-#: lib/tuist_web/live/modules_live.ex:317
+#: lib/tuist_web/live/modules_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "Dependents"
 msgstr ""
@@ -1158,7 +1158,7 @@ msgid "Upstream"
 msgstr ""
 
 #: lib/tuist_web/live/module_cache_module_live.ex:308
-#: lib/tuist_web/live/modules_live.ex:205
+#: lib/tuist_web/live/modules_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Upstream misses"
 msgstr ""
@@ -1242,7 +1242,7 @@ msgid "All"
 msgstr ""
 
 #: lib/tuist_web/live/module_cache_module_live.ex:307
-#: lib/tuist_web/live/modules_live.ex:204
+#: lib/tuist_web/live/modules_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Changed misses"
 msgstr ""

--- a/server/test/tuist_web/live/modules_live_test.exs
+++ b/server/test/tuist_web/live/modules_live_test.exs
@@ -343,7 +343,7 @@ defmodule TuistWeb.ModulesLiveTest do
     organization: organization,
     project: project
   } do
-    stub(Analytics, :module_invalidations, fn _opts ->
+    stub(Analytics, :module_invalidation_breakdown, fn _opts ->
       raise Ch.Error, code: 159, message: "Code: 159. DB::Exception: Timeout exceeded"
     end)
 
@@ -356,9 +356,10 @@ defmodule TuistWeb.ModulesLiveTest do
     refute has_element?(lv, ~s([data-part="modules-table-section"] [data-part="skeleton"]))
     refute has_element?(lv, "#all-modules-table")
 
-    # The analytics card loads independently of the table.
-    assert has_element?(lv, ~s([data-part="analytics"] [data-part="widgets"]))
-    refute has_element?(lv, "[data-part=\"analytics-error\"]")
+    # The miss reasons chart is derived from the same breakdown, so the
+    # analytics card fails with the table.
+    refute has_element?(lv, ~s([data-part="analytics"] [data-part="widgets"]))
+    assert has_element?(lv, "[data-part=\"analytics-error\"]")
   end
 
   describe "page_of/3" do


### PR DESCRIPTION
## What changed

The Modules page computed the same branch-partitioned window twice: `module_invalidations/1` grouped it by module for the list and `module_miss_reasons_timeseries/1` grouped it by day for the miss reasons chart. Both now derive from `module_invalidation_breakdown/1`, which runs the window once grouped by day and module, and the page runs it once for both assigns. The two public functions keep their contracts on top of it for the dashboard summary, the module detail page and the API, so nothing else changes.

## Why

After #12949 the two queries were the whole cost of the page on large projects. Each read 1.1 GiB, peaked at about 1.2 GiB and took 3 to 5 seconds, and because the page ran them concurrently they competed for the replica's four threads. Half of that work was duplicated.

The breakdown is small: 25,807 rows for the busiest project's 30-day window, summed in Elixir into the module list and the daily series.

Measured in production on that project, from `system.query_log`:

| | Rows read | Bytes read | Peak memory | CPU | Duration |
|---|---|---|---|---|---|
| Module list query (during a page load) | 13.5M | 1.12 GiB | 1.16 GiB | | 4.9 s |
| Miss reasons query (same page load) | 13.5M | 1.12 GiB | 1.21 GiB | | 3.4 s |
| Breakdown query, run alone | 13.6M | 713 MiB | 210 MiB | 2.1 s | 1.3 s |

The breakdown replaces both rows above. The 210 MiB was measured from the Grafana datasource user, whose settings differ from the application's, so the app's peak will land somewhere between that and the figures above; the read volume and the single pass do not depend on settings.

## Behaviour

- Ordering and `:limit` of the module list moved from SQL to Elixir: modules with at least one miss, by misses then appearances, first `limit`. The LiveView re-sorts in memory anyway.
- A failure of the breakdown now fails both the table and the analytics card, since the miss reasons chart is derived from it. The test from #12911 covering the failed state is updated accordingly; the other widgets still load from their own task.

## Validation

- 114 tests across the module analytics and the Modules page pass, plus the module detail and dashboard suites (which stub `module_invalidations/1` and keep working through the wrapper). `mix format` and `mix credo` clean. Gettext template references refreshed, no string changes.
- After deploy, `system.query_log` for the busiest project should show one query starting with `SELECT day, name, product, count() AS appearances` per page load instead of the two heavy shapes, reading about 700 MiB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
