### PR TITLE
fix(server): reclaim idle PgBouncer clients after processor rollouts

### DIFF
--- a/infra/cnpg/README.md
+++ b/infra/cnpg/README.md
@@ -75,7 +75,7 @@ Three reasons: `CREATE ROLE` is superuser-only, role state is infra rather than 
 
 ## Connection pooler (PgBouncer)
 
-The chart can put a CNPG `Pooler` (PgBouncer) in front of the cluster's primary, gated on `postgresql.cnpg.pooler.enabled` (off by default). It is a **transaction-mode pooler for the processor only**, matching the processor's `prepare: :unnamed` connection shape.
+The chart can put a CNPG `Pooler` (PgBouncer) in front of the cluster's primary, gated on `postgresql.cnpg.pooler.enabled` (off by default). The managed deployment routes the Linux build processors, macOS xcresult processors, and Swift registry sync consumer through it in **transaction mode**, matching their `prepare: :unnamed` connection shape.
 
 ### Why the web tier is not pooled
 
@@ -94,6 +94,53 @@ To activate:
 3. Confirm the processor reconnected — its `DATABASE_URL` now resolves to `-pooler-rw`.
 
 There is no separate cluster-bootstrap step, so this is safe to flip on an existing cluster; the processor briefly retries its connection while the pooler pods come up, then settles.
