### PR TITLE
fix(server): render a :correct Kura placement proposal on the ops account page

### DIFF
--- a/server/lib/tuist_web/live/ops_account_live.ex
+++ b/server/lib/tuist_web/live/ops_account_live.ex
@@ -926,6 +926,28 @@ defmodule TuistWeb.OpsAccountLive do
     )
   end
 
+  defp placement_proposal_summary(%{kind: :relocate} = proposal) do
+    dgettext("dashboard", "Placement proposes moving this account from %{from} to %{to}.",
+      from: proposal.from_region,
+      to: proposal.to_region
+    )
+  end
+
+  defp placement_proposal_summary(%{kind: :correct} = proposal) do
+    dgettext("dashboard", "Placement proposes moving this account off its first region, %{from}, to %{to}.",
+      from: proposal.from_region,
+      to: proposal.to_region
+    )
+  end
+
+  defp placement_proposal_summary(%{kind: :expand} = proposal) do
+    dgettext("dashboard", "Placement proposes also serving this account from %{to}.", to: proposal.to_region)
+  end
+
+  defp placement_proposal_summary(%{kind: :retire} = proposal) do
+    dgettext("dashboard", "Placement proposes giving up %{from} for this account.", from: proposal.from_region)
+  end
+
   # What the apply actually did, rather than "saved". Nothing moves at the
   # moment a proposal is applied: the lifecycle provisions the destination on
   # the account's next demand, and the source leaves only once it is serving.

--- a/server/lib/tuist_web/live/ops_account_live.html.heex
+++ b/server/lib/tuist_web/live/ops_account_live.html.heex
@@ -144,25 +144,7 @@
     </.card_section>
     <.card_section :if={@kura_placement_proposal}>
       <p data-part="kura-placement-proposal-summary">
-        {case @kura_placement_proposal.kind do
-          :relocate ->
-            dgettext(
-              "dashboard",
-              "Placement proposes moving this account from %{from} to %{to}.",
-              from: @kura_placement_proposal.from_region,
-              to: @kura_placement_proposal.to_region
-            )
-
-          :expand ->
-            dgettext("dashboard", "Placement proposes also serving this account from %{to}.",
-              to: @kura_placement_proposal.to_region
-            )
-
-          :retire ->
-            dgettext("dashboard", "Placement proposes giving up %{from} for this account.",
-              from: @kura_placement_proposal.from_region
-            )
-        end}
+        {placement_proposal_summary(@kura_placement_proposal)}
       </p>
       <p data-part="kura-placement-proposal-evidence">
         {placement_history_reason(@kura_placement_proposal)}

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -680,12 +680,12 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:734
+#: lib/tuist_web/live/ops_account_live.html.heex:716
 #, elixir-autogen, elixir-format
 msgid "Address line 1"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:742
+#: lib/tuist_web/live/ops_account_live.html.heex:724
 #, elixir-autogen, elixir-format
 msgid "Address line 2 (optional)"
 msgstr ""
@@ -695,54 +695,54 @@ msgstr ""
 msgid "Air"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:999
+#: lib/tuist_web/live/ops_account_live.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Argentina"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1000
+#: lib/tuist_web/live/ops_account_live.ex:1022
 #, elixir-autogen, elixir-format
 msgid "Australia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1001
+#: lib/tuist_web/live/ops_account_live.ex:1023
 #, elixir-autogen, elixir-format
 msgid "Austria"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1002
+#: lib/tuist_web/live/ops_account_live.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Belgium"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:643
-#: lib/tuist_web/live/ops_account_live.html.heex:726
+#: lib/tuist_web/live/ops_account_live.html.heex:625
+#: lib/tuist_web/live/ops_account_live.html.heex:708
 #: lib/tuist_web/live/ops_accounts_live.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Billing email"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1003
+#: lib/tuist_web/live/ops_account_live.ex:1025
 #, elixir-autogen, elixir-format
 msgid "Brazil"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1004
+#: lib/tuist_web/live/ops_account_live.ex:1026
 #, elixir-autogen, elixir-format
 msgid "Bulgaria"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1005
+#: lib/tuist_web/live/ops_account_live.ex:1027
 #, elixir-autogen, elixir-format
 msgid "Canada"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:784
+#: lib/tuist_web/live/ops_account_live.html.heex:766
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:676
+#: lib/tuist_web/live/ops_account_live.html.heex:658
 #, elixir-autogen, elixir-format
 msgid "Cancel %{account}'s subscription at the end of the current billing period? Access is kept until then."
 msgstr ""
@@ -752,7 +752,7 @@ msgstr ""
 msgid "Cancel failed: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:673
+#: lib/tuist_web/live/ops_account_live.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "Cancel plan"
 msgstr ""
@@ -763,37 +763,37 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1006
+#: lib/tuist_web/live/ops_account_live.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Chile"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1007
+#: lib/tuist_web/live/ops_account_live.ex:1029
 #, elixir-autogen, elixir-format
 msgid "China"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:748
