### PR TITLE
fix(hetzner-robot-controller): pin the mgmt cluster to 0.2.0

### DIFF
--- a/infra/k8s/mgmt/hetzner-robot-controller.yaml
+++ b/infra/k8s/mgmt/hetzner-robot-controller.yaml
@@ -136,7 +136,7 @@ spec:
           # this line, so bump it by hand to the released version.
           # `hetzner-robot-controller-image.yml` only builds
           # `:sha-*`/`:latest` for pre-release iteration.
-          image: ghcr.io/tuist/tuist-hetzner-robot-controller:0.1.0
+          image: ghcr.io/tuist/tuist-hetzner-robot-controller:0.2.0
           imagePullPolicy: IfNotPresent
           args:
             - --leader-elect=true


### PR DESCRIPTION
## What changed

One line: the mgmt-cluster Deployment now pins `ghcr.io/tuist/tuist-hetzner-robot-controller:0.2.0` instead of `0.1.0`.

## Why

`0.2.0` carries the WWN filler's four-disk fix, released today by [#12955](https://github.com/tuist/tuist/pull/12955) and published to ghcr at 15:57 (verified present in the registry, tagged `0.2.0` and `latest`).

The mgmt cluster has been running `0.1.0` since that tag was cut. Its `WWNFillReconciler` promotes only the first two discovered WWNs into `spec.rootDeviceHints.raid.wwn`, which was correct while every box we owned was an AX-class pair. On a four-disk host it installs across two disks and leaves the other two out of the array, silently. The partition layout is fixed at the first rescue boot, so the only way back is a reinstall.

That is the gate on the ClickHouse migration's next hardware step. Production's box is an EX131-2-LTD with four NVMe at RAID 10, and `hetzner-robot-controller` only sees a Robot server once it is named `tuist-bm-*`. So the rename is what triggers the install, and it must not happen before this is deployed.

## Why by hand rather than via Renovate

`renovate.json` does manage this line: a `custom.regex` manager matches the image on `infra/k8s/mgmt/hetzner-robot-controller.yaml`, with `automerge: true`. But the global `schedule` is `["before 6am on monday"]`, and `0.2.0` was published at 15:57 on Monday, after this week's window closed. Left alone, the bump PR would appear next Monday.

## Impact

Merging triggers `mgmt-cluster-apply.yml`, whose path filter includes this manifest, which rolls the controller Deployment on the mgmt cluster. That controller reconciles Robot inventory into `HetznerBareMetalHost` CRs and fills WWNs; it does not touch running nodes, and no host is currently mid-install, so the rollout is a restart of a single Deployment.

This file is not under `infra/hetzner-robot-controller/`, so it is outside that component's `include_paths` and this change cuts no further release.

## Worth a second opinion

The comment above the pin says "Nothing rewrites this line, so bump it by hand to the released version." That contradicts the Renovate manager described above. It was written in [#12655](https://github.com/tuist/tuist/pull/12655), which corrected an older and by-then-wrong claim that a `bump-chart-image-pins` step owned the line, and it landed *after* the Renovate manager was added in [#11160](https://github.com/tuist/tuist/pull/11160).

Since `0.1.0` was the only release until today, Renovate has never had a bump to open here, so neither claim has been exercised. I have left the comment alone rather than guess which is stale. If Renovate does open its own PR next Monday it will be a no-op against this, and that will settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
