### PR TITLE
fix(server): bind flaky automation test IDs as an array

### DIFF
--- a/server/cla/signatures.json
+++ b/server/cla/signatures.json
@@ -55,6 +55,14 @@
       "created_at": "2026-06-01T18:07:56Z",
       "repoId": 250427618,
       "pullRequestNo": null
+    },
+    {
+      "name": "Krishna Barnwal",
+      "id": 37033294,
+      "comment_id": "",
+      "created_at": "2026-09-08T12:33:45Z",
+      "repoId": 250427618,
+      "pullRequestNo": null
     }
   ]
 }

--- a/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
+++ b/server/lib/tuist/automations/monitors/flaky_tests_monitor.ex
@@ -226,7 +226,7 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
           )
           |> apply_sample_floor(scope)
           |> filter_test_case_ids(test_case_ids)
-          |> ClickHouseRepo.all()
+          |> ClickHouseRepo.all(multipart: true)
 
         {:rolling, size} ->
           rolling_triggered_test_case_ids(project_id, scope, "flakiness_rate", size, threshold, comparison, test_case_ids)
@@ -255,7 +255,7 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
           )
           |> apply_sample_floor(scope)
           |> filter_test_case_ids(test_case_ids)
-          |> ClickHouseRepo.all()
+          |> ClickHouseRepo.all(multipart: true)
 
         {:rolling, size} ->
           rolling_triggered_test_case_ids(
@@ -292,7 +292,7 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
           )
           |> apply_sample_floor(scope)
           |> filter_test_case_ids(test_case_ids)
-          |> ClickHouseRepo.all()
+          |> ClickHouseRepo.all(multipart: true)
 
         {:rolling, size} ->
           rolling_triggered_test_case_ids(
@@ -772,7 +772,11 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitor do
   defp filter_test_case_ids(query, []), do: where(query, false)
 
   defp filter_test_case_ids(query, test_case_ids) do
-    where(query, [row], row.test_case_id in ^test_case_ids)
+    where(
+      query,
+      [row],
+      fragment("? IN (?)", row.test_case_id, type(^test_case_ids, {:array, Ecto.UUID}))
+    )
   end
 
   # Persisted alerts always carry an explicit `window_type` after the backfill

--- a/server/test/tuist/automations/monitors/flaky_tests_monitor_test.exs
+++ b/server/test/tuist/automations/monitors/flaky_tests_monitor_test.exs
@@ -574,6 +574,27 @@ defmodule Tuist.Automations.Monitors.FlakyTestsMonitorTest do
     end
   end
 
+  describe "evaluate_by_run_count/2 with last-days window" do
+    test "scopes evaluation to a large batch of test cases" do
+      project = ProjectsFixtures.project_fixture()
+      test_case_ids = Enum.map(1..2_000, fn _index -> Ecto.UUID.generate() end)
+
+      alert =
+        AutomationsFixtures.automation_alert_fixture(
+          project: project,
+          monitor_type: "flaky_run_count",
+          trigger_config: %{
+            "threshold" => 3,
+            "window_type" => "last_days",
+            "window" => "30d",
+            "comparison" => "gte"
+          }
+        )
+
+      assert %{triggered: []} = FlakyTestsMonitor.evaluate_by_run_count(alert, test_case_ids)
+    end
+  end
+
   describe "evaluate_by_run_count/1 with rolling window" do
     test "fires when flaky run count in last N runs meets the threshold" do
       project = ProjectsFixtures.project_fixture()


### PR DESCRIPTION
## Problem

Rebuilding the baseline of a flaky-test automation can fail on its first page with:

```text
Poco::Exception ... HTML Form Exception: Too many form fields
```

The bounded baseline implementation evaluates candidate test cases in batches of 2,000. `filter_test_case_ids/2` used `row.test_case_id in ^test_case_ids`, which `ecto_ch` expands into one ClickHouse HTTP query parameter per UUID. A default ClickHouse server accepts at most 1,000 HTTP form fields, so the request is rejected during form parsing before the SQL executes.

This is latent during normal incremental evaluation because those scopes are usually small. Creating an automation, or editing its monitor configuration and thereby resetting its baseline, exercises the full 2,000-ID batch.

## Fix

Bind the candidate IDs as one typed `Array(UUID)` parameter and execute the three last-days monitor queries as multipart requests. This preserves the existing 2,000-test paging while reducing the request from roughly 2,000 form fields to one array field.

The same treatment is applied to flakiness rate, flaky run count, and reliability rate because all three last-days paths share `filter_test_case_ids/2`.

Increasing ClickHouse's `http_max_fields` was not chosen because it would couple the application batch size to a server parser limit and only move the failure to a larger batch.

## How to reproduce locally

1. Start the repository's PostgreSQL and Keeper-enabled ClickHouse test dependencies.

```bash
cd server
brew services start postgresql@16
mise run clickhouse:start
```

2. On the parent commit, add/run the regression case included in this PR. It creates a last-days `flaky_run_count` alert and evaluates it against 2,000 generated UUIDs:

```bash
mix test test/tuist/automations/monitors/flaky_tests_monitor_test.exs:578
```

3. Without the production change, the test fails with `HTML Form Exception: Too many form fields`.
4. With this PR, the same test returns `%{triggered: []}` and passes.

## Validation

- Confirmed the new regression test is red against the original expanding `IN`: `0/1 passed`, exact `Too many form fields` error.
- Confirmed the same test is green with the typed array and multipart request: `1/1 passed`.
- `mix test test/tuist/automations/monitors/flaky_tests_monitor_test.exs`: 40 passed.
- `mix format --check-formatted` passed on both changed files.
- `git diff --check` passed.