+#: lib/tuist_web/live/ops_account_live.html.heex:730
 #, elixir-autogen, elixir-format
 msgid "City"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1008
+#: lib/tuist_web/live/ops_account_live.ex:1030
 #, elixir-autogen, elixir-format
 msgid "Colombia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:768
+#: lib/tuist_web/live/ops_account_live.html.heex:750
 #, elixir-autogen, elixir-format
 msgid "Country"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:696
+#: lib/tuist_web/live/ops_account_live.html.heex:678
 #, elixir-autogen, elixir-format
 msgid "Creates a Stripe customer (if missing), sets the billing address, and starts an invoice-billed Enterprise subscription. The customer receives an invoice by email; no card is collected here."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1009
+#: lib/tuist_web/live/ops_account_live.ex:1031
 #, elixir-autogen, elixir-format
 msgid "Croatia"
 msgstr ""
@@ -803,17 +803,17 @@ msgstr ""
 msgid "Current version"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1010
+#: lib/tuist_web/live/ops_account_live.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Cyprus"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1011
+#: lib/tuist_web/live/ops_account_live.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Czechia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1012
+#: lib/tuist_web/live/ops_account_live.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Denmark"
 msgstr ""
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1013
+#: lib/tuist_web/live/ops_account_live.ex:1035
 #, elixir-autogen, elixir-format
 msgid "Estonia"
 msgstr ""
@@ -850,67 +850,67 @@ msgstr ""
 msgid "Finished"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1014
+#: lib/tuist_web/live/ops_account_live.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Finland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1015
+#: lib/tuist_web/live/ops_account_live.ex:1037
 #, elixir-autogen, elixir-format
 msgid "France"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1016
+#: lib/tuist_web/live/ops_account_live.ex:1038
 #, elixir-autogen, elixir-format
 msgid "Germany"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1017
+#: lib/tuist_web/live/ops_account_live.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Greece"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1018
+#: lib/tuist_web/live/ops_account_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "Hong Kong"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1019
+#: lib/tuist_web/live/ops_account_live.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Hungary"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1020
+#: lib/tuist_web/live/ops_account_live.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Iceland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1021
+#: lib/tuist_web/live/ops_account_live.ex:1043
 #, elixir-autogen, elixir-format
 msgid "India"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1022
+#: lib/tuist_web/live/ops_account_live.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Indonesia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1023
+#: lib/tuist_web/live/ops_account_live.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Ireland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1024
+#: lib/tuist_web/live/ops_account_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Israel"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1025
+#: lib/tuist_web/live/ops_account_live.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Italy"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1026
+#: lib/tuist_web/live/ops_account_live.ex:1048
 #, elixir-autogen, elixir-format
 msgid "Japan"
 msgstr ""
@@ -931,37 +931,37 @@ msgstr ""
 msgid "Latest deployment"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1027
+#: lib/tuist_web/live/ops_account_live.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Latvia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1028
+#: lib/tuist_web/live/ops_account_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Lithuania"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1029
+#: lib/tuist_web/live/ops_account_live.ex:1051
 #, elixir-autogen, elixir-format
 msgid "Luxembourg"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1030
+#: lib/tuist_web/live/ops_account_live.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Malaysia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1031
+#: lib/tuist_web/live/ops_account_live.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Malta"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:656
+#: lib/tuist_web/live/ops_account_live.html.heex:638
 #, elixir-autogen, elixir-format
 msgid "Manage on Stripe"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1032
+#: lib/tuist_web/live/ops_account_live.ex:1054
 #, elixir-autogen, elixir-format
 msgid "Mexico"
 msgstr ""
@@ -973,17 +973,17 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:718
+#: lib/tuist_web/live/ops_account_live.html.heex:700
 #, elixir-autogen, elixir-format
 msgid "Name on invoice"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1033
+#: lib/tuist_web/live/ops_account_live.ex:1055
 #, elixir-autogen, elixir-format
 msgid "Netherlands"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1034
+#: lib/tuist_web/live/ops_account_live.ex:1056
 #, elixir-autogen, elixir-format
 msgid "New Zealand"
 msgstr ""
@@ -1011,18 +1011,18 @@ msgstr ""
 #: lib/tuist_web/live/ops_account_live.html.heex:53
 #: lib/tuist_web/live/ops_account_live.html.heex:57
 #: lib/tuist_web/live/ops_account_live.html.heex:63
-#: lib/tuist_web/live/ops_account_live.html.heex:644
+#: lib/tuist_web/live/ops_account_live.html.heex:626
 #: lib/tuist_web/live/ops_accounts_live.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1035
+#: lib/tuist_web/live/ops_account_live.ex:1057
 #, elixir-autogen, elixir-format
 msgid "Norway"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:647
+#: lib/tuist_web/live/ops_account_live.html.heex:629
 #: lib/tuist_web/live/ops_accounts_live.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Not created"
