### PR TITLE
fix(infra): cut Kura histogram cardinality and add an on-demand per-pod metrics endpoint

### DIFF
--- a/infra/grafana-dashboards/tuist-kura-details.json
+++ b/infra/grafana-dashboards/tuist-kura-details.json
@@ -13,7 +13,7 @@
           "enable": true,
           "hide": true,
           "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations \u0026 Alerts",
+          "name": "Annotations & Alerts",
           "query": {
             "datasource": {
               "name": "-- Grafana --"
@@ -2238,140 +2238,6 @@
           }
         }
       },
-      "panel-120": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.5, sum by (pod, le) (rate(kura_file_descriptor_wait_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p50 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.95, sum by (pod, le) (rate(kura_file_descriptor_wait_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p95 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.99, sum by (pod, le) (rate(kura_file_descriptor_wait_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p99 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "Time spent waiting to acquire a file descriptor permit\n\nPrometheus name: `kura_file_descriptor_wait_seconds`_bucket/_count/_sum · labels: result",
-          "id": 120,
-          "links": [],
-          "title": "file_descriptor_wait_seconds (p50 / p95 / p99)",
-          "vizConfig": {
-            "group": "timeseries",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "lineWidth": 1,
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  },
-                  "unit": "s"
-                },
-                "overrides": []
-              },
-              "options": {
-                "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "desc"
-                }
-              }
-            },
-            "version": "12.0.0"
-          }
-        }
-      },
       "panel-121": {
         "kind": "Panel",
         "spec": {
@@ -2534,140 +2400,6 @@
                     ]
                   },
                   "unit": "Bps"
-                },
-                "overrides": []
-              },
-              "options": {
-                "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "desc"
-                }
-              }
-            },
-            "version": "12.0.0"
-          }
-        }
-      },
-      "panel-123": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.5, sum by (pod, le) (rate(kura_file_operation_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p50 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.95, sum by (pod, le) (rate(kura_file_operation_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p95 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.99, sum by (pod, le) (rate(kura_file_operation_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p99 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "File operation latency by operation\n\nPrometheus name: `kura_file_operation_duration_seconds`_bucket/_count/_sum · labels: operation",
-          "id": 123,
-          "links": [],
-          "title": "file_operation_duration_seconds (p50 / p95 / p99)",
-          "vizConfig": {
-            "group": "timeseries",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "lineWidth": 1,
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  },
-                  "unit": "s"
                 },
                 "overrides": []
               },
@@ -6297,140 +6029,6 @@
           }
         }
       },
-      "panel-157": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.5, sum by (pod, le) (rate(kura_auth_backend_request_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p50 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.95, sum by (pod, le) (rate(kura_auth_backend_request_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p95 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.99, sum by (pod, le) (rate(kura_auth_backend_request_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p99 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "Authentication backend request latency by route\n\nPrometheus name: `kura_auth_backend_request_duration_seconds`_bucket/_count/_sum · labels: route",
-          "id": 157,
-          "links": [],
-          "title": "auth_backend_request_duration_seconds (p50 / p95 / p99)",
-          "vizConfig": {
-            "group": "timeseries",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "lineWidth": 1,
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  },
-                  "unit": "s"
-                },
-                "overrides": []
-              },
-              "options": {
-                "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "desc"
-                }
-              }
-            },
-            "version": "12.0.0"
-          }
-        }
-      },
       "panel-158": {
         "kind": "Panel",
         "spec": {
@@ -6770,140 +6368,6 @@
           }
         }
       },
-      "panel-160": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.5, sum by (pod, le) (rate(kura_auth_decision_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p50 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.95, sum by (pod, le) (rate(kura_auth_decision_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p95 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.99, sum by (pod, le) (rate(kura_auth_decision_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p99 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "Authorization decision latency by stage\n\nPrometheus name: `kura_auth_decision_duration_seconds`_bucket/_count/_sum · labels: stage",
-          "id": 160,
-          "links": [],
-          "title": "auth_decision_duration_seconds (p50 / p95 / p99)",
-          "vizConfig": {
-            "group": "timeseries",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "lineWidth": 1,
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  },
-                  "unit": "s"
-                },
-                "overrides": []
-              },
-              "options": {
-                "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "desc"
-                }
-              }
-            },
-            "version": "12.0.0"
-          }
-        }
-      },
       "panel-161": {
         "kind": "Panel",
         "spec": {
@@ -7066,140 +6530,6 @@
                     ]
                   },
                   "unit": "short"
-                },
-                "overrides": []
-              },
-              "options": {
-                "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "desc"
-                }
-              }
-            },
-            "version": "12.0.0"
-          }
-        }
-      },
-      "panel-163": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.5, sum by (pod, le) (rate(kura_analytics_batch_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p50 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.95, sum by (pod, le) (rate(kura_analytics_batch_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p95 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.99, sum by (pod, le) (rate(kura_analytics_batch_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p99 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "Analytics webhook batch latency by pipeline\n\nPrometheus name: `kura_analytics_batch_duration_seconds`_bucket/_count/_sum · labels: pipeline",
-          "id": 163,
-          "links": [],
-          "title": "analytics_batch_duration_seconds (p50 / p95 / p99)",
-          "vizConfig": {
-            "group": "timeseries",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "lineWidth": 1,
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  },
-                  "unit": "s"
                 },
                 "overrides": []
               },
@@ -8920,161 +8250,6 @@
           }
         }
       },
-      "panel-18": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.5, sum by (pod, le) (rate(kura_internal_backfill_http_request_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p50 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.95, sum by (pod, le) (rate(kura_internal_backfill_http_request_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p95 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.99, sum by (pod, le) (rate(kura_internal_backfill_http_request_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p99 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "Internal backfill HTTP request latency by route\n\nPrometheus name: `kura_internal_backfill_http_request_duration_seconds`_bucket/_count/_sum · labels: route",
-          "id": 18,
-          "links": [],
-          "title": "internal_backfill_http_request_duration_seconds (p50 / p95 / p99)",
-          "vizConfig": {
-            "group": "timeseries",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisBorderShow": false,
-                    "axisCenteredZero": false,
-                    "axisColorMode": "text",
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "barWidthFactor": 0.6,
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "insertNulls": false,
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "never",
-                    "showValues": false,
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  },
-                  "unit": "s"
-                },
-                "overrides": []
-              },
-              "options": {
-                "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "hideZeros": false,
-                  "mode": "multi",
-                  "sort": "desc"
-                }
-              }
-            },
-            "version": "13.3.0-32457798232"
-          }
-        }
-      },
       "panel-180": {
         "kind": "Panel",
         "spec": {
@@ -9129,7 +8304,7 @@
               "transformations": []
             }
           },
