### PR TITLE
fix(server): stop nil commit SHAs and ClickHouse memory limits from failing PR comments

### DIFF
--- a/server/lib/tuist/clickhouse_retry.ex
+++ b/server/lib/tuist/clickhouse_retry.ex
@@ -10,11 +10,11 @@ defmodule Tuist.ClickHouseRetry do
   half-dead socket surface as `:timeout`. Both clear within
   milliseconds and are safe to retry on idempotent reads/writes.
 
-  `with_result_retry/2` additionally retries ClickHouse's memory-limit
-  error (code 241). Both the per-user budget and the process-wide ceiling
-  raise it, and both clear on their own once the queries holding the
-  memory finish, so the write is worth re-attempting rather than failing
-  the caller. The code is matched directly: the message wording differs
+  Both functions also retry ClickHouse's memory-limit error (code 241).
+  Both the per-user budget and the process-wide ceiling raise it, and both
+  clear on their own once the queries holding the memory finish, so the
+  call is worth re-attempting rather than failing the caller. The code is
+  matched directly: the message wording differs
   between the two limits and has changed across ClickHouse releases, so
   matching on it silently stops recognising the error.
 
@@ -31,19 +31,59 @@ defmodule Tuist.ClickHouseRetry do
   @max_retries 3
   @max_memory_retries 8
 
-  def with_retry(fun, retries_left \\ @max_retries) do
+  def with_retry(fun, opts \\ [])
+
+  def with_retry(fun, transport_retries) when is_integer(transport_retries),
+    do: with_retry(fun, transport_retries: transport_retries)
+
+  def with_retry(fun, opts) when is_list(opts) do
+    transport_retries = Keyword.get(opts, :transport_retries, @max_retries)
+    memory_retries = Keyword.get(opts, :memory_retries, @max_retries)
+
+    with_retry(fun, transport_retries, transport_retries, memory_retries, memory_retries)
+  end
+
+  defp with_retry(fun, transport_retries_left, initial_transport_retries, memory_retries_left, initial_memory_retries) do
     fun.()
   rescue
     e in [Mint.TransportError, DBConnection.ConnectionError] ->
-      if retries_left > 0 do
-        delay = Integer.pow(2, @max_retries - retries_left) * 100
+      if transport_retries_left > 0 do
+        delay = retry_delay(initial_transport_retries, transport_retries_left)
 
         Logger.warning(
-          "ClickHouse operation failed (#{Exception.message(e)}), retrying in #{delay}ms (#{retries_left} retries left)"
+          "ClickHouse operation failed (#{Exception.message(e)}), retrying in #{delay}ms (#{transport_retries_left} retries left)"
         )
 
         Process.sleep(delay)
-        with_retry(fun, retries_left - 1)
+
+        with_retry(
+          fun,
+          transport_retries_left - 1,
+          initial_transport_retries,
+          memory_retries_left,
+          initial_memory_retries
+        )
+      else
+        reraise e, __STACKTRACE__
+      end
+
+    e in Ch.Error ->
+      if memory_limit_error?(e) and memory_retries_left > 0 do
+        delay = retry_delay(initial_memory_retries, memory_retries_left, 2_000)
+
+        Logger.warning(
+          "ClickHouse is over its memory budget, retrying in #{delay}ms (#{memory_retries_left} retries left)"
+        )
+
+        Process.sleep(delay)
+
+        with_retry(
+          fun,
+          transport_retries_left,
+          initial_transport_retries,
+          memory_retries_left - 1,
+          initial_memory_retries
+        )
       else
         reraise e, __STACKTRACE__
       end

--- a/server/lib/tuist/ingest_repo.ex
+++ b/server/lib/tuist/ingest_repo.ex
@@ -38,5 +38,5 @@ defmodule Tuist.IngestRepo do
   end
 
   defdelegate with_retry(fun), to: ClickHouseRetry