@@ -1044,33 +1044,33 @@ msgstr ""
 msgid "Pending"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1036
+#: lib/tuist_web/live/ops_account_live.ex:1058
 #, elixir-autogen, elixir-format
 msgid "Philippines"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:629
+#: lib/tuist_web/live/ops_account_live.html.heex:611
 #: lib/tuist_web/live/ops_accounts_live.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Plan"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:626
+#: lib/tuist_web/live/ops_account_live.html.heex:608
 #, elixir-autogen, elixir-format
 msgid "Plan & billing"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1037
+#: lib/tuist_web/live/ops_account_live.ex:1059
 #, elixir-autogen, elixir-format
 msgid "Poland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1038
+#: lib/tuist_web/live/ops_account_live.ex:1060
 #, elixir-autogen, elixir-format
 msgid "Portugal"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:762
+#: lib/tuist_web/live/ops_account_live.html.heex:744
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr ""
@@ -1083,14 +1083,14 @@ msgstr ""
 #: lib/tuist_web/live/ops_account_kura_sizing_live.html.heex:26
 #: lib/tuist_web/live/ops_account_live.html.heex:28
 #: lib/tuist_web/live/ops_account_live.html.heex:84
-#: lib/tuist_web/live/ops_account_live.html.heex:285
-#: lib/tuist_web/live/ops_account_live.html.heex:326
-#: lib/tuist_web/live/ops_account_live.html.heex:347
+#: lib/tuist_web/live/ops_account_live.html.heex:267
+#: lib/tuist_web/live/ops_account_live.html.heex:308
+#: lib/tuist_web/live/ops_account_live.html.heex:329
 #, elixir-autogen, elixir-format
 msgid "Region"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1039
+#: lib/tuist_web/live/ops_account_live.ex:1061
 #, elixir-autogen, elixir-format
 msgid "Romania"
 msgstr ""
@@ -1105,37 +1105,37 @@ msgstr ""
 msgid "Search by name"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:771
+#: lib/tuist_web/live/ops_account_live.html.heex:753
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1040
+#: lib/tuist_web/live/ops_account_live.ex:1062
 #, elixir-autogen, elixir-format
 msgid "Singapore"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1041
+#: lib/tuist_web/live/ops_account_live.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Slovakia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1042
+#: lib/tuist_web/live/ops_account_live.ex:1064
 #, elixir-autogen, elixir-format
 msgid "Slovenia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1043
+#: lib/tuist_web/live/ops_account_live.ex:1065
 #, elixir-autogen, elixir-format
 msgid "South Africa"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1044
+#: lib/tuist_web/live/ops_account_live.ex:1066
 #, elixir-autogen, elixir-format
 msgid "South Korea"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1045
+#: lib/tuist_web/live/ops_account_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Spain"
 msgstr ""
@@ -1145,7 +1145,7 @@ msgstr ""
 msgid "Started"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:756
+#: lib/tuist_web/live/ops_account_live.html.heex:738
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
@@ -1154,13 +1154,13 @@ msgstr ""
 #: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:18
 #: lib/tuist_web/live/ops_account_live.html.heex:31
 #: lib/tuist_web/live/ops_account_live.html.heex:99
-#: lib/tuist_web/live/ops_account_live.html.heex:636
+#: lib/tuist_web/live/ops_account_live.html.heex:618
 #: lib/tuist_web/live/ops_accounts_live.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:646
+#: lib/tuist_web/live/ops_account_live.html.heex:628
 #: lib/tuist_web/live/ops_accounts_live.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Stripe customer"
@@ -1171,22 +1171,22 @@ msgstr ""
 msgid "Succeeded"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1046
+#: lib/tuist_web/live/ops_account_live.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Sweden"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1047
+#: lib/tuist_web/live/ops_account_live.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Switzerland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1048
+#: lib/tuist_web/live/ops_account_live.ex:1070
 #, elixir-autogen, elixir-format
 msgid "Taiwan"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1049
+#: lib/tuist_web/live/ops_account_live.ex:1071
 #, elixir-autogen, elixir-format
 msgid "Thailand"
 msgstr ""
@@ -1196,7 +1196,7 @@ msgstr ""
 msgid "Trialing"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1050
+#: lib/tuist_web/live/ops_account_live.ex:1072
 #, elixir-autogen, elixir-format
 msgid "Turkey"
 msgstr ""
@@ -1212,38 +1212,38 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1051
+#: lib/tuist_web/live/ops_account_live.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Ukraine"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1052
+#: lib/tuist_web/live/ops_account_live.ex:1074
 #, elixir-autogen, elixir-format
 msgid "United Arab Emirates"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1053
+#: lib/tuist_web/live/ops_account_live.ex:1075
 #, elixir-autogen, elixir-format
 msgid "United Kingdom"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1054