-          "description": "kubelet volume stats for the pod's data PVC (data-\u003cpod\u003e). Empty where the CSI driver does not report volume stats.",
+          "description": "kubelet volume stats for the pod's data PVC (data-<pod>). Empty where the CSI driver does not report volume stats.",
           "id": 180,
           "links": [],
           "title": "Cache volume usage",
@@ -9739,7 +8914,7 @@
           "description": "kura_egress_tree_link_reattach_total, _return_attach_failures_total, _sibling_overflow_total rates. Node-level agent series, shown for the node(s) hosting the selected pod(s).",
           "id": 185,
           "links": [],
-          "title": "Attach churn \u0026 map overflow",
+          "title": "Attach churn & map overflow",
           "vizConfig": {
             "group": "timeseries",
             "kind": "VizConfig",
@@ -9891,7 +9066,7 @@
               "transformations": []
             }
           },
-          "description": "kura_egress_tree_class_sent_bytes by account and classid — kernel counter exported as a gauge, rate() × 8 — against the rate and ceiling the kernel is enforcing (_class_rate_bytes_per_second, _class_ceil_bytes_per_second, also × 8). A tenant riding its ceiling wants a larger floor; one far under its rate is reserving room it does not use. classid 1:\u003chex\u003e is allocated per account by kura-controller and freed when the account's last instance goes, so the account label is what identifies the tenant over time. Node-level agent series, shown for the node(s) hosting the selected pod(s) — every class on those nodes, neighbours included, since they are what the tenant contends with.",
+          "description": "kura_egress_tree_class_sent_bytes by account and classid — kernel counter exported as a gauge, rate() × 8 — against the rate and ceiling the kernel is enforcing (_class_rate_bytes_per_second, _class_ceil_bytes_per_second, also × 8). A tenant riding its ceiling wants a larger floor; one far under its rate is reserving room it does not use. classid 1:<hex> is allocated per account by kura-controller and freed when the account's last instance goes, so the account label is what identifies the tenant over time. Node-level agent series, shown for the node(s) hosting the selected pod(s) — every class on those nodes, neighbours included, since they are what the tenant contends with.",
           "id": 186,
           "links": [],
           "title": "Class throughput (bits/s)",
@@ -11339,274 +10514,6 @@
                     ]
                   },
                   "unit": "ops"
-                },
-                "overrides": []
-              },
-              "options": {
-                "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "desc"
-                }
-              }
-            },
-            "version": "12.0.0"
-          }
-        }
-      },
-      "panel-24": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.5, sum by (pod, le) (rate(kura_artifact_egress_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p50 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.95, sum by (pod, le) (rate(kura_artifact_egress_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p95 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.99, sum by (pod, le) (rate(kura_artifact_egress_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p99 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "Time from artifact response body creation until stream completion, error, or drop\n\nPrometheus name: `kura_artifact_egress_duration_seconds`_bucket/_count/_sum · labels: producer",
-          "id": 24,
-          "links": [],
-          "title": "artifact_egress_duration_seconds (p50 / p95 / p99)",
-          "vizConfig": {
-            "group": "timeseries",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "lineWidth": 1,
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  },
-                  "unit": "s"
-                },
-                "overrides": []
-              },
-              "options": {
-                "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "desc"
-                }
-              }
-            },
-            "version": "12.0.0"
-          }
-        }
-      },
-      "panel-25": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.5, sum by (pod, le) (rate(kura_artifact_egress_throughput_bytes_per_second_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p50 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.95, sum by (pod, le) (rate(kura_artifact_egress_throughput_bytes_per_second_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p95 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.99, sum by (pod, le) (rate(kura_artifact_egress_throughput_bytes_per_second_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p99 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "Achieved per-response artifact egress throughput in bytes per second, used to detect bandwidth saturation and plan sharding\n\nPrometheus name: `kura_artifact_egress_throughput_bytes_per_second`_bucket/_count/_sum · labels: producer",
-          "id": 25,
-          "links": [],
-          "title": "artifact_egress_throughput_bytes_per_second (p50 / p95 / p99)",
-          "vizConfig": {
-            "group": "timeseries",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "lineWidth": 1,
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  },
-                  "unit": "Bps"
                 },
                 "overrides": []
               },
@@ -13692,140 +12599,6 @@
           }
         }
       },
-      "panel-46": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.5, sum by (pod, le) (rate(kura_segment_refresh_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p50 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.95, sum by (pod, le) (rate(kura_segment_refresh_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p95 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.99, sum by (pod, le) (rate(kura_segment_refresh_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p99 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "Time spent refreshing artifacts out of old segments, by trigger\n\nPrometheus name: `kura_segment_refresh_duration_seconds`_bucket/_count/_sum · labels: producer, trigger",
-          "id": 46,
-          "links": [],
-          "title": "segment_refresh_duration_seconds (p50 / p95 / p99)",
-          "vizConfig": {
-            "group": "timeseries",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "lineWidth": 1,
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  },
-                  "unit": "s"
-                },
-                "overrides": []
-              },
-              "options": {
-                "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "desc"
-                }
-              }
-            },
-            "version": "12.0.0"
-          }
-        }
-      },
       "panel-47": {
         "kind": "Panel",
         "spec": {
@@ -14976,140 +13749,6 @@
                     ]
                   },
                   "unit": "short"