-  defdelegate with_retry(fun, retries_left), to: ClickHouseRetry
+  defdelegate with_retry(fun, opts), to: ClickHouseRetry
 end

--- a/server/lib/tuist/vcs.ex
+++ b/server/lib/tuist/vcs.ex
@@ -658,7 +658,7 @@ defmodule Tuist.VCS do
       #{Enum.map(bundles, fn bundle ->
         {install_size_deviation, download_size_deviation} = project_bundle_size_deviations(project, bundle)
         """
-        | [#{bundle.name}](#{bundle_url.(%{project: project, bundle: bundle})}) | [#{String.slice(bundle.git_commit_sha, 0, 9)}](#{git_remote_url_origin}/commit/#{bundle.git_commit_sha}) | <div align="center">#{ByteFormatter.format_bytes(bundle.install_size)}#{install_size_deviation}</div> | <div align="center">#{format_bundle_download_size(bundle.download_size)}#{download_size_deviation}</div> |
+        | [#{bundle.name}](#{bundle_url.(%{project: project, bundle: bundle})}) | #{commit_link(bundle.git_commit_sha, git_remote_url_origin)} | <div align="center">#{ByteFormatter.format_bytes(bundle.install_size)}#{install_size_deviation}</div> | <div align="center">#{format_bundle_download_size(bundle.download_size)}#{download_size_deviation}</div> |
         """
       end)}
       """
@@ -704,6 +704,11 @@ defmodule Tuist.VCS do
   defp format_bundle_download_size(nil), do: dgettext("dashboard_account", "Unknown")
   defp format_bundle_download_size(size) when is_integer(size), do: ByteFormatter.format_bytes(size)
 
+  defp commit_link(nil, _git_remote_url_origin), do: ""
+
+  defp commit_link(git_commit_sha, git_remote_url_origin),
+    do: "[#{String.slice(git_commit_sha, 0, 9)}](#{git_remote_url_origin}/commit/#{git_commit_sha})"
+
   defp get_issue_id_from_git_ref(git_ref) do
     [issue_id, _merge] = git_ref |> String.split("/") |> Enum.take(-2)
     issue_id
@@ -747,12 +752,11 @@ defmodule Tuist.VCS do
       | App | Commit |#{if contains_ipas, do: " Open on device |", else: ""}
       | - | - |#{if contains_ipas, do: " - |", else: ""}
       #{Enum.map(previews, fn preview ->
-        git_commit_sha = preview.git_commit_sha
         preview_url = preview_url.(%{project: project, preview: preview})
         qr_code_image = get_qr_code_image(%{project: project, preview: preview, contains_ipas: contains_ipas, preview_qr_code_url: preview_qr_code_url})
 
         """