+#: lib/tuist_web/live/ops_account_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:691
+#: lib/tuist_web/live/ops_account_live.html.heex:673
 #, elixir-autogen, elixir-format
 msgid "Upgrade %{account} to Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:664
-#: lib/tuist_web/live/ops_account_live.html.heex:792
+#: lib/tuist_web/live/ops_account_live.html.heex:646
+#: lib/tuist_web/live/ops_account_live.html.heex:774
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1055
+#: lib/tuist_web/live/ops_account_live.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Uruguay"
 msgstr ""
@@ -1253,7 +1253,7 @@ msgstr ""
 msgid "User"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1056
+#: lib/tuist_web/live/ops_account_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Vietnam"
 msgstr ""
@@ -1831,23 +1831,23 @@ msgstr ""
 msgid "Tokens"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:415
+#: lib/tuist_web/live/ops_account_live.html.heex:397
 #, elixir-autogen, elixir-format
 msgid "Limits apply independently to Linux and macOS. A new runner starts only when both its vCPU and memory fit within that platform's remaining capacity."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:427
+#: lib/tuist_web/live/ops_account_live.html.heex:409
 #, elixir-autogen, elixir-format
 msgid "Linux"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:440
-#: lib/tuist_web/live/ops_account_live.html.heex:459
+#: lib/tuist_web/live/ops_account_live.html.heex:422
+#: lib/tuist_web/live/ops_account_live.html.heex:441
 #, elixir-autogen, elixir-format
 msgid "Memory limit (GB)"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:412
+#: lib/tuist_web/live/ops_account_live.html.heex:394
 #, elixir-autogen, elixir-format
 msgid "Runner concurrency"
 msgstr ""
@@ -1862,18 +1862,18 @@ msgstr ""
 msgid "Runner concurrency limits updated."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:469
+#: lib/tuist_web/live/ops_account_live.html.heex:451
 #, elixir-autogen, elixir-format
 msgid "Save runner limits"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:446
+#: lib/tuist_web/live/ops_account_live.html.heex:428
 #, elixir-autogen, elixir-format
 msgid "macOS"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:432
-#: lib/tuist_web/live/ops_account_live.html.heex:451
+#: lib/tuist_web/live/ops_account_live.html.heex:414
+#: lib/tuist_web/live/ops_account_live.html.heex:433
 #, elixir-autogen, elixir-format
 msgid "vCPU limit"
 msgstr ""
@@ -1903,52 +1903,52 @@ msgstr ""
 msgid "Account visibility could not be updated."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:609
+#: lib/tuist_web/live/ops_account_live.html.heex:591
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:591
+#: lib/tuist_web/live/ops_account_live.html.heex:573
 #, elixir-autogen, elixir-format
 msgid "Dashboards"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:615
+#: lib/tuist_web/live/ops_account_live.html.heex:597
 #, elixir-autogen, elixir-format
 msgid "Make private"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:616
+#: lib/tuist_web/live/ops_account_live.html.heex:598
 #, elixir-autogen, elixir-format
 msgid "Make public"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:606
+#: lib/tuist_web/live/ops_account_live.html.heex:588
 #, elixir-autogen, elixir-format
 msgid "Nothing."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:595
+#: lib/tuist_web/live/ops_account_live.html.heex:577
 #, elixir-autogen, elixir-format
 msgid "Private"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:594
+#: lib/tuist_web/live/ops_account_live.html.heex:576
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:602
+#: lib/tuist_web/live/ops_account_live.html.heex:584
 #, elixir-autogen, elixir-format
 msgid "Public projects, runners, and usage. Members, webhooks, cache, billing, and settings stay private."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:598
+#: lib/tuist_web/live/ops_account_live.html.heex:580
 #, elixir-autogen, elixir-format
 msgid "Signed-out visitors see"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:588
+#: lib/tuist_web/live/ops_account_live.html.heex:570
 #, elixir-autogen, elixir-format
 msgid "Visibility"
 msgstr ""
@@ -1958,19 +1958,19 @@ msgstr ""
 msgid "Claim"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:961
+#: lib/tuist_web/live/ops_account_live.ex:983
 #, elixir-autogen, elixir-format
 msgid "Kura disk claim set to %{claim}. No running instance changed; it applies the next time volumes are built."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:969
+#: lib/tuist_web/live/ops_account_live.ex:991
 #, elixir-autogen, elixir-format
 msgid "Kura disk claim lowered to %{claim}. %{count} running instance keeps its cache and evicts down to the new budget."
 msgid_plural "Kura disk claim lowered to %{claim}. %{count} running instances keep their caches and evict down to the new budget."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.ex:984
+#: lib/tuist_web/live/ops_account_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "Kura disk claim raised to %{claim}. Up to %{count} running instance rebuilds its volumes, one replica at a time behind the standby that keeps serving."
 msgid_plural "Kura disk claim raised to %{claim}. Up to %{count} running instances rebuild their volumes, one replica at a time behind the standby that keeps serving."