-                },
-                "overrides": []
-              },
-              "options": {
-                "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "desc"
-                }
-              }
-            },
-            "version": "12.0.0"
-          }
-        }
-      },
-      "panel-58": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.5, sum by (pod, le) (rate(kura_manifest_index_rebuild_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p50 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.95, sum by (pod, le) (rate(kura_manifest_index_rebuild_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p95 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.99, sum by (pod, le) (rate(kura_manifest_index_rebuild_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p99 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "Time spent rebuilding the warm in-memory manifest index from RocksDB\n\nPrometheus name: `kura_manifest_index_rebuild_duration_seconds`_bucket/_count/_sum",
-          "id": 58,
-          "links": [],
-          "title": "manifest_index_rebuild_duration_seconds (p50 / p95 / p99)",
-          "vizConfig": {
-            "group": "timeseries",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "lineWidth": 1,
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  },
-                  "unit": "s"
                 },
                 "overrides": []
               },
@@ -18209,140 +16848,6 @@
           }
         }
       },
-      "panel-89": {
-        "kind": "Panel",
-        "spec": {
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.5, sum by (pod, le) (rate(kura_response_stream_wait_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p50 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.95, sum by (pod, le) (rate(kura_response_stream_wait_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p95 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "$datasource"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "expr": "histogram_quantile(0.99, sum by (pod, le) (rate(kura_response_stream_wait_duration_seconds_bucket{cluster=~\"tuist-$env\", pod=~\"$pod\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "p99 {{pod}}",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
-                  }
-                }
-              ],
-              "queryOptions": {},
-              "transformations": []
-            }
-          },
-          "description": "Time spent acquiring response stream admission by protocol\n\nPrometheus name: `kura_response_stream_wait_duration_seconds`_bucket/_count/_sum · labels: protocol",
-          "id": 89,
-          "links": [],
-          "title": "response_stream_wait_duration_seconds (p50 / p95 / p99)",
-          "vizConfig": {
-            "group": "timeseries",
-            "kind": "VizConfig",
-            "spec": {
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "lineWidth": 1,
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green",
-                        "value": 0
-                      }
-                    ]
-                  },
-                  "unit": "s"
-                },
-                "overrides": []
-              },
-              "options": {
-                "legend": {
-                  "calcs": [
-                    "lastNotNull"
-                  ],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "desc"
-                }
-              }
-            },
-            "version": "12.0.0"
-          }
-        }
-      },
       "panel-9": {
         "kind": "Panel",
         "spec": {
@@ -19753,7 +18258,7 @@
           "description": "ERROR and WARN lines only. Expand a line to read the span fields the runtime stamps on every log (`span_kura_tenant_id`, `span_kura_region`, `trace_id`) and use `trace_id` to jump to the matching trace in the Traces row.",
           "id": 196,
           "links": [],
-          "title": "Errors \u0026 warnings",
+          "title": "Errors & warnings",
           "vizConfig": {
             "group": "logs",
             "kind": "VizConfig",
@@ -19868,7 +18373,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "limit": 50,
-                        "query": "{ resource.service.namespace = \"kura\" \u0026\u0026 resource.deployment.environment.name = \"$env\" \u0026\u0026 resource.service.name =~ \"^(${pod})$\"\n  \u0026\u0026 span.http.route !~ \"^(/up|/ready|/metrics|/status/rollout)$\" } with (most_recent=true)",
+                        "query": "{ resource.service.namespace = \"kura\" && resource.deployment.environment.name = \"$env\" && resource.service.name =~ \"^(${pod})$\"\n  && span.http.route !~ \"^(/up|/ready|/metrics|/status/rollout)$\" } with (most_recent=true)",
                         "queryType": "traceql",
                         "tableType": "traces"
                       },
@@ -19946,7 +18451,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "limit": 50,
-                        "query": "{ resource.service.namespace = \"kura\" \u0026\u0026 resource.deployment.environment.name = \"$env\" \u0026\u0026 resource.service.name =~ \"^(${pod})$\"\n  \u0026\u0026 span.http.route !~ \"^(/up|/ready|/metrics|/status/rollout)$\"\n  \u0026\u0026 duration \u003e 500ms } with (most_recent=true)",
+                        "query": "{ resource.service.namespace = \"kura\" && resource.deployment.environment.name = \"$env\" && resource.service.name =~ \"^(${pod})$\"\n  && span.http.route !~ \"^(/up|/ready|/metrics|/status/rollout)$\"\n  && duration > 500ms } with (most_recent=true)",
                         "queryType": "traceql",
                         "tableType": "traces"
                       },
@@ -19963,7 +18468,7 @@
           "description": "Requests that took longer than half a second. Read alongside `public_request_latency_seconds` in the HTTP row: the histogram says the tail exists, this says which routes and payloads are in it.",
           "id": 199,
           "links": [],
-          "title": "Slow traces (\u003e 500 ms)",
+          "title": "Slow traces (> 500 ms)",
           "vizConfig": {
             "group": "table",
             "kind": "VizConfig",
@@ -20024,7 +18529,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "limit": 50,
-                        "query": "{ resource.service.namespace = \"kura\" \u0026\u0026 resource.deployment.environment.name = \"$env\" \u0026\u0026 resource.service.name =~ \"^(${pod})$\"\n  \u0026\u0026 (status = error || span.http.response.status_code \u003e= 500) } with (most_recent=true)",
+                        "query": "{ resource.service.namespace = \"kura\" && resource.deployment.environment.name = \"$env\" && resource.service.name =~ \"^(${pod})$\"\n  && (status = error || span.http.response.status_code >= 500) } with (most_recent=true)",
                         "queryType": "traceql",
                         "tableType": "traces"
                       },
@@ -20102,7 +18607,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "limit": 50,
-                        "query": "{ resource.service.namespace = \"kura\" \u0026\u0026 resource.deployment.environment.name = \"$env\" \u0026\u0026 resource.service.name =~ \"^(${pod})$\"\n  \u0026\u0026 span.http.route =~ \"^/_internal/.*\" } with (most_recent=true)",
+                        "query": "{ resource.service.namespace = \"kura\" && resource.deployment.environment.name = \"$env\" && resource.service.name =~ \"^(${pod})$\"\n  && span.http.route =~ \"^/_internal/.*\" } with (most_recent=true)",
                         "queryType": "traceql",
                         "tableType": "traces"
                       },