-        | [#{preview.display_name}](#{preview_url}) | [#{String.slice(git_commit_sha, 0, 9)}](#{git_remote_url_origin}/commit/#{git_commit_sha}) |#{qr_code_image}
+        | [#{preview.display_name}](#{preview_url}) | #{commit_link(preview.git_commit_sha, git_remote_url_origin)} |#{qr_code_image}
         """
       end)}
       """
@@ -848,7 +852,6 @@ defmodule Tuist.VCS do
       Enum.map_join(test_runs, "", fn test_run ->
         test_run_metrics = Map.get(metrics_map, test_run.id)
 
-        git_commit_sha = test_run.git_commit_sha
         test_url = test_run_url.(%{project: project, test_run: test_run})
         scheme = if test_run.scheme == "", do: "Unknown", else: test_run.scheme
 
@@ -857,7 +860,7 @@ defmodule Tuist.VCS do
         skipped_tests = if test_run_metrics, do: test_run_metrics.skipped_tests, else: 0
         ran_tests = if test_run_metrics, do: test_run_metrics.ran_tests, else: 0
 
-        "| [#{scheme}](#{test_url}) | #{get_test_run_status_text(test_run)} | #{cache_hit_rate} | #{total_tests} | #{skipped_tests} | #{ran_tests} | [#{String.slice(git_commit_sha, 0, 9)}](#{git_remote_url_origin}/commit/#{git_commit_sha}) |\n"
+        "| [#{scheme}](#{test_url}) | #{get_test_run_status_text(test_run)} | #{cache_hit_rate} | #{total_tests} | #{skipped_tests} | #{ran_tests} | #{commit_link(test_run.git_commit_sha, git_remote_url_origin)} |\n"
       end)
 
     "| Scheme | Status | Cache hit rate | Tests | Skipped | Ran | Commit |\n" <>
@@ -880,12 +883,11 @@ defmodule Tuist.VCS do
       Enum.map_join(test_runs, "", fn test_run ->
         test_run_metrics = Map.get(metrics_map, test_run.id)
 
-        git_commit_sha = test_run.git_commit_sha
         test_url = test_run_url.(%{project: project, test_run: test_run})
         scheme = if test_run.scheme == "", do: "Unknown", else: test_run.scheme
         total_tests = if test_run_metrics, do: test_run_metrics.total_tests, else: 0
 
-        "| [#{scheme}](#{test_url}) | #{get_test_run_status_text(test_run)} | #{total_tests} | [#{String.slice(git_commit_sha, 0, 9)}](#{git_remote_url_origin}/commit/#{git_commit_sha}) |\n"
+        "| [#{scheme}](#{test_url}) | #{get_test_run_status_text(test_run)} | #{total_tests} | #{commit_link(test_run.git_commit_sha, git_remote_url_origin)} |\n"
       end)
 
     "| Project | Status | Tests | Commit |\n" <>
@@ -907,12 +909,11 @@ defmodule Tuist.VCS do
     rows =
       Enum.map_join(test_runs, "", fn test_run ->
         test_run_metrics = Map.get(metrics_map, test_run.id)
-        git_commit_sha = test_run.git_commit_sha
         test_url = test_run_url.(%{project: project, test_run: test_run})
         target_patterns = if test_run.scheme == "", do: "Unknown", else: test_run.scheme
         total_tests = if test_run_metrics, do: test_run_metrics.total_tests, else: 0
 
-        "| [#{target_patterns}](#{test_url}) | #{get_test_run_status_text(test_run)} | #{total_tests} | [#{String.slice(git_commit_sha, 0, 9)}](#{git_remote_url_origin}/commit/#{git_commit_sha}) |\n"
+        "| [#{target_patterns}](#{test_url}) | #{get_test_run_status_text(test_run)} | #{total_tests} | #{commit_link(test_run.git_commit_sha, git_remote_url_origin)} |\n"
       end)
 
     "| Target patterns | Status | Tests | Commit |\n" <>
@@ -1276,7 +1277,7 @@ defmodule Tuist.VCS do
         url = build_url.(%{project: project, build: %{id: build.id}})
         duration = DateFormatter.format_duration_from_milliseconds(build.duration)
 
-        "| [#{build.scheme}](#{url}) | #{get_build_status_text(build)} | #{duration} | [#{String.slice(build.git_commit_sha, 0, 9)}](#{git_remote_url_origin}/commit/#{build.git_commit_sha}) |\n"
+        "| [#{build.scheme}](#{url}) | #{get_build_status_text(build)} | #{duration} | #{commit_link(build.git_commit_sha, git_remote_url_origin)} |\n"
       end)
 
     "| Scheme | Status | Duration | Commit |\n" <>
@@ -1297,7 +1298,7 @@ defmodule Tuist.VCS do
         url = build_url.(%{project: project, build: %{id: build.id}})
         duration = DateFormatter.format_duration_from_milliseconds(build.duration_ms)
 
-        "| [#{build.root_project_name}](#{url}) | #{get_build_status_text(build)} | #{duration} | [#{String.slice(build.git_commit_sha, 0, 9)}](#{git_remote_url_origin}/commit/#{build.git_commit_sha}) |\n"
+        "| [#{build.root_project_name}](#{url}) | #{get_build_status_text(build)} | #{duration} | #{commit_link(build.git_commit_sha, git_remote_url_origin)} |\n"
       end)
 
     "| Project | Status | Duration | Commit |\n" <>

