### PR TITLE
feat(gradle): make Kura cache routing the default

### DIFF
--- a/gradle/src/main/kotlin/dev/tuist/gradle/FeatureFlagsHeaders.kt
+++ b/gradle/src/main/kotlin/dev/tuist/gradle/FeatureFlagsHeaders.kt
@@ -6,13 +6,21 @@ object FeatureFlagsHeaders {
     const val HEADER_NAME = "x-tuist-feature-flags"
     private const val ENVIRONMENT_PREFIX = "TUIST_FEATURE_FLAG_"
 
-    fun headerValue(environmentVariables: Map<String, String>): String? {
-        val featureFlags = TreeSet<String>()
+    /** Feature flags that are on unless a `TUIST_FEATURE_FLAG_<NAME>` variable turns them off. */
+    private val DEFAULT_ENABLED = setOf("KURA")
 
-        environmentVariables.forEach { (name, _) ->
-            val featureName = name.removePrefix(ENVIRONMENT_PREFIX)
-            if (name.startsWith(ENVIRONMENT_PREFIX) && featureName.isNotEmpty()) {
+    private val DISABLING_VALUES = setOf("", "0", "false", "no", "off")
+
+    fun headerValue(environmentVariables: Map<String, String>): String? {
+        val featureFlags = TreeSet(DEFAULT_ENABLED)
+
+        environmentVariables.forEach { (name, value) ->
+            val featureName = featureName(name) ?: return@forEach
+
+            if (isEnabling(value)) {
                 featureFlags.add(featureName)
+            } else {
+                featureFlags.remove(featureName)
             }
         }
 
@@ -20,4 +28,13 @@ object FeatureFlagsHeaders {
 
         return featureFlags.joinToString(",")
     }
+
+    private fun featureName(variableName: String): String? {
+        if (!variableName.startsWith(ENVIRONMENT_PREFIX)) return null
+
+        val featureName = variableName.removePrefix(ENVIRONMENT_PREFIX)
+        return if (featureName.isEmpty()) null else featureName.uppercase()
+    }
+
+    private fun isEnabling(value: String): Boolean = value.trim().lowercase() !in DISABLING_VALUES
 }

--- a/gradle/src/test/kotlin/dev/tuist/gradle/FeatureFlagsHeadersTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/FeatureFlagsHeadersTest.kt
@@ -1,0 +1,66 @@
+package dev.tuist.gradle
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class FeatureFlagsHeadersTest {
+
+    @Test
+    fun `carries the default enabled flags when no variable is set`() {
+        assertEquals("KURA", FeatureFlagsHeaders.headerValue(emptyMap()))
+    }
+
+    @Test
+    fun `carries the default enabled flags when no flag variable is set`() {
+        assertEquals("KURA", FeatureFlagsHeaders.headerValue(mapOf("TUIST_TOKEN" to "token")))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["0", "false", "FALSE", "no", "off", "", " 0 "])
+    fun `a falsey value disables a default enabled flag`(value: String) {
+        assertNull(FeatureFlagsHeaders.headerValue(mapOf("TUIST_FEATURE_FLAG_KURA" to value)))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["1", "true", "yes", "enabled"])
+    fun `a truthy value enables a flag`(value: String) {
+        assertEquals("A,KURA", FeatureFlagsHeaders.headerValue(mapOf("TUIST_FEATURE_FLAG_A" to value)))
+    }
+
+    @Test
+    fun `a falsey value disables a flag declared in lowercase`() {
+        assertNull(FeatureFlagsHeaders.headerValue(mapOf("TUIST_FEATURE_FLAG_kura" to "0")))
+    }
+
+    @Test
+    fun `encodes feature flags as a sorted comma separated list`() {
+        val headerValue = FeatureFlagsHeaders.headerValue(
+            mapOf(
+                "TUIST_FEATURE_FLAG_B" to "1",
+                "TUIST_FEATURE_FLAG_A" to "1"
+            )
+        )
+
+        assertEquals("A,B,KURA", headerValue)
+    }
+
+    @Test
+    fun `a falsey value disables only the flag it names`() {
+        val headerValue = FeatureFlagsHeaders.headerValue(
+            mapOf(
+                "TUIST_FEATURE_FLAG_KURA" to "0",
+                "TUIST_FEATURE_FLAG_A" to "1"
+            )
+        )
+
+        assertEquals("A", headerValue)
+    }
+
+    @Test
+    fun `ignores a variable that names no flag`() {
+        assertEquals("KURA", FeatureFlagsHeaders.headerValue(mapOf("TUIST_FEATURE_FLAG_" to "1")))
+    }
+}

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistHttpClientTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistHttpClientTest.kt
@@ -76,7 +76,7 @@ class TuistHttpClientTest {
         }
 
         val request = mockWebServer.takeRequest()
-        assertEquals("A", request.getHeader(FeatureFlagsHeaders.HEADER_NAME))
+        assertEquals("A,KURA", request.getHeader(FeatureFlagsHeaders.HEADER_NAME))
     }
 
     @Test

--- a/gradle/src/test/kotlin/dev/tuist/gradle/TuistHttpClientsTest.kt
+++ b/gradle/src/test/kotlin/dev/tuist/gradle/TuistHttpClientsTest.kt
@@ -83,15 +83,31 @@ class TuistHttpClientsTest {
         api.refreshToken(RefreshTokenBody("any")).execute()
 
         val request = server.takeRequest()
-        assertEquals("A,B", request.getHeader(FeatureFlagsHeaders.HEADER_NAME))
+        assertEquals("A,B,KURA", request.getHeader(FeatureFlagsHeaders.HEADER_NAME))
     }
 
     @Test
-    fun `retrofit clients skip client feature flags header when absent`() {
+    fun `retrofit clients send the default feature flags when no flag variable is set`() {
         server.enqueue(MockResponse().setResponseCode(200).setBody("""{"access_token":"at","refresh_token":"rt"}"""))
 
         val httpClients = TuistHttpClients(
             environmentVariables = mapOf("TUIST_TOKEN" to "token")
+        )
+        val api = httpClients.unauthenticatedRetrofit(URI(server.url("/").toString().trimEnd('/')))
+            .create(AuthenticationApi::class.java)
+
+        api.refreshToken(RefreshTokenBody("any")).execute()
+
+        val request = server.takeRequest()
+        assertEquals("KURA", request.getHeader(FeatureFlagsHeaders.HEADER_NAME))
+    }
+
+    @Test
+    fun `retrofit clients skip client feature flags header when every flag is disabled`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"access_token":"at","refresh_token":"rt"}"""))
+
+        val httpClients = TuistHttpClients(
+            environmentVariables = mapOf("TUIST_FEATURE_FLAG_KURA" to "0")
         )
         val api = httpClients.unauthenticatedRetrofit(URI(server.url("/").toString().trimEnd('/')))
             .create(AuthenticationApi::class.java)


### PR DESCRIPTION
Kura became opt-out in the Tuist CLI in [#12760](https://github.com/tuist/tuist/pull/12760), but that change landed only in `cli/`. This brings the Gradle plugin to the same behavior.

### What changed

`FeatureFlagsHeaders` gains the two halves of the CLI's `ClientFeatureFlags`:

- A `DEFAULT_ENABLED` set seeding `KURA`, so the plugin sends the flag with no configuration.
- A `DISABLING_VALUES` set (`""`, `"0"`, `"false"`, `"no"`, `"off"`, compared after trimming and lowercasing) so a variable can remove a flag rather than only add one.

Feature names are also upcased on the way in, matching the CLI.

### Why

Both clients drive the same server switch. `TuistWeb.API.CacheController` picks the `:kura` lane over `:default` purely from whether `x-tuist-feature-flags` carries `kura`. The Gradle plugin has sent that header since [#10382](https://github.com/tuist/tuist/pull/10382), but built it solely from the environment, so Gradle builds stayed on the default lane unless someone exported `TUIST_FEATURE_FLAG_KURA` by hand.

### Root cause of the opt-out being unavailable

Seeding `KURA` on its own would have produced a flag nothing could turn off. The header builder iterated environment variables as `forEach { (name, _) -> ... }`, keying off a variable's presence and discarding its value, so `TUIST_FEATURE_FLAG_KURA=0` enabled Kura rather than disabling it. That was already a latent bug while the flag was opt-in. It becomes load-bearing the moment the flag is on by default, which is why the value semantics ship in the same change rather than as a follow-up.

The upcasing is load-bearing for the same reason, and is not cosmetic alignment with the CLI. Without it, a lowercase `TUIST_FEATURE_FLAG_kura=0` would sit beside the seeded `KURA` rather than cancelling it, leaving a second way to think you had opted out while still being routed to Kura. The server upcases on receipt, so this had no visible effect before the default existed.

### Impact

Gradle consumers reach the Kura lane on their next build after picking up the release, with no configuration. Stepping back to the default lane means setting `TUIST_FEATURE_FLAG_KURA` to any of `0`, `false`, `no`, `off`, or empty.

Worth flagging for release timing: this flips which cache lane every existing Gradle consumer hits. The lane itself is proven, since the CLI has been defaulting to it since [#12760](https://github.com/tuist/tuist/pull/12760), but the flip may deserve a deliberate release rather than riding along in an unrelated one.

`TUIST_FEATURE_FLAG_KURA` is currently documented nowhere in the repository. That was tolerable while the flag was opt-in. Now that it is the only way back to the default lane, it likely deserves a line in the Gradle documentation, left out of this PR as a separate call about where it belongs.

### Test changes

Two existing assertions were updated for the seeded flag. The case named `retrofit clients skip client feature flags header when absent` no longer had a scenario, because with a default the header is always present unless something disables it, so it was rewritten to cover a build that disables every flag, and a separate test now covers the plain default.

New `FeatureFlagsHeadersTest` covers the default, each disabling value, truthy values, the lowercase opt-out, sorted comma separated encoding, disabling only the flag a variable names, and a bare prefix that names no flag.

### How to test locally

Run the plugin suite from `gradle/`:

```
./gradlew test
```

This ran green in full: 206 tests across 24 classes, no failures and none skipped, confirmed from the JUnit XML in `build/test-results/test/` rather than the task's exit status alone. CI for this directory runs the same `./gradlew test` and there is no ktlint, detekt, or spotless configured.

To check the routing by hand, run a Gradle build against a Tuist project and confirm the request to the cache endpoints API carries `x-tuist-feature-flags: KURA`, then run it again with `TUIST_FEATURE_FLAG_KURA=0` and confirm the header is gone and the server serves the default lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
