### PR TITLE
feat(infra): add a Vultr bare-metal prep task

### DIFF
--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -683,6 +683,25 @@ the fleet key + a known sudo password) and marked *before* it joins the pool. Th
    Pass `PREP_SKIP_MARK=1` to stage capacity without marking it in yet, then
    release it later with `baremetal:mark-dedibox` / `baremetal:mark-ovh` (those
    are also the tasks to re-name a box).
+
+   **Vultr is a conversion, not an install.** Its API exposes no partitioning
+   control and its installer offers only RAID 1 across both disks (one
+   filesystem spanning the pair) or no RAID, so neither option yields the
+   mirrored root plus separate XFS `/data` the OVH and Dedibox installs lay
+   down. Order the box as RAID 1 with the fleet key attached, then convert it in
+   place, which splits the mirror and hands the freed disk to `/data`:
+   ```bash
+   PREP_NAMESPACE=tuist-production mise run baremetal:prep-vultr 64.176.17.88
+   ```
+   The root keeps running on the remaining leg, so there is no reinstall, no
+   reboot and no bootloader change; the cost is that the root is no longer
+   mirrored. `/data` is what the cluster gates on rather than the mirror:
+   `tuist.kuraVolumeQuotaProgram` leaves every cache volume unbounded without an
+   XFS `/data` carrying project quotas, and the self-join refuses a box that
+   cannot enforce. It lands on the disk that does not hold the ESP, so losing
+   the data disk leaves a box that still boots. The task waits on any in-flight
+   array rebuild, is a no-op on an already-converted box, and prints the four
+   gates at the end.
 3. **Declare the fleet at `replicas: 1`** in `values-managed-<env>.yaml` and
    deploy. The controller claims the marked box and self-joins it in ~2-5 min.
    `replicas` here is the **box** count (one per region today); a region's

--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -24,6 +24,13 @@ Apple Silicon uses the `tart-kubelet` role. The Elastic Metal kind is
 designed in `docs/scaleway-elastic-metal-support.md`; the sections below
 detail the Apple Silicon kind.
 
+A fifth kind for Vultr is designed but not built, in
+`docs/vultr-baremetal-support.md`. It is the only provider whose API cannot be
+given a partitioning plan, so its box is converted after install by
+`baremetal:prep-vultr` rather than installed into the right layout, and that
+pushes a conversion stage into the release-then-reinstall lifecycle the other
+Linux kinds share. Until it exists, the `sa-west` box is hand-joined.
+
 ## CRDs
 
 | Kind | Purpose |

--- a/infra/cluster-api-provider-tuist/docs/vultr-baremetal-support.md
+++ b/infra/cluster-api-provider-tuist/docs/vultr-baremetal-support.md
@@ -73,47 +73,76 @@ Everything else is shared: the stub `TuistCluster`, the `controllers/linux`
 package (`linux_cloudinit.go`, `node_storage.go`, the kubelet and containerd
 drift checks), and the operator-minted kubelet identity.
 
-## Adoption
+## Adoption: tags, not a label prefix
 
-The other kinds adopt by a provider-side marker set as the last step of prep:
-an OVH `displayName` prefix, a Dedibox tag. Vultr bare metal carries both a
-`label` and a `tags` list (the singular `tag` field is deprecated), so either
-can serve. The label is already in use here (`tuist-kura-vultr-production-sa-west`,
-set at order time and following the `adoptDisplayNamePrefix` convention), which
-argues for prefix-matching the label and keeping `tags` free.
+Verified against the live API 2026-09-07.
 