@@ -1987,17 +1987,17 @@ msgstr ""
 msgid "%{account}'s runner trial is over. Runner usage is billable from now on."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:569
+#: lib/tuist_web/live/ops_account_live.html.heex:551
 #, elixir-autogen, elixir-format
 msgid "Added to next invoice"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:479
+#: lib/tuist_web/live/ops_account_live.html.heex:461
 #, elixir-autogen, elixir-format
 msgid "An account on a runner trial is not billed for runner usage. Usage is still metered and still reported, but the subscription carries no runner item for Stripe to invoice it against. The trial runs until it is cancelled here."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:508
+#: lib/tuist_web/live/ops_account_live.html.heex:490
 #, elixir-autogen, elixir-format
 msgid "Cancel runner trial"
 msgstr ""
@@ -2012,12 +2012,12 @@ msgstr ""
 msgid "Could not start the trial: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:546
+#: lib/tuist_web/live/ops_account_live.html.heex:528
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:527
+#: lib/tuist_web/live/ops_account_live.html.heex:509
 #, elixir-autogen, elixir-format
 msgid "No active subscription"
 msgstr ""
@@ -2027,32 +2027,32 @@ msgstr ""
 msgid "No expiry"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:489
+#: lib/tuist_web/live/ops_account_live.html.heex:471
 #, elixir-autogen, elixir-format
 msgid "On a runner trial"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:565
+#: lib/tuist_web/live/ops_account_live.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Prepaid minutes (macOS 6 vCPU / 14 GB)"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:476
+#: lib/tuist_web/live/ops_account_live.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Runner trial"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:502
+#: lib/tuist_web/live/ops_account_live.html.heex:484
 #, elixir-autogen, elixir-format
 msgid "Start runner trial"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:529
+#: lib/tuist_web/live/ops_account_live.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "This account has no subscription, so Stripe never generates an invoice for it. A prepaid charge added now would sit unbilled until one exists."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:543
+#: lib/tuist_web/live/ops_account_live.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "Minutes remaining"
 msgstr ""
@@ -2062,17 +2062,17 @@ msgstr ""
 msgid "Prepaid"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:514
+#: lib/tuist_web/live/ops_account_live.html.heex:496
 #, elixir-autogen, elixir-format
 msgid "Prepaid runner minutes"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:540
+#: lib/tuist_web/live/ops_account_live.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Source"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:551
+#: lib/tuist_web/live/ops_account_live.html.heex:533
 #, elixir-autogen, elixir-format
 msgid "This account has no prepaid runner minutes."
 msgstr ""
@@ -2082,12 +2082,12 @@ msgstr ""
 msgid "Trial"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:491
+#: lib/tuist_web/live/ops_account_live.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "Cancelling adds the runner items to this account's subscription, which makes its runner usage billable from that moment. Minutes it ran during the trial stay free, including those already recorded in the current billing period."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:573
+#: lib/tuist_web/live/ops_account_live.html.heex:555
 #, elixir-autogen, elixir-format
 msgid "Granted now"
 msgstr ""
@@ -2107,12 +2107,12 @@ msgstr ""
 msgid "Enter a whole number of minutes, or zero to clear."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:581
+#: lib/tuist_web/live/ops_account_live.html.heex:563
 #, elixir-autogen, elixir-format
 msgid "Set minutes"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:517
+#: lib/tuist_web/live/ops_account_live.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "Setting this replaces what the account holds rather than adding to it, and the minutes are granted straight away so it can run on them. The charge rides its next invoice alongside the rest of the bill. Minutes expire at the end of the billing period they were bought for and do not roll over. The figures are minutes on the macOS 6 vCPU / 14 GB baseline; a larger machine draws them down faster than one minute per minute it runs."
 msgstr ""
@@ -2132,7 +2132,7 @@ msgstr ""
 msgid "%{mbps} Mbps"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:373
+#: lib/tuist_web/live/ops_account_live.html.heex:355
 #, elixir-autogen, elixir-format
 msgid "Ceiling override (Mbps)"
 msgstr ""
@@ -2142,27 +2142,27 @@ msgstr ""
 msgid "Egress floor / ceiling"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:362
+#: lib/tuist_web/live/ops_account_live.html.heex:344
 #, elixir-autogen, elixir-format
 msgid "Floor override (Mbps)"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:356
+#: lib/tuist_web/live/ops_account_live.html.heex:338
 #, elixir-autogen, elixir-format
 msgid "Node limit"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:350
+#: lib/tuist_web/live/ops_account_live.html.heex:332
 #, elixir-autogen, elixir-format
 msgid "Now"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:353
+#: lib/tuist_web/live/ops_account_live.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Region default"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:399
+#: lib/tuist_web/live/ops_account_live.html.heex:381
 #, elixir-autogen, elixir-format
 msgid "Save egress limits"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:336
