### PR TITLE
fix(infra): pin mise and install it through one composite action

### DIFF
--- a/.github/actions/build-runner-image-binaries/action.yml
+++ b/.github/actions/build-runner-image-binaries/action.yml
@@ -13,9 +13,6 @@ description: |
   binary means adding it here, once.
 
 inputs:
-  mise-version:
-    description: Version of mise to install (pass the workflow's MISE_VERSION)
-    required: true
   github-token:
     description: GitHub token for mise (falls back to MISE_GITHUB_TOKEN)
     required: false
@@ -41,7 +38,6 @@ runs:
     # rather than pinned here (single source of truth, as cli-build-publish does).
     - uses: ./.github/actions/mise-install
       with:
-        version: ${{ inputs.mise-version }}
         install: rust
         cache: "false"
         working-directory: cas-plugin

--- a/.github/actions/mise-install/action.yml
+++ b/.github/actions/mise-install/action.yml
@@ -7,12 +7,12 @@ description: |
   direct URLs instead of api.github.com, which gets rate-limited under CI concurrency.
 
 inputs:
-  version:
-    description: Version of mise to install
-    required: true
   install:
-    description: Space-separated tools to install (same value you would pass to mise-action's install_args)
-    required: true
+    description: |
+      Space-separated tools to install (same value you would pass to mise-action's
+      install_args). Leave unset to put mise on PATH without installing any tools.
+    required: false
+    default: ""
   cache:
     description: Whether mise-action should read/write its tool cache
     required: false
@@ -46,9 +46,8 @@ runs:
         done
         echo "core=${core# }" >> "$GITHUB_OUTPUT"
         echo "locked=${locked# }" >> "$GITHUB_OUTPUT"
-    - uses: jdx/mise-action@v4.0.1
+    - uses: ./.github/actions/mise
       with:
-        version: ${{ inputs.version }}
         install: ${{ steps.split.outputs.core != '' }}
         install_args: ${{ steps.split.outputs.core }}
         cache: ${{ inputs.cache }}

--- a/.github/actions/mise/action.yml
+++ b/.github/actions/mise/action.yml
@@ -1,0 +1,60 @@
+name: mise
+description: |
+  Installs mise and the tools a job needs. Wraps jdx/mise-action so the mise
+  version and the action version are pinned in this file and nowhere else.
+
+  Use this instead of jdx/mise-action directly. An unpinned mise-action
+  resolves "latest" from mise.jdx.dev/VERSION, which has advertised versions
+  that were never published as GitHub releases, and the download 404s.
+
+  The version below is a dependency pin: mise must stay at or above 2026.5.15,
+  the first release where --locked installs download from the lockfile's direct
+  CDN URLs instead of api.github.com, which gets rate-limited under CI
+  concurrency. Renovate bumps it from here.
+
+inputs:
+  install:
+    description: If false, skips `mise install`
+    required: false
+    default: "true"
+  install_args:
+    description: Arguments passed to `mise install`, such as "--locked helm kubectl"
+    required: false
+  cache:
+    description: If false, the action neither reads nor writes its tool cache
+    required: false
+    default: "true"
+  cache_key:
+    description: Overrides the complete cache key
+    required: false
+  working_directory:
+    description: Directory mise runs in, selecting which mise.toml/mise.lock applies
+    required: false
+  github_token:
+    description: GitHub token for mise, falling back to MISE_GITHUB_TOKEN then the job token
+    required: false
+  env:
+    description: If false, mise env vars are not loaded into GITHUB_ENV
+    required: false
+    default: "true"
+
+outputs:
+  cache-hit:
+    description: Whether the tool cache was hit
+    value: ${{ steps.mise.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - id: mise
+      uses: jdx/mise-action@v4.0.1
+      with:
+        # renovate: datasource=github-releases depName=jdx/mise
+        version: "2026.5.15"
+        install: ${{ inputs.install }}
+        install_args: ${{ inputs.install_args }}
+        cache: ${{ inputs.cache }}
+        cache_key: ${{ inputs.cache_key }}
+        working_directory: ${{ inputs.working_directory }}
+        github_token: ${{ inputs.github_token || env.MISE_GITHUB_TOKEN || github.token }}
+        env: ${{ inputs.env }}

--- a/.github/actions/setup-server-mix/action.yml
+++ b/.github/actions/setup-server-mix/action.yml
@@ -2,9 +2,6 @@ name: Setup Server Mix
 description: Install mise tools, restore mix deps + _build cache, fetch hex deps for server jobs.
 
 inputs:
-  mise-version:
-    description: Version of mise to install
-    required: true
   mise-install-args:
     description: Tools to install via mise (passed to install_args)
     required: false
@@ -41,7 +38,6 @@ runs:
       run: echo "MIX_OS_DEPS_COMPILE_PARTITION_COUNT=${{ inputs.mix-os-deps-compile-partition-count }}" >> "$GITHUB_ENV"
     - uses: ./.github/actions/mise-install
       with:
-        version: ${{ inputs.mise-version }}
         install: ${{ inputs.mise-install-args }}
         cache: "true"
         working-directory: server

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,7 +22,6 @@ permissions:
   contents: read
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MISE_GITHUB_ATTESTATIONS: 0
@@ -54,9 +53,8 @@ jobs:
           distribution: temurin
           java-version: "21"
       - uses: gradle/actions/setup-gradle@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "tuist"
           cache: "false"
       - name: Authenticate with Tuist
@@ -96,9 +94,8 @@ jobs:
           distribution: temurin
           java-version: "21"
       - uses: gradle/actions/setup-gradle@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "tuist"
           cache: "false"
       - name: Authenticate with Tuist

--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -39,7 +39,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   TUIST_ENABLE_CACHING: "true"
@@ -58,9 +57,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -90,9 +88,8 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked tuist git-cliff 1password-cli jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -191,9 +188,8 @@ jobs:
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Skip Xcode Package Validation
         run: defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidation -bool YES
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked tuist 1password-cli"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -240,9 +236,8 @@ jobs:
         with:
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked java gradle 1password-cli tuist"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -290,9 +285,8 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -28,7 +28,6 @@ permissions:
   contents: read
 
 env:
-  MISE_VERSION: "2026.5.15"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_APP_GITHUB_TOKEN || github.token }}
   TUIST_ENABLE_CACHING: ${{ github.event.pull_request.head.repo.fork != true }}
@@ -120,9 +119,8 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved', 'Package.swift') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
@@ -177,9 +175,8 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved', 'Package.swift') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true
@@ -225,9 +222,8 @@ jobs:
         with:
           path: .build
           key: ${{ runner.os }}-app-${{ hashFiles('Package.resolved', 'Package.swift') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Authenticate with Tuist
         if: github.event.pull_request.head.repo.fork != true

--- a/.github/workflows/cache-deploy.yml
+++ b/.github/workflows/cache-deploy.yml
@@ -22,7 +22,6 @@ defaults:
     working-directory: cache
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
@@ -39,9 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: 1password/install-cli-action@v2
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           working_directory: cache
       - name: Setup SSH
         uses: webfactory/ssh-agent@v0.9.1
@@ -68,9 +66,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: 1password/install-cli-action@v2
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           working_directory: cache
       - name: Setup SSH
         uses: webfactory/ssh-agent@v0.9.1

--- a/.github/workflows/cache-migration-safety.yml
+++ b/.github/workflows/cache-migration-safety.yml
@@ -21,7 +21,6 @@ defaults:
     working-directory: cache
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -33,9 +32,8 @@ jobs:
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir"
           cache: "true"
           working_directory: cache

--- a/.github/workflows/cache-release.yml
+++ b/.github/workflows/cache-release.yml
@@ -29,7 +29,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
 
@@ -46,9 +45,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -67,9 +65,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -28,7 +28,6 @@ defaults:
     working-directory: cache
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MISE_GITHUB_ATTESTATIONS: 0
@@ -48,9 +47,8 @@ jobs:
             cache/deps
             cache/_build
           key: cache-mix-${{ hashFiles('cache/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir ruby"
           working_directory: cache
       - name: Install dependencies
@@ -72,9 +70,8 @@ jobs:
             cache/deps
             cache/_build
           key: cache-mix-${{ hashFiles('cache/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir ruby"
           working_directory: cache
       - name: Install dependencies
@@ -96,9 +93,8 @@ jobs:
             cache/deps
             cache/_build
           key: cache-mix-${{ hashFiles('cache/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir ruby"
           working_directory: cache
       - name: Install dependencies
@@ -120,9 +116,8 @@ jobs:
             cache/deps
             cache/_build
           key: cache-mix-${{ hashFiles('cache/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir ruby"
           working_directory: cache
       - name: Install dependencies

--- a/.github/workflows/cilium-apply.yml
+++ b/.github/workflows/cilium-apply.yml
@@ -36,9 +36,6 @@ on:
 permissions:
   contents: read
 
-env:
-  MISE_VERSION: "2026.5.15"
-
 jobs:
   apply:
     name: Cilium (${{ inputs.environment }})
@@ -65,9 +62,8 @@ jobs:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl jq"
           cache: "false"
 

--- a/.github/workflows/cilium-apply.yml
+++ b/.github/workflows/cilium-apply.yml
@@ -36,6 +36,9 @@ on:
 permissions:
   contents: read
 
+env:
+  MISE_VERSION: "2026.5.15"
+
 jobs:
   apply:
     name: Cilium (${{ inputs.environment }})
@@ -64,6 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl jq"
           cache: "false"
 

--- a/.github/workflows/cli-backport.yml
+++ b/.github/workflows/cli-backport.yml
@@ -59,7 +59,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   MISE_GITHUB_ATTESTATIONS: 0

--- a/.github/workflows/cli-build-publish.yml
+++ b/.github/workflows/cli-build-publish.yml
@@ -39,7 +39,6 @@ on:
 # Top-level env does not cross the workflow_call boundary, so it is redeclared
 # here rather than inherited from the caller.
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   TUIST_ENABLE_CACHING: "true"
@@ -66,9 +65,8 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked tuist git-cliff 1password-cli jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -76,10 +74,9 @@ jobs:
       # version from cas-plugin/mise.toml rather than pinning it here (single
       # source of truth, matching how kura pins its toolchain). Older release
       # branches that predate cas-plugin do not need this toolchain.
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         if: ${{ hashFiles('cas-plugin/mise.toml') != '' }}
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: rust
           working_directory: cas-plugin
           cache: "false"
@@ -269,9 +266,8 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/cli-promote.yml
+++ b/.github/workflows/cli-promote.yml
@@ -32,7 +32,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   MISE_GITHUB_ATTESTATIONS: 0
@@ -52,9 +51,8 @@ jobs:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/cli-rc.yml
+++ b/.github/workflows/cli-rc.yml
@@ -43,7 +43,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   MISE_GITHUB_ATTESTATIONS: 0
@@ -65,9 +64,8 @@ jobs:
           ref: ${{ inputs.branch == '' && github.event.repository.default_branch || inputs.branch }}
           fetch-depth: 0
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -57,7 +57,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   TUIST_ENABLE_CACHING: "true"
@@ -76,9 +75,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -67,7 +67,6 @@ permissions:
   contents: read
 
 env:
-  MISE_VERSION: "2026.5.15"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN || github.token }}
   TUIST_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN }}
@@ -106,9 +105,8 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "tuist swiftlint swiftformat"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -144,9 +142,8 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "tuist"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -186,9 +183,8 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "tuist"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
       - name: Authenticate with Tuist
@@ -230,9 +226,8 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "tuist"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -271,9 +266,8 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "tuist"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -321,9 +315,8 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "tuist"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -345,7 +338,7 @@ jobs:
       # TUIST_CAS_PLUGIN_PATH / TUIST_CAS_PROXY_PATH overrides ResourceLocator
       # honours. Forks skip this: they do not check out the EE submodule, so the
       # suite that needs the plugin is not in the scheme there.
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         if: github.event.pull_request.head.repo.fork != true
         env:
           # The rust pin lives in cas-plugin/mise.toml and has no lockfile entry,
@@ -353,7 +346,6 @@ jobs:
           # workflow that builds the plugin installs this toolchain unlocked.
           MISE_LOCKED: 0
         with:
-          version: ${{ env.MISE_VERSION }}
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
           install_args: rust
           working_directory: cas-plugin
@@ -408,9 +400,8 @@ jobs:
           key: ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
           restore-keys: |
             ${{ runner.os }}-cli-${{ hashFiles('.xcode-version') }}-${{ hashFiles('Package.swift') }}-
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "tuist"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/cnpg-restore-drill.yml
+++ b/.github/workflows/cnpg-restore-drill.yml
@@ -35,6 +35,9 @@ on:
 permissions:
   contents: read
 
+env:
+  MISE_VERSION: "2026.5.15"
+
 jobs:
   restore-drill:
     name: Restore drill (${{ inputs.environment || 'staging' }})
@@ -55,6 +58,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/cnpg-restore-drill.yml
+++ b/.github/workflows/cnpg-restore-drill.yml
@@ -35,9 +35,6 @@ on:
 permissions:
   contents: read
 
-env:
-  MISE_VERSION: "2026.5.15"
-
 jobs:
   restore-drill:
     name: Restore drill (${{ inputs.environment || 'staging' }})
@@ -56,9 +53,8 @@ jobs:
       RECOVERY: pg-restore-drill-${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/codebase-search.yml
+++ b/.github/workflows/codebase-search.yml
@@ -26,7 +26,6 @@ defaults:
     working-directory: codebase-search
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN || github.token }}
 
 jobs:
@@ -37,9 +36,8 @@ jobs:
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: rust
           cache: "false"
           working_directory: codebase-search

--- a/.github/workflows/csi-deployment.yml
+++ b/.github/workflows/csi-deployment.yml
@@ -48,6 +48,9 @@ on:
 permissions:
   contents: read
 
+env:
+  MISE_VERSION: "2026.5.15"
+
 jobs:
   apply:
     name: CSI (${{ matrix.environment }})
@@ -74,6 +77,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/csi-deployment.yml
+++ b/.github/workflows/csi-deployment.yml
@@ -48,9 +48,6 @@ on:
 permissions:
   contents: read
 
-env:
-  MISE_VERSION: "2026.5.15"
-
 jobs:
   apply:
     name: CSI (${{ matrix.environment }})
@@ -75,9 +72,8 @@ jobs:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/eso-token-refresh.yml
+++ b/.github/workflows/eso-token-refresh.yml
@@ -40,9 +40,6 @@ on:
 permissions:
   contents: read
 
-env:
-  MISE_VERSION: "2026.5.15"
-
 jobs:
   refresh:
     name: Refresh ESO 1Password token (${{ inputs.environment }})
@@ -54,9 +51,8 @@ jobs:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/eso-token-refresh.yml
+++ b/.github/workflows/eso-token-refresh.yml
@@ -40,6 +40,9 @@ on:
 permissions:
   contents: read
 
+env:
+  MISE_VERSION: "2026.5.15"
+
 jobs:
   refresh:
     name: Refresh ESO 1Password token (${{ inputs.environment }})
@@ -53,6 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/flux-diff.yml
+++ b/.github/workflows/flux-diff.yml
@@ -45,6 +45,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  MISE_VERSION: "2026.5.15"
+
 jobs:
   diff:
     name: flux diff
@@ -62,6 +65,7 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked kubectl"
           cache: "false"
       - uses: fluxcd/flux2/action@v2.9.5

--- a/.github/workflows/flux-diff.yml
+++ b/.github/workflows/flux-diff.yml
@@ -45,9 +45,6 @@ permissions:
   contents: read
   pull-requests: write
 
-env:
-  MISE_VERSION: "2026.5.15"
-
 jobs:
   diff:
     name: flux diff
@@ -63,9 +60,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked kubectl"
           cache: "false"
       - uses: fluxcd/flux2/action@v2.9.5

--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -26,7 +26,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MISE_TASK_RUN_AUTO_INSTALL: 0
@@ -70,13 +69,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "erlang elixir java gradle tuist bats"
           cache: "true"
           working-directory: .
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "erlang elixir asdf:aeons/asdf-minio github:ClickHouse/ClickHouse"
           cache: "true"
           working-directory: server

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -28,7 +28,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
 
@@ -45,9 +44,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -67,9 +65,8 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked java gradle git-cliff 1password-cli"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,6 @@ permissions:
   contents: read
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MISE_GITHUB_ATTESTATIONS: 0
@@ -55,9 +54,8 @@ jobs:
           distribution: temurin
           java-version: "21"
       - uses: gradle/actions/setup-gradle@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: tuist
           cache: "false"
           working_directory: .
@@ -79,9 +77,8 @@ jobs:
           distribution: temurin
           java-version: "21"
       - uses: gradle/actions/setup-gradle@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: tuist
           cache: "false"
           working_directory: .

--- a/.github/workflows/grafana-datasource-release.yml
+++ b/.github/workflows/grafana-datasource-release.yml
@@ -19,7 +19,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
 
 jobs:
@@ -35,9 +34,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -69,9 +67,8 @@ jobs:
         with:
           go-version: "1.26.4"
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/grafana-datasource.yml
+++ b/.github/workflows/grafana-datasource.yml
@@ -26,7 +26,6 @@ defaults:
     working-directory: grafana-datasource
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN || github.token }}
 
 jobs:
@@ -39,7 +38,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "go node"
           working-directory: grafana-datasource
           github-token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -55,7 +53,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "go node"
           working-directory: grafana-datasource
           github-token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -71,7 +68,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "go node"
           working-directory: grafana-datasource
           github-token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -87,7 +83,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "go node"
           working-directory: grafana-datasource
           github-token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -103,7 +98,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "go node"
           working-directory: grafana-datasource
           github-token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -118,7 +112,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "go node"
           working-directory: grafana-datasource
           github-token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -133,7 +126,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "go node"
           working-directory: grafana-datasource
           github-token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/handbook.yml
+++ b/.github/workflows/handbook.yml
@@ -26,7 +26,6 @@ permissions:
   contents: read
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
@@ -46,9 +45,8 @@ jobs:
             ~/.local/share/aube
             ~/.cache/aube
           key: aube-${{ hashFiles('handbook/aube-lock.yaml') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           working_directory: handbook
       - name: Build handbook
         working-directory: handbook

--- a/.github/workflows/hccm-deployment.yml
+++ b/.github/workflows/hccm-deployment.yml
@@ -25,9 +25,6 @@ on:
 permissions:
   contents: read
 
-env:
-  MISE_VERSION: "2026.5.15"
-
 jobs:
   apply:
     name: HCCM (${{ matrix.environment }})
@@ -61,9 +58,8 @@ jobs:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/hccm-deployment.yml
+++ b/.github/workflows/hccm-deployment.yml
@@ -25,6 +25,9 @@ on:
 permissions:
   contents: read
 
+env:
+  MISE_VERSION: "2026.5.15"
+
 jobs:
   apply:
     name: HCCM (${{ matrix.environment }})
@@ -60,6 +63,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -58,7 +58,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
   # Helm is pinned here for the generic lint and render jobs. The K3s
   # smoke job uses the infra mise tool pins instead.
@@ -73,9 +72,8 @@ jobs:
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "false"
       - name: Install helm
         run: mise use -g "helm@${HELM_VERSION}"
@@ -124,9 +122,8 @@ jobs:
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "false"
       - name: Install helm
         run: mise use -g "helm@${HELM_VERSION}"
@@ -225,9 +222,8 @@ jobs:
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "false"
       - name: Install smoke test tools
         run: mise -C infra install helm kubectl k3d

--- a/.github/workflows/hetzner-robot-controller-release.yml
+++ b/.github/workflows/hetzner-robot-controller-release.yml
@@ -31,7 +31,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
 
@@ -48,9 +47,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -69,9 +67,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "true"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/kura-runtime-image.yml
+++ b/.github/workflows/kura-runtime-image.yml
@@ -28,7 +28,6 @@ defaults:
     working-directory: kura
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN || github.token }}
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/kura
@@ -41,9 +40,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "rust bazel tuist"
           working_directory: kura
 

--- a/.github/workflows/kura.yml
+++ b/.github/workflows/kura.yml
@@ -26,7 +26,6 @@ defaults:
     working-directory: kura
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN || github.token }}
 
 jobs:
@@ -38,9 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "bazel"
           working_directory: kura
 
@@ -63,9 +61,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "rust bazel tuist"
           working_directory: kura
 
@@ -98,9 +95,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "rust bazel"
           working_directory: kura
 
@@ -140,9 +136,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "rust bazel tuist"
           working_directory: kura
 
@@ -172,9 +167,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "rust bazel"
           working_directory: kura
 
@@ -214,9 +208,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "rust bazel tuist"
           working_directory: kura
 
@@ -247,9 +240,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "rust bazel"
           working_directory: kura
 
@@ -282,9 +274,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: rust
           working_directory: kura
 
@@ -319,9 +310,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "rust bazel tuist"
           working_directory: kura
 
@@ -369,9 +359,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "rust bazel"
           working_directory: kura
 
@@ -472,7 +461,6 @@ jobs:
 
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "rust shellspec bazel aqua:facebook/buck2"
           working-directory: kura
 

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -26,7 +26,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
@@ -36,9 +35,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "elixir erlang"
           cache: "true"
       - name: Install server dependencies

--- a/.github/workflows/mdm-deployment.yml
+++ b/.github/workflows/mdm-deployment.yml
@@ -42,7 +42,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
   REGISTRY: ghcr.io
   HELM_CHART_PATH: infra/helm/mdm
@@ -108,9 +107,8 @@ jobs:
         with:
           ref: ${{ env.DEPLOY_REF }}
           persist-credentials: false
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/mgmt-cluster-apply.yml
+++ b/.github/workflows/mgmt-cluster-apply.yml
@@ -60,6 +60,9 @@ concurrency:
 
 permissions: {}
 
+env:
+  MISE_VERSION: "2026.5.15"
+
 jobs:
   apply:
     name: kubectl apply
@@ -79,6 +82,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/mgmt-cluster-apply.yml
+++ b/.github/workflows/mgmt-cluster-apply.yml
@@ -60,9 +60,6 @@ concurrency:
 
 permissions: {}
 
-env:
-  MISE_VERSION: "2026.5.15"
-
 jobs:
   apply:
     name: kubectl apply
@@ -80,9 +77,8 @@ jobs:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/noora-release.yml
+++ b/.github/workflows/noora-release.yml
@@ -24,7 +24,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
 
@@ -41,9 +40,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -62,7 +60,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "erlang elixir node aube git-cliff"
           cache: "false"
           working-directory: noora
@@ -103,7 +100,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "erlang elixir node aube git-cliff 1password-cli"
           cache: "false"
           working-directory: noora

--- a/.github/workflows/noora-storybook-deployment.yml
+++ b/.github/workflows/noora-storybook-deployment.yml
@@ -26,7 +26,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/noora-storybook
@@ -79,9 +78,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.DEPLOY_SHA }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/noora.yml
+++ b/.github/workflows/noora.yml
@@ -24,7 +24,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
   MIX_ENV: test
   MISE_GITHUB_ATTESTATIONS: 0
@@ -45,7 +44,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "erlang elixir node aube"
           cache: "true"
           working-directory: noora
@@ -69,7 +67,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "erlang elixir node aube"
           cache: "true"
           working-directory: noora
@@ -94,7 +91,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "erlang elixir node aube"
           cache: "true"
           working-directory: noora

--- a/.github/workflows/pentest-cluster-retirement.yml
+++ b/.github/workflows/pentest-cluster-retirement.yml
@@ -21,6 +21,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  MISE_VERSION: "2026.5.15"
   CLUSTER_NAME: tuist-pentest
   CLUSTER_NAMESPACE: org-tuist
   APPLICATION_NAMESPACE: tuist-pentest
@@ -67,6 +68,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/pentest-cluster-retirement.yml
+++ b/.github/workflows/pentest-cluster-retirement.yml
@@ -21,7 +21,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   CLUSTER_NAME: tuist-pentest
   CLUSTER_NAMESPACE: org-tuist
   APPLICATION_NAMESPACE: tuist-pentest
@@ -66,9 +65,8 @@ jobs:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/pentest-deployment.yml
+++ b/.github/workflows/pentest-deployment.yml
@@ -41,7 +41,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   REGISTRY: ghcr.io
   SERVER_IMAGE_NAME: tuist/tuist
   HELM_CHART_PATH: infra/helm/tuist
@@ -120,9 +119,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.resolve.outputs.sha }}
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "helm jq kubectl"
           cache: "false"
           env: "false"
@@ -291,9 +289,8 @@ jobs:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "kubectl"
           cache: "false"
           env: "false"
@@ -323,9 +320,8 @@ jobs:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "helm kubectl"
           cache: "false"
           env: "false"
@@ -361,9 +357,8 @@ jobs:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "helm kubectl"
           cache: "false"
           env: "false"

--- a/.github/workflows/pentest-deployment.yml
+++ b/.github/workflows/pentest-deployment.yml
@@ -41,6 +41,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  MISE_VERSION: "2026.5.15"
   REGISTRY: ghcr.io
   SERVER_IMAGE_NAME: tuist/tuist
   HELM_CHART_PATH: infra/helm/tuist
@@ -121,6 +122,7 @@ jobs:
           ref: ${{ needs.resolve.outputs.sha }}
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "helm jq kubectl"
           cache: "false"
           env: "false"
@@ -291,6 +293,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "kubectl"
           cache: "false"
           env: "false"
@@ -322,6 +325,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "helm kubectl"
           cache: "false"
           env: "false"
@@ -359,6 +363,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "helm kubectl"
           cache: "false"
           env: "false"

--- a/.github/workflows/pentest-platform-reconcile.yml
+++ b/.github/workflows/pentest-platform-reconcile.yml
@@ -13,9 +13,6 @@ concurrency:
   group: pentest-platform-reconcile
   cancel-in-progress: false
 
-env:
-  MISE_VERSION: "2026.5.15"
-
 jobs:
   reconcile:
     name: Reconcile pentest cluster platform
@@ -29,9 +26,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "helm kubectl"
           cache: "false"
           env: "false"

--- a/.github/workflows/pentest-platform-reconcile.yml
+++ b/.github/workflows/pentest-platform-reconcile.yml
@@ -13,6 +13,9 @@ concurrency:
   group: pentest-platform-reconcile
   cancel-in-progress: false
 
+env:
+  MISE_VERSION: "2026.5.15"
+
 jobs:
   reconcile:
     name: Reconcile pentest cluster platform
@@ -28,6 +31,7 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "helm kubectl"
           cache: "false"
           env: "false"

--- a/.github/workflows/pomerium-deployment.yml
+++ b/.github/workflows/pomerium-deployment.yml
@@ -42,6 +42,7 @@ permissions:
   packages: write
 
 env:
+  MISE_VERSION: "2026.5.15"
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/kube-impersonator
   DEPLOY_SHA: ${{ github.sha }}
@@ -134,6 +135,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@v4.0.1
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/pomerium-deployment.yml
+++ b/.github/workflows/pomerium-deployment.yml
@@ -42,7 +42,6 @@ permissions:
   packages: write
 
 env:
-  MISE_VERSION: "2026.5.15"
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/kube-impersonator
   DEPLOY_SHA: ${{ github.sha }}
@@ -133,9 +132,8 @@ jobs:
         with:
           ref: ${{ env.DEPLOY_SHA }}
           persist-credentials: false
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -111,6 +111,7 @@ permissions:
   deployments: write
 
 env:
+  MISE_VERSION: "2026.5.15"
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/tuist
   REGISTRY_IMAGE_NAME: tuist/registry
@@ -504,6 +505,7 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "helm kubectl jq"
           cache: "false"
       - name: Resolve immutable Kura runtime image tag
@@ -1114,6 +1116,7 @@ jobs:
     steps:
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "helm kubectl"
           cache: "false"
       - name: Load kubeconfig

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -111,7 +111,6 @@ permissions:
   deployments: write
 
 env:
-  MISE_VERSION: "2026.5.15"
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/tuist
   REGISTRY_IMAGE_NAME: tuist/registry
@@ -503,9 +502,8 @@ jobs:
         with:
           ref: ${{ needs.resolve.outputs.platform_ref }}
           fetch-depth: 0
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "helm kubectl jq"
           cache: "false"
       - name: Resolve immutable Kura runtime image tag
@@ -1114,9 +1112,11 @@ jobs:
       RELEASE: ${{ needs.resolve.outputs.release }}
       NAMESPACE: ${{ needs.resolve.outputs.namespace }}
     steps:
-      - uses: jdx/mise-action@v3.2.0
+      - uses: actions/checkout@v4
         with:
-          version: ${{ env.MISE_VERSION }}
+          sparse-checkout: .github/actions
+      - uses: ./.github/actions/mise
+        with:
           install_args: "helm kubectl"
           cache: "false"
       - name: Load kubeconfig

--- a/.github/workflows/preview-platform-reconcile.yml
+++ b/.github/workflows/preview-platform-reconcile.yml
@@ -50,6 +50,7 @@ permissions:
   packages: read
 
 env:
+  MISE_VERSION: "2026.5.15"
   KURA_CONTROLLER_IMAGE_NAME: tuist/kura-controller
 
 concurrency:
@@ -77,6 +78,7 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "helm kubectl jq"
           cache: "false"
       - name: Load kubeconfig

--- a/.github/workflows/preview-platform-reconcile.yml
+++ b/.github/workflows/preview-platform-reconcile.yml
@@ -50,7 +50,6 @@ permissions:
   packages: read
 
 env:
-  MISE_VERSION: "2026.5.15"
   KURA_CONTROLLER_IMAGE_NAME: tuist/kura-controller
 
 concurrency:
@@ -76,9 +75,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "helm kubectl jq"
           cache: "false"
       - name: Load kubeconfig

--- a/.github/workflows/preview-sweep.yml
+++ b/.github/workflows/preview-sweep.yml
@@ -21,9 +21,6 @@ on:
 permissions:
   contents: read
 
-env:
-  MISE_VERSION: "2026.5.15"
-
 jobs:
   sweep:
     name: Sweep expired previews
@@ -35,9 +32,8 @@ jobs:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm@4.2.0 kubectl@1.36.1 jq@1.8.1"
           cache: "false"
       - name: Load kubeconfig

--- a/.github/workflows/preview-sweep.yml
+++ b/.github/workflows/preview-sweep.yml
@@ -21,6 +21,9 @@ on:
 permissions:
   contents: read
 
+env:
+  MISE_VERSION: "2026.5.15"
+
 jobs:
   sweep:
     name: Sweep expired previews
@@ -34,6 +37,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm@4.2.0 kubectl@1.36.1 jq@1.8.1"
           cache: "false"
       - name: Load kubeconfig

--- a/.github/workflows/project-description-docs.yml
+++ b/.github/workflows/project-description-docs.yml
@@ -28,7 +28,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
@@ -46,9 +45,8 @@ jobs:
           path: .build
           key: linux-project-description-docc-${{ hashFiles('Package.resolved') }}
           restore-keys: linux-project-description-docc-
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "swift@6.2.4 node@20.12.0 npm:wrangler@4.30.0"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -28,7 +28,6 @@ defaults:
     working-directory: registry
 
 env:
-  MISE_VERSION: "2026.4.18"
   MISE_GITHUB_TOKEN: ${{ github.token }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MISE_GITHUB_ATTESTATIONS: 0
@@ -48,9 +47,8 @@ jobs:
             registry/deps
             registry/_build
           key: registry-mix-${{ hashFiles('registry/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir ruby"
           working_directory: registry
       - name: Install dependencies
@@ -72,9 +70,8 @@ jobs:
             registry/deps
             registry/_build
           key: registry-mix-${{ hashFiles('registry/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir ruby"
           working_directory: registry
       - name: Install dependencies
@@ -96,9 +93,8 @@ jobs:
             registry/deps
             registry/_build
           key: registry-mix-${{ hashFiles('registry/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir ruby"
           working_directory: registry
       - name: Install dependencies
@@ -120,9 +116,8 @@ jobs:
             registry/deps
             registry/_build
           key: registry-mix-${{ hashFiles('registry/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir ruby"
           working_directory: registry
       - name: Install dependencies

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -40,9 +40,6 @@ permissions:
   contents: read
   packages: write
 
-env:
-  MISE_VERSION: "2026.5.15"
-
 jobs:
   build:
     runs-on: [self-hosted, macos, bare-metal, vm-image-builder]
@@ -69,7 +66,6 @@ jobs:
       # production cascade builds them — see the action for why it is shared.
       - uses: ./.github/actions/build-runner-image-binaries
         with:
-          mise-version: ${{ env.MISE_VERSION }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image

--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -26,7 +26,6 @@ defaults:
     working-directory: search
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
   # Install only this project's tools and stop mise auto-installing the rest of the
   # merged root toolset when `mise run` executes (which would hit the GitHub API).
@@ -42,7 +41,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           working-directory: search
       - name: Build and verify health
         run: mise run test

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -188,7 +188,6 @@ permissions:
   packages: write
 
 env:
-  MISE_VERSION: "2026.5.15"
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/tuist
   REGISTRY_IMAGE_NAME: tuist/registry
@@ -389,9 +388,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.DEPLOY_SHA }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "rust bazel tuist"
           working_directory: kura
       - name: Install C/C++ toolchain for -sys crates (rocksdb/aws-lc bindgen)
@@ -463,9 +461,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.DEPLOY_SHA }}
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v4
@@ -548,9 +545,8 @@ jobs:
             echo "$VALUES not present; skipping tailscale-operator install for this env."
           fi
       - if: steps.check-values.outputs.exists == 'true'
-        uses: jdx/mise-action@v3.2.0
+        uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - if: steps.check-values.outputs.exists == 'true'
@@ -615,9 +611,8 @@ jobs:
           # Full history + tags so k8s:install-platform can resolve the
           # stable-egress-controller@<semver> image tag reachable from this commit.
           fetch-depth: 0
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v4
@@ -780,9 +775,8 @@ jobs:
             echo "RUNNERS_CONTROLLER_TAG=$(resolve 'runners-controller@' 'tuist/tuist-runners-controller')"
             echo "EGRESS_TREE_AGENT_TAG=$(resolve 'egress-tree-agent@' "$EGRESS_TREE_AGENT_IMAGE_NAME")"
           } >> "$GITHUB_ENV"
-      - uses: jdx/mise-action@v3.2.0
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v4

--- a/.github/workflows/server-deployment.yml
+++ b/.github/workflows/server-deployment.yml
@@ -465,6 +465,7 @@ jobs:
           ref: ${{ env.DEPLOY_SHA }}
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v4
@@ -549,6 +550,7 @@ jobs:
       - if: steps.check-values.outputs.exists == 'true'
         uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - if: steps.check-values.outputs.exists == 'true'
@@ -615,6 +617,7 @@ jobs:
           fetch-depth: 0
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v4
@@ -779,6 +782,7 @@ jobs:
           } >> "$GITHUB_ENV"
       - uses: jdx/mise-action@v3.2.0
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v4

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -2152,6 +2152,7 @@ jobs:
           submodules: recursive
       - uses: jdx/mise-action@v4.0.1
         with:
+          version: ${{ env.MISE_VERSION }}
           github_token: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
       - name: Authenticate with Tuist
         run: tuist auth login
@@ -2170,6 +2171,7 @@ jobs:
       # honours.
       - uses: jdx/mise-action@v4.0.1
         with:
+          version: ${{ env.MISE_VERSION }}
           github_token: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
           install_args: rust
           working_directory: cas-plugin
@@ -2256,6 +2258,7 @@ jobs:
           echo "Minimum supported CLI: ${min_version}; testing backward-compat with: ${version}"
       - uses: jdx/mise-action@v4.0.1
         with:
+          version: ${{ env.MISE_VERSION }}
           github_token: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
           install_args: "--locked bats"
       - name: Install backward-compatibility tuist

--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -57,7 +57,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   TUIST_ENABLE_CACHING: "true"
@@ -144,9 +143,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -205,9 +203,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -354,7 +351,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "git-cliff rust"
           cache: "false"
           working-directory: kura
@@ -426,9 +422,8 @@ jobs:
             compile-args: "--config=macos-x86_64-cross"
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "rust bazel tuist"
           cache: "false"
           working_directory: kura
@@ -567,9 +562,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -647,9 +641,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -732,9 +725,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "true"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -811,9 +803,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "true"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -892,9 +883,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "true"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -981,7 +971,6 @@ jobs:
 
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "git-cliff erlang elixir"
           working-directory: server
 
@@ -1199,7 +1188,6 @@ jobs:
       # taking down the whole release cascade. See the action.
       - uses: ./.github/actions/build-runner-image-binaries
         with:
-          mise-version: ${{ env.MISE_VERSION }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build profile
@@ -1282,9 +1270,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
 
       - name: Render active profile image refs
@@ -1358,9 +1345,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "true"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -1478,9 +1464,8 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN }}
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -2150,9 +2135,8 @@ jobs:
           ref: ${{ github.sha }}
           token: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN }}
           submodules: recursive
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           github_token: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
       - name: Authenticate with Tuist
         run: tuist auth login
@@ -2169,9 +2153,8 @@ jobs:
       # socket. Build both from source and hand their paths to the test via the
       # TUIST_CAS_PLUGIN_PATH / TUIST_CAS_PROXY_PATH overrides ResourceLocator
       # honours.
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           github_token: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
           install_args: rust
           working_directory: cas-plugin
@@ -2256,9 +2239,8 @@ jobs:
           version="$(printf '%s\n%s\n' "$min_version" "$xcode_build_floor" | sort -V | tail -n1)"
           echo "BACKWARD_COMPAT_TUIST_VERSION=$version" >> "$GITHUB_ENV"
           echo "Minimum supported CLI: ${min_version}; testing backward-compat with: ${version}"
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           github_token: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
           install_args: "--locked bats"
       - name: Install backward-compatibility tuist

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -10,6 +10,7 @@ on:
       - noora/**
       - .github/workflows/server.yml
       - .github/actions/setup-server-mix/action.yml
+      - .github/actions/mise/action.yml
       - server/pnpm-lock.yaml
       - mise/tasks/marketing/**
       - .trivyignore
@@ -21,6 +22,7 @@ on:
       - noora/**
       - .github/workflows/server.yml
       - .github/actions/setup-server-mix/action.yml
+      - .github/actions/mise/action.yml
       - server/pnpm-lock.yaml
       - noora/aube-lock.yaml
       - mise/tasks/marketing/**
@@ -35,7 +37,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_CLI_GITHUB_TOKEN || github.token }}
   MIX_ENV: test
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -102,8 +103,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-server-mix
-        with:
-          mise-version: ${{ env.MISE_VERSION }}
       # Pre-compile the project in its own step so the OOM (if any)
       # surfaces here rather than inside the extract heartbeat loop —
       # makes the failure mode obvious. The throttle stack:
@@ -259,7 +258,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-server-mix
         with:
-          mise-version: ${{ env.MISE_VERSION }}
           mise-install-args: erlang elixir github:ClickHouse/ClickHouse
           mix-cache-key: mix-test-v2
           mix-cache-restore-key: mix-test-v2-
@@ -329,7 +327,6 @@ jobs:
           echo "Testing against ClickHouse ${version}"
       - uses: ./.github/actions/setup-server-mix
         with:
-          mise-version: ${{ env.MISE_VERSION }}
           mix-cache-key: mix-test-v2
           mix-cache-restore-key: mix-test-v2-
           restore-mix-cache: "false"
@@ -363,8 +360,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-server-mix
-        with:
-          mise-version: ${{ env.MISE_VERSION }}
       - name: Run Credo
         env:
           MIX_OS_DEPS_COMPILE_PARTITION_COUNT: 1
@@ -376,9 +371,8 @@ jobs:
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: erlang elixir node aube npm:prettier
           cache: "true"
           working_directory: server
@@ -414,7 +408,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-server-mix
         with:
-          mise-version: ${{ env.MISE_VERSION }}
           mise-install-args: erlang elixir node aube
       - name: Restore Aube Cache
         uses: actions/cache@v4
@@ -458,8 +451,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-server-mix
-        with:
-          mise-version: ${{ env.MISE_VERSION }}
       - name: Install Trivy
         env:
           TRIVY_VERSION: "0.69.3"
@@ -612,7 +603,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-server-mix
         with:
-          mise-version: ${{ env.MISE_VERSION }}
           mise-install-args: erlang elixir github:ClickHouse/ClickHouse
           restore-mix-cache: "false"
       - name: Start ClickHouse

--- a/.github/workflows/skills-release.yml
+++ b/.github/workflows/skills-release.yml
@@ -28,7 +28,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
   GITHUB_TOKEN: ${{ secrets.TUIST_RELEASE_GITHUB_TOKEN || github.token }}
 
@@ -45,9 +44,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff jq"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
@@ -66,9 +64,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked git-cliff"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}

--- a/.github/workflows/slack-deployment.yml
+++ b/.github/workflows/slack-deployment.yml
@@ -27,7 +27,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/slack
@@ -82,9 +81,8 @@ jobs:
         with:
           ref: ${{ env.DEPLOY_SHA }}
           persist-credentials: false
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -28,7 +28,6 @@ defaults:
     working-directory: slack
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_ATTESTATIONS: 0
   MISE_CEILING_PATHS: ${{ github.workspace }}
 
@@ -48,9 +47,8 @@ jobs:
             slack/deps
             slack/_build
           key: slack-mix-${{ hashFiles('slack/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir"
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
           working_directory: slack
@@ -75,9 +73,8 @@ jobs:
             slack/deps
             slack/_build
           key: slack-mix-${{ hashFiles('slack/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir"
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
           working_directory: slack
@@ -102,9 +99,8 @@ jobs:
             slack/deps
             slack/_build
           key: slack-mix-${{ hashFiles('slack/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir"
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
           working_directory: slack
@@ -129,9 +125,8 @@ jobs:
             slack/deps
             slack/_build
           key: slack-mix-${{ hashFiles('slack/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir"
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
           working_directory: slack

--- a/.github/workflows/status-deploy.yml
+++ b/.github/workflows/status-deploy.yml
@@ -21,7 +21,6 @@ defaults:
     working-directory: status
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
   # Install only this project's tools and stop mise auto-installing the rest of the
   # merged root toolset when `mise run` executes (which would hit the GitHub API).
@@ -37,7 +36,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "node aube npm:wrangler"
           working-directory: status
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -26,7 +26,6 @@ defaults:
     working-directory: status
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
@@ -46,7 +45,6 @@ jobs:
           key: aube-${{ hashFiles('status/aube-lock.yaml') }}
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "node aube npm:wrangler"
           working-directory: status
       - run: aube run typecheck
@@ -67,7 +65,6 @@ jobs:
           key: aube-${{ hashFiles('status/aube-lock.yaml') }}
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "node aube npm:wrangler"
           working-directory: status
       - run: aube run format:check
@@ -88,7 +85,6 @@ jobs:
           key: aube-${{ hashFiles('status/aube-lock.yaml') }}
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "node aube npm:wrangler"
           working-directory: status
       - run: aube run test
@@ -109,7 +105,6 @@ jobs:
           key: aube-${{ hashFiles('status/aube-lock.yaml') }}
       - uses: ./.github/actions/mise-install
         with:
-          version: ${{ env.MISE_VERSION }}
           install: "node aube npm:wrangler"
           working-directory: status
       - run: aube run build

--- a/.github/workflows/swifterpm.yml
+++ b/.github/workflows/swifterpm.yml
@@ -16,9 +16,6 @@ on:
 permissions:
   contents: read
 
-env:
-  MISE_VERSION: "2026.5.15"
-
 concurrency:
   group: swifterpm-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -30,9 +27,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "bazel"
           working_directory: swifterpm
           cache: "false"

--- a/.github/workflows/tuist-ops-deployment.yml
+++ b/.github/workflows/tuist-ops-deployment.yml
@@ -26,7 +26,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/tuist-ops
@@ -90,9 +89,8 @@ jobs:
         with:
           ref: ${{ env.DEPLOY_SHA }}
           persist-credentials: false
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/tuist-ops-deployment.yml
+++ b/.github/workflows/tuist-ops-deployment.yml
@@ -26,6 +26,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/tuist-ops
@@ -91,6 +92,7 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@v4.0.1
         with:
+          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/tuist-ops.yml
+++ b/.github/workflows/tuist-ops.yml
@@ -18,7 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_ATTESTATIONS: 0
   MISE_CEILING_PATHS: ${{ github.workspace }}
 
@@ -42,9 +41,8 @@ jobs:
             tuist-ops/deps
             tuist-ops/_build
           key: tuist-ops-mix-${{ hashFiles('tuist-ops/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir"
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
           working_directory: tuist-ops
@@ -69,9 +67,8 @@ jobs:
             tuist-ops/deps
             tuist-ops/_build
           key: tuist-ops-mix-${{ hashFiles('tuist-ops/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir"
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
           working_directory: tuist-ops
@@ -110,9 +107,8 @@ jobs:
             tuist-ops/deps
             tuist-ops/_build
           key: tuist-ops-mix-${{ hashFiles('tuist-ops/mix.lock') }}
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir"
           cache_key: "{{default}}-{{env.NSC_BASE_IMAGE_REF_ID}}"
           working_directory: tuist-ops

--- a/.github/workflows/typesense-deployment.yml
+++ b/.github/workflows/typesense-deployment.yml
@@ -26,7 +26,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ secrets.TUIST_DEPLOY_GITHUB_TOKEN || github.token }}
   REGISTRY: ghcr.io
   IMAGE_NAME: tuist/search
@@ -81,9 +80,8 @@ jobs:
         with:
           ref: ${{ env.DEPLOY_SHA }}
           persist-credentials: false
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "--locked helm kubectl"
           cache: "false"
       - uses: 1password/install-cli-action@v2

--- a/.github/workflows/update-tuist-cli.yml
+++ b/.github/workflows/update-tuist-cli.yml
@@ -23,7 +23,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MISE_VERSION: "2026.5.15"
   MISE_GITHUB_TOKEN: ${{ github.token }}
 
 jobs:
@@ -65,10 +64,9 @@ jobs:
           set -euo pipefail
           sed -i -E "s|^([[:space:]]*tuist = \")[^\"]+(\")|\1${VERSION}\2|" mise.toml
           grep -E '^[[:space:]]*tuist = "' mise.toml
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         if: steps.resolve.outputs.changed == 'true'
         with:
-          version: ${{ env.MISE_VERSION }}
           # Installing tuist unlocked rewrites its mise.lock entry across all
           # platforms (checksums come from the release SHASUMS, so one host
           # covers macOS and Linux).

--- a/.github/workflows/xcresult-processor-image.yml
+++ b/.github/workflows/xcresult-processor-image.yml
@@ -46,14 +46,12 @@ jobs:
     timeout-minutes: 150
     env:
       PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
-      MISE_VERSION: "2026.5.15"
       MISE_GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jdx/mise-action@v4.0.1
+      - uses: ./.github/actions/mise
         with:
-          version: ${{ env.MISE_VERSION }}
           install_args: "erlang elixir"
           working_directory: server
 

--- a/renovate.json
+++ b/renovate.json
@@ -47,9 +47,9 @@
     },
     {
       "customType": "regex",
-      "description": "Single source for the mise CLI version pinned across every GitHub Actions workflow (MISE_VERSION env). Renovate tracks jdx/mise releases and bumps all MISE_VERSION literals together in one PR, keeping the whole repo on one version. Stay on mise >= 2026.5.15: only there do --locked installs download from the lockfile's direct CDN URLs; older mise still hits api.github.com for github-backend tools and gets rate-limited.",
-      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
-      "matchStrings": ["MISE_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
+      "description": "Single source for the mise CLI version. Every workflow installs mise through .github/actions/mise, so the pin exists once and this manager bumps that one line. Stay on mise >= 2026.5.15: only there do --locked installs download from the lockfile's direct CDN URLs; older mise still hits api.github.com for github-backend tools and gets rate-limited.",
+      "fileMatch": ["^\\.github/actions/mise/action\\.yml$"],
+      "matchStrings": ["# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s+version: \"(?<currentValue>[^\"]+)\""],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "jdx/mise",
       "extractVersionTemplate": "^v?(?<version>.+)$"


### PR DESCRIPTION
## What changed

Two commits:

1. **Pin the mise version in every mise-action step** — the deploy fix. 26 steps across 17 workflows resolved mise's "latest" instead of a pin.
2. **Install mise through one composite action** — `.github/actions/mise` now wraps `jdx/mise-action` and holds the only copy of the version. The 61 per-workflow `MISE_VERSION` declarations are gone.

## Why

The production deployment cascade was red. The three canary chart jobs (Tailscale operator, Platform, Observability) failed in `Run jdx/mise-action@v3.2.0` before doing any work:

```
[command]/usr/bin/curl -fsSL https://mise.jdx.dev/VERSION
2026.9.2
[command]/usr/bin/sh -c curl -fsSL https://github.com/jdx/mise/releases/download/v2026.9.2/mise-v2026.9.2-linux-x64.tar.gz | tar -xzf - -C /tmp && ...
curl: (22) The requested URL returned error: 404
gzip: stdin: unexpected end of file
##[error]The process '/usr/bin/sh' failed with exit code 2
```

## Root cause

Upstream, not us. `https://mise.jdx.dev/VERSION` advertises `2026.9.2`, but that release was never published: the newest tag on `jdx/mise` is `v2026.9.1` from 2026-09-02. mise-action resolves "latest" from that endpoint when no `version` input is given, then downloads a release asset that does not exist. Every step without a pin has been broken since the endpoint moved ahead of the releases, and re-running the failed jobs could not have helped.

The repo was already half-protected: 93 mise-action steps passed `version: ${{ env.MISE_VERSION }}` and all of them installed fine in the same run. The 26 unpinned ones, concentrated in the infrastructure deploy workflows, are what broke.

## Why the second commit

Pinning restores the deploy but leaves the underlying shape that allowed it: the version was written out 61 times, once per workflow, kept in sync by a Renovate custom manager that rewrites all the literals together. That fan-out had already failed silently. `registry.yml` was still on `2026.4.18`, below the `2026.5.15` floor where `--locked` installs stop resolving through `api.github.com`, so that workflow was sitting on a pin we know gets rate-limited. Nothing in the repo could tell you that, because there was no single value to compare against.

So the version now lives in exactly one file. `.github/actions/mise` is a thin wrapper over `jdx/mise-action` that forwards the seven inputs the repo actually uses (`install`, `install_args`, `cache`, `cache_key`, `working_directory`, `github_token`, `env`) and re-exposes `cache-hit`. All 119 direct call sites use it. `mise-install`, `setup-server-mix` and `build-runner-image-binaries` delegate to it and dropped their version inputs, so the 32 call sites of those composites lost a parameter too.

Two alternatives were considered and rejected. A repository variable would be one place, but it takes a dependency pin out of git, out of PR review and out of Renovate's reach, and an unset variable evaluates to empty and silently falls back to "latest", which is exactly the failure being fixed. Leaving the fan-out in place with a CI consistency check would have been cheaper, but keeps 61 copies of a value that only ever has one correct setting.

## Incidental cleanups

- The 20 steps still on `jdx/mise-action@v3.2.0`, all in infrastructure deploy workflows, now go through the same v4.0.1 pin as everything else. v4.0.0 is a Node 20 to Node 24 runtime bump with no configuration changes, and it clears the Node 20 deprecation warnings those jobs were emitting.
- `registry.yml` comes off the stale `2026.4.18` pin.
- `mise-install`'s `install` input becomes optional. `search.yml` calls it with no tools deliberately, since `search/mise.toml` declares none and the job only needs mise on `PATH`; the input was marked required, so that call site was technically in violation and actionlint flagged it once the required set changed.
- `preview-deploy`'s `delete` job gains a sparse checkout limited to `.github/actions`. It was the only job running mise before any checkout, and a local action has to exist in the workspace to run.
- `server.yml`'s path filters track `.github/actions/mise/action.yml`, matching how they already track `setup-server-mix`, so a version bump exercises server CI.

## Impact and risk

Deploy jobs install mise deterministically at the version the rest of CI already uses. One behavioural note worth knowing: a local composite action is read from the checked-out tree, so a deploy dispatched with a `commit_sha` older than this change will fail at the mise step. It fails loudly, before the job touches any cluster, and the window closes as the change ages.

## Validation

- Confirmed the upstream mismatch directly: `curl https://mise.jdx.dev/VERSION` returns `2026.9.2`, `gh api repos/jdx/mise/releases/tags/v2026.9.2` returns 404, and `releases/latest` is `v2026.9.1`.
- `actionlint` over all 65 workflows against a baseline built from `main`'s full `.github` tree: 230 findings before, 230 after, none new and none resolved. The first baseline attempt copied only `.github/workflows`, which made actionlint skip local-action checks; it was rebuilt with `git archive main .github` after that was caught.
- Semantic diff of every mise step against `main`: 119 before, 119 after, matched one to one, with zero differences in forwarded inputs, `if:` or step `env:`. The only index shift is `preview-deploy`'s `delete` job, from the added checkout.
- Same comparison for the 32 `mise-install` / `setup-server-mix` / `build-runner-image-binaries` call sites: no input changed apart from the removed version.
- Every workflow and action file parses as YAML (86 files), with no empty `env:` or `with:` mappings left behind by the removals.
- Verified the Renovate regex matches the new pin, extracting `datasource=github-releases depName=jdx/mise currentValue=2026.5.15`, and that `renovate.json` is still valid JSON.
- Confirmed no `MISE_VERSION` reference survives anywhere under `.github`, and that no job runs a local action before its checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