@@ -20119,7 +18624,7 @@
           "description": "Mesh-internal traffic only (`/_internal/*`): peer replication applies, backfill listings and body fetches. This is the row to open when the outbox or backfill panels show work that is not draining.",
           "id": 201,
           "links": [],
-          "title": "Peer replication \u0026 backfill traces",
+          "title": "Peer replication & backfill traces",
           "vizConfig": {
             "group": "table",
             "kind": "VizConfig",
@@ -20260,7 +18765,7 @@
           "description": "Where the selected pods run (white markers, labelled by region) and how much public request traffic each region is taking (amber bubbles, sized and coloured by client req/s). Coordinates are the datacentre cities behind `Tuist.Kura.Regions`; a region with no mapped coordinates is left off the map and shows up only in the table beside it.",
           "id": 202,
           "links": [],
-          "title": "Node locations \u0026 request traffic",
+          "title": "Node locations & request traffic",
           "vizConfig": {
             "group": "geomap",
             "kind": "VizConfig",
@@ -21836,19 +20341,6 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-18"
-                        },
-                        "height": 7,
-                        "width": 8,
-                        "x": 0,
-                        "y": 14
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "element": {
-                          "kind": "ElementReference",
                           "name": "panel-19"
                         },
                         "height": 7,
@@ -21886,7 +20378,7 @@
                   ]
                 }
               },
-              "title": "HTTP, gRPC \u0026 request admission (10)"
+              "title": "HTTP, gRPC & request admission (10)"
             }
           },
           {
@@ -21921,32 +20413,6 @@
                         "width": 8,
                         "x": 8,
                         "y": 0
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-24"
-                        },
-                        "height": 7,
-                        "width": 8,
-                        "x": 16,
-                        "y": 0
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-25"
-                        },
-                        "height": 7,
-                        "width": 8,
-                        "x": 0,
-                        "y": 7
                       }
                     },
                     {
@@ -22056,7 +20522,7 @@
                   ]
                 }
               },
-              "title": "Artifact reads, writes \u0026 egress (12)"
+              "title": "Artifact reads, writes & egress (12)"
             }
           },
           {
@@ -22228,19 +20694,6 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-46"
-                        },
-                        "height": 7,
-                        "width": 8,
-                        "x": 0,
-                        "y": 28
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "element": {
-                          "kind": "ElementReference",
                           "name": "panel-47"
                         },
                         "height": 7,
@@ -22304,7 +20757,7 @@
                   ]
                 }
               },
-              "title": "Segment store, promotion \u0026 durability (18)"
+              "title": "Segment store, promotion & durability (18)"
             }
           },
           {
@@ -22391,19 +20844,6 @@
                         "width": 8,
                         "x": 16,
                         "y": 7
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-58"
-                        },
-                        "height": 7,
-                        "width": 8,
-                        "x": 0,
-                        "y": 14
                       }
                     },
                     {
@@ -22500,7 +20940,7 @@
                   ]
                 }
               },
-              "title": "Manifest index, manifest cache \u0026 snapshot cache (14)"
+              "title": "Manifest index, manifest cache & snapshot cache (14)"
             }
           },
           {
@@ -22855,19 +21295,6 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-89"
-                        },
-                        "height": 7,
-                        "width": 8,
-                        "x": 0,
-                        "y": 49
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "element": {
-                          "kind": "ElementReference",
                           "name": "panel-90"
                         },
                         "height": 7,
@@ -22879,7 +21306,7 @@
                   ]
                 }
               },
-              "title": "Memory pressure, admission \u0026 response-stream pool (20)"
+              "title": "Memory pressure, admission & response-stream pool (20)"
             }
           },
           {
@@ -23231,7 +21658,7 @@
                   ]
                 }
               },
-              "title": "Process, container cgroup \u0026 jemalloc memory (26)"
+              "title": "Process, container cgroup & jemalloc memory (26)"
             }
           },
           {
@@ -23286,19 +21713,6 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-120"
-                        },
-                        "height": 7,
-                        "width": 8,
-                        "x": 0,
-                        "y": 7
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "element": {
-                          "kind": "ElementReference",
                           "name": "panel-121"
                         },
                         "height": 7,
@@ -23325,19 +21739,6 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-123"
-                        },
-                        "height": 7,
-                        "width": 8,
-                        "x": 0,
-                        "y": 14
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "element": {
-                          "kind": "ElementReference",
                           "name": "panel-124"
                         },
                         "height": 7,
@@ -23349,7 +21750,7 @@
                   ]
                 }
               },
-              "title": "File descriptors \u0026 file operations (8)"
+              "title": "File descriptors & file operations (8)"
             }
           },
           {
@@ -23519,7 +21920,7 @@
                   ]
                 }
               },
-              "title": "Peer replication \u0026 outbox (12)"
+              "title": "Peer replication & outbox (12)"
             }
           },
           {
@@ -23872,7 +22273,7 @@
                   ]
                 }
               },
-              "title": "Membership, readiness \u0026 node identity (10)"
+              "title": "Membership, readiness & node identity (10)"
             }
           },
           {
@@ -23967,19 +22368,6 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-157"
-                        },
-                        "height": 7,
-                        "width": 8,
-                        "x": 0,
-                        "y": 0
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "element": {
-                          "kind": "ElementReference",
                           "name": "panel-158"
                         },
                         "height": 7,
@@ -24006,19 +22394,6 @@
                       "spec": {
                         "element": {
                           "kind": "ElementReference",
-                          "name": "panel-160"
-                        },
-                        "height": 7,
-                        "width": 8,
-                        "x": 0,
-                        "y": 7
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "element": {
-                          "kind": "ElementReference",
                           "name": "panel-161"
                         },
                         "height": 7,
@@ -24030,7 +22405,7 @@
                   ]
                 }
               },