-Whichever is chosen, the marker has to be settable independently of the install,
-because prep names a box into the pool only after it is converted.
+The other kinds adopt by a provider-side marker set as the last step of prep: an
+OVH `displayName` **prefix**, a Dedibox **tag**. `GET /v2/bare-metals` does
+filter server-side, on `label`, `tag` and `region`, but **`label` matches
+exactly**, not by prefix:
+
+| query | matches |
+|---|---|
+| `label=tuist-kura-vultr-production-sa-west` | 1 |
+| `label=tuist-kura-vultr-production` (prefix) | 0 |
+| `label=TUIST-KURA-VULTR-PRODUCTION-SA-WEST` | 1 (case-insensitive) |
+
+So the OVH `adoptDisplayNamePrefix` pattern has no server-side equivalent here.
+Adoption follows **Dedibox instead**: an `adoptTag` on the `tags` list, narrowed
+by `region` and `plan`, which is one query rather than listing the fleet and
+filtering client-side. The `label` stays what it is now, the human-readable
+per-box name.
+
+The mark step is `PATCH /v2/bare-metals/{id}` with a `tags` array, which returns
+202 and is immediately visible to `?tag=`. Both halves are confirmed working on
+`kura-sa-west-1`, which now carries `tags: ["tuist-kura-vultr-production"]`.
+
+The marker is settable independently of the install, which the conversion stage
+requires: prep tags a box into the pool only once it has been converted.
 
 ## Provider client (`internal/vultr`)
 
 The surface the reconciler needs, mirroring `internal/ovh`:
 
-| Operation | Endpoint |
-|---|---|
-| `FindAdoptableServer` | `GET /v2/bare-metals` filtered by region, plan and label prefix, minus already-claimed |
-| `GetServer` | `GET /v2/bare-metals/{id}` for IP and status |
-| `RegisterSSHKey` | `POST /v2/ssh-keys` |
-| `StartInstall` | `POST /v2/bare-metals/{id}/reinstall` |
-| `InstallState` | poll `GET /v2/bare-metals/{id}` status |
-| `SetLabel` | `PATCH /v2/bare-metals/{id}` for the mark step |
+| Operation | Endpoint | Status |
+|---|---|---|
+| `FindAdoptableServer` | `GET /v2/bare-metals?tag=&region=`, minus already-claimed | verified |
+| `GetServer` | `GET /v2/bare-metals/{id}` | verified |
+| `SetTags` (mark) | `PATCH /v2/bare-metals/{id}` with `tags` | verified, 202 |
+| `RegisterSSHKey` | `POST /v2/ssh-keys` | unverified |
+| `StartInstall` | `POST /v2/bare-metals/{id}/reinstall` | unverified |
+| `InstallState` | poll `GET /v2/bare-metals/{id}` `status` | unverified |
 
-Unverified and worth confirming against a live key before building: whether the
-list endpoint supports server-side filtering by label or tag, or whether the
-client filters client-side; and what the status field reads during and after a
-reinstall.
+A bare-metal object carries `app_id, cpu_count, date_created, disk, features,
+gateway_v4, id, image_id, internal_ip, label, mac_address, main_ip, netmask_v4,
+os, os_id, plan, power_status, preemptible, region, snapshot_id, status, tag,
+tags, user_scheme, v6_main_ip, v6_network, v6_network_size, vpcs`. `status` reads
+`active` on a healthy box; `power_status` is separate.
+
+**Still unverified: what `status` reads through a reinstall**, which is what
+`InstallState` has to interpret. Testing it means wiping `kura-sa-west-1`, which
+is prepared and hand-joinable, so it is left for the first box that is genuinely
+disposable, or for the moment the fleet has a second one.
 
 ## Credential
 
 `VULTR_API` in `tuist-k8s-<env>`, an API Credential item with an `api-key`
-field, mirroring `OVH_API` and `DEDIBOX_SCW_API`. It does not exist yet;
-`VULTR_FLEET_SSH` is currently the only Vultr item.
+field, mirroring `OVH_API` and `DEDIBOX_SCW_API`. Created 2026-09-07 in
+`tuist-k8s-production`.
 
 Vultr gates API keys on a **source IP allowlist**, which the other providers do
-not. A key that works from a laptop will fail from the controller unless the
-cluster's egress address is allowlisted, and that address is the one the
-`stable-egress-controller` keeps pinned. This is the first thing to check when
-the controller gets 401s that a local `curl` does not reproduce.
+not, and the allowlist starts empty: a fresh key authenticates from nowhere and
+returns `401 Unauthorized IP address: <caller>`. The error names the address it
+rejected, which is the fastest way to see whether the caller was reached over
+IPv4 or IPv6.
+
+The production key currently allows any IPv4 and any IPv6, which is what
+unblocked bring-up. That should narrow to the cluster's stable egress address
+once the controller is the only consumer, since the key does not expire and can
+destroy servers, and a wide-open ACL is not a control. That address is the
+Hetzner Floating IP the `stable-egress-controller` pins to the `md-egress` pool
+rather than a literal in this repo.
 
 ## Out of scope
 

