### PR TITLE
fix(server): avoid activity log parser output pipe errors

### DIFF
--- a/server/lib/tuist/AGENTS.md
+++ b/server/lib/tuist/AGENTS.md
@@ -16,6 +16,10 @@ This directory contains the core business logic and domain modules for the serve
 
 - Web controllers and LiveView code live in `server/lib/tuist_web`.
 - Data migrations live in `server/priv`.
+- `Processor.XCActivityLogParser` runs the MuonTrap executable through
+  `System.cmd` in a timed task, collecting the parser's inherited stderr without
+  MuonTrap's output acknowledgement protocol. This avoids `:epipe` on fast exits
+  while retaining process cleanup when the task times out or its caller dies.
 
 ## Related Context (Downlinks)
 

--- a/server/lib/tuist/processor/xcactivitylog_parser.ex
+++ b/server/lib/tuist/processor/xcactivitylog_parser.ex
@@ -56,25 +56,34 @@ defmodule Tuist.Processor.XCActivityLogParser do
   end
 
   defp run(executable, arguments) do
-    case MuonTrap.cmd(executable, arguments,
-           timeout: @timeout,
-           delay_to_sigkill: @delay_to_sigkill,
-           stderr_to_stdout: true
-         ) do
-      {_output, 0} ->
+    # MuonTrap.cmd acknowledges output over stdin, which can exit the caller
+    # with :epipe when the parser exits before the acknowledgement is written.
+    # The wrapper leaves stderr inherited without capture flags, so System.cmd
+    # can collect diagnostics directly while MuonTrap still owns child cleanup.
+    task =
+      Task.async(fn ->
+        System.cmd(
+          MuonTrap.muontrap_path(),
+          ["--delay-to-sigkill", to_string(@delay_to_sigkill), "--", executable | arguments],
+          stderr_to_stdout: true
+        )
+      end)
+
+    case Task.yield(task, @timeout) || Task.shutdown(task, :brutal_kill) do
+      {:ok, {_output, 0}} ->
         :ok
 
-      {_output, :timeout} ->
+      nil ->
         {:error, :parse_timeout}
 
       # muontrap reports a child killed by a signal as 128 + signum, so a Swift
       # trap (SIGILL) arrives here as 132. Keep it distinguishable from an
       # error the parser reported itself: a crash means a build we cannot parse
       # until the trap is fixed, not a transient failure worth retrying.
-      {output, status} when status > 128 ->
+      {:ok, {output, status}} when status > 128 ->
         {:error, {:parser_crashed, status, String.trim(output)}}
 
-      {output, _status} ->
+      {:ok, {output, _status}} ->
         {:error, String.trim(output)}
     end
   end

--- a/server/test/tuist/processor/xcactivitylog_parser_test.exs
+++ b/server/test/tuist/processor/xcactivitylog_parser_test.exs
@@ -35,6 +35,21 @@ defmodule Tuist.Processor.XCActivityLogParserTest do
     assert {:error, "unsupported log version"} = parse()
   end
 
+  test "handles repeated immediate exits after writing diagnostics" do
+    install_parser(~S|echo "unsupported log version" >&2; exit 1|)
+
+    for _ <- 1..100 do
+      assert {:error, "unsupported log version"} = parse()
+    end
+  end
+
+  test "captures diagnostics larger than MuonTrap's output window" do
+    message = String.duplicate("unsupported log version\n", 1000)
+    install_parser("printf '" <> message <> "' >&2; exit 1")
+
+    assert {:error, String.trim(message)} == parse()
+  end
+
   # The reason this module shells out at all: a Swift runtime trap aborts the
   # parser process, and that has to surface as an error rather than take the
   # BEAM down with it.


### PR DESCRIPTION
## Summary

- Fix activity log parsing failures caused by MuonTrap's output acknowledgement protocol.
- Run MuonTrap through a timed task and `System.cmd` so fast parser exits no longer trigger `:epipe`.
- Preserve timeout cleanup and distinguish parser crashes from ordinary parser errors.
- Add guidance documenting the process execution behavior.

The bug occurred when the parser exited immediately after writing diagnostics, before MuonTrap could acknowledge the output, causing an `:epipe` instead of returning the parser's actual error. The previous output handling could also fail to capture diagnostics beyond MuonTrap's output window.

The implementation delegates process execution to a task, invokes MuonTrap directly with the existing SIGKILL delay, collects stderr merged into stdout, and shuts down the task when the timeout expires. Tests repeatedly exercise immediate diagnostic exits and verify capture of large diagnostic output.

## Testing

- Added unit coverage for 100 repeated immediate exits with diagnostics.
- Added unit coverage for diagnostics larger than MuonTrap's output window.