+#: lib/tuist_web/live/ops_account_live.html.heex:318
 #, elixir-autogen, elixir-format
 msgid "The floor this account's pods reserve and the ceiling they may burst to, set per region because the boxes differ. Empty a field to hand that number back to the region, which is a default rather than a limit: where the two disagree the region's half gives way to the one you set. The only limit is each region's node budget, since the floor is what the scheduler bin-packs against it. Saving recreates the account's instances in that region so the new pair takes effect. They keep their volumes and restart one at a time behind the standby, so no cache is lost."
 msgstr ""
@@ -2207,7 +2207,7 @@ msgid_plural "Nothing was saved: %{regions} were rejected."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:401
+#: lib/tuist_web/live/ops_account_live.html.heex:383
 #, elixir-autogen, elixir-format
 msgid "Saving recreates this account's Kura instances in the regions you changed. They keep their volumes and restart one at a time behind the standby, so no cache is lost. Continue?"
 msgstr ""
@@ -2259,55 +2259,55 @@ msgstr ""
 msgid "%{count} minutes"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:950
+#: lib/tuist_web/live/ops_account_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "%{used} of %{budget}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:181
-#: lib/tuist_web/live/ops_account_live.html.heex:257
+#: lib/tuist_web/live/ops_account_live.html.heex:163
+#: lib/tuist_web/live/ops_account_live.html.heex:239
 #, elixir-autogen, elixir-format
 msgid "Apply proposal"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:252
+#: lib/tuist_web/live/ops_account_live.html.heex:234
 #, elixir-autogen, elixir-format
 msgid "Apply the proposed claim? Growing rebuilds volumes one replica at a time behind the standby; shrinking keeps the cache and evicts down."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:275
+#: lib/tuist_web/live/ops_account_live.html.heex:257
 #, elixir-autogen, elixir-format
 msgid "Automatic sizing set this account's claim to %{claim}."
 msgstr ""
 
 #: lib/tuist_web/live/ops_account_kura_placement_live.html.heex:23
 #: lib/tuist_web/live/ops_account_kura_sizing_live.html.heex:23
-#: lib/tuist_web/live/ops_account_live.html.heex:212
-#: lib/tuist_web/live/ops_account_live.html.heex:323
+#: lib/tuist_web/live/ops_account_live.html.heex:194
+#: lib/tuist_web/live/ops_account_live.html.heex:305
 #, elixir-autogen, elixir-format
 msgid "By"
 msgstr ""
 
 #: lib/tuist_web/live/ops_account_kura_placement_live.html.heex:16
 #: lib/tuist_web/live/ops_account_kura_sizing_live.html.heex:16
-#: lib/tuist_web/live/ops_account_live.html.heex:205
-#: lib/tuist_web/live/ops_account_live.html.heex:316
+#: lib/tuist_web/live/ops_account_live.html.heex:187
+#: lib/tuist_web/live/ops_account_live.html.heex:298
 #, elixir-autogen, elixir-format
 msgid "Change"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:269
+#: lib/tuist_web/live/ops_account_live.html.heex:251
 #, elixir-autogen, elixir-format
 msgid "Disk is sized automatically: the claim grows when the cache starts discarding work sooner than the plan promises to keep it, and shrinks when it goes a long time without filling up. Growing rebuilds volumes one replica at a time behind the standby that keeps serving; shrinking keeps the cache and evicts down."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:288
+#: lib/tuist_web/live/ops_account_live.html.heex:270
 #, elixir-autogen, elixir-format
 msgid "Disk used"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:187
-#: lib/tuist_web/live/ops_account_live.html.heex:263
+#: lib/tuist_web/live/ops_account_live.html.heex:169
+#: lib/tuist_web/live/ops_account_live.html.heex:245
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -2318,7 +2318,7 @@ msgstr ""
 msgid "History"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:299
+#: lib/tuist_web/live/ops_account_live.html.heex:281
 #, elixir-autogen, elixir-format
 msgid "No pod has reported its disk in the last week."
 msgstr ""
@@ -2336,18 +2336,18 @@ msgstr ""
 
 #: lib/tuist_web/live/ops_account_kura_placement_live.html.heex:19
 #: lib/tuist_web/live/ops_account_kura_sizing_live.html.heex:19
-#: lib/tuist_web/live/ops_account_live.html.heex:208
-#: lib/tuist_web/live/ops_account_live.html.heex:319
+#: lib/tuist_web/live/ops_account_live.html.heex:190
+#: lib/tuist_web/live/ops_account_live.html.heex:301
 #, elixir-autogen, elixir-format
 msgid "Outcome"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:282
+#: lib/tuist_web/live/ops_account_live.html.heex:264
 #, elixir-autogen, elixir-format
 msgid "Pod"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:294
+#: lib/tuist_web/live/ops_account_live.html.heex:276
 #, elixir-autogen, elixir-format
 msgid "Reported"
 msgstr ""