-              "title": "Authentication \u0026 authorization (5)"
+              "title": "Authentication & authorization (5)"
             }
           },
           {
@@ -24051,19 +22426,6 @@
                         "height": 7,
                         "width": 8,
                         "x": 0,
-                        "y": 0
-                      }
-                    },
-                    {
-                      "kind": "GridLayoutItem",
-                      "spec": {
-                        "element": {
-                          "kind": "ElementReference",
-                          "name": "panel-163"
-                        },
-                        "height": 7,
-                        "width": 8,
-                        "x": 8,
                         "y": 0
                       }
                     },
@@ -24161,7 +22523,7 @@
                   ]
                 }
               },
-              "title": "Usage reporting \u0026 analytics (analytics webhook pipeline is unconfigured in hosted deployments) (9)"
+              "title": "Usage reporting & analytics (analytics webhook pipeline is unconfigured in hosted deployments) (9)"
             }
           },
           {
@@ -24318,7 +22680,7 @@
                   ]
                 }
               },
-              "title": "Kubernetes \u0026 cAdvisor (pod)"
+              "title": "Kubernetes & cAdvisor (pod)"
             }
           },
           {

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -151,6 +151,16 @@ k8s-monitoring:
           regex = "tuist-(staging|canary|pentest);.+_bucket"
           action = "drop"
         }
+        // Kura histograms whose buckets no dashboard or alert reads. Their
+        // cardinality is pod count x `le`, so it grows with every account
+        // admitted to a region. `_count` and `_sum` survive, and a pod's full
+        // distribution is readable on demand from
+        // /api/ops/kura/pods/:pod/metrics.
+        write_relabel_config {
+          source_labels = ["__name__"]
+          regex = "kura_(analytics_batch_duration_seconds|artifact_egress_duration_seconds|artifact_egress_throughput_bytes_per_second|artifact_write_size_bytes|auth_backend_request_duration_seconds|auth_decision_duration_seconds|file_descriptor_wait_seconds|file_operation_duration_seconds|internal_backfill_http_request_duration_seconds|manifest_index_rebuild_duration_seconds|response_stream_wait_duration_seconds|segment_refresh_duration_seconds)_bucket"
+          action = "drop"
+        }
 
     grafana-cloud-logs:
       type: loki

--- a/server/lib/tuist.ex
+++ b/server/lib/tuist.ex
@@ -72,6 +72,7 @@ defmodule Tuist do
       Kura.PlacementProposal,
       Kura.PlacementProposals,
       Kura.PlacerRegions,
+      Kura.PodMetrics,
       Kura.Provisioner,
       Kura.Provisioner.KubernetesController,
       Kura.Regions,

--- a/server/lib/tuist/kura/pod_metrics.ex
+++ b/server/lib/tuist/kura/pod_metrics.ex
@@ -1,0 +1,66 @@
+defmodule Tuist.Kura.PodMetrics do
+  @moduledoc """
+  Reads one cache pod's Prometheus exposition over the in-cluster network.
+
+  Pods are addressed through their StatefulSet's governing headless Service,
+  which publishes not-ready addresses, so a pod that has stopped serving is
+  still readable. The host is built from the `Server` row's
+  `provisioner_node_ref` rather than from the requested name.
+  """
+
+  alias Tuist.Kura.Server
+  alias Tuist.Repo
+
+  @namespace "kura"
+  @port 4000
+  @path "/metrics"
+  @receive_timeout to_timeout(second: 10)
+  @pod_name_format ~r/\A[a-z0-9][a-z0-9-]*-\d{1,3}\z/
+
+  @doc """
+  Fetches the exposition text for `pod_name`, a StatefulSet pod name of the
+  form `<provisioner_node_ref>-<ordinal>`.
+
+  Returns `{:ok, body}`, or `{:error, :invalid_pod_name}`,
+  `{:error, :not_found}` when no server owns the ref, or
+  `{:error, {:unreachable, reason}}` / `{:error, {:unexpected_status, status}}`.
+  """
+  def fetch(pod_name) when is_binary(pod_name) do
+    with {:ok, ref, ordinal} <- parse(pod_name),
+         {:ok, server} <- fetch_server(ref) do
+      get(url(server.provisioner_node_ref, ordinal))
+    end
+  end
+
+  defp parse(pod_name) do
+    if Regex.match?(@pod_name_format, pod_name) do
+      {ordinal, ref_parts} = pod_name |> String.split("-") |> List.pop_at(-1)
+
+      case Enum.join(ref_parts, "-") do
+        "" -> {:error, :invalid_pod_name}
+        ref -> {:ok, ref, String.to_integer(ordinal)}
+      end
+    else
+      {:error, :invalid_pod_name}
+    end
+  end
+
+  defp fetch_server(ref) do
+    case Repo.get_by(Server, provisioner_node_ref: ref) do
+      nil -> {:error, :not_found}
+      %Server{} = server -> {:ok, server}
+    end
+  end
+
+  defp url(ref, ordinal) do
+    "http://#{ref}-#{ordinal}.#{ref}-headless.#{@namespace}.svc.cluster.local:#{@port}#{@path}"
+  end
+
+  defp get(url) do
+    case Req.get(url, retry: false, receive_timeout: @receive_timeout) do
+      {:ok, %Req.Response{status: 200, body: body}} -> {:ok, body}
+      {:ok, %Req.Response{status: status}} -> {:error, {:unexpected_status, status}}
+      {:error, reason} -> {:error, {:unreachable, reason}}
+    end
+  end
+end

