### PR TITLE
fix(noora): preserve date picker navigation after DOM updates

### DIFF
--- a/noora/AGENTS.md
+++ b/noora/AGENTS.md
@@ -36,6 +36,8 @@ Do not bootstrap the npm package from a local machine. The first automated relea
 
 - Use `noora` as the conventional commit scope for changes in this directory
 - The Tuist server depends on noora via a local path dependency (`{:noora, path: "../noora"}`)
+- Delegate date-picker month navigation from the hook root so LiveView can replace
+  calendar controls without losing their click handlers.
 - The LiveView chart hook supports opt-in `data-lazy="true"` initialization near
   the viewport. Keep offscreen updates and destruction safe, and register resize
   listeners once per hook lifetime rather than once per render.

--- a/noora/js/DatePicker/index.js
+++ b/noora/js/DatePicker/index.js
@@ -49,48 +49,40 @@ export class DatePicker extends Component {
   setupNavigationHandlers() {
     const signal = this.abortController.signal;
 
-    // Use event delegation on month elements
-    const months = this.el.querySelectorAll(
-      "[data-part='months'] > [data-part='month']",
-    );
+    // Delegate from the hook root so navigation survives LiveView DOM patches.
+    this.el.addEventListener(
+      "click",
+      (e) => {
+        const navigationTrigger = e.target.closest(
+          "[data-part='prev-trigger'], [data-part='next-trigger']",
+        );
+        if (navigationTrigger) {
+          if (navigationTrigger.disabled) return;
 
-    months.forEach((monthEl, monthIndex) => {
-      const prevTrigger = monthEl.querySelector("[data-part='prev-trigger']");
-      const nextTrigger = monthEl.querySelector("[data-part='next-trigger']");
+          const months = Array.from(
+            this.el.querySelectorAll(
+              "[data-part='months'] > [data-part='month']",
+            ),
+          );
+          const monthIndex = months.indexOf(
+            navigationTrigger.closest("[data-part='month']"),
+          );
+          if (monthIndex < 0) return;
 
-      if (prevTrigger) {
-        prevTrigger.addEventListener(
-          "click",
-          () => {
+          if (navigationTrigger.dataset.part === "prev-trigger") {
             if (monthIndex === 0) {
               this.calendarNav.navigatePrevStart();
             } else {
               this.calendarNav.navigatePrevEnd();
             }
-          },
-          { signal },
-        );
-      }
+          } else if (monthIndex === 0) {
+            this.calendarNav.navigateNextStart();
+          } else {
+            this.calendarNav.navigateNextEnd();
+          }
+          return;
+        }
 
-      if (nextTrigger) {
-        nextTrigger.addEventListener(
-          "click",
-          () => {
-            if (monthIndex === 0) {
-              this.calendarNav.navigateNextStart();
-            } else {
-              this.calendarNav.navigateNextEnd();
-            }
-          },
-          { signal },
-        );
-      }
-    });
-
-    // Event delegation for preset buttons
-    this.el.addEventListener(
-      "click",
-      (e) => {
         const presetItem = e.target.closest("[data-part='preset-item']");
         if (presetItem) {
           const presetId = presetItem.dataset.presetId;

--- a/noora/js/DatePicker/index.test.js
+++ b/noora/js/DatePicker/index.test.js
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import DatePickerHook from "./index.js";
+
+let hook;
+
+afterEach(() => {
+  hook.beforeDestroy();
+  hook.destroyed();
+  document.body.replaceChildren();
+});
+
+function mount() {
+  const el = document.createElement("div");
+  el.id = "date-picker";
+  el.dataset.periodStart = "2026-08-01";
+  el.dataset.periodEnd = "2026-09-08";
+  el.dataset.min = "2026-06-01";
+  el.dataset.max = "2026-09-08";
+  el.innerHTML = `
+    <div data-part="control"><button data-part="trigger"></button></div>
+    <div data-part="positioner">
+      <div data-part="content">
+        <div data-part="months">
+          ${[0, 1]
+            .map(
+              (index) => `
+            <div data-part="month" data-index="${index}">
+              <div data-part="view-control">
+                <button type="button" data-part="prev-trigger"><svg><path /></svg></button>
+                <span data-part="view-trigger"></span>
+                <button type="button" data-part="next-trigger"><svg><path /></svg></button>
+              </div>
+            </div>
+          `,
+            )
+            .join("")}
+        </div>
+      </div>
+    </div>
+  `;
+  document.body.append(el);
+  hook = { ...DatePickerHook, el, pushEvent: vi.fn() };
+  hook.mounted();
+  return el;
+}
+
+function months(el) {
+  return [...el.querySelectorAll('[data-part="view-trigger"]')].map(
+    (month) => month.textContent,
+  );
+}
+
+function clickArrow(el, index, direction) {
+  el.querySelectorAll(`[data-part="${direction}-trigger"]`)
+    [index].querySelector("path")
+    .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}
+
+describe("date picker month navigation", () => {
+  it("navigates both calendars independently without changing the selected range", () => {
+    const el = mount();
+    expect(months(el)).toEqual(["August 2026", "September 2026"]);
+
+    clickArrow(el, 0, "prev");
+    expect(months(el)).toEqual(["July 2026", "September 2026"]);
+    clickArrow(el, 1, "prev");
+    expect(months(el)).toEqual(["July 2026", "August 2026"]);
+    clickArrow(el, 1, "next");
+    expect(months(el)).toEqual(["July 2026", "September 2026"]);
+    clickArrow(el, 0, "next");
+    expect(months(el)).toEqual(["August 2026", "September 2026"]);
+
+    expect(hook.datePicker.api.value.map((date) => date.toString())).toEqual([
+      "2026-08-01",
+      "2026-09-08",
+    ]);
+    expect(hook.pushEvent).not.toHaveBeenCalled();
+  });
+
+  it("keeps navigation working after LiveView replaces the calendar controls", () => {
+    const el = mount();
+    for (const control of el.querySelectorAll('[data-part="view-control"]')) {
+      control.replaceWith(control.cloneNode(true));
+    }
+    hook.updated();
+
+    clickArrow(el, 0, "prev");
+    expect(months(el)).toEqual(["July 2026", "September 2026"]);
+    clickArrow(el, 1, "prev");
+    expect(months(el)).toEqual(["July 2026", "August 2026"]);
+    hook.updated();
+    hook.updated();
+    clickArrow(el, 1, "next");
+    expect(months(el)).toEqual(["July 2026", "September 2026"]);
+    clickArrow(el, 0, "next");
+    expect(months(el)).toEqual(["August 2026", "September 2026"]);
+  });
+
+  it("ignores disabled arrows at date bounds and between adjacent months", () => {
+    const el = mount();
+    clickArrow(el, 0, "next");
+    clickArrow(el, 1, "prev");
+    clickArrow(el, 1, "next");
+    expect(months(el)).toEqual(["August 2026", "September 2026"]);
+
+    clickArrow(el, 0, "prev");
+    clickArrow(el, 0, "prev");
+    expect(months(el)).toEqual(["June 2026", "September 2026"]);
+    clickArrow(el, 0, "prev");
+    expect(months(el)).toEqual(["June 2026", "September 2026"]);
+  });
+});


### PR DESCRIPTION
The Overview date-range picker could show enabled month arrows that did nothing. Its navigation listeners were attached directly to the buttons once at mount time. Replacing those controls leaves the visible buttons without listeners, while the hook's update callback only redraws the calendar.

This change delegates month-arrow clicks from the stable picker root, resolving the current button and calendar when a click occurs. This handles clicks on the SVG chevrons and continues working after controls are replaced or the hook updates repeatedly. Disabled arrows still enforce the date bounds and prevent the calendars from crossing. Browsing months does not change or submit the selected range.

Delegation uses the same root listener as presets and avoids rebinding handlers on each update, which would require tracking replaced elements and preventing duplicate listeners.

### Before and after

The recording uses the real Noora controller and styles in a local component fixture. The refresh button explicitly replaces the calendar header controls, reproducing the DOM-replacement failure covered by the regression test; this is not a recording of a full Overview LiveView session. Both versions receive the same refresh and arrow clicks. Before, July/August remain unchanged; after, the left calendar moves to June and the right calendar moves to September.

![Before and after: calendar month navigation](https://raw.githubusercontent.com/tuist/tuist/ea7fd793943a213cef1efa242e3039f98b0800f4/calendar-before-after.gif)

[Watch or download the MP4 recording](https://github.com/tuist/tuist/blob/ea7fd793943a213cef1efa242e3039f98b0800f4/calendar-before-after.mp4)

The recording is stored on a separate media-only branch so it does not add binary files to this PR's source diff.

### Validation

- Confirmed the new DOM-replacement regression test fails against the original implementation and passes with the fix.
- Ran `vitest run js/DatePicker js/web-components/Remaining.test.js` from `noora/`: **155 tests passed across four files**.
- Regression coverage includes both calendars and directions, SVG clicks, repeated updates, unchanged selected dates, and disabled arrows at date bounds and adjacent months.
- Verified the before/after behavior in a browser using the local fixture.
- Prettier checks and `git diff --check` pass.

### How to test locally

From `noora/`, install the JavaScript dependencies with `aube install`, then run:

```sh
aube run test --run js/DatePicker js/web-components/Remaining.test.js
```

For an application check, open the Overview date picker, trigger a LiveView update that replaces its calendar controls, then use the month arrows. They should continue navigating independently without applying a new date range.