--- a/infra/cluster-api-provider-tuist/docs/vultr-baremetal-support.md
+++ b/infra/cluster-api-provider-tuist/docs/vultr-baremetal-support.md
@@ -1,0 +1,127 @@
+# Design: declarative Vultr bare-metal nodes via the in-house provider
+
+Status: design. The Santiago box behind the `sa-west` Kura region
+(`kura-sa-west-1`) is prepared but hand-joined; nothing adopts, heals or
+releases it yet.
+
+## Scope
+
+`sa-west` is the first Kura region on Vultr. South America is the reason:
+neither OVH nor Scaleway nor Hetzner sells there, which is what put a fourth
+provider in the fleet at all. OVH's own datacenter availability API returns
+`bhs, ca-east-tor-a, eu-west-par-{a,b,c}, fra, gra, hil, lon, rbx, sbg, sgp,
+syd, waw, ynm`.
+
+The box is a worker in the same cluster as every other region's node pool, so
+this is the Elastic Metal pattern with a different provisioning call. See
+[scaleway-elastic-metal-support.md](scaleway-elastic-metal-support.md) for the
+shared parts: the stub `TuistCluster`, the identity-mint self-join, the orphan
+reclaimer, and why upstream per-provider CAPI providers do not fit clusters
+whose infrastructure provider is caph.
+
+## The contract Vultr cannot honour
+
+Every existing Linux kind implements the same lifecycle: adopt a pre-prepped
+box, self-join it, and **reinstall it back to the pool on release**. The
+reinstall is what makes a released box safe to re-adopt, and on OVH and Dedibox
+it is also what lays down the disk layout, because both APIs take a
+partitioning plan (`internal/ovh` `PlanStorage`, `internal/dedibox`
+`planPartitions`): a mirrored root plus a separate XFS `/data`.
+
+**Vultr's API has no partitioning control.** Its installer offers RAID 1 across
+both disks, which is one filesystem spanning the pair, or no RAID.
+`POST /v2/bare-metals/{id}/reinstall` takes an optional hostname and nothing
+else. So the layout the cluster requires cannot be produced by the install, and
+`mise run baremetal:prep-vultr` exists to convert the box afterwards: split the
+mirror, hand the freed disk to XFS `/data`, leave the root running on the
+remaining leg.
+
+That layout is not cosmetic. `tuist.kuraVolumeQuotaProgram` leaves every cache
+volume unbounded unless `/data` is a separate XFS filesystem mounted with
+project quotas, and the self-join refuses a box that cannot enforce. An
+unbounded `/data` is what caused the 2026-07-16 eu-central outage.
+
+**Consequence for this kind:** release-then-reinstall returns a box in a state
+the cluster will refuse to re-adopt. A `VultrMachine` therefore needs a
+conversion stage the other kinds do not have, run over SSH after the reinstall
+reports done and before the box is marked adoptable. The alternative, leaving
+released boxes unconverted, turns every release into manual work and silently
+breaks the "scale a MachineDeployment" contract that makes the other fleets
+declarative.
+
+Two ways to place that stage, to be decided when this is built:
+
+1. **In the controller**, as a `Converting` stage between `Installing` and
+   `Adopting`. Keeps the lifecycle closed, at the cost of the controller owning
+   a disk-surgery step and needing the fleet key to reach a box it has just
+   reinstalled.
+2. **In `prep-vultr`**, with release leaving the box out of the pool until an
+   operator re-preps it. Simpler controller, but release stops being automatic,
+   which is most of what the kind is for.
+
+(1) is the better fit for a fleet that scales by `kubectl scale`, and the
+conversion is already scripted and idempotent, so the controller is re-running
+a known-good procedure rather than inventing one.
+
+## CRDs
+
+| Kind | Purpose |
+|---|---|
+| `VultrMachine` (+ `…Template`) | One Vultr bare-metal server: region, plan, OS, `fleetName`, `nodeTaints`, and the adoption selector. Reinstall-on-release, with the conversion stage above. |
+
+Everything else is shared: the stub `TuistCluster`, the `controllers/linux`
+package (`linux_cloudinit.go`, `node_storage.go`, the kubelet and containerd
+drift checks), and the operator-minted kubelet identity.
+
+## Adoption
+
+The other kinds adopt by a provider-side marker set as the last step of prep:
+an OVH `displayName` prefix, a Dedibox tag. Vultr bare metal carries both a
+`label` and a `tags` list (the singular `tag` field is deprecated), so either
+can serve. The label is already in use here (`tuist-kura-vultr-production-sa-west`,
+set at order time and following the `adoptDisplayNamePrefix` convention), which
+argues for prefix-matching the label and keeping `tags` free.
+
+Whichever is chosen, the marker has to be settable independently of the install,
+because prep names a box into the pool only after it is converted.
+
+## Provider client (`internal/vultr`)
+
+The surface the reconciler needs, mirroring `internal/ovh`:
+
+| Operation | Endpoint |
+|---|---|
+| `FindAdoptableServer` | `GET /v2/bare-metals` filtered by region, plan and label prefix, minus already-claimed |
+| `GetServer` | `GET /v2/bare-metals/{id}` for IP and status |
+| `RegisterSSHKey` | `POST /v2/ssh-keys` |
+| `StartInstall` | `POST /v2/bare-metals/{id}/reinstall` |
+| `InstallState` | poll `GET /v2/bare-metals/{id}` status |
+| `SetLabel` | `PATCH /v2/bare-metals/{id}` for the mark step |
+
+Unverified and worth confirming against a live key before building: whether the
+list endpoint supports server-side filtering by label or tag, or whether the
+client filters client-side; and what the status field reads during and after a
+reinstall.
+
+## Credential
+
+`VULTR_API` in `tuist-k8s-<env>`, an API Credential item with an `api-key`
+field, mirroring `OVH_API` and `DEDIBOX_SCW_API`. It does not exist yet;
+`VULTR_FLEET_SSH` is currently the only Vultr item.
+
+Vultr gates API keys on a **source IP allowlist**, which the other providers do
+not. A key that works from a laptop will fail from the controller unless the
+cluster's egress address is allowlisted, and that address is the one the
+`stable-egress-controller` keeps pinned. This is the first thing to check when
+the controller gets 401s that a local `curl` does not reproduce.
+
+## Out of scope
+
+- Ordering. As with every other kind, boxes are pre-ordered in the console; the
+  controllers never buy hardware.
+- Private networking. `sa-west` is a single-box region whose gateway binds the
+  box's public IP, and Kura's peer plane is a public host. A VPC would be an
+  unused interface, and unused private networks on bare metal have caused
+  problems before.
+- Multi-box regions. `replicas` stays 1 until South American volume argues
+  otherwise.