--- a/server/lib/tuist/kura/pod_metrics.ex
+++ b/server/lib/tuist/kura/pod_metrics.ex
@@ -8,6 +8,8 @@ defmodule Tuist.Kura.PodMetrics do
   `provisioner_node_ref` rather than from the requested name.
   """
 
+  import Ecto.Query
+
   alias Tuist.Kura.Server
   alias Tuist.Repo
 
@@ -46,7 +48,12 @@ defmodule Tuist.Kura.PodMetrics do
   end
 
   defp fetch_server(ref) do
-    case Repo.get_by(Server, provisioner_node_ref: ref) do
+    # `provisioner_node_ref` is unique only among servers that are not
+    # destroyed: teardown keeps the row and its ref, and recreating the same
+    # account and region derives the same ref again.
+    query = from(s in Server, where: s.provisioner_node_ref == ^ref and s.status != :destroyed)
+
+    case Repo.one(query) do
       nil -> {:error, :not_found}
       %Server{} = server -> {:ok, server}
     end

--- a/server/lib/tuist_web/controllers/ops_kura_metrics_controller.ex
+++ b/server/lib/tuist_web/controllers/ops_kura_metrics_controller.ex
@@ -1,0 +1,39 @@
+defmodule TuistWeb.OpsKuraMetricsController do
+  @moduledoc """
+  Serves one Kura cache pod's live Prometheus exposition to an operator.
+
+  Grafana Cloud stores the cache histograms aggregated by region, so the
+  per-pod distribution exists only on the pod. Responds with the exposition
+  verbatim as `text/plain`.
+  """
+  use TuistWeb, :controller
+
+  alias Tuist.Kura.PodMetrics
+
+  def show(conn, %{"pod" => pod}) do
+    case PodMetrics.fetch(pod) do
+      {:ok, body} ->
+        conn
+        |> put_resp_content_type("text/plain")
+        |> send_resp(:ok, body)
+
+      {:error, :invalid_pod_name} ->
+        error(conn, :bad_request, "#{pod} is not a Kura pod name of the form <instance>-<ordinal>.")
+
+      {:error, :not_found} ->
+        error(conn, :not_found, "No Kura server is registered for #{pod}.")
+
+      {:error, {:unexpected_status, status}} ->
+        error(conn, :bad_gateway, "#{pod} answered #{status} on its metrics endpoint.")
+
+      {:error, {:unreachable, _reason}} ->
+        error(conn, :bad_gateway, "#{pod} could not be reached in the cluster.")
+    end
+  end
+
+  defp error(conn, status, message) do
+    conn
+    |> put_status(status)
+    |> json(%{error: message})
+  end
+end

--- a/server/lib/tuist_web/router.ex
+++ b/server/lib/tuist_web/router.ex
@@ -251,6 +251,10 @@ defmodule TuistWeb.Router do
     plug ObservabilityContextPlug
   end
 
+  pipeline :ops_api do
+    plug TuistWeb.Authorization, [:current_user, :read, :ops]
+  end
+
   pipeline :scim_api do
     plug :put_request_kind, "scim"
     plug :accepts, ["scim+json", "json"]
@@ -477,6 +481,12 @@ defmodule TuistWeb.Router do
     pipe_through [:open_api]
 
     get "/api/kura/rollout-status", KuraRolloutStatusController, :show
+  end
+
+  scope "/", TuistWeb do
+    pipe_through [:open_api, :authenticated_api, :ops_api]
+
+    get "/api/ops/kura/pods/:pod/metrics", OpsKuraMetricsController, :show
   end
 
   scope "/", TuistWeb do

--- a/server/test/tuist/kura/pod_metrics_test.exs
+++ b/server/test/tuist/kura/pod_metrics_test.exs
@@ -1,0 +1,79 @@
+defmodule Tuist.Kura.PodMetricsTest do
+  use TuistTestSupport.Cases.DataCase, async: true
+  use Mimic
+
+  alias Tuist.Accounts
+  alias Tuist.Kura.PodMetrics
+  alias Tuist.Kura.Server
+  alias Tuist.Repo
+  alias TuistTestSupport.Fixtures.AccountsFixtures
+
+  setup do
+    user = AccountsFixtures.user_fixture()
+    account = Accounts.get_account_from_user(user)
+
+    {:ok, server} =
+      %Server{}
+      |> Server.create_changeset(%{
+        account_id: account.id,
+        region: "us-east",
+        provisioner_node_ref: "kura-acme-us-east-1"
+      })
+      |> Repo.insert()
+
+    %{server: server}
+  end
+
+  test "reads the pod through its headless service" do
+    expect(Req, :get, fn url, _opts ->
+      assert url ==
+               "http://kura-acme-us-east-1-1.kura-acme-us-east-1-headless.kura.svc.cluster.local:4000/metrics"
+
+      {:ok, %Req.Response{status: 200, body: "kura_http_requests_total 1\n"}}
+    end)
+
+    assert {:ok, "kura_http_requests_total 1\n"} = PodMetrics.fetch("kura-acme-us-east-1-1")
+  end
+
+  test "reads a multi-digit ordinal rather than folding it into the ref" do
+    expect(Req, :get, fn url, _opts ->
+      assert url =~ "http://kura-acme-us-east-1-12.kura-acme-us-east-1-headless."
+      {:ok, %Req.Response{status: 200, body: ""}}
+    end)
+
+    assert {:ok, ""} = PodMetrics.fetch("kura-acme-us-east-1-12")
+  end
+
+  test "rejects a name that cannot be a statefulset pod" do
+    reject(&Req.get/2)
+
+    assert {:error, :invalid_pod_name} = PodMetrics.fetch("kura-acme-us-east")
+    assert {:error, :invalid_pod_name} = PodMetrics.fetch("../../secrets-0")
+    assert {:error, :invalid_pod_name} = PodMetrics.fetch("evil.example.com-0")
+    assert {:error, :invalid_pod_name} = PodMetrics.fetch("kura-acme-us-east-1-1:9090/x")
+  end
+
+  test "refuses a ref that no server owns" do
+    reject(&Req.get/2)
+
+    assert {:error, :not_found} = PodMetrics.fetch("kura-other-us-east-1-0")
+  end
+
+  test "refuses an instance name, whose trailing segment is not an ordinal" do
+    reject(&Req.get/2)
+
+    assert {:error, :not_found} = PodMetrics.fetch("kura-acme-us-east-1")
+  end
+
+  test "reports an unreachable pod" do
+    expect(Req, :get, fn _url, _opts -> {:error, %Mint.TransportError{reason: :timeout}} end)
+
+    assert {:error, {:unreachable, _}} = PodMetrics.fetch("kura-acme-us-east-1-0")
+  end
+
+  test "reports an unexpected status" do
+    expect(Req, :get, fn _url, _opts -> {:ok, %Req.Response{status: 503, body: ""}} end)
+
+    assert {:error, {:unexpected_status, 503}} = PodMetrics.fetch("kura-acme-us-east-1-0")
+  end
+end

--- a/server/test/tuist/kura/pod_metrics_test.exs
+++ b/server/test/tuist/kura/pod_metrics_test.exs
@@ -65,6 +65,30 @@ defmodule Tuist.Kura.PodMetricsTest do
     assert {:error, :not_found} = PodMetrics.fetch("kura-acme-us-east-1")
   end
 
+  test "reads the live server when a destroyed one kept the same ref", %{server: server} do
+    {:ok, destroyed} =
+      server
+      |> Server.status_changeset(%{status: :destroying})
+      |> Repo.update()
+
+    {:ok, _} = destroyed |> Server.status_changeset(%{status: :destroyed}) |> Repo.update()
+
+    user = AccountsFixtures.user_fixture()
+
+    {:ok, _recreated} =
+      %Server{}
+      |> Server.create_changeset(%{
+        account_id: Accounts.get_account_from_user(user).id,
+        region: "us-east",
+        provisioner_node_ref: "kura-acme-us-east-1"
+      })
+      |> Repo.insert()
+
+    expect(Req, :get, fn _url, _opts -> {:ok, %Req.Response{status: 200, body: "ok\n"}} end)
+
+    assert {:ok, "ok\n"} = PodMetrics.fetch("kura-acme-us-east-1-0")
+  end
+
   test "reports an unreachable pod" do
     expect(Req, :get, fn _url, _opts -> {:error, %Mint.TransportError{reason: :timeout}} end)
 

--- a/server/test/tuist_web/controllers/ops_kura_metrics_controller_test.exs
+++ b/server/test/tuist_web/controllers/ops_kura_metrics_controller_test.exs
@@ -1,0 +1,78 @@
+defmodule TuistWeb.OpsKuraMetricsControllerTest do
+  use TuistTestSupport.Cases.ConnCase, async: true
+  use Mimic
+
+  alias Tuist.Accounts
+  alias Tuist.Kura.Server
+  alias Tuist.Repo
+  alias TuistTestSupport.Fixtures.AccountsFixtures
+
+  setup %{conn: conn} do
+    user = AccountsFixtures.user_fixture()
+    account = Accounts.get_account_from_user(user)
+
+    {:ok, _server} =
+      %Server{}
+      |> Server.create_changeset(%{
+        account_id: account.id,
+        region: "us-east",
+        provisioner_node_ref: "kura-acme-us-east-1"
+      })
+      |> Repo.insert()
+
+    %{conn: assign(conn, :current_user, user), user: user}
+  end
+
+  describe "GET /api/ops/kura/pods/:pod/metrics" do
+    test "returns the pod's exposition to an operator", %{conn: conn} do
+      stub(Accounts, :tuist_operator?, fn _ -> true end)
+
+      expect(Req, :get, fn _url, _opts ->
+        {:ok, %Req.Response{status: 200, body: "kura_http_requests_total 7\n"}}
+      end)
+
+      conn = get(conn, "/api/ops/kura/pods/kura-acme-us-east-1-1/metrics")
+
+      assert response(conn, 200) == "kura_http_requests_total 7\n"
+      assert response_content_type(conn, :text) =~ "text/plain"
+    end
+
+    test "refuses a user who is not an operator", %{conn: conn} do
+      stub(Accounts, :tuist_operator?, fn _ -> false end)
+      reject(&Req.get/2)
+
+      assert_raise TuistWeb.Errors.UnauthorizedError, fn ->
+        get(conn, "/api/ops/kura/pods/kura-acme-us-east-1-1/metrics")
+      end
+    end
+
+    test "refuses an unauthenticated request", %{conn: conn} do
+      reject(&Req.get/2)
+
+      conn =
+        conn
+        |> assign(:current_user, nil)
+        |> get("/api/ops/kura/pods/kura-acme-us-east-1-1/metrics")
+
+      assert conn.status in [401, 403]
+    end
+
+    test "404s a pod no server owns", %{conn: conn} do
+      stub(Accounts, :tuist_operator?, fn _ -> true end)
+      reject(&Req.get/2)
+
+      conn = get(conn, "/api/ops/kura/pods/kura-other-us-east-1-0/metrics")
+
+      assert json_response(conn, 404)["error"] =~ "No Kura server is registered"
+    end
+
+    test "502s a pod that cannot be reached", %{conn: conn} do
+      stub(Accounts, :tuist_operator?, fn _ -> true end)
+      expect(Req, :get, fn _url, _opts -> {:error, %Mint.TransportError{reason: :timeout}} end)
+
+      conn = get(conn, "/api/ops/kura/pods/kura-acme-us-east-1-0/metrics")
+
+      assert json_response(conn, 502)["error"] =~ "could not be reached"
+    end
+  end
+end


### PR DESCRIPTION
Cuts the fastest growing line in the Grafana Cloud metrics bill, and adds the on-demand path that makes the cut safe.

There is no issue for this; it came out of triaging a Grafana Cloud "Anomaly: Metrics Usage" alert.

### Why

The alert was explained growth rather than a runaway, but it surfaced a real scaling problem. Production's `kura` namespace went from 12,606 active series to 40,528 in a week, as the fleet grew from 23 instances to 53 once a region gained capacity and a backlog of admission blocked accounts was let in. 17,545 of those series are histogram buckets.

Kura bucket cardinality is pod count multiplied by a 17 step `le` ladder, so it grows with every account admitted to a region. At roughly 750 series per two replica instance it works out near $6 per tenant per month in observability alone, and the fleet is expected to grow again.

### What changed

**Drop the buckets nothing reads.** I audited all 24 Kura alert rules and all 8 in-repo Kura dashboards against every `kura_*_bucket` family. Twelve are read by no alert at all, and their only dashboard consumer was a p50/p95/p99 panel on the per-pod details dashboard. Those are now dropped at remote_write.

Two families that look droppable are not, and are kept: `public_request_latency` backs the region latency alert, and `segment_shed_age` backs the retention alert per pod. The alert on `public_request_latency` is easy to misread as per-pod; it groups `by (cluster, pod, le)` only to join `kura:pod_region`, then collapses to region. `http_request_duration` and `replication_request_duration` are kept for the main Kura dashboard.

`_count` and `_sum` survive, so request rates and mean latency still work per pod for every family. Only the bucket shape goes.

**Add an ops endpoint so per-pod detail stays reachable.** `GET /api/ops/kura/pods/:pod/metrics` returns one cache pod's full Prometheus exposition verbatim as `text/plain` to an authenticated operator.

It was needed because nothing else works. Measured against production and staging: `kubectl exec` and `port-forward` lose their connection upgrade at the kubectl gateway; `pods/proxy` is RBAC denied on production; and on staging, where the verb is granted, the apiserver's dial times out instead, because each per-instance NetworkPolicy admits port 4000 only from cluster pods and from the Private Network block, and the apiserver proxies from the control plane host network. Widening that NetworkPolicy so the apiserver can reach a customer facing cache is the wrong trade. The server is already on the allowed path: it runs as a pod, and `Tuist.Kura.Regions` already carries the in-cluster address form.

### Things a reviewer should know

**Aggregating the `pod` label away was the first design and does not work.** Two replicas would then write identical label sets and collide on ingest. Aggregation of that shape belongs to Adaptive Metrics, which is a runtime rule rather than chart config, and its recommendations are query driven so it will not propose it for metrics a dashboard reads by those labels. Dropping the buckets outright is the in-repo equivalent.

**The details dashboard is trimmed, not deleted.** My first plan was to delete it. Counting first showed only 33 of its 255 queries read a dropped bucket; the other 222 are counters and gauges that still work and still resolve per pod. Deleting it would have thrown away the per-pod view this reduction depends on having. The 11 affected panels are removed and each row's grid is reflowed so nothing leaves a vertical gap.

**The endpoint addresses the governing headless Service, not the primary Service.** The primary HTTP Service deliberately pins to a single pod through `statefulset.kubernetes.io/pod-name` so steady state reads are read your writes consistent, which means it cannot name a replica. The headless Service can, and it sets `publishNotReadyAddresses: true`, so a pod that has stopped serving is still readable. That is the case worth reading.

**The endpoint builds its host from the database, never from the request,** using the `Server` row's `provisioner_node_ref`, so a path parameter cannot steer the fetch at an arbitrary host. Pod names split on the last hyphen rather than through a greedy regex, which would read a two digit ordinal as its first digit.

### Not included, deliberately

The shared bucket ladder, `exponential_buckets(0.001, 2.0, 16)` repeated 13 times in `kura/src/metrics.rs`, is mis-cut and worth fixing on its own. Measured over 6h in production, 83.5% of `http_request_duration` and 72.7% of `public_request_latency` observations land in the first bucket at or below 1ms, while the top four buckets from 4.1s to 32.8s hold under 0.1%. `histogram_quantile(0.5, ...)` therefore interpolates inside the bucket holding most of the mass, so the p50 panels are not measuring what they claim.

Re-cutting it is worth about $28/month against the $75 here, but it changes the p95 the region latency alert computes against its threshold, introduces a one-time histogram discontinuity, and lives in a separately released service. That belongs in its own `feat(kura)` change rather than bundled here.

### Deploy ordering

Review raised this and it is correct: within a single deploy these two do not land in the order the change wants. `observability-install` is a dependency of the server rollout in `server-deployment.yml`, so the drop rule takes effect minutes before the endpoint serving its replacement does, and a failed server rollout extends that window.

The exposure is smaller than the ordering suggests, because the twelve dropped families are read by no alert. Nothing that pages goes blind in that window; what is unavailable is ad-hoc per-pod quantiles for metrics that were already unread, which is why they are being dropped. My earlier claim in the second commit message that there is "never a window" is wrong, and this section is the correction.

To close it completely, merge and deploy `feat(server): serve a Kura pod's live metrics to operators` on its own first, then the drop commit. Both are on this branch in that order and neither depends on the other at compile time.

### Impact

9,306 fewer active series in production, 10,547 across all clusters, about $75/month at the measured rate, and the share of Kura bucket cardinality that scales with tenant count drops with it. Operators and agents gain a way to read a single pod's full fidelity histograms on demand, including from a pod that is wedged and no longer serving.

### How to test locally

Run the new server tests:

```bash
cd server && mix test test/tuist/kura/pod_metrics_test.exs test/tuist_web/controllers/ops_kura_metrics_controller_test.exs
```

12 tests cover URL construction, multi digit ordinals, name rejection including traversal and host shaped input, unknown refs, transport and status failures, and the operator, non operator and unauthenticated paths. `mix credo` is clean on both new modules.

Confirm the drop rule renders into the metrics destination:

```bash
cd infra/helm/k8s-monitoring && helm dependency build && helm template k8s-monitoring . -f values.yaml -f values-production.yaml | grep -c 'kura_(analytics_batch'
```

Confirm the trimmed dashboard is structurally intact:

```bash
python3 -c "import json;d=json.load(open('infra/grafana-dashboards/tuist-kura-details.json'));els=set(d['spec']['elements']);refs={i['spec']['element']['name'] for r in d['spec']['layout']['spec']['rows'] for i in r['spec']['layout']['spec']['items']};print('dangling',refs-els,'orphans',len(els-refs))"
```

The endpoint itself only resolves in cluster, since the address is Kubernetes Service DNS. Exercising it end to end means calling it against a deployed environment as an operator:

```bash
curl -H "Authorization: Bearer $TOKEN" https://<host>/api/ops/kura/pods/<instance>-<ordinal>/metrics
```