--- a/server/test/tuist/clickhouse_retry_test.exs
+++ b/server/test/tuist/clickhouse_retry_test.exs
@@ -88,6 +88,60 @@ defmodule Tuist.ClickHouseRetryTest do
 
       assert :counters.get(counter, 1) == 1
     end
+
+    test "retries a raised memory-limit error and returns once the call succeeds" do
+      counter = :counters.new(1, [])
+
+      log =
+        capture_log(fn ->
+          assert ClickHouseRetry.with_retry(
+                   fn ->
+                     :counters.add(counter, 1, 1)
+
+                     if :counters.get(counter, 1) < 2 do
+                       raise %Ch.Error{code: 241, message: "Memory limit (for query) exceeded"}
+                     end
+
+                     :ok
+                   end,
+                   memory_retries: 1
+                 ) == :ok
+        end)
+
+      assert :counters.get(counter, 1) == 2
+      assert log =~ "ClickHouse is over its memory budget"
+    end
+
+    test "reraises the memory-limit error after exhausting retries" do
+      counter = :counters.new(1, [])
+
+      capture_log(fn ->
+        assert_raise Ch.Error, fn ->
+          ClickHouseRetry.with_retry(
+            fn ->
+              :counters.add(counter, 1, 1)
+              raise %Ch.Error{code: 241, message: "Memory limit (for query) exceeded"}
+            end,
+            memory_retries: 1
+          )
+        end
+      end)
+
+      assert :counters.get(counter, 1) == 2
+    end
+
+    test "does not retry unrelated raised ClickHouse errors" do
+      counter = :counters.new(1, [])
+
+      assert_raise Ch.Error, fn ->
+        ClickHouseRetry.with_retry(fn ->
+          :counters.add(counter, 1, 1)
+          raise %Ch.Error{code: 62, message: "Syntax error"}
+        end)
+      end
+
+      assert :counters.get(counter, 1) == 1
+    end
   end
 
   describe "with_result_retry/2" do

--- a/server/test/tuist/vcs_test.exs
+++ b/server/test/tuist/vcs_test.exs
@@ -472,6 +472,135 @@ defmodule Tuist.VCSTest do
       })
     end
 