@@ -2366,7 +2366,7 @@ msgid_plural "Seen on %{count} consecutive days of measurements."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:291
+#: lib/tuist_web/live/ops_account_live.html.heex:273
 #, elixir-autogen, elixir-format
 msgid "Segments"
 msgstr ""
@@ -2378,7 +2378,7 @@ msgid "Sizing"
 msgstr ""
 
 #: lib/tuist_web/live/ops_account_kura_sizing_live.html.heex:3
-#: lib/tuist_web/live/ops_account_live.html.heex:304
+#: lib/tuist_web/live/ops_account_live.html.heex:286
 #, elixir-autogen, elixir-format
 msgid "Sizing decisions"
 msgstr ""
@@ -2393,12 +2393,12 @@ msgstr ""
 msgid "Sizing proposal dismissed."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:224
+#: lib/tuist_web/live/ops_account_live.html.heex:206
 #, elixir-autogen, elixir-format
 msgid "Sizing proposes growing the disk claim from %{current} to %{recommended}."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:232
+#: lib/tuist_web/live/ops_account_live.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Sizing proposes shrinking the disk claim from %{current} to %{recommended}."
 msgstr ""
@@ -2418,24 +2418,24 @@ msgstr ""
 msgid "The proposal no longer applies; the next sizing sweep re-evaluates the account."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:196
-#: lib/tuist_web/live/ops_account_live.html.heex:307
+#: lib/tuist_web/live/ops_account_live.html.heex:178
+#: lib/tuist_web/live/ops_account_live.html.heex:289
 #, elixir-autogen, elixir-format
 msgid "View more"
 msgstr ""
 
 #: lib/tuist_web/live/ops_account_kura_placement_live.html.heex:13
 #: lib/tuist_web/live/ops_account_kura_sizing_live.html.heex:13
-#: lib/tuist_web/live/ops_account_live.html.heex:202
-#: lib/tuist_web/live/ops_account_live.html.heex:313
+#: lib/tuist_web/live/ops_account_live.html.heex:184
+#: lib/tuist_web/live/ops_account_live.html.heex:295
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr ""
 
 #: lib/tuist_web/live/ops_account_kura_placement_live.html.heex:26
 #: lib/tuist_web/live/ops_account_kura_sizing_live.html.heex:29
-#: lib/tuist_web/live/ops_account_live.html.heex:215
-#: lib/tuist_web/live/ops_account_live.html.heex:329
+#: lib/tuist_web/live/ops_account_live.html.heex:197
+#: lib/tuist_web/live/ops_account_live.html.heex:311
 #, elixir-autogen, elixir-format
 msgid "Why"
 msgstr ""
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "%{share}%% of runs over %{days} days"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:176
+#: lib/tuist_web/live/ops_account_live.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Apply the proposed placement? A new region starts empty and warms from its peers; a region being left keeps serving until the account is up elsewhere, then drains."
 msgstr ""
@@ -2497,13 +2497,13 @@ msgstr ""
 msgid "Placement"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:942
+#: lib/tuist_web/live/ops_account_live.ex:964
 #, elixir-autogen, elixir-format
 msgid "Placement added %{region}. It is provisioned on the account's next cache demand."
 msgstr ""
 
 #: lib/tuist_web/live/ops_account_kura_placement_live.html.heex:3
-#: lib/tuist_web/live/ops_account_live.html.heex:193
+#: lib/tuist_web/live/ops_account_live.html.heex:175
 #, elixir-autogen, elixir-format
 msgid "Placement decisions"
 msgstr ""
@@ -2518,12 +2518,12 @@ msgstr ""
 msgid "Placement has recorded nothing for this account; it is served from wherever its instances already are."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:946
+#: lib/tuist_web/live/ops_account_live.ex:968
 #, elixir-autogen, elixir-format
 msgid "Placement is leaving %{region}. It drains once nothing else is waiting on it."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:933
+#: lib/tuist_web/live/ops_account_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Placement moved to %{to}. %{from} keeps serving until %{to} is up, then drains."
 msgstr ""
@@ -2533,17 +2533,17 @@ msgstr ""
 msgid "Placement proposal dismissed."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:157
+#: lib/tuist_web/live/ops_account_live.ex:944
 #, elixir-autogen, elixir-format
 msgid "Placement proposes also serving this account from %{to}."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:162
+#: lib/tuist_web/live/ops_account_live.ex:948
 #, elixir-autogen, elixir-format
 msgid "Placement proposes giving up %{from} for this account."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:149
+#: lib/tuist_web/live/ops_account_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Placement proposes moving this account from %{from} to %{to}."
 msgstr ""
@@ -2694,3 +2694,8 @@ msgid "Seen on %{count} day of measurements (%{bytes} discarded)."
 msgid_plural "Seen on %{count} consecutive days of measurements (%{bytes} discarded)."
 msgstr[0] ""
 msgstr[1] ""