+
+### Client connections through Tailscale
+
+The macOS xcresult processors reach PgBouncer through a Tailscale operator
+proxy. The proxy's TCP connection to PgBouncer can survive a lost VM. TCP
+keepalives on that connection test the proxy, not the original VM, so they
+cannot by themselves bound how long an abandoned client occupies a slot.
+
+On September 7, 2026, production reached its 100-client limit during processor
+rollouts. One xcresult processor could not fetch Oban jobs from 19:36 to 19:52
+UTC. The pooler rejected new clients with `max_client_conn` until ten older
+connections from the Tailscale proxy closed together at 19:52:45. Sixty such
+connections were released in batches of ten by 21:46, returning the pooler to
+its normal 50 application clients plus the monitoring connection. These
+observations point to connections surviving earlier VM replacements; they do
+not establish a leak of Postgres backend connections.
+
+The managed common values apply two controls to staging, canary, and production:
+
+- `client_idle_timeout: "300"` closes clients after five minutes without
+  PostgreSQL protocol traffic. DBConnection's default one-second idle checks
+  call Postgrex's `Sync` ping, which refreshes PgBouncer's client activity
+  timestamp. Healthy idle pools therefore stay connected. PgBouncer skips
+  clients linked to a backend, including running queries and open transactions;
+  this is not a query or transaction timeout. A client that stops sending
+  traffic for five minutes outside a transaction must reconnect.
+- `max_client_conn: "200"` provides admission headroom while abandoned clients
+  age out and old/new consumers overlap. Production's normal topology has two Linux
+  processors, two xcresult processors, and one Swift registry sync consumer,
+  each with ten connections. The backend `default_pool_size` remains 20 per
+  database/user pair, and Postgres `max_connections` is unchanged. Increasing
+  the application pools or only increasing this admission limit would not
+  reclaim abandoned connections.
+
+These overrides are limited to managed environments. The base chart leaves
+the idle timeout disabled, since other clients may not send idle heartbeats.
+See [PgBouncer's timeout documentation](https://www.pgbouncer.org/config.html#client_idle_timeout)
+and the [1.25.1 client maintenance implementation](https://github.com/pgbouncer/pgbouncer/blob/pgbouncer_1_25_1/src/janitor.c#L376-L401).
+
+After deployment, verify the `Pooler` parameters, then observe a processor
+rollout: `cnpg_pgbouncer_lists_used_clients` should return near the steady-state
+baseline within five minutes of the old clients' last protocol traffic. Check
+PgBouncer logs for `client_idle_timeout` and absence of `max_client_conn`
+rejections, and confirm `process_xcresult` continues completing jobs. Sustained
+idle-timeout disconnects from live consumers indicate their heartbeat behavior
+needs investigation. To roll back, set the managed `client_idle_timeout` to
+`"0"`; the client admission limit can be reverted independently.
 
 ## Password rotation
 

--- a/infra/helm/AGENTS.md
+++ b/infra/helm/AGENTS.md
@@ -15,6 +15,7 @@ This node covers Helm assets under `infra/helm/`.
 - Model infrastructure dependencies with capability names such as `objectStorage`, not provider names such as `minio`.
 - Support both `embedded` and `external` dependency modes when practical.
 - Keep local validation simple: `helm template` first, then a small-cluster install path such as `kind`.
+- Managed PgBouncer client limits and idle cleanup live in `tuist/values-managed-common.yaml`. Keep the connection lifecycle and rollout validation in [`../cnpg/README.md`](../cnpg/README.md#client-connections-through-tailscale) aligned when changing them.
 - Grafana-managed alert queries and their operational rationale live in
   `k8s-monitoring/alerts.md`. Keep that runbook aligned with live rule changes;
   browser LCP p99 also requires distinct affected sessions, not just total samples.

--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -432,6 +432,17 @@ postgresql:
     password: ""
   cnpg:
     enabled: true
+    pooler:
+      parameters:
+        # Production's five consumer pools normally use 50 clients. Leave room for
+        # overlapping rollouts while retaining default_pool_size=20 per
+        # database/user on the Postgres side.
+        max_client_conn: "200"
+        # A lost Tart VM can leave the Tailscale proxy's pooler socket
+        # open for hours. Reap clients with no protocol traffic; healthy
+        # Postgrex pools send Sync pings every second. This timeout does
+        # not interrupt a client linked to an active backend transaction.
+        client_idle_timeout: "300"
     backup:
       # Per-env bucket name lives in the env overlay's destinationPath.
       endpointURL: https://t3.storage.dev


### PR DESCRIPTION
## Problem and investigation

Processor rollouts can leave idle connections occupying PgBouncer's client slots long after the original macOS VM is gone. On September 7, production's xcresult processor `5d577fc889-bwpfw` hit a `max_client_conn` rejection at 19:36:11 UTC, followed by 45 connection checkout failures through 19:52:31. The failing stack runs through `Tuist.Oban.Engine.fetch_jobs/3`, so this processor could not acquire new jobs.

The live CNPG Pooler runs PgBouncer 1.25.1 with `max_client_conn=100` and `default_pool_size=20`. Its used-client metric plateaued at 101, including monitoring. All rejected connections came from `192.168.7.114`, verified against Kubernetes metadata as the Tailscale operator proxy for the pooler.

At 19:52:45, ten older `tuist_processor` connections from that proxy closed together with `client unexpected eof`, immediately after the error burst. Six batches of ten closed between 19:52 and 21:46, each roughly three hours old, and the pooler returned to 51 clients. This is consistent with connections surviving earlier VM replacements. It does not establish the exact point where the VM-side disconnect was lost or a leak of Postgres backend connections.

Hive issue: https://hive.tuist.dev/errors/2ad9232c-c458-51f1-a761-2ad0219c680a

## Approach

Apply two overrides in the managed common values, covering staging, canary, and production:

- Set `client_idle_timeout=300` to reclaim clients after five minutes without PostgreSQL protocol traffic. TCP keepalives between PgBouncer and the still-running proxy do not test the original VM. An application-level timeout bounds the lifetime of those silent connections.
- Raise `max_client_conn` from 100 to 200 so overlapping consumers and connections awaiting cleanup have admission headroom. Production normally has five ten-connection consumer pools: two Linux processors, two xcresult processors, and one Swift registry sync consumer. Postgres `max_connections` and PgBouncer's 20-connection backend limit per database/user are unchanged.

DBConnection's default idle checks invoke Postgrex's `Sync` ping every second. PgBouncer refreshes the client's activity timestamp on this traffic, so healthy idle pools remain connected. The 1.25.1 idle cleanup skips clients linked to a backend; running queries and open transactions are not subject to this timeout. A live client that sends nothing for five minutes outside a transaction will need to reconnect.

Only raising the client cap would delay recurrence without reclaiming abandoned connections. Increasing application pool sizes would consume more admission slots. Keep the base chart unchanged because arbitrary self-hosted clients may not send heartbeats. Document the incident, connection budget, rollout checks, and rollback in the CNPG runbook and link it from the Helm intent node.

References: [PgBouncer timeout semantics](https://www.pgbouncer.org/config.html#client_idle_timeout), [1.25.1 cleanup implementation](https://github.com/pgbouncer/pgbouncer/blob/pgbouncer_1_25_1/src/janitor.c#L376-L401).

## Validation

- Built the official PgBouncer 1.25.1 source and ran an isolated PostgreSQL 17.5 backend on localhost with temporary data. With idle cleanup disabled, five silent clients continued occupying a five-client test limit and a sixth client was rejected after four seconds.
- Reloaded the same PgBouncer process with a three-second idle timeout to accelerate the five-minute production setting. Two silent clients were disconnected with `client_idle_timeout`, and a replacement connected and queried successfully. A Postgrex-style `Sync` heartbeat every 500 ms, a six-second query, and a transaction held open for over four seconds all survived.
- Full `helm template` renders passed for staging, canary, and production using the managed common/environment overlays and `values-ci.yaml`. Each Pooler renders the 300-second timeout, 200-client cap, and unchanged 20-connection backend pool.
- A self-hosted CNPG Pooler render retains the 100-client cap and no idle timeout.
- `git diff --check` passed.
- Full production `helm lint` fails on a pre-existing malformed YAML document separator in `templates/dedibox-fleet.yaml`. Reproduced the same failure using the unmodified baseline. Disabling that fleet reveals the same existing separator problem in `templates/kura-fleet.yaml`; neither template is changed here.

## Rollout and scope

This PR has not changed production. After deployment, verify the reconciled Pooler parameters and watch a processor rollout: the client count should settle near its normal baseline within five minutes of old clients' last traffic, `max_client_conn` rejections should stop, and xcresult jobs should continue completing. Investigate sustained idle-timeout disconnects from live consumers. Setting `client_idle_timeout` back to `"0"` rolls back cleanup independently of the client cap.

This addresses the confirmed admission-exhaustion burst. Hive currently groups unrelated exceptions under this issue's literal default fingerprint, so its total event count is not a count of connection failures. The isolated 410 ms timeout at 07:00 UTC on September 8 occurred at 51 clients and is not explained by the capacity evidence above.