--- a/mise/tasks/baremetal/prep-vultr.sh
+++ b/mise/tasks/baremetal/prep-vultr.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#MISE description="Prep a Vultr bare-metal box: split the installer's mirror into a single-disk root plus the separate XFS /data the cache volume quota needs"
+#
+# Why this is a conversion rather than an install, unlike prep-ovh / prep-dedibox:
+# Vultr's API exposes no partitioning control, and its installer offers only
+# "RAID 1 across both disks" (one filesystem spanning the pair) or "no RAID".
+# Neither produces the mirrored root plus separate XFS /data those installs lay
+# down. So the box is ordered as RAID 1 and converted here: the mirror is split,
+# the freed disk becomes /data, and the root keeps running on the remaining leg.
+# No reinstall, no reboot, no bootloader change.
+#
+# What that costs: the root loses its mirror. On a two-disk box Vultr's installer
+# forces a choice between mirroring everything and having a second filesystem,
+# and /data is the one the cluster actually gates on -- tuist.kuraVolumeQuotaProgram
+# leaves every cache volume unbounded without an XFS /data carrying project
+# quotas, and the self-join refuses a box that cannot enforce.
+#
+# /data is placed on the disk that does NOT hold the ESP, so losing the data disk
+# leaves a box that still boots.
+#
+# Usage:
+#   mise run baremetal:prep-vultr <host>
+#   e.g. mise run baremetal:prep-vultr 64.176.17.88
+#
+# The fleet key comes from the env's 1Password vault (tuist-k8s-<env>, derived
+# from PREP_NAMESPACE; override with PREP_VAULT). Re-running on a prepared box is
+# a no-op.
+
+set -euo pipefail
+
+host="${1:-}"
+ns="${PREP_NAMESPACE:-tuist-production}"
+env="${ns#tuist-}"
+vault="${PREP_VAULT:-tuist-k8s-$env}"
+item="${PREP_SSH_ITEM:-VULTR_FLEET_SSH}"
+
+if [ -z "$host" ]; then
+  echo "usage: mise run baremetal:prep-vultr <host>" >&2
+  exit 2
+fi
+
+key="$(mktemp)"
+trap 'rm -f "$key"' EXIT
+chmod 600 "$key"
+op read "op://$vault/$item/private-key" > "$key" 2>/dev/null ||
+  { echo "no fleet key at op://$vault/$item/private-key" >&2; exit 1; }
+
+ssh -i "$key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+  -o ConnectTimeout=20 "root@$host" 'bash -s' <<'REMOTE'
+set -euo pipefail
+
+log() { echo "prep-vultr: $*"; }
+
+if mountpoint -q /data; then
+  log "/data already mounted from $(findmnt -no SOURCE /data) ($(findmnt -no FSTYPE /data)); nothing to do"
+  exit 0
+fi
+
+if grep -qE 'recovery|resync' /proc/mdstat; then
+  log "an array is still rebuilding; wait for it to finish before splitting the mirror"
+  grep -E 'recovery|resync' /proc/mdstat >&2
+  exit 1
+fi
+
+root_dev="$(findmnt -no SOURCE /)"
+case "$root_dev" in
+  /dev/md*) ;;
+  *) log "root is $root_dev, not an md array; this box was not installed with RAID 1"; exit 1 ;;
+esac
+
+# Keep the leg on the disk that holds the ESP, so the boot-critical disk carries
+# root, and hand the other disk to /data.
+esp_disk="/dev/$(lsblk -no PKNAME "$(findmnt -no SOURCE /boot/efi)")"
+legs="$(mdadm --detail "$root_dev" | awk '/active sync/ {print $NF}')"
+[ "$(echo "$legs" | wc -l)" -eq 2 ] || { log "expected 2 active legs in $root_dev, got: $(echo $legs)"; exit 1; }
+
+data_leg=""
+for leg in $legs; do
+  [ "/dev/$(lsblk -no PKNAME "$leg")" = "$esp_disk" ] || data_leg="$leg"
+done
+[ -n "$data_leg" ] || { log "could not pick a leg off the ESP disk ($esp_disk)"; exit 1; }
+
+log "root=$root_dev esp_disk=$esp_disk -> handing $data_leg to /data"
+
+mdadm "$root_dev" --fail "$data_leg"
+mdadm "$root_dev" --remove "$data_leg"
+# Drop to a clean single-device array so the root does not sit permanently
+# "degraded" and trip array monitoring.
+mdadm --grow "$root_dev" --raid-devices=1 --force
+
+wipefs -a "$data_leg"
+# crc + project quotas: the quota program refuses anything that is not xfs with
+# prjquota, and the ceiling it assigns comes straight from the PVC.
+mkfs.xfs -f -m crc=1 "$data_leg"
+
+mkdir -p /data
+uuid="$(blkid -s UUID -o value "$data_leg")"
+sed -i '\| /data |d' /etc/fstab
+echo "UUID=$uuid /data xfs defaults,prjquota 0 2" >> /etc/fstab
+mount /data
+
+# The array changed shape, so persist it or the next boot assembles the old one.
+mdadm --detail --scan > /etc/mdadm/mdadm.conf
+update-initramfs -u >/dev/null 2>&1
+
+log "done"
+REMOTE
+
+echo
+echo "verifying the self-join gates on $host:"
+ssh -i "$key" -o BatchMode=yes -o ConnectTimeout=20 "root@$host" 'bash -s' <<'CHECK'
+set -eu
+data=/data
+p() { printf "  %-34s %s\n" "$1" "$2"; }
+mountpoint -q "$data" && p "/data is a mountpoint" PASS || { p "/data is a mountpoint" FAIL; exit 1; }
+[ "$(findmnt -no SOURCE $data)" != "$(findmnt -no SOURCE /)" ] && p "/data is not the root filesystem" PASS || { p "/data is not the root filesystem" FAIL; exit 1; }
+[ "$(findmnt -no FSTYPE $data)" = xfs ] && p "/data is xfs" PASS || { p "/data is xfs" FAIL; exit 1; }
+case ",$(findmnt -no OPTIONS $data)," in
+  *,prjquota,*|*,pquota,*) p "/data has project quotas" PASS ;;
+  *) p "/data has project quotas" FAIL; exit 1 ;;
+esac
+p "usable /data" "$(df -h $data | awk 'NR==2{print $2}')"
+CHECK

