### PR TITLE
ci(docs): front the registry with an HTTP/1.1 proxy

### DIFF
--- a/.github/workflows/project-description-docs.yml
+++ b/.github/workflows/project-description-docs.yml
@@ -49,9 +49,34 @@ jobs:
       - uses: jdx/mise-action@v4.0.1
         with:
           version: ${{ env.MISE_VERSION }}
-          install_args: "swift@6.2.4 node@20.12.0 npm:wrangler@4.30.0"
+          install_args: "swift@6.2.4 node@20.12.0 npm:wrangler@4.30.0 caddy"
           cache: "false"
           github_token: ${{ env.MISE_GITHUB_TOKEN }}
+      # Swift 6.2's FoundationNetworking traps on a redirect served over HTTP/2
+      # (see #12229), and the registry answers 303 to storage over h2. Terminating
+      # the first hop as plaintext HTTP/1.1 removes the precondition; the redirect
+      # target negotiates http/1.1 on its own, so only this hop needs forcing.
+      - name: Front the registry with an HTTP/1.1 proxy
+        shell: bash
+        run: |
+          nohup mise exec caddy -- caddy reverse-proxy \
+            --from :8080 --to https://tuist.dev --change-host-header \
+            > /tmp/registry-proxy.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if (exec 3<>/dev/tcp/127.0.0.1/8080) 2>/dev/null; then
+              exec 3>&-
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::registry proxy did not start listening on :8080"
+          cat /tmp/registry-proxy.log || true
+          exit 1
+      - name: Point SwiftPM at the proxy
+        run: >-
+          mise exec swift@6.2.4 --
+          swift package-registry set --allow-insecure-http
+          http://localhost:8080/api/registry/swift
       - name: Build ProjectDescription documentation
         run: >-
           MISE_PROJECT_ROOT="$GITHUB_WORKSPACE" mise exec swift@6.2.4 --


### PR DESCRIPTION
The `Build and deploy` job of `project-description-docs.yml` has been failing on `main`. Its `Build ProjectDescription documentation` step crashes during SwiftPM package resolution:

```
FoundationNetworking/EasyHandle.swift:293: Fatal error: try! expression unexpectedly
  raised an error: Error Domain=libcurl.Easy Code=43 "(null)"
*** Program crashed: Illegal instruction ***
##[error]Process completed with exit code 132
```

## Root cause

This is [#12229](https://github.com/tuist/tuist/issues/12229), and the registry response is not malformed.

`EasyHandle.swift:293` is `set(preferredReceiveBufferSize:)`, which sets `CURLOPT_BUFFERSIZE`. libcurl rejects that option with `CURLE_BAD_FUNCTION_ARGUMENT` (43) in exactly one case, `if(data->state.buffer) return CURLE_BAD_FUNCTION_ARGUMENT;`, meaning while the easy handle still owns a receive buffer. That buffer is freed at the end of `multi_done()`, but `multi_done()` returns early while other easy handles are still attached to the same connection, which is precisely what HTTP/2 multiplexing produces.

corelibs performs redirects itself rather than setting `CURLOPT_FOLLOWLOCATION`, so on a 3xx it reconfigures a handle whose buffer was never released, and it wraps the rejected `curl_easy_setopt` in `try!`. A recoverable error becomes an unconditional trap. The crash backtrace shows exactly this path:

```
_HTTPURLProtocol.redirectFor(request:)
  -> didCompleteRedirectCallback
    -> _NativeProtocol.startNewTransfer
      -> _HTTPURLProtocol.configureEasyHandle   <- traps
```

So the crash needs HTTP/2 and a redirect together. `registry.tuist.dev` is Cloudflare proxied, so the client hop negotiates h2, and the source archive endpoint answers `303` to storage. A cold resolve of this package pulls all 85 registry pins concurrently, which is what supplies the multiplexing.

## What changed

Terminating the first hop as plaintext HTTP/1.1 removes the multiplexing precondition. The redirect target negotiates `http/1.1` on its own, so only this hop needs forcing.

This is the same workaround [#12231](https://github.com/tuist/tuist/pull/12231) applied to the CLI Linux jobs. This workflow was missed at the time and stayed green because a warm `.build` cache meant it never fetched from the registry. Once that cache aged out, every run crashed.

caddy is installed through the existing `mise-action` step and inherits the `caddy = "2.11.2"` pin already in `mise.toml`, rather than introducing a second version to keep in sync.

## Why not the alternatives

- **Retrying resolution.** A crashed attempt leaves almost nothing downloaded, so the loop does not converge. Both attempts of the failing run completed only 4 of 85 downloads before trapping, and the issue records the same result over 12 consecutive attempts.
- **Bumping the toolchain or the runner distro.** The libcurl guard is still present in curl 8.5.0 (Ubuntu 24.04) and was only dropped in 8.7. `release/6.2` and `release/6.3` both still carry the `try!` call sites, so no currently installable stable Swift avoids it.
- **Changing the redirect status code.** The status code is irrelevant; 301, 302, 303, 307 and 308 all trap under h2.

## Impact

Restores publishing of the ProjectDescription documentation site, which has not deployed since the last successful `main` run on 2026-09-03.

The underlying defect is unchanged and still affects any Linux client on Swift 6.2/6.3 resolving from the registry with a cold cache. That is tracked in [#12229](https://github.com/tuist/tuist/issues/12229), which weighs the server side options.

## Validation

Dispatched `project-description-docs.yml` on this branch: [run 34203106822](https://github.com/tuist/tuist/actions/runs/34203106822), success.

The run is a genuine reproduction of the failing conditions:

- `Cache not found for input keys: linux-project-description-docc-e061778...`, the same cold cache as the three failing runs.
- 86 packages fetched, so every registry archive went through the `303`.
- 0 occurrences of `Fatal error` and 0 of `Illegal instruction`.
- `Documentation generated at .build/documentation`.
- The Cloudflare Pages steps are gated on `github.ref == 'refs/heads/main'` and skipped, so the branch run published nothing.

Locally confirmed that the proxy serves the registry over HTTP/1.1 while the archive still downloads intact (322283 bytes, identical to a direct fetch), and that `swift package-registry set` preserves the `security` and `authentication` blocks of the checked in `registries.json`, swapping only the default registry URL.

For reference, the failing runs were [34201365833](https://github.com/tuist/tuist/actions/runs/34201365833) (a `workflow_dispatch` of the unmodified workflow from a branch cut at `origin/main`, confirming the breakage is pre-existing) and [34200527163](https://github.com/tuist/tuist/actions/runs/34200527163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)