### PR TITLE
fix(infra): protect a freshly seated runner Pod from a rival pool's drain

### DIFF
--- a/infra/runners-controller/AGENTS.md
+++ b/infra/runners-controller/AGENTS.md
@@ -180,7 +180,10 @@ independent workqueues:
     tolerates that key at its OWN pool's value, so the host stops
     admitting everyone else while its seats accumulate. Running jobs are
     waited out, never evicted; only idle Pods of other pools are
-    retired. The taint is removed when the Pod lands or after
+    retired, and only once they have been bound longer than `seatGrace`
+    (2m) — a Pod that bound more recently is the seat some other
+    reservation just produced, and dispatch has not yet reached it. The
+    taint is removed when the Pod lands or after
     `reservationTimeout` (15m), and at most one host is held per fleet
     (`maxFleetReservations`; the count is taken over the pool's own
     fleet nodes, so darwin and linux hold separate budgets), since a

--- a/infra/runners-controller/controllers/reservation.go
+++ b/infra/runners-controller/controllers/reservation.go
@@ -86,6 +86,12 @@ const (
 	reservationCooldownAnnotation = "tuist.dev/reservation-cooldown-until"
 	reservationCooldown           = 15 * time.Minute
 
+	// seatGrace is how long a Pod is safe from another pool's drain after
+	// it binds. A reservation releases as soon as its Pod lands, so
+	// without this the seat it produced is retirable before dispatch has
+	// reached the Pod and labelled it owned.
+	seatGrace = 2 * time.Minute
+
 	// maxFleetReservations is how many hosts may be held at once. The
 	// count is taken over the pool's OWN fleet nodes, so each fleet gets
 	// its own budget and a macOS reservation never blocks a Linux one.
@@ -151,7 +157,7 @@ func (r *RunnerPoolReconciler) reconcileReservation(
 				"cooldown", reservationCooldown)
 			return r.releaseReservation(ctx, held, now.Add(reservationCooldown))
 		default:
-			return r.retireIdlePodsOnReservedNode(ctx, held, pool)
+			return r.retireIdlePodsOnReservedNode(ctx, held, pool, now)
 		}
 	}
 