+    test "creates a comment when a preview has no commit SHA" do
+      # Given
+      project =
+        ProjectsFixtures.project_fixture(
+          vcs_connection: [
+            repository_full_handle: "tuist/tuist",
+            provider: :github
+          ]
+        )
+
+      preview =
+        AppBuildsFixtures.preview_fixture(
+          project: project,
+          display_name: "App",
+          git_ref: @git_ref,
+          git_commit_sha: nil,
+          inserted_at: ~N[2024-04-30 03:00:00]
+        )
+
+      _app_build =
+        AppBuildsFixtures.app_build_fixture(
+          preview: preview,
+          project: project,
+          display_name: "App"
+        )
+
+      stub(Req, :get, fn _opts ->
+        {:ok, %Req.Response{status: 200, body: []}}
+      end)
+
+      expected_body =
+        """
+        ### 🛠️ Tuist Run Report 🛠️
+
+        #### Previews 📦
+
+        | App | Commit |
+        | - | - |
+        | [App](https://tuist.dev/previews/#{preview.id}) |  |
+
+        """
+
+      expect(Req, :post, fn opts ->
+        assert opts[:json] == %{body: expected_body}
+
+        {:ok, %Req.Response{status: 200, body: %{}}}
+      end)
+
+      # When / Then
+      VCS.post_vcs_pull_request_comment(%{
+        project: project,
+        git_commit_sha: @git_commit_sha,
+        git_ref: @git_ref,
+        git_remote_url_origin: @git_remote_url_origin,
+        preview_url: fn %{preview: preview} -> "https://tuist.dev/previews/#{preview.id}" end,
+        preview_qr_code_url: fn %{preview: preview} ->
+          "https://tuist.dev/previews/#{preview.id}/qr-code.svg"
+        end,
+        command_run_url: fn %{command_event: command_event} ->
+          "https://tuist.dev/runs/#{command_event.id}"
+        end,
+        test_run_url: fn %{test_run: test_run} -> "https://tuist.dev/test_runs/#{test_run.id}" end,
+        bundle_url: fn _ -> "" end,
+        build_url: fn _ -> "" end
+      })
+    end
+
+    test "creates a comment when a bundle has no commit SHA" do
+      # Given
+      project =
+        ProjectsFixtures.project_fixture(
+          vcs_connection: [
+            repository_full_handle: "tuist/tuist",
+            provider: :github
+          ]
+        )
+
+      bundle =
+        BundlesFixtures.bundle_fixture(
+          project: project,
+          install_size: 1000,
+          download_size: 3000,
+          git_branch: "feat/my-feature",
+          git_ref: @git_ref,
+          git_commit_sha: nil,
+          inserted_at: ~U[2024-01-01 05:00:00Z]
+        )
+
+      stub(Req, :get, fn _opts ->
+        {:ok, %Req.Response{status: 200, body: []}}
+      end)
+
+      expected_body =
+        """
+        ### 🛠️ Tuist Run Report 🛠️
+
+        #### Bundles 🧰
+
+        | Bundle | Commit | Install size | Download size |
+        | - | - | - | - |
+        | [App](https://tuist.dev/bundles/#{bundle.id}) |  | <div align=\"center\">1.0 KB</div> | <div align=\"center\">3.0 KB</div> |
+
+        """
+
+      expect(Req, :post, fn opts ->
+        assert opts[:json] == %{body: expected_body}
+
+        {:ok, %Req.Response{status: 200, body: %{}}}
+      end)
+
+      # When / Then
+      VCS.post_vcs_pull_request_comment(%{
+        project: project,
+        git_commit_sha: @git_commit_sha,
+        git_ref: @git_ref,
+        git_remote_url_origin: @git_remote_url_origin,
+        preview_url: fn %{preview: preview} -> "https://tuist.dev/previews/#{preview.id}" end,
+        preview_qr_code_url: fn %{preview: preview} ->
+          "https://tuist.dev/previews/#{preview.id}/qr-code.svg"
+        end,
+        command_run_url: fn %{command_event: command_event} ->
+          "https://tuist.dev/runs/#{command_event.id}"
+        end,
+        test_run_url: fn %{test_run: test_run} -> "https://tuist.dev/test_runs/#{test_run.id}" end,
+        bundle_url: fn %{bundle: bundle} -> "https://tuist.dev/bundles/#{bundle.id}" end,
+        build_url: fn _ -> "" end
+      })
+    end
+
     test "creates a comment when full handle and provider is the same but url is different" do
       # Given
       project =


### PR DESCRIPTION
Resolves <https://hive.tuist.dev/errors/e27a21cc-897d-5f8c-a65b-30cc3e4feb2a>

`Tuist.VCS.Workers.CommentWorker` has been failing in production with `FunctionClauseError: no function clause matching in String.slice/3`. This fixes that crash and a second, higher volume failure mode in the same worker.

### Nil commit SHAs crash the whole comment

Every commit cell in the pull request comment body called `String.slice(git_commit_sha, 0, 9)` directly. `git_commit_sha` is nullable on both `previews` and `bundles`, and neither changeset lists it in `validate_required`, so a record that lands without a commit SHA takes down the entire comment rather than just its own row.