--- a/mise/tasks/baremetal/prep-vultr.sh
+++ b/mise/tasks/baremetal/prep-vultr.sh
@@ -96,7 +96,13 @@ mkfs.xfs -f -m crc=1 "$data_leg"
 mkdir -p /data
 uuid="$(blkid -s UUID -o value "$data_leg")"
 sed -i '\| /data |d' /etc/fstab
-echo "UUID=$uuid /data xfs defaults,prjquota 0 2" >> /etc/fstab
+# nofail so a failed data disk cannot block boot -- placing /data off the ESP
+# disk is only worth something if the box still comes up without it. The quota
+# program then reports the volume as unbounded and kura_volume_quota_enforced
+# goes to 0, which is the intended loud no-op rather than an unschedulable node.
+# Pass 0 for the same reason: fsck must not hold boot on this filesystem.
+echo "UUID=$uuid /data xfs defaults,prjquota,nofail,x-systemd.device-timeout=30s 0 0" >> /etc/fstab
+systemctl daemon-reload
 mount /data
 
 # The array changed shape, so persist it or the next boot assembles the old one.


### PR DESCRIPTION
Adds `mise run baremetal:prep-vultr <host>`, the sibling of `baremetal:prep-ovh` and `baremetal:prep-dedibox`, so a Vultr box can be brought to the layout the cluster requires.