@@ -507,8 +513,10 @@ func (r *RunnerPoolReconciler) pickReservationTarget(
 // a cold start and nothing else.
 //
 // This pool's own Pods are left alone — an idle one here is the seat the
-// reservation was taken to produce. Pods running customer jobs are never
-// touched; the reservation waits them out, or times out.
+// reservation was taken to produce. So is any Pod that bound within
+// `seatGrace`, which is that same seat one reservation earlier. Pods
+// running customer jobs are never touched; the reservation waits them
+// out, or times out.
 //
 // Idleness is read through `isIdle`, matching the node-drain path: the
 // owner label alone is best-effort and can be missing on a Pod that is
@@ -517,6 +525,7 @@ func (r *RunnerPoolReconciler) retireIdlePodsOnReservedNode(
 	ctx context.Context,
 	node *corev1.Node,
 	pool *tuistv1.RunnerPool,
+	now time.Time,
 ) error {
 	logger := log.FromContext(ctx)
 
@@ -534,6 +543,9 @@ func (r *RunnerPoolReconciler) retireIdlePodsOnReservedNode(
 			continue
 		}
 		if !isIdle(pod) {
+			continue
+		}
+		if seatedAt, ok := linuxProvisioningStartedAt(pod); ok && now.Sub(seatedAt) < seatGrace {
 			continue
 		}
 		if err := r.reapRunner(ctx, pod); err != nil {

--- a/infra/runners-controller/controllers/reservation_test.go
+++ b/infra/runners-controller/controllers/reservation_test.go
@@ -86,6 +86,16 @@ func placedPod(name, pool, node string, owner string) *corev1.Pod {
 	return pod
 }
 
+func seatedPod(name, pool, node string, seatedAt time.Time) *corev1.Pod {
+	p := placedPod(name, pool, node, "")
+	p.Status.Conditions = []corev1.PodCondition{{
+		Type:               corev1.PodScheduled,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(seatedAt),
+	}}
+	return p
+}
+
 // smallPool is the 6 vCPU shape the large one competes with. A
 // reservation is only taken for a shape that is large RELATIVE to what
 // else runs on the fleet, so the sibling has to exist for the large
@@ -515,6 +525,45 @@ func TestReservation_RetiresIdleLinuxPodsButNeverRunningJobs(t *testing.T) {
 // genuinely IS coarser than its siblings on one big host, so it passes
 // that test and would close the fleet. Reachable in practice — the
 // Linux fleet is small and moving to smaller boxes.
+// A reservation releases the moment its Pod binds, so the seat it just
+// produced is exposed to the next reservation on the same host while
+// dispatch is still reaching for it.
+func TestReservation_DoesNotRetireAFreshlySeatedPod(t *testing.T) {
+	pool := linuxLargePool()
+	node := ax162Node("bm-0")
+	node.Spec.Taints = []corev1.Taint{{
+		Key:    podtemplate.ReservationTaintKey,
+		Value:  podtemplate.ReservationValue(pool.Name),
+		Effect: corev1.TaintEffectNoSchedule,
+	}}
+	node.Annotations = map[string]string{reservationAtAnnotation: reservationNow.Format(time.RFC3339)}
+
+	starved := pendingPod("large-0", pool.Name, 5*time.Minute)
+	fresh := seatedPod("small-fresh", linuxSmallPoolName, "bm-0", reservationNow.Add(-30*time.Second))
+	stale := seatedPod("small-stale", linuxSmallPoolName, "bm-0", reservationNow.Add(-10*time.Minute))
+
+	r := reservationReconciler(pool, linuxSmallPool(), node, starved, fresh, stale)
+	if err := r.reconcileReservation(context.Background(), pool, []corev1.Pod{*starved}); err != nil {
+		t.Fatalf("reconcileReservation: %v", err)
+	}
+
+	remaining := &corev1.PodList{}
+	if err := r.List(context.Background(), remaining, client.InNamespace("runners")); err != nil {
+		t.Fatalf("list pods: %v", err)
+	}
+	names := map[string]bool{}
+	for i := range remaining.Items {
+		names[remaining.Items[i].Name] = true
+	}
+
+	if !names["small-fresh"] {
+		t.Error("a Pod seated within the grace period must survive: dispatch has not had a chance to claim it")
+	}
+	if names["small-stale"] {
+		t.Error("a Pod idle since well before the grace period should still be retired")
+	}
+}
+
 func TestReservation_NeverTakesTheFleetsLastHost(t *testing.T) {
 	pool := linuxLargePool()
 	node := ax162Node("bm-0")


### PR DESCRIPTION
## What changed

`retireIdlePodsOnReservedNode` no longer retires a Pod that bound within a new `seatGrace` (2m). The clock is the `PodScheduled` transition, read through the existing `linuxProvisioningStartedAt`, not `CreationTimestamp`.

## Why

A node reservation releases the instant its Pod binds, and that is also the instant the Pod stops being protected. `maxFleetReservations` is 1, so the freed slot is immediately available, and the node its predecessor just drained is the emptiest in the fleet, so `pickReservationTarget` hands the next reservation the same node. That reservation's drain then retires the Pod that landed seconds earlier: it is unclaimed and still polling, so `isIdle` reports true, and dispatch never gets the chance to label it owned.

Observed in production on 2026-09-07, on a 16 vCPU / 64 GB Linux shape:

```
16:41:20  RELEASE 16vcpu-64gb reservation on 2c6zk  "pool is served"
16:41:20  RESERVE 2c6zk for 4vcpu-16gb
16:41:20  RETIRE  16vcpu-64gb-runner-0d82501f "to clear a reserved node"
16:52:08  RELEASE 16vcpu-64gb on sfkd5  "pool is served"
16:52:08  RESERVE sfkd5 for 4vcpu-16gb
16:52:08  RETIRE  16vcpu-64gb-runner-64d6a32c
```

Both releases were correct: the Pod really had bound. The defect is what is allowed to happen to it next. The job behind this sat queued 59 minutes on a fleet where normal waits are 0 to 3 minutes, and the same fleet shows 171 and 84 minute waits earlier in the week.

This is a livelock rather than a slow path. On a fleet at 92 to 99 percent memory allocation, a Pod costing 66.5 GiB after kata overhead can reach a seat only through the reservation, so a seat destroyed before it is claimed puts the pool back where it started with nothing learned. The pool that keeps taking the reservation is itself persistently starved, so it wins the race reliably rather than occasionally.

## Why this rather than the alternatives

**Cooldown on a successful release.** The node cooldown already exists but is deliberately set only on a timeout, since a reservation that ended because the Pod landed achieved what it was for. Extending it here would work, but it rests the whole host for 15 minutes and blocks a genuinely starved pool from a node that may have room for it. The thing that needs protecting is the seat, not the host.

**Reservation priority by shape coarseness.** Worth doing, and it would reduce how often the race is lost, but it does not close it: any pool that takes the next reservation on that node retires the seat. That change is also a policy change with its own starvation trade-offs, whereas this one restores an invariant the drain already intends.

**Pod age instead of bind time.** `CreationTimestamp` is wrong for the same reason `linuxProvisioningStartedAt` exists: a Pod can wait unscheduled far longer than the grace period, so starting the clock at creation strips the protection off exactly the Pods that waited longest to get a seat.

## Impact

A drain now waits up to 2 minutes longer on a node holding recently bound Pods of other pools. That is bounded by `reservationTimeout` (15m), which is unchanged. No behaviour change for Pods running customer jobs, which were already never touched, or for the reserving pool's own Pods, which were already exempt.

## Validation

`TestReservation_DoesNotRetireAFreshlySeatedPod` asserts both directions: a Pod seated 30s ago survives the drain, and one seated 10 minutes ago is still retired. Confirmed red before the change with the fresh Pod retired, green after. Full `go test ./...` and `go vet ./...` pass in `infra/runners-controller`.

Not yet exercised against the live fleet, which is why this is a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