That is what happened. A preview arrived for a customer's pull request with a null SHA at 19:08:56, the worker crashed on attempts 1 through 6, and attempt 7 succeeded at 19:13:12 only because a second preview carrying a SHA had landed at 19:12:01 and displaced the broken one in the `distinct on (display_name)` query. The comment went out roughly four minutes late. Had no later preview arrived, the job would have exhausted all 20 attempts and the comment would never have been posted at all.

This is not a one off. Previews with a pull request ref and no commit SHA have appeared at a low rate for at least two weeks.

`commit_link/2` now renders an empty cell for a nil SHA, and all seven call sites go through it: previews, bundles, the three test run tables, and the two build tables. The test run and build tables read ClickHouse columns declared `String DEFAULT ''` and so cannot reach nil today, but they share the shape, and routing them through the same helper closes the class rather than the single instance.

The helper renders an empty cell rather than dropping the row, because a preview without a commit SHA is still worth showing: the preview link and QR code are the point of that table.

### ClickHouse memory limits were never retried on the raising path

The same worker also failed on ClickHouse's memory limit error (code 241) raised out of `ClickHouseRepo.all/2` while loading test runs.

`Tuist.ClickHouseRetry` already treats code 241 as retryable, and the read path sets a per query `max_memory_usage` specifically so a heavy read fails on its own with a retryable error instead of driving the process to the server ceiling. But that retry only existed on `with_result_retry/2`, which serves the tuple returning path used by the ingestion buffer. The raising path, `with_retry/2`, is what every `ClickHouseRepo` read and every `IngestRepo` write goes through, and it rescued transport errors alone. The one path the configuration was written for was the one path that could not retry.

`with_retry/2` now accepts the same options as `with_result_retry/2` and retries code 241 on its own budget, reusing the existing `memory_limit_error?/1` predicate and capped backoff. An integer second argument is still accepted so the `IngestRepo.with_retry/2` delegate keeps working.

The memory budget defaults to 3 rather than the 8 that `with_result_retry/2` uses. `with_retry` sits on the read path for LiveView and web requests, which already run behind a 15 second `max_execution_time` and a 20 second client timeout. Eight retries at a 2 second cap would add roughly 9 seconds to a request that is already slow, whereas three attempts is about 700ms of backoff and is still strictly better than the current zero.

### Validation

Both fixes were reproduced failing against the pre-fix code before being fixed.

- `creates a comment when a preview has no commit SHA` reproduced the production stack trace frame for frame: `string.ex:2415`, `vcs.ex:755`, `enum.ex:1725`, `vcs.ex:749`, `vcs.ex:573`, `vcs.ex:445`. It matches the captured error exactly.
- `creates a comment when a bundle has no commit SHA` crashed at `vcs.ex:661` in `bundles_body/1`, confirming that path is a live crash waiting for the first nil SHA bundle rather than a theoretical one.
- Both new `with_retry/2` memory limit tests failed as expected, with the `Ch.Error` propagating uncaught and the function body called once instead of twice.

After the fix: 106 passing in `vcs_test.exs`, 15 in `clickhouse_retry_test.exs`, and 27 across `clickhouse_repo_test.exs`, `ingest_repo/shadow_write_test.exs` and `test/tuist/ingestion`. No existing test needed changing, which confirms `commit_link/2` produces identical output for non nil SHAs. Credo reports no issues and the changed modules compile without warnings.

### Note for reviewers

The Hive issue this came from bundles three unrelated exceptions under one title, because the Sentry SDK's Oban reporter sets `fingerprint: [job.worker, "{{ default }}"]` and Hive hashes the `{{ default }}` placeholder literally instead of expanding it. Every Oban failure of a given worker therefore collapses into a single issue. That is a change in `tuist/hive` and is not addressed here.

### How to test locally

From `server/`:

```
mix test test/tuist/vcs_test.exs test/tuist/clickhouse_retry_test.exs
```

To observe the pre-fix failures, check out the parent commit and apply only the new test cases: the two in `test/tuist/vcs_test.exs` and the three in `test/tuist/clickhouse_retry_test.exs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