+
+#: lib/tuist_web/live/ops_account_live.ex:937
+#, elixir-autogen, elixir-format
+msgid "Placement proposes moving this account off its first region, %{from}, to %{to}."
+msgstr ""

--- a/server/test/tuist_web/live/ops_account_live_test.exs
+++ b/server/test/tuist_web/live/ops_account_live_test.exs
@@ -10,6 +10,7 @@ defmodule TuistWeb.OpsAccountLiveTest do
   alias Tuist.Kura
   alias Tuist.Kura.Capacity
   alias Tuist.Kura.ClaimProposal
+  alias Tuist.Kura.PlacementProposal
   alias Tuist.Kura.Server
   alias Tuist.Repo
   alias Tuist.Runners.Concurrency
@@ -189,6 +190,30 @@ defmodule TuistWeb.OpsAccountLiveTest do
 
     assert html =~ "kura-#{user.account.id}-us-east-0"
     assert html =~ "12.9 GB of 26.8 GB"
+  end
+
+  test "renders an open placement proposal of every kind", %{conn: conn, user: user} do
+    for {kind, summary} <- [
+          {:relocate, "Placement proposes moving this account from us-east to eu-central."},
+          {:correct, "Placement proposes moving this account off its first region, us-east, to eu-central."},
+          {:expand, "Placement proposes also serving this account from eu-central."},
+          {:retire, "Placement proposes giving up us-east for this account."}
+        ] do
+      Repo.delete_all(PlacementProposal)
+
+      Repo.insert!(%PlacementProposal{
+        account_id: user.account.id,
+        kind: kind,
+        from_region: "us-east",
+        to_region: "eu-central",
+        evidence: %{"share" => 0.82, "window_days" => 7, "runs_per_day" => 20},
+        status: :open
+      })
+
+      {:ok, _lv, html} = live(conn, ~p"/ops/accounts/#{user.account.id}")
+
+      assert html =~ summary
+    end
   end
 
   defp kura_server(user, region) do


### PR DESCRIPTION
## What changed

The Kura placement proposal summary on the ops account page (`/ops/accounts/:id`) dispatched on the proposal kind with a `case` written inline in the HEEx template, and that `case` covered only `:relocate`, `:expand` and `:retire`. `:correct` was missing, so rendering the page for an account with an open `:correct` proposal raised:

```
CaseClauseError: no case clause matching: :correct
  anonymous fn/3 in TuistWeb.OpsAccountLive.render/1
  at lib/tuist_web/live/ops_account_live.html.heex:147
```

The dispatch now lives in `TuistWeb.OpsAccountLive` as `placement_proposal_summary/1`, alongside the other kind-dispatching helpers in that module, with a clause for every kind in `PlacementProposal`'s `@kinds`.

## Why

`:correct` is a first-placement correction, kept distinct from `:relocate` so it does not spend the quarterly relocation budget. Every other kind dispatch for placement proposals already handled it: `placement_history_change/1`, `placement_history_reason/1` and `kura_placement_message/1` all match `kind in [:relocate, :correct]`. The proposal summary was the one dispatch written inline in the template rather than beside them, and it was the one that never got the clause. Moving it into the module puts all four kind dispatches in one place, so the next kind is added where the others already are.

The wording distinguishes the two moves rather than reusing the `:relocate` sentence, since an operator reading the summary should be able to tell a corrected guess from a deliberate move:

- `:relocate` — "Placement proposes moving this account from us-east to eu-central."
- `:correct` — "Placement proposes moving this account off its first region, us-east, to eu-central."

## Impact

The ops account page 500s for any account whose open placement proposal is a `:correct`. 517 events since 2026-09-04, and the page is unusable for the affected accounts until this ships. Operators cannot apply or dismiss those proposals from the UI either, since the whole card section fails to render.

No behaviour changes for the other three kinds; their strings are unchanged and keep their existing translations.

## Validation

- Added `renders an open placement proposal of every kind` to `TuistWeb.OpsAccountLiveTest`, inserting an open proposal of each of the four kinds and asserting the rendered summary.
- Confirmed the test is red without the `:correct` clause, failing through `Phoenix.LiveView.Diff.traverse/6` with the same shape as the production stack trace, and green with it.
- `mix test test/tuist_web/live/ops_account_live_test.exs` — 48 passed.
- `mix format --check-formatted` and `mix credo` clean on the changed files.
- `mix gettext.extract` run; only `priv/gettext/dashboard.pot` changed, no `.po` files touched.

## Note

`server/mix.lock` is inconsistent on `main`: it pins `tzdata 1.1.4`, which requires `hackney ~> 1.17`, next to `hackney 4.7.4`. Any `mix deps.get` resolves forward to `tzdata 1.1.5` and `quic 1.8.2` and rewrites the lock. That is unrelated to this fix, so it is left out of this PR, but it means a fresh checkout cannot run `mix test` without first re-resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
