### PR TITLE
feat(infra): pin the ClickHouse volume to a host and enable the workload on canary

### DIFF
--- a/infra/helm/tuist/templates/clickhouse-managed.yaml
+++ b/infra/helm/tuist/templates/clickhouse-managed.yaml
@@ -239,6 +239,9 @@ data:
       </prometheus>
     </clickhouse>
 {{- if $m.persistence.localVolume.enabled }}
+{{- if not $m.persistence.localVolume.nodeName }}
+{{- fail "clickhouse.managed.persistence.localVolume.nodeName is required: without it the volume binds on the pool label, and on a pool with more than one node the ClickHouse pod can be scheduled onto a host that does not hold the data." }}
+{{- end }}
 ---
 {{- /*
 A `local` PersistentVolume rather than the local-path provisioner the Kura
@@ -249,11 +252,17 @@ retention. A static volume also fails visibly. If the node is gone the claim
 stays Pending, instead of a provisioner quietly carving a directory somewhere
 else.
 
-Node affinity binds on the pool label rather than a node name, so replacing
-the box does not need a manifest edit. The data does not survive that
-replacement: reinstalling a Robot host wipes `/data`, and the replica refills
-from its peer. On a single-replica staging there is no peer, so a node
-replacement means re-running the schema bootstrap and backfill.
+Node affinity binds on a single node's `kubernetes.io/hostname`, not on the
+pool label. The pool label was safe only while a pool held one node; with two,
+one volume whose affinity admits both lets the scheduler place the pod on the
+node that does not hold the data, and ClickHouse starts on an empty directory
+under a replica identity Keeper already knows.
+
+The data does not survive replacing the box: reinstalling a Robot host wipes
+`/data`, and the replica refills from its peer. On a single-replica
+environment there is no peer, so a node replacement means re-running the
+schema bootstrap and backfill, and updating `persistence.localVolume.nodeName`
+in the same change.
 */}}
 apiVersion: v1
 kind: PersistentVolume
@@ -288,10 +297,10 @@ spec:
     required:
       nodeSelectorTerms:
         - matchExpressions:
-            - key: node.cluster.x-k8s.io/pool
+            - key: kubernetes.io/hostname
               operator: In
               values:
-                - {{ $m.nodePool }}
+                - {{ $m.persistence.localVolume.nodeName }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -250,32 +250,35 @@ objectStorage:
       default: tuist-can-storage
 
 clickhouse:
-  # The in-cluster ClickHouse (spec #73). Off until the machines exist: with
-  # `enabled: true` and no node in the `clickhouse` pool the StatefulSet's pods
-  # and their volume stay Pending and `helm --wait` fails the deploy.
+  # The in-cluster ClickHouse (spec #73). On: both AX42-1 are installed and
+  # Ready in the `clickhouse` pool, each with `/data` as XFS on its 2x512 GB
+  # mirror.
   #
-  # Turning it on is step 2 of the rollout plan in the pull request, and the
-  # steps after it are `shadowWrites.enabled`, then `migration` with the
-  # backfill in the background, then the read flag. Each is its own deploy, and
-  # each has a gate.
+  # This is step 2 of the rollout plan, and it brings the server up empty and
+  # nothing more. The steps after it are the schema clone, then
+  # `shadowWrites.enabled`, then `migration` with the backfill in the
+  # background, then the read flag. Each is its own deploy, and each has a
+  # gate.
   managed:
-    enabled: false
+    enabled: true
     # Canary carries no production-sized copy: its AX42-1 has a 2x512 GB
     # mirror, so this is sized for the environment's own data. What canary is
     # for is the shape production will run — a second replica and a
     # three-member quorum, neither of which staging exercises.
     #
-    # Both are still 1 here, because two replicas need a volume per replica and
-    # a database initialised on each of them, and neither exists yet. Raise
-    # them together once they do.
-    #
-    # The volume per replica is what gates `enabled: true` above, not just this
-    # count: the pool is two nodes and the local PersistentVolume binds on the
-    # pool label rather than a node name, so even one pod can be scheduled onto
-    # the node that does not hold the data.
+    # Both are still 1. Two replicas need a database initialised on each of
+    # them, which the init Job does not do: it reaches whichever pod the
+    # Service picks. The volume half is solved, by `nodeName` below, so raising
+    # these is now gated on the init alone.
     replicas: 1
     persistence:
       size: 200Gi
+      localVolume:
+        # The pool has two nodes, so this names which one holds the data. See
+        # the `nodeName` comment in values.yaml for why it is a hostname and
+        # not the pool label. The second box is joined, tainted and idle until
+        # the two-replica work lands.
+        nodeName: bm-tuist-canary-md-clickhouse-zxbdh-hkgcf-nlxk4
     keeper:
       replicas: 1
     backup:

--- a/infra/helm/tuist/values-managed-staging.yaml
+++ b/infra/helm/tuist/values-managed-staging.yaml
@@ -338,6 +338,12 @@ clickhouse:
     enabled: true
     persistence:
       size: 60Gi
+      localVolume:
+        # Staging's pool is one node, so this changes nothing here today. It is
+        # required rather than optional because the pool-label binding it
+        # replaces is safe only at one node, and an environment that grew a
+        # second one would otherwise regress silently.
+        nodeName: bm-tuist-staging-md-clickhouse-7mhfx-zzxjb-5nhg8
     # Dual writes come before the backfill, not after it. From the moment this
     # is on, every new row reaches both servers; the backfill then copies what
     # was written before a stated cutoff. Doing it the other way round leaves

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -3072,6 +3072,23 @@ clickhouse:
         # A directory on the stateful node's XFS `/data`, which is the
         # filesystem the `stateful-worker` class carves for exactly this.
         path: /data/clickhouse
+        # The node holding that directory, as `kubernetes.io/hostname`.
+        # Required whenever the managed workload is enabled, and the chart
+        # refuses to render without it.
+        #
+        # This used to bind on the pool label instead, which is safe only
+        # while the pool has exactly one node. With two, one volume and a
+        # pool-wide affinity let the scheduler place the pod on the node that
+        # does not hold the data: ClickHouse then starts on an empty
+        # directory under a replica identity Keeper already knows.
+        #
+        # There is no stable per-host label to use instead. These nodes carry
+        # only `kubernetes.io/hostname`, which CAPI generates, so replacing a
+        # box means editing this. That is the right cost: reinstalling a Robot
+        # host wipes `/data`, so a replacement is already a manual
+        # re-bootstrap of that replica, and a stale name here leaves the claim
+        # Pending rather than quietly binding somewhere empty.
+        nodeName: ""
     keeper:
       # One member is not a quorum and cannot tolerate a loss. It is the right
       # shape for staging, whose job is to exercise the replicated engines and


### PR DESCRIPTION
## What changed

- The managed ClickHouse `local` PersistentVolume now binds its node affinity on `kubernetes.io/hostname`, taken from a new required `clickhouse.managed.persistence.localVolume.nodeName`, instead of on `node.cluster.x-k8s.io/pool`. The chart fails to render without it.
- Staging and canary set their node name. Staging's behaviour is unchanged; canary's is what makes enabling possible.
- Canary sets `clickhouse.managed.enabled: true`.

## Why

Pool-label affinity is safe only while a pool holds exactly one node, which was true of staging when this was written. Canary's `md-clickhouse` pool is two nodes, both installed and Ready since the hardware landed.

With one volume whose affinity admits both nodes, nothing stops the scheduler placing the pod on the node that does not hold the data. ClickHouse then starts on an empty `/data/clickhouse` under a replica identity Keeper already knows about, at one replica just as much as at two. So this was not a two-replica problem: it blocked enabling canary at all.

## Why not the local-path provisioner

That was the obvious alternative, and the one this PR's author recommended before checking what it actually is. The provisioner running on canary is Kura's, and it is unusable for a database on three counts:

- `reclaimPolicy: Delete`, because "cache volumes are disposable". A PVC deletion would take the ClickHouse data with it. This chart deliberately uses `Retain` plus `helm.sh/resource-policy: keep`.
- Its `nodePathMap` carves under `/opt/local-path-provisioner`, which is the 67 GB ext4 root, not the 441.7 GB XFS `/data` that the `stateful-worker` class exists to provide. A 200Gi claim would land on the root filesystem.
- Its provisioning hooks apply XFS project quotas sized from each PVC, which is its per-account carving model and not something a single database directory wants.

A ClickHouse-specific provisioner instance would fix all three, at the cost of roughly 150 lines of new privileged infrastructure modelled on `kura-fleet-storage.yaml`, landing directly ahead of the production cutover. Deferred deliberately.

## Why a hostname, given CAPI generates it

It is the only stable handle these nodes offer. They carry exactly two useful labels, `kubernetes.io/hostname` and `node.cluster.x-k8s.io/pool`, so there is no per-host identity to bind to that survives a machine replacement.

That cost is the right one to pay. Reinstalling a Robot host wipes `/data`, so replacing a box is already a manual re-bootstrap of that replica rather than a transparent swap, and editing one value belongs in that same change. A stale name also fails the way the original design wanted: the claim stays Pending instead of quietly binding somewhere empty.

The `fail` guard matters for the same reason. Falling back to the pool label when `nodeName` is unset would reintroduce silent data loss on exactly the environments that grow a second node.

## Scope

This is step 2 of the rollout plan and brings canary's server up empty. It does not clone the schema, turn on dual writes, backfill, or move reads; each of those is a separate deploy with its own gate.

Replicas stay at 1. The second box is joined, tainted and idle. Raising it is now gated only on initialising the database on each replica, which the init Job cannot do today because it reaches whichever pod the Service picks. The volume half of that blocker is what this PR removes.

## Validation

Rendered all three environments the way the deploy actually does, with `values-managed-common.yaml` followed by the per-env overlay:

| | Result |
|---|---|
| staging | PV pinned to `bm-tuist-staging-md-clickhouse-7mhfx-zzxjb-5nhg8` |
| canary | PV pinned to `bm-tuist-canary-md-clickhouse-zxbdh-hkgcf-nlxk4` |
| production | no managed ClickHouse rendered at all, `enabled: false` |
| canary with `nodeName=""` | render fails with the reason |

All four workloads that write to ClickHouse carry `TUIST_CLICKHOUSE_BARE_METAL_URL` on staging and canary: `server-deployment`, `server-migration-job`, `processor-deployment` and `xcresult-processor-deployment`. Checked that production would too, by rendering it with `managed.enabled=true`, so the mirror will not miss rows parsed out of an xcresult when it is enabled there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