Prerequisite for [#12962](https://github.com/tuist/tuist/pull/12962) (the `sa-west` region), but independently useful for any future Vultr box.

## Why this is a conversion, not an install

Vultr is the first provider in the fleet whose install cannot be given the layout we need:

- its API exposes **no partitioning control**
- its installer offers only **RAID 1 across both disks** (one filesystem spanning the pair) or **no RAID**

Neither produces the mirrored root plus separate XFS `/data` that the OVH and Dedibox installs lay down through their provider APIs. So the box is ordered as RAID 1 with the fleet key attached, and converted in place: split the mirror, hand the freed disk to `/data`. The root keeps running on the remaining leg, so there is no reinstall, no reboot and no bootloader change, and a failure leaves the box exactly as it was.

## Why `/data` is worth the root mirror

`/data` is what the cluster gates on; the mirror is not. `tuist.kuraVolumeQuotaProgram` leaves every cache volume unbounded unless `/data` is a separate XFS filesystem mounted with project quotas, and the self-join refuses a box that cannot enforce. An unbounded `/data` is what caused the 2026-07-16 eu-central outage, where one account's instance filled the box and kubelet evicted every tenant on it.

On a two-disk box Vultr's installer makes the two mutually exclusive, and losing the root mirror is the weaker exposure of the pair.

## Safety properties

- **Refuses to run while an array is rebuilding.** Splitting a resyncing mirror would leave the root on a leg that was never fully populated.
- **`/data` lands on the disk that does not hold the ESP**, so losing the data disk leaves a box that still boots.
- **No-op on an already-converted box**, so it is safe to re-run.
- **Verifies rather than assumes**: prints the four gates the quota program checks (`/data` is a mountpoint, is not the root filesystem, is xfs, has project quotas) and exits non-zero if any fail.
- The root array is grown down to a clean single-device array rather than left permanently `degraded`, so it does not trip array monitoring.

## Validation

`bash -n` clean; `mise tasks` lists it alongside its siblings. Run against the Santiago box that motivated it, with the gate output as the acceptance check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)