### PR TITLE
fix(server): start the job the runner shuffle displaces onto a Pod

### DIFF
--- a/server/lib/tuist/oban/runtime_config.ex
+++ b/server/lib/tuist/oban/runtime_config.ex
@@ -54,6 +54,7 @@ defmodule Tuist.Oban.RuntimeConfig do
     {"* * * * *", Tuist.Runners.Workers.OrphanedRunnersWorker},
     {"* * * * *", Tuist.Runners.Workers.PodReconciliationWorker},
     {"* * * * *", Tuist.Runners.Workers.OrphanedStampedPodsWorker},
+    {"* * * * *", Tuist.Runners.Workers.UnstartedExecutionsWorker},
     {"* * * * *", Tuist.Runners.Workers.ExpireInteractiveSessionsWorker},
     {"*/5 * * * *", Tuist.Runners.Workers.WebhookRedeliveryWorker},
     {"*/5 * * * *", Tuist.Runners.Workers.StaleQueuedJobsWorker},

--- a/server/lib/tuist/runners.ex
+++ b/server/lib/tuist/runners.ex
@@ -46,6 +46,18 @@ defmodule Tuist.Runners do
   same transaction so the next poll can pick the workflow_job up
   again.
 
+  ## The runner shuffle
+
+  GitHub binds a JIT runner to a label set, not to a job, so it
+  routinely places job B on the Pod minted for job A. Both jobs move on
+  the `workflow_job.in_progress` webhook, in the transaction that moves
+  the claim (`Claims.record_execution/3`): A is detached and re-queued
+  so another Pod can take it, and B starts on the Pod's slot. B has no
+  other way in — it was never claimed here, so no mint transitions it,
+  and GitHub announces nothing further about a job it has already
+  started. `UnstartedExecutionsWorker` is the backstop for a delivery
+  that never lands.
+
   ## Who releases a claim, and why there is a backstop
 
   A claim is a reservation against the account's concurrency budget.

--- a/server/lib/tuist/runners/claims.ex
+++ b/server/lib/tuist/runners/claims.ex
@@ -82,6 +82,7 @@ defmodule Tuist.Runners.Claims do
   alias Tuist.Runners.Concurrency
   alias Tuist.Runners.ConcurrencyLimit
   alias Tuist.Runners.JobCompletion
+  alias Tuist.Runners.WorkflowJob
   alias Tuist.Runners.WorkflowJobs
 
   require Logger
@@ -387,10 +388,18 @@ defmodule Tuist.Runners.Claims do
 
         # The lifecycle row re-queues in the same transaction as the
         # claim delete, so claim and row state cannot diverge across
-        # a crash. Terminal rows never match `requeue/1`'s guard and
+        # a crash. Terminal rows never match the requeue guard and
         # stay completed.
+        #
+        # Handle-guarded, like the row's own claim transition: the row
+        # carries this claim's `claimed_at` only while it belongs to
+        # this generation. A job the runner shuffle displaced *onto*
+        # another Pod carries that Pod's execution handle instead, and
+        # ClickHouse dispatch lag can still hand it a second, stale
+        # claim; re-queueing off that one would put a job that is
+        # actively running back in the queue.
         if count == 1 do
-          WorkflowJobs.requeue(workflow_job_id)
+          WorkflowJobs.requeue_by_handle(workflow_job_id, claimed_at)
           :ok
         else
           {:error, :stale_claim}
@@ -935,6 +944,47 @@ defmodule Tuist.Runners.Claims do
   end
 
   @doc """
+  Lifecycle rows still reading `queued` that a live claim proves are
+  executing: the claim records this row as its `executed_workflow_job_id`
+  and the row already carries that runner's name. Up to `limit` of them,
+  oldest arrival first, in the shape
+  `Tuist.Runners.WorkflowJobs.transition_executing/3` needs.
+
+  The backstop for `record_execution/3`. That path starts the executed
+  job in the same transaction as the detach, but only for deliveries it
+  sees: a row stranded before the transition existed, or by an
+  `in_progress` that never landed and was recovered by the `completed`
+  attribution instead, has nothing left to move it. Both leave the same
+  provable shape — a queued row bound to a runner whose claim is holding
+  a slot for it — so it is recoverable without asking GitHub anything.
+
+  Driven from the claim side because that table is bounded by concurrent
+  Pods (hundreds), where the lifecycle table is bounded by the queue.
+  `runner_name` has to agree on both rows: it is the only evidence that
+  the binding on the lifecycle row came from this claim's runner, and a
+  runner name is unique per account by 32 bits of randomness alone.
+  """
+  def list_executing_queued(limit) when is_integer(limit) and limit > 0 do
+    Repo.all(
+      from(c in Claim,
+        join: j in WorkflowJob,
+        on: j.workflow_job_id == c.executed_workflow_job_id and j.account_id == c.account_id,
+        where: c.lifecycle_state == "running" and j.status == "queued" and j.runner_name == c.runner_name,
+        order_by: [asc: j.enqueued_at, asc: j.workflow_job_id],
+        limit: ^limit,
+        select: %{
+          workflow_job_id: j.workflow_job_id,
+          account_id: j.account_id,
+          fleet_name: j.fleet_name,
+          enqueued_at: j.enqueued_at,
+          runner_name: c.runner_name,
+          pod_name: c.pod_name
+        }
+      )
+    )
+  end
+
+  @doc """
   Records the workflow_job GitHub actually placed on the runner named
   `runner_name`, learned from the `workflow_job.in_progress` /
   `completed` webhook. The mint-chosen `runner_name` is unique per
@@ -955,6 +1005,12 @@ defmodule Tuist.Runners.Claims do
   runner needs for the job it actually took, and clears the unique index
   so another Pod can claim it. The claim is keyed by `pod_name`, so it
   survives losing its job.
+
+  The same transaction starts the job the runner *did* take
+  (`Tuist.Runners.WorkflowJobs.transition_executing/3`). The Pod's slot
+  has moved from one job to the other, and both lifecycle rows have to
+  move with it: the executed job was never claimed here, so no mint will
+  ever transition it, and GitHub sends nothing more until it completes.
 
   The detach and the re-queue must commit together. Split across two
   transactions, a crash or a failed write between them leaves the job
@@ -1014,12 +1070,26 @@ defmodule Tuist.Runners.Claims do
                executed_workflow_job_id: executed_workflow_job_id,
                workflow_job_id: nil
              ) do
-          1 -> requeue_displaced_job(claimed_job_id, claimed_at)
-          0 -> nil
+          1 ->
+            adopt_executed_job(claim, executed_workflow_job_id)
+            requeue_displaced_job(claimed_job_id, claimed_at)
+
+          0 ->
+            nil
         end
       end)
 
     displaced
+  end
+
+  # The slot moves from the claimed job to the executed one, so both
+  # lifecycle rows move with it, in the transaction that moves the claim.
+  # Nothing else will start the executed job: it was never claimed by this
+  # Pod, so `mark_running/3` runs for a different row, and GitHub sends no
+  # further webhook until the job is over. Guarded on `queued`, so a row
+  # another Pod holds under its own claim generation is left to it.
+  defp adopt_executed_job(%Claim{pod_name: pod_name, runner_name: runner_name}, executed_workflow_job_id) do
+    WorkflowJobs.transition_executing(executed_workflow_job_id, runner_name, pod_name)
   end
 
   # Writes the claim that was read, by its primary key, rather than every

--- a/server/lib/tuist/runners/claims.ex
+++ b/server/lib/tuist/runners/claims.ex
@@ -82,7 +82,6 @@ defmodule Tuist.Runners.Claims do
   alias Tuist.Runners.Concurrency
   alias Tuist.Runners.ConcurrencyLimit
   alias Tuist.Runners.JobCompletion
-  alias Tuist.Runners.WorkflowJob
   alias Tuist.Runners.WorkflowJobs
 
   require Logger
@@ -876,6 +875,12 @@ defmodule Tuist.Runners.Claims do
   re-claimed row carries a NULL `pod_missing_since`, so the handle no
   longer matches and nothing is deleted. Same reason `release/2` keys on
   `claimed_at`.
+
+  The re-queue is `claimed_at`-guarded for the same reason `release/2`'s
+  is: the job this claim names may be running on a *different* Pod, the
+  one GitHub actually placed it on. Dispatch can hand a second claim to
+  a job the runner shuffle already started elsewhere, and this Pod
+  vanishing says nothing about that execution.
   """
   def release_pod_missing(pod_name, %DateTime{} = pod_missing_since) when is_binary(pod_name) do
     {:ok, outcome} =
@@ -884,7 +889,7 @@ defmodule Tuist.Runners.Claims do
           Repo.delete_all(
             from(c in Claim,
               where: c.pod_name == ^pod_name and c.pod_missing_since == ^pod_missing_since,
-              select: c.workflow_job_id
+              select: {c.workflow_job_id, c.claimed_at}
             )
           )
 
@@ -902,8 +907,8 @@ defmodule Tuist.Runners.Claims do
   # A displaced claim names no job: `record_execution/3` handed it back to
   # the queue the moment GitHub proved the Pod was running a different one,
   # so there is nothing left here to re-queue.
-  defp requeue_released_job([workflow_job_id]) when is_integer(workflow_job_id) do
-    WorkflowJobs.requeue(workflow_job_id)
+  defp requeue_released_job([{workflow_job_id, %DateTime{} = claimed_at}]) when is_integer(workflow_job_id) do
+    WorkflowJobs.requeue_by_handle(workflow_job_id, claimed_at)
   end
 
   defp requeue_released_job(_released), do: :ok
@@ -939,47 +944,6 @@ defmodule Tuist.Runners.Claims do
     Repo.exists?(
       from(c in Claim,
         where: c.workflow_job_id == ^workflow_job_id and not is_nil(c.executed_workflow_job_id)
-      )
-    )
-  end
-
-  @doc """
-  Lifecycle rows still reading `queued` that a live claim proves are
-  executing: the claim records this row as its `executed_workflow_job_id`
-  and the row already carries that runner's name. Up to `limit` of them,
-  oldest arrival first, in the shape
-  `Tuist.Runners.WorkflowJobs.transition_executing/3` needs.
-
-  The backstop for `record_execution/3`. That path starts the executed
-  job in the same transaction as the detach, but only for deliveries it
-  sees: a row stranded before the transition existed, or by an
-  `in_progress` that never landed and was recovered by the `completed`
-  attribution instead, has nothing left to move it. Both leave the same
-  provable shape — a queued row bound to a runner whose claim is holding
-  a slot for it — so it is recoverable without asking GitHub anything.
-
-  Driven from the claim side because that table is bounded by concurrent
-  Pods (hundreds), where the lifecycle table is bounded by the queue.
-  `runner_name` has to agree on both rows: it is the only evidence that
-  the binding on the lifecycle row came from this claim's runner, and a
-  runner name is unique per account by 32 bits of randomness alone.
-  """
-  def list_executing_queued(limit) when is_integer(limit) and limit > 0 do
-    Repo.all(
-      from(c in Claim,
-        join: j in WorkflowJob,
-        on: j.workflow_job_id == c.executed_workflow_job_id and j.account_id == c.account_id,
-        where: c.lifecycle_state == "running" and j.status == "queued" and j.runner_name == c.runner_name,
-        order_by: [asc: j.enqueued_at, asc: j.workflow_job_id],
-        limit: ^limit,
-        select: %{
-          workflow_job_id: j.workflow_job_id,
-          account_id: j.account_id,
-          fleet_name: j.fleet_name,
-          enqueued_at: j.enqueued_at,
-          runner_name: c.runner_name,
-          pod_name: c.pod_name
-        }
       )
     )
   end

--- a/server/lib/tuist/runners/workers/unstarted_executions_worker.ex
+++ b/server/lib/tuist/runners/workers/unstarted_executions_worker.ex
@@ -1,7 +1,7 @@
 defmodule Tuist.Runners.Workers.UnstartedExecutionsWorker do
   @moduledoc """
-  Starts lifecycle rows stuck in `status = 'queued'` while GitHub is
-  already running them.
+  Starts lifecycle rows stuck in `status = 'queued'` while a live claim
+  already records GitHub running them.
 
   ## How a row gets stuck
 
@@ -13,38 +13,48 @@ defmodule Tuist.Runners.Workers.UnstartedExecutionsWorker do
   claimed here, so no mint transitions it, and GitHub announces nothing
   further about a job it has already started.
 
-  So a delivery that never lands strands B in `queued` for its whole
-  runtime. The `completed` attribution path
-  (`Claims.complete_by_runner_name/3`) recovers the claim in that case
-  but not the row, and rows stranded before the webhook path started
-  moving them have nothing coming at all.
+  That CAS can still miss. B may be `claimed` by another Pod at the
+  time, so the transition is refused and the later release drops B back
+  to `queued`; or B's own `queued` webhook may not have arrived yet, so
+  there is no row to move and the one inserted afterwards starts life
+  `queued` under a runner that is already executing it. Rows stranded
+  before that transition existed have nothing coming at all.
 
   ## The evidence
 
-  A `queued` row whose `runner_name` matches a live claim that names it
-  as `executed_workflow_job_id` is running. GitHub told us so when it
-  reported the runner, the claim is still holding that account's slot,
-  and both rows agree on the runner. Nothing needs to be asked of
-  GitHub, which is why this sweep carries no age gate: a row is stuck
-  the moment it has this shape, and every minute it stays that way is a
-  minute the dashboard shows a live build as Queued and the queue
-  gauges — and the autoscaler reading them — provision for work that is
-  already running.
+  The claim, and only the claim. `executed_workflow_job_id` is written
+  from a delivery where GitHub named this runner running that job,
+  scoped to the account, and a claim is deleted on completion — so a
+  live claim still naming a `queued` row proves that row is running.
+  Nothing needs to be asked of GitHub, which is why this sweep has no
+  age gate: a row is stuck the moment it has this shape, and every
+  minute it stays that way is a minute the dashboard shows a live build
+  as Queued and the queue gauges — and the autoscaler reading them —
+  provision for work already running.
+
+  ## What it does not cover
+
+  An `in_progress` delivery that never lands at all. Nothing then writes
+  `executed_workflow_job_id`, so no claim carries the evidence, and the
+  `completed` webhook deletes the claim while flipping the row terminal
+  (`Claims.complete_by_runner_name/3`). Those rows end as phantom
+  terminals — `started_at` NULL with a `runner_name` — and closing that
+  class needs the durable `runner_sessions` binding, which outlives the
+  Pod, rather than this sweep.
 
   ## Safety
 
-  `Tuist.Runners.WorkflowJobs.transition_executing/3` CASes from
-  `queued` only, so a row a Pod has since claimed, or one a completion
-  has settled, is left where it is. The per-tick cap bounds a
-  wrong-but-plausible read the same way the other sweeps do; a
-  sustained `tuist_runners_recovery_count{kind="unstarted_execution"}`
-  means `in_progress` deliveries are being lost, which is the thing to
-  fix rather than this.
+  `Tuist.Runners.WorkflowJobs.start_executing_queued/1` re-applies its
+  guards in the write and moves rows out of `queued` only, so a row a
+  Pod has since claimed, or one a completion has settled, is left where
+  it is. A sustained
+  `tuist_runners_recovery_count{kind="unstarted_execution"}` means
+  `in_progress` deliveries are being lost, which is the thing to fix
+  rather than this.
   """
 
   use Oban.Worker, queue: :default, max_attempts: 1
 
-  alias Tuist.Runners.Claims
   alias Tuist.Runners.Telemetry
   alias Tuist.Runners.WorkflowJobs
 
@@ -54,32 +64,23 @@ defmodule Tuist.Runners.Workers.UnstartedExecutionsWorker do
 
   @impl Oban.Worker
   def perform(_job) do
-    started =
-      @max_starts_per_tick
-      |> Claims.list_executing_queued()
-      |> Enum.count(&start_one/1)
+    started = WorkflowJobs.start_executing_queued(@max_starts_per_tick)
 
-    if started > 0 do
-      Logger.warning("runners: started rows stuck queued while executing", count: started)
+    Enum.each(started, &report_started/1)
+
+    if started != [] do
+      Logger.warning("runners: started rows stuck queued while executing", count: length(started))
     end
 
     :ok
   end
 
-  defp start_one(%{workflow_job_id: workflow_job_id, runner_name: runner_name, pod_name: pod_name} = row) do
-    case WorkflowJobs.transition_executing(workflow_job_id, runner_name, pod_name) do
-      :ok ->
-        :telemetry.execute(
-          Telemetry.event_name_recovery(),
-          %{count: 1, stranded_ms: stranded_ms(row.enqueued_at)},
-          %{kind: "unstarted_execution", fleet: row.fleet_name || ""}
-        )
-
-        true
-
-      :noop ->
-        false
-    end
+  defp report_started(row) do
+    :telemetry.execute(
+      Telemetry.event_name_recovery(),
+      %{count: 1, stranded_ms: stranded_ms(row.enqueued_at)},
+      %{kind: "unstarted_execution", fleet: row.fleet_name || ""}
+    )
   end
 
   defp stranded_ms(%DateTime{} = enqueued_at) do

--- a/server/lib/tuist/runners/workers/unstarted_executions_worker.ex
+++ b/server/lib/tuist/runners/workers/unstarted_executions_worker.ex
@@ -1,0 +1,90 @@
+defmodule Tuist.Runners.Workers.UnstartedExecutionsWorker do
+  @moduledoc """
+  Starts lifecycle rows stuck in `status = 'queued'` while GitHub is
+  already running them.
+
+  ## How a row gets stuck
+
+  GitHub binds a JIT runner to a label set, not to a job, so it
+  routinely places job B on the Pod we minted for job A — the runner
+  shuffle. `Tuist.Runners.Claims.record_execution/3` handles both halves
+  on the `workflow_job.in_progress` webhook: A goes back to the queue,
+  and B starts on the Pod's slot. B has no other way in. It was never
+  claimed here, so no mint transitions it, and GitHub announces nothing
+  further about a job it has already started.
+
+  So a delivery that never lands strands B in `queued` for its whole
+  runtime. The `completed` attribution path
+  (`Claims.complete_by_runner_name/3`) recovers the claim in that case
+  but not the row, and rows stranded before the webhook path started
+  moving them have nothing coming at all.
+
+  ## The evidence
+
+  A `queued` row whose `runner_name` matches a live claim that names it
+  as `executed_workflow_job_id` is running. GitHub told us so when it
+  reported the runner, the claim is still holding that account's slot,
+  and both rows agree on the runner. Nothing needs to be asked of
+  GitHub, which is why this sweep carries no age gate: a row is stuck
+  the moment it has this shape, and every minute it stays that way is a
+  minute the dashboard shows a live build as Queued and the queue
+  gauges — and the autoscaler reading them — provision for work that is
+  already running.
+
+  ## Safety
+
+  `Tuist.Runners.WorkflowJobs.transition_executing/3` CASes from
+  `queued` only, so a row a Pod has since claimed, or one a completion
+  has settled, is left where it is. The per-tick cap bounds a
+  wrong-but-plausible read the same way the other sweeps do; a
+  sustained `tuist_runners_recovery_count{kind="unstarted_execution"}`
+  means `in_progress` deliveries are being lost, which is the thing to
+  fix rather than this.
+  """
+
+  use Oban.Worker, queue: :default, max_attempts: 1
+
+  alias Tuist.Runners.Claims
+  alias Tuist.Runners.Telemetry
+  alias Tuist.Runners.WorkflowJobs
+
+  require Logger
+
+  @max_starts_per_tick 100
+
+  @impl Oban.Worker
+  def perform(_job) do
+    started =
+      @max_starts_per_tick
+      |> Claims.list_executing_queued()
+      |> Enum.count(&start_one/1)
+
+    if started > 0 do
+      Logger.warning("runners: started rows stuck queued while executing", count: started)
+    end
+
+    :ok
+  end
+
+  defp start_one(%{workflow_job_id: workflow_job_id, runner_name: runner_name, pod_name: pod_name} = row) do
+    case WorkflowJobs.transition_executing(workflow_job_id, runner_name, pod_name) do
+      :ok ->
+        :telemetry.execute(
+          Telemetry.event_name_recovery(),
+          %{count: 1, stranded_ms: stranded_ms(row.enqueued_at)},
+          %{kind: "unstarted_execution", fleet: row.fleet_name || ""}
+        )
+
+        true
+
+      :noop ->
+        false
+    end
+  end
+
+  defp stranded_ms(%DateTime{} = enqueued_at) do
+    DateTime.utc_now() |> DateTime.diff(enqueued_at, :millisecond) |> max(0)
+  end
+
+  defp stranded_ms(_enqueued_at), do: 0
+end

--- a/server/lib/tuist/runners/workflow_jobs.ex
+++ b/server/lib/tuist/runners/workflow_jobs.ex
@@ -26,9 +26,11 @@ defmodule Tuist.Runners.WorkflowJobs do
     * `Tuist.Runners.Claims.mark_running/3` → `transition_running/3`
     * `Tuist.Runners.Claims.record_execution/3` (webhook `in_progress`,
       same transaction as the claim detach) → `transition_executing/3`
-    * `Tuist.Runners.Claims.release/2` (same transaction as the claim
-      delete) → `requeue_by_handle/2`, and `release_pod_missing/2` →
-      `requeue/1`
+    * `Tuist.Runners.Claims.release/2` and `release_pod_missing/2`
+      (same transaction as the claim delete) → `requeue_by_handle/2`
+    * `Tuist.Runners.Workers.UnstartedExecutionsWorker` (backstop sweep)
+      → `start_executing_queued/1`
+    * `Tuist.Runners.Buildkite` reservation expiry → `requeue/1`
     * `Tuist.Runners.Jobs` completion choke point (webhook `completed`
       plus the recovery workers' force-completes) → `record_completed/3`
 
@@ -41,6 +43,7 @@ defmodule Tuist.Runners.WorkflowJobs do
   import Ecto.Query
 
   alias Tuist.Repo
+  alias Tuist.Runners.Claim
   alias Tuist.Runners.JobCompletion
   alias Tuist.Runners.Jobs
   alias Tuist.Runners.Telemetry
@@ -254,6 +257,98 @@ defmodule Tuist.Runners.WorkflowJobs do
   end
 
   defp finish_executing(:noop), do: :noop
+
+  @doc """
+  Batch `queued → running` for every row a live claim already records as
+  the job its runner is executing, up to `limit`, oldest arrival first.
+  Returns the rows it started.
+
+  The backstop arm of `transition_executing/3`, for rows the webhook
+  path left behind. `Tuist.Runners.Claims.record_execution/3` starts the
+  executed job in the transaction that moves the claim, but that CAS can
+  miss — the row was `claimed` by another Pod at the time, or the
+  `queued` webhook had not arrived yet and there was no row to move —
+  and rows stranded before that transition existed have nothing coming
+  at all.
+
+  The claim is the whole evidence. `executed_workflow_job_id` is written
+  only from a delivery where GitHub named this runner running that job,
+  scoped to the account, and the claim is deleted on completion, so a
+  live one still naming the job proves the job is still running. The
+  row's own `runner_name` is *not* required to agree: it is stamped by a
+  separate write that a re-queue clears and that never ran at all when
+  the row arrived after the execution did, so requiring it would exclude
+  exactly the rows this sweep is for.
+
+  One statement rather than one transaction per row: the values come
+  from the claim, so Postgres joins to it and copies them across, and
+  the outbox events for the whole batch insert together. The guards are
+  re-applied in the write, so a row that moved between the candidate
+  read and the update is left alone.
+  """
+  def start_executing_queued(limit) when is_integer(limit) and limit > 0 do
+    now = DateTime.utc_now()
+
+    {:ok, started} =
+      Repo.transaction(fn ->
+        case Repo.all(executing_queued_candidates(limit)) do
+          [] ->
+            []
+
+          workflow_job_ids ->
+            {_count, rows} = Repo.update_all(start_executing_query(workflow_job_ids, now), [])
+            rows = rows || []
+
+            emit_transition_events(rows, now)
+            broadcast_running(rows)
+
+            rows
+        end
+      end)
+
+    started
+  end
+
+  # Bounded and ordered here because `update_all` takes neither.
+  defp executing_queued_candidates(limit) do
+    from(c in Claim,
+      join: j in WorkflowJob,
+      on: j.workflow_job_id == c.executed_workflow_job_id and j.account_id == c.account_id,
+      where: c.lifecycle_state == "running" and c.runner_name != "" and j.status == "queued",
+      order_by: [asc: j.enqueued_at, asc: j.workflow_job_id],
+      limit: ^limit,
+      select: j.workflow_job_id
+    )
+  end
+
+  defp start_executing_query(workflow_job_ids, %DateTime{} = now) do
+    from(j in WorkflowJob,
+      join: c in Claim,
+      on: c.executed_workflow_job_id == j.workflow_job_id and c.account_id == j.account_id,
+      where:
+        j.workflow_job_id in ^workflow_job_ids and j.status == "queued" and c.lifecycle_state == "running" and
+          c.runner_name != "",
+      select: j,
+      update: [
+        set: [
+          status: "running",
+          runner_name: c.runner_name,
+          pod_name: c.pod_name,
+          executed_workflow_job_id: j.workflow_job_id,
+          claimed_at: ^now,
+          started_at: ^now,
+          updated_at: ^DateTime.truncate(now, :second)
+        ]
+      ]
+    )
+  end
+
+  defp broadcast_running(rows) do
+    rows
+    |> Enum.map(& &1.account_id)
+    |> Enum.uniq()
+    |> Enum.each(&Tuist.PubSub.broadcast(%{status: "running"}, Jobs.topic(&1), :runner_jobs_status_changed))
+  end
 
   @doc """
   CAS `claimed | running → queued` — the claim-release transition.

--- a/server/lib/tuist/runners/workflow_jobs.ex
+++ b/server/lib/tuist/runners/workflow_jobs.ex
@@ -24,8 +24,11 @@ defmodule Tuist.Runners.WorkflowJobs do
     * `Tuist.Runners.Claims.attempt/5` (same transaction as the claim
       insert) → `transition_claimed/3`
     * `Tuist.Runners.Claims.mark_running/3` → `transition_running/3`
-    * `Tuist.Runners.Claims.release/2` and `release_pod_missing/2`
-      (same transaction as the claim delete) → `requeue/1`
+    * `Tuist.Runners.Claims.record_execution/3` (webhook `in_progress`,
+      same transaction as the claim detach) → `transition_executing/3`
+    * `Tuist.Runners.Claims.release/2` (same transaction as the claim
+      delete) → `requeue_by_handle/2`, and `release_pod_missing/2` →
+      `requeue/1`
     * `Tuist.Runners.Jobs` completion choke point (webhook `completed`
       plus the recovery workers' force-completes) → `record_completed/3`
 
@@ -197,6 +200,60 @@ defmodule Tuist.Runners.WorkflowJobs do
       :noop -> :noop
     end
   end
+
+  @doc """
+  CAS `queued → running` for a job the `in_progress` webhook proves is
+  executing on a runner it never claimed — the other half of the runner
+  shuffle.
+
+  GitHub binds a JIT runner to a label set, not to a job, so it
+  routinely places job B on the Pod we minted for job A.
+  `Tuist.Runners.Claims.record_execution/3` already hands A back to the
+  queue; this moves B, whose own row nothing else touches.
+  `transition_running/3` cannot: it CASes the Pod's own
+  `claimed → running` under the `claimed_at` handle, and B was never
+  claimed by this Pod. Left alone B reads `queued` until its
+  `completed` webhook flips it terminal — for its entire runtime the
+  dashboard says Queued, and the queue depth and age gauges (and the
+  autoscaler reading them) count a job that is already burning CPU.
+
+  Guarded on `queued` alone, so it cannot resurrect a terminal row or
+  overwrite a generation another Pod holds: a row already `claimed` or
+  `running` belongs to whichever claim moved it there, and stamping
+  this Pod over it would misattribute the next execution.
+
+  The Pod's identity rides along. `pod_name` is what
+  `list_running_for_pod/1` reads, so B is recoverable when the Pod it
+  is actually on goes away, and `claimed_at` gives the row a release
+  handle of its own — a `running` row without one crashes the recovery
+  sweeps, and a distinct handle is what stops a stale claim naming B
+  from re-queueing it mid-flight (see
+  `Tuist.Runners.Claims.release/2`). Both are the execution's own
+  moment rather than the minting claim's: B waited in the queue until
+  GitHub placed it here, not until the Pod that took it was reserved.
+  """
+  def transition_executing(workflow_job_id, runner_name, pod_name)
+      when is_integer(workflow_job_id) and is_binary(runner_name) and runner_name != "" and is_binary(pod_name) and
+             pod_name != "" do
+    now = DateTime.utc_now()
+
+    workflow_job_id
+    |> transition(["queued"], "running",
+      runner_name: runner_name,
+      pod_name: pod_name,
+      claimed_at: now,
+      started_at: now,
+      executed_workflow_job_id: workflow_job_id
+    )
+    |> finish_executing()
+  end
+
+  defp finish_executing({:applied, row}) do
+    Tuist.PubSub.broadcast(%{status: "running"}, Jobs.topic(row.account_id), :runner_jobs_status_changed)
+    :ok
+  end
+
+  defp finish_executing(:noop), do: :noop
 
   @doc """
   CAS `claimed | running → queued` — the claim-release transition.

--- a/server/test/tuist/runners/claims_test.exs
+++ b/server/test/tuist/runners/claims_test.exs
@@ -265,56 +265,6 @@ defmodule Tuist.Runners.ClaimsTest do
     end
   end
 
-  describe "list_executing_queued/1" do
-    test "returns queued rows a live claim proves are executing" do
-      account = account_fixture()
-      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2020))
-      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2021))
-      {:ok, _} = Claims.attempt(2020, account.id, "fleet-a", "pod-1", @linux_resources)
-      :ok = mark_running!(2020, "runner-stuck")
-
-      # The strand this sweep exists for: the claim records the execution
-      # and the row learned the runner, but nothing moved the row out of
-      # `queued`.
-      :ok = WorkflowJobs.record_execution("runner-stuck", 2021, account.id)
-      Repo.update_all(from(c in Claim, where: c.pod_name == "pod-1"), set: [executed_workflow_job_id: 2021])
-
-      assert [candidate] = Claims.list_executing_queued(10)
-      assert candidate.workflow_job_id == 2021
-      assert candidate.runner_name == "runner-stuck"
-      assert candidate.pod_name == "pod-1"
-      assert candidate.fleet_name == "fleet-a"
-    end
-
-    # A runner name is unique per account by 32 bits of randomness alone,
-    # so agreement on both rows is the evidence that this claim's runner
-    # is the one holding the job.
-    test "skips a queued row whose runner_name does not match the claim's" do
-      account = account_fixture()
-      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2030))
-      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2031))
-      {:ok, _} = Claims.attempt(2030, account.id, "fleet-a", "pod-1", @linux_resources)
-      :ok = mark_running!(2030, "runner-a")
-
-      Repo.update_all(from(c in Claim, where: c.pod_name == "pod-1"), set: [executed_workflow_job_id: 2031])
-
-      assert Claims.list_executing_queued(10) == []
-    end
-
-    test "skips a row that is no longer queued" do
-      account = account_fixture()
-      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2040))
-      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2041))
-      {:ok, _} = Claims.attempt(2040, account.id, "fleet-a", "pod-1", @linux_resources)
-      :ok = mark_running!(2040, "runner-done")
-      :ok = WorkflowJobs.record_execution("runner-done", 2041, account.id)
-      Repo.update_all(from(c in Claim, where: c.pod_name == "pod-1"), set: [executed_workflow_job_id: 2041])
-      :ok = WorkflowJobs.record_completed(lifecycle_attrs(account, 2041), "success", DateTime.utc_now())
-
-      assert Claims.list_executing_queued(10) == []
-    end
-  end
-
   describe "counts_per_account/0" do
     test "returns per-account inflight counts across ALL fleets" do
       a = account_fixture()
@@ -1044,6 +994,39 @@ defmodule Tuist.Runners.ClaimsTest do
 
       assert :ok = Claims.release_pod_missing("pod-1", handle)
       refute Repo.exists?(from(c in Claim, where: c.workflow_job_id == 7402))
+    end
+
+    test "re-queues the job when the row still belongs to the vanished Pod" do
+      account = account_fixture()
+      handle = DateTime.add(DateTime.utc_now(), -600, :second)
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 7403))
+
+      assert {:ok, _} = Claims.attempt(7403, account.id, "fleet-a", "pod-1", @linux_resources)
+      Repo.update_all(from(c in Claim, where: c.workflow_job_id == 7403), set: [pod_missing_since: handle])
+
+      assert :ok = Claims.release_pod_missing("pod-1", handle)
+      assert Repo.get!(WorkflowJob, 7403).status == "queued"
+    end
+
+    # The same door `release/2` closes, reached from the other side. This
+    # Pod vanishing says nothing about the Pod GitHub actually placed the
+    # job on, so re-queueing here would send a job that is burning CPU
+    # back through dispatch.
+    test "does not re-queue a job running under another Pod's handle" do
+      account = account_fixture()
+      handle = DateTime.add(DateTime.utc_now(), -600, :second)
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 7404))
+      :ok = WorkflowJobs.transition_executing(7404, "runner-elsewhere", "pod-elsewhere")
+
+      assert {:ok, _} = Claims.attempt(7404, account.id, "fleet-a", "pod-late", @linux_resources)
+      Repo.update_all(from(c in Claim, where: c.workflow_job_id == 7404), set: [pod_missing_since: handle])
+
+      assert :ok = Claims.release_pod_missing("pod-late", handle)
+
+      row = Repo.get!(WorkflowJob, 7404)
+      assert row.status == "running"
+      assert row.pod_name == "pod-elsewhere"
+      assert Claims.counts_per_account() == %{}
     end
   end
 

--- a/server/test/tuist/runners/claims_test.exs
+++ b/server/test/tuist/runners/claims_test.exs
@@ -243,6 +243,76 @@ defmodule Tuist.Runners.ClaimsTest do
     test "returns :stale_claim when the row is gone" do
       assert {:error, :stale_claim} = Claims.release(9_999_999, DateTime.utc_now())
     end
+
+    # ClickHouse dispatch lag can hand a second claim to a job the runner
+    # shuffle already started on someone else's Pod. Releasing that claim
+    # must free the slot without putting a job that is actively burning
+    # CPU back in the queue — where the autoscaler would then provision
+    # for it a second time.
+    test "does not re-queue a job running under another Pod's handle" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2010))
+      :ok = WorkflowJobs.transition_executing(2010, "runner-elsewhere", "pod-elsewhere")
+
+      {:ok, stale} = Claims.attempt(2010, account.id, "fleet-a", "pod-late", @linux_resources)
+
+      assert :ok = Claims.release(2010, stale.claimed_at)
+
+      row = Repo.get!(WorkflowJob, 2010)
+      assert row.status == "running"
+      assert row.pod_name == "pod-elsewhere"
+      assert Claims.counts_per_account() == %{}
+    end
+  end
+
+  describe "list_executing_queued/1" do
+    test "returns queued rows a live claim proves are executing" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2020))
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2021))
+      {:ok, _} = Claims.attempt(2020, account.id, "fleet-a", "pod-1", @linux_resources)
+      :ok = mark_running!(2020, "runner-stuck")
+
+      # The strand this sweep exists for: the claim records the execution
+      # and the row learned the runner, but nothing moved the row out of
+      # `queued`.
+      :ok = WorkflowJobs.record_execution("runner-stuck", 2021, account.id)
+      Repo.update_all(from(c in Claim, where: c.pod_name == "pod-1"), set: [executed_workflow_job_id: 2021])
+
+      assert [candidate] = Claims.list_executing_queued(10)
+      assert candidate.workflow_job_id == 2021
+      assert candidate.runner_name == "runner-stuck"
+      assert candidate.pod_name == "pod-1"
+      assert candidate.fleet_name == "fleet-a"
+    end
+
+    # A runner name is unique per account by 32 bits of randomness alone,
+    # so agreement on both rows is the evidence that this claim's runner
+    # is the one holding the job.
+    test "skips a queued row whose runner_name does not match the claim's" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2030))
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2031))
+      {:ok, _} = Claims.attempt(2030, account.id, "fleet-a", "pod-1", @linux_resources)
+      :ok = mark_running!(2030, "runner-a")
+
+      Repo.update_all(from(c in Claim, where: c.pod_name == "pod-1"), set: [executed_workflow_job_id: 2031])
+
+      assert Claims.list_executing_queued(10) == []
+    end
+
+    test "skips a row that is no longer queued" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2040))
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 2041))
+      {:ok, _} = Claims.attempt(2040, account.id, "fleet-a", "pod-1", @linux_resources)
+      :ok = mark_running!(2040, "runner-done")
+      :ok = WorkflowJobs.record_execution("runner-done", 2041, account.id)
+      Repo.update_all(from(c in Claim, where: c.pod_name == "pod-1"), set: [executed_workflow_job_id: 2041])
+      :ok = WorkflowJobs.record_completed(lifecycle_attrs(account, 2041), "success", DateTime.utc_now())
+
+      assert Claims.list_executing_queued(10) == []
+    end
   end
 
   describe "counts_per_account/0" do
@@ -602,6 +672,44 @@ defmodule Tuist.Runners.ClaimsTest do
       assert row.workflow_job_id == nil
       assert Claims.counts_per_account() == %{account.id => 1}
       assert Repo.get!(WorkflowJob, 7002).status == "queued"
+    end
+
+    # The slot moved from one job to the other, so both rows move with it.
+    # Nothing else would start the executed one: it was never claimed
+    # here, so no mint transitions it, and GitHub announces nothing more
+    # about a job it has already placed.
+    test "starts the executed job's lifecycle row on the claim's Pod" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 7020))
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 7021))
+      {:ok, _} = Claims.attempt(7020, account.id, "fleet-a", "pod-1", @linux_resources)
+      :ok = mark_running!(7020, "runner-shuffle")
+
+      assert {:mismatch, %{workflow_job_id: 7020}} = Claims.record_execution("runner-shuffle", 7021, account.id)
+
+      executed = Repo.get!(WorkflowJob, 7021)
+      assert executed.status == "running"
+      assert executed.runner_name == "runner-shuffle"
+      assert executed.pod_name == "pod-1"
+      assert %DateTime{} = executed.started_at
+    end
+
+    # The executed job may already belong to another Pod's claim
+    # generation — the shuffle does not stop dispatch from having handed
+    # it out. That generation owns the row.
+    test "leaves the executed job alone when another Pod already claimed it" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 7022))
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 7023))
+      {:ok, _} = Claims.attempt(7022, account.id, "fleet-a", "pod-1", @linux_resources)
+      {:ok, _} = Claims.attempt(7023, account.id, "fleet-a", "pod-2", @linux_resources)
+      :ok = mark_running!(7022, "runner-late")
+
+      assert {:mismatch, _displaced} = Claims.record_execution("runner-late", 7023, account.id)
+
+      executed = Repo.get!(WorkflowJob, 7023)
+      assert executed.status == "claimed"
+      assert executed.pod_name == "pod-2"
     end
 
     # The failure the transaction closes. Committed separately, a re-queue

--- a/server/test/tuist/runners/dispatch_test.exs
+++ b/server/test/tuist/runners/dispatch_test.exs
@@ -148,6 +148,19 @@ defmodule Tuist.Runners.DispatchTest do
     claim
   end
 
+  defp queue_job!(account, workflow_job_id) do
+    :ok =
+      WorkflowJobs.upsert_queued(%{
+        workflow_job_id: workflow_job_id,
+        account_id: account.id,
+        fleet_name: "macos-pool",
+        platform: "macos",
+        vcpus: 6,
+        memory_gb: 14,
+        repository: "tuist/tuist"
+      })
+  end
+
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
@@ -567,6 +580,62 @@ defmodule Tuist.Runners.DispatchTest do
 
       assert Claims.counts_per_account() == %{account.id => 1}
       assert Claims.by_pod_name(claim.pod_name) == :error
+    end
+
+    # The other half of the shuffle. The job GitHub actually placed on the
+    # runner was never claimed by this Pod, so nothing in the claim path
+    # moves it: `transition_running/3` only CASes the Pod's own
+    # `claimed → running`. Left alone it reads `queued` for its entire
+    # runtime — the dashboard says Queued while the build burns CPU, and
+    # the queue gauges the autoscaler reads count it as work still to
+    # provision for.
+    test "moves the job GitHub actually ran to running", %{account: account} do
+      claimed_job_id = 4420
+      executed_job_id = 4421
+      claim_running!(account, claimed_job_id, "pod-shuffle", "runner-shuffle")
+      queue_job!(account, executed_job_id)
+
+      stub(RunnerSessions, :record_execution, fn "runner-shuffle", 4421, _acct -> :mismatch end)
+
+      assert {:ok, :mismatch} =
+               Dispatch.handle_webhook(in_progress_payload(id: executed_job_id, runner_name: "runner-shuffle"), 1)
+
+      executed = Repo.get!(WorkflowJob, executed_job_id)
+      assert executed.status == "running"
+      assert executed.runner_name == "runner-shuffle"
+      assert executed.pod_name == "pod-shuffle"
+      assert executed.executed_workflow_job_id == executed_job_id
+      assert %DateTime{} = executed.started_at
+      assert %DateTime{} = executed.claimed_at
+
+      assert Repo.get!(WorkflowJob, claimed_job_id).status == "queued"
+    end
+
+    # A job the shuffle displaced onto this runner is no longer a dispatch
+    # candidate, so the only way back to `queued` is a stale claim naming
+    # it — the ClickHouse-lag double-claim shape. Releasing that claim must
+    # not re-queue a job that is executing on someone else's Pod.
+    test "keeps an executing job out of the queue when a stale claim is released", %{account: account} do
+      claimed_job_id = 4430
+      executed_job_id = 4431
+      claim_running!(account, claimed_job_id, "pod-stale", "runner-stale")
+      queue_job!(account, executed_job_id)
+
+      stub(RunnerSessions, :record_execution, fn "runner-stale", 4431, _acct -> :mismatch end)
+
+      assert {:ok, :mismatch} =
+               Dispatch.handle_webhook(in_progress_payload(id: executed_job_id, runner_name: "runner-stale"), 1)
+
+      {:ok, stale_claim} =
+        Claims.attempt(executed_job_id, account.id, "macos-pool", "pod-late", %{
+          platform: :macos,
+          vcpus: 6,
+          memory_gb: 14
+        })
+
+      assert :ok = Claims.release(executed_job_id, stale_claim.claimed_at)
+
+      assert Repo.get!(WorkflowJob, executed_job_id).status == "running"
     end
 
     test "a mismatch on either store wins over a matched on the other" do

--- a/server/test/tuist/runners/workers/pod_reconciliation_worker_test.exs
+++ b/server/test/tuist/runners/workers/pod_reconciliation_worker_test.exs
@@ -31,8 +31,9 @@ defmodule Tuist.Runners.Workers.PodReconciliationWorkerTest do
     {:ok, _} = Claims.attempt(workflow_job_id, account.id, "fleet-a", pod_name, @resources)
 
     age = Keyword.get(opts, :age_seconds, 3600)
+    claimed_at = DateTime.add(DateTime.utc_now(), -age, :second)
 
-    updates = [claimed_at: DateTime.add(DateTime.utc_now(), -age, :second)]
+    updates = [claimed_at: claimed_at]
 
     updates =
       case Keyword.get(opts, :missing_for_seconds) do
@@ -41,6 +42,14 @@ defmodule Tuist.Runners.Workers.PodReconciliationWorkerTest do
       end
 
     Repo.update_all(from(c in Claim, where: c.workflow_job_id == ^workflow_job_id), set: updates)
+
+    # The claim and its lifecycle row are written from one `claimed_at` in
+    # a single transaction, and the release path is guarded on that handle
+    # agreeing. Ageing only the claim would model a state production
+    # cannot reach.
+    Repo.update_all(from(j in WorkflowJob, where: j.workflow_job_id == ^workflow_job_id and j.status == "claimed"),
+      set: [claimed_at: claimed_at]
+    )
   end
 
   defp claim(workflow_job_id), do: Repo.one(from(c in Claim, where: c.workflow_job_id == ^workflow_job_id))

--- a/server/test/tuist/runners/workers/unstarted_executions_worker_test.exs
+++ b/server/test/tuist/runners/workers/unstarted_executions_worker_test.exs
@@ -1,11 +1,9 @@
 defmodule Tuist.Runners.Workers.UnstartedExecutionsWorkerTest do
   use TuistTestSupport.Cases.DataCase, async: true
 
-  import Ecto.Query
   import TuistTestSupport.Fixtures.AccountsFixtures
 
   alias Tuist.Repo
-  alias Tuist.Runners.Claim
   alias Tuist.Runners.Claims
   alias Tuist.Runners.Workers.UnstartedExecutionsWorker
   alias Tuist.Runners.WorkflowJob
@@ -25,21 +23,20 @@ defmodule Tuist.Runners.Workers.UnstartedExecutionsWorkerTest do
     }
   end
 
-  # The strand this sweep exists for, built the way the webhook path left
-  # it before it started the executed job: the claim records the
-  # execution and the executed job's row learned the runner, but nothing
-  # moved that row out of `queued`, so it reads Queued while the build
-  # runs.
+  # The runner shuffle, end to end through the real claim path: a Pod is
+  # minted for one job and GitHub places another on it. `record_execution/3`
+  # starts the executed job itself, so the sweep is exercised by putting
+  # that row back to `queued` afterwards — the state the transition left
+  # behind before it existed, and the state a Pod's release still produces
+  # when it was `claimed` elsewhere at the time.
   defp strand_executing!(account, claimed_job_id, executed_job_id, pod_name, runner_name) do
     :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, claimed_job_id))
     :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, executed_job_id))
     {:ok, claim} = Claims.attempt(claimed_job_id, account.id, "fleet-a", pod_name, @linux_resources)
     :ok = Claims.mark_running(claimed_job_id, runner_name, claim.claimed_at)
-    :ok = WorkflowJobs.record_execution(runner_name, executed_job_id, account.id)
 
-    Repo.update_all(from(c in Claim, where: c.pod_name == ^pod_name),
-      set: [executed_workflow_job_id: executed_job_id]
-    )
+    {:mismatch, _displaced} = Claims.record_execution(runner_name, executed_job_id, account.id)
+    :ok = WorkflowJobs.requeue(executed_job_id)
 
     :ok
   end
@@ -48,6 +45,7 @@ defmodule Tuist.Runners.Workers.UnstartedExecutionsWorkerTest do
     test "starts a queued row a live claim proves is executing" do
       account = account_fixture()
       strand_executing!(account, 8001, 8002, "pod-1", "runner-stuck")
+      assert Repo.get!(WorkflowJob, 8002).status == "queued"
 
       assert :ok = perform_job(UnstartedExecutionsWorker, %{})
 
@@ -65,7 +63,7 @@ defmodule Tuist.Runners.Workers.UnstartedExecutionsWorkerTest do
       assert :ok = perform_job(UnstartedExecutionsWorker, %{})
 
       assert Claims.counts_per_account() == %{account.id => 1}
-      assert Repo.get!(WorkflowJob, 8011).status == "running"
+      assert Repo.get!(WorkflowJob, 8011).status == "queued"
     end
 
     test "does nothing when every row already agrees with its claim" do
@@ -88,6 +86,21 @@ defmodule Tuist.Runners.Workers.UnstartedExecutionsWorkerTest do
       assert :ok = perform_job(UnstartedExecutionsWorker, %{})
 
       assert Repo.get!(WorkflowJob, 8032).status == "completed"
+    end
+
+    # The boundary the moduledoc claims. Without the `in_progress`
+    # delivery no claim carries `executed_workflow_job_id`, so there is
+    # no evidence to sweep on and the row waits for its completion.
+    test "cannot reach a row whose in_progress delivery never landed" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 8041))
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 8042))
+      {:ok, claim} = Claims.attempt(8041, account.id, "fleet-a", "pod-1", @linux_resources)
+      :ok = Claims.mark_running(8041, "runner-silent", claim.claimed_at)
+
+      assert :ok = perform_job(UnstartedExecutionsWorker, %{})
+
+      assert Repo.get!(WorkflowJob, 8042).status == "queued"
     end
   end
 end

--- a/server/test/tuist/runners/workers/unstarted_executions_worker_test.exs
+++ b/server/test/tuist/runners/workers/unstarted_executions_worker_test.exs
@@ -1,0 +1,93 @@
+defmodule Tuist.Runners.Workers.UnstartedExecutionsWorkerTest do
+  use TuistTestSupport.Cases.DataCase, async: true
+
+  import Ecto.Query
+  import TuistTestSupport.Fixtures.AccountsFixtures
+
+  alias Tuist.Repo
+  alias Tuist.Runners.Claim
+  alias Tuist.Runners.Claims
+  alias Tuist.Runners.Workers.UnstartedExecutionsWorker
+  alias Tuist.Runners.WorkflowJob
+  alias Tuist.Runners.WorkflowJobs
+
+  @linux_resources %{platform: :linux, vcpus: 1, memory_gb: 1}
+
+  defp lifecycle_attrs(account, workflow_job_id) do
+    %{
+      workflow_job_id: workflow_job_id,
+      account_id: account.id,
+      fleet_name: "fleet-a",
+      platform: "linux",
+      vcpus: 1,
+      memory_gb: 1,
+      repository: "acme/cli"
+    }
+  end
+
+  # The strand this sweep exists for, built the way the webhook path left
+  # it before it started the executed job: the claim records the
+  # execution and the executed job's row learned the runner, but nothing
+  # moved that row out of `queued`, so it reads Queued while the build
+  # runs.
+  defp strand_executing!(account, claimed_job_id, executed_job_id, pod_name, runner_name) do
+    :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, claimed_job_id))
+    :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, executed_job_id))
+    {:ok, claim} = Claims.attempt(claimed_job_id, account.id, "fleet-a", pod_name, @linux_resources)
+    :ok = Claims.mark_running(claimed_job_id, runner_name, claim.claimed_at)
+    :ok = WorkflowJobs.record_execution(runner_name, executed_job_id, account.id)
+
+    Repo.update_all(from(c in Claim, where: c.pod_name == ^pod_name),
+      set: [executed_workflow_job_id: executed_job_id]
+    )
+
+    :ok
+  end
+
+  describe "perform/1" do
+    test "starts a queued row a live claim proves is executing" do
+      account = account_fixture()
+      strand_executing!(account, 8001, 8002, "pod-1", "runner-stuck")
+
+      assert :ok = perform_job(UnstartedExecutionsWorker, %{})
+
+      row = Repo.get!(WorkflowJob, 8002)
+      assert row.status == "running"
+      assert row.runner_name == "runner-stuck"
+      assert row.pod_name == "pod-1"
+      assert %DateTime{} = row.started_at
+    end
+
+    test "leaves the claim and the displaced job alone" do
+      account = account_fixture()
+      strand_executing!(account, 8011, 8012, "pod-1", "runner-keep")
+
+      assert :ok = perform_job(UnstartedExecutionsWorker, %{})
+
+      assert Claims.counts_per_account() == %{account.id => 1}
+      assert Repo.get!(WorkflowJob, 8011).status == "running"
+    end
+
+    test "does nothing when every row already agrees with its claim" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(lifecycle_attrs(account, 8021))
+      {:ok, claim} = Claims.attempt(8021, account.id, "fleet-a", "pod-1", @linux_resources)
+      :ok = Claims.mark_running(8021, "runner-matched", claim.claimed_at)
+      :ok = WorkflowJobs.record_execution("runner-matched", 8021, account.id)
+
+      assert :ok = perform_job(UnstartedExecutionsWorker, %{})
+
+      assert Repo.get!(WorkflowJob, 8021).status == "running"
+    end
+
+    test "cannot resurrect a row a completion already settled" do
+      account = account_fixture()
+      strand_executing!(account, 8031, 8032, "pod-1", "runner-late")
+      :ok = WorkflowJobs.record_completed(lifecycle_attrs(account, 8032), "success", DateTime.utc_now())
+
+      assert :ok = perform_job(UnstartedExecutionsWorker, %{})
+
+      assert Repo.get!(WorkflowJob, 8032).status == "completed"
+    end
+  end
+end

--- a/server/test/tuist/runners/workflow_jobs_test.exs
+++ b/server/test/tuist/runners/workflow_jobs_test.exs
@@ -1,9 +1,11 @@
 defmodule Tuist.Runners.WorkflowJobsTest do
   use TuistTestSupport.Cases.DataCase, async: true
 
+  import Ecto.Query
   import TuistTestSupport.Fixtures.AccountsFixtures
 
   alias Tuist.Repo
+  alias Tuist.Runners.Claim
   alias Tuist.Runners.JobCompletion
   alias Tuist.Runners.WorkflowJob
   alias Tuist.Runners.WorkflowJobs
@@ -189,6 +191,126 @@ defmodule Tuist.Runners.WorkflowJobsTest do
 
       assert :noop = WorkflowJobs.requeue_by_handle(910_028, minting_claimed_at)
       assert get_row!(910_028).status == "running"
+    end
+  end
+
+  describe "start_executing_queued/1" do
+    # The claim carries the whole proof, so the strand is built the way
+    # the webhook path leaves it: the claim records the execution, and
+    # the row it names never moved out of `queued`.
+    defp strand_executing!(account, workflow_job_id, pod_name, runner_name) do
+      Repo.insert_all(Claim, [
+        %{
+          workflow_job_id: nil,
+          account_id: account.id,
+          fleet_name: "fleet-a",
+          pod_name: pod_name,
+          claimed_at: DateTime.utc_now(),
+          platform: :linux,
+          vcpus: 4,
+          memory_gb: 16,
+          lifecycle_state: "running",
+          runner_name: runner_name,
+          executed_workflow_job_id: workflow_job_id
+        }
+      ])
+    end
+
+    test "starts the rows a live claim proves are executing" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_060))
+      strand_executing!(account, 910_060, "pod-1", "runner-stuck")
+
+      assert [started] = WorkflowJobs.start_executing_queued(10)
+      assert started.workflow_job_id == 910_060
+
+      row = get_row!(910_060)
+      assert row.status == "running"
+      assert row.runner_name == "runner-stuck"
+      assert row.pod_name == "pod-1"
+      assert %DateTime{} = row.started_at
+      assert %DateTime{} = row.claimed_at
+    end
+
+    # The row's own `runner_name` is stamped by a separate write that
+    # never ran when the `queued` webhook arrived after the execution
+    # did. Requiring the two to agree would exclude exactly this row.
+    test "starts a row that never learned the runner's name" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_061))
+      strand_executing!(account, 910_061, "pod-1", "runner-late")
+
+      assert [_started] = WorkflowJobs.start_executing_queued(10)
+
+      row = get_row!(910_061)
+      assert row.status == "running"
+      assert row.runner_name == "runner-late"
+    end
+
+    test "leaves a row another Pod has since claimed alone" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_062))
+      strand_executing!(account, 910_062, "pod-1", "runner-raced")
+      :ok = WorkflowJobs.transition_claimed(910_062, "pod-other", DateTime.utc_now())
+
+      assert WorkflowJobs.start_executing_queued(10) == []
+      assert get_row!(910_062).status == "claimed"
+    end
+
+    test "cannot resurrect a row a completion already settled" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_063))
+      strand_executing!(account, 910_063, "pod-1", "runner-done")
+      :ok = WorkflowJobs.record_completed(attrs(account, 910_063), "success", DateTime.utc_now())
+
+      assert WorkflowJobs.start_executing_queued(10) == []
+      assert get_row!(910_063).status == "completed"
+    end
+
+    test "does not cross accounts" do
+      account = account_fixture()
+      other_account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_064))
+      strand_executing!(other_account, 910_064, "pod-1", "runner-foreign")
+
+      assert WorkflowJobs.start_executing_queued(10) == []
+      assert get_row!(910_064).status == "queued"
+    end
+
+    test "honours the per-tick limit, oldest arrival first" do
+      account = account_fixture()
+      now = DateTime.utc_now()
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_065, enqueued_at: DateTime.add(now, -60, :second)))
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_066, enqueued_at: DateTime.add(now, -600, :second)))
+      strand_executing!(account, 910_065, "pod-1", "runner-newer")
+      strand_executing!(account, 910_066, "pod-2", "runner-older")
+
+      assert [started] = WorkflowJobs.start_executing_queued(1)
+      assert started.workflow_job_id == 910_066
+      assert get_row!(910_065).status == "queued"
+    end
+
+    # One statement for the batch, one outbox insert alongside it — the
+    # ClickHouse replay has to see every row this moved.
+    test "emits one transition event per started row" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_067))
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_068))
+      strand_executing!(account, 910_067, "pod-1", "runner-a")
+      strand_executing!(account, 910_068, "pod-2", "runner-b")
+
+      Repo.delete_all(WorkflowJobTransitionEvent)
+
+      assert length(WorkflowJobs.start_executing_queued(10)) == 2
+
+      events = Repo.all(WorkflowJobTransitionEvent)
+      assert length(events) == 2
+      assert Enum.all?(events, &(&1.payload["status"] == "running"))
+      assert Enum.sort(Enum.map(events, & &1.workflow_job_id)) == [910_067, 910_068]
+    end
+
+    test "returns an empty list when nothing is stranded" do
+      assert WorkflowJobs.start_executing_queued(10) == []
     end
   end
 

--- a/server/test/tuist/runners/workflow_jobs_test.exs
+++ b/server/test/tuist/runners/workflow_jobs_test.exs
@@ -137,6 +137,61 @@ defmodule Tuist.Runners.WorkflowJobsTest do
     end
   end
 
+  describe "transition_executing/3" do
+    test "CAS queued → running stamps the executing Pod's identity" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_025))
+
+      assert :ok = WorkflowJobs.transition_executing(910_025, "runner-x", "pod-1")
+
+      row = get_row!(910_025)
+      assert row.status == "running"
+      assert row.runner_name == "runner-x"
+      assert row.pod_name == "pod-1"
+      assert row.executed_workflow_job_id == 910_025
+      assert %DateTime{} = row.started_at
+      assert %DateTime{} = row.claimed_at
+    end
+
+    # A row another Pod holds belongs to that Pod's claim generation;
+    # stamping this runner over it would misattribute the next execution.
+    test "leaves a row another Pod already claimed alone" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_026))
+      claimed_at = DateTime.utc_now()
+      :ok = WorkflowJobs.transition_claimed(910_026, "pod-other", claimed_at)
+
+      assert :noop = WorkflowJobs.transition_executing(910_026, "runner-x", "pod-1")
+
+      row = get_row!(910_026)
+      assert row.status == "claimed"
+      assert row.pod_name == "pod-other"
+    end
+
+    test "cannot resurrect a terminal row" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_027))
+      :ok = WorkflowJobs.record_completed(attrs(account, 910_027), "success", DateTime.utc_now())
+
+      assert :noop = WorkflowJobs.transition_executing(910_027, "runner-x", "pod-1")
+      assert get_row!(910_027).status == "completed"
+    end
+
+    # The handle it stamps is its own, not the minting claim's, so the
+    # stale claim a ClickHouse-lagged dispatch can still hand this job
+    # cannot re-queue it mid-flight.
+    test "the stamped handle does not match the minting claim's" do
+      account = account_fixture()
+      :ok = WorkflowJobs.upsert_queued(attrs(account, 910_028))
+      minting_claimed_at = DateTime.utc_now()
+
+      assert :ok = WorkflowJobs.transition_executing(910_028, "runner-x", "pod-1")
+
+      assert :noop = WorkflowJobs.requeue_by_handle(910_028, minting_claimed_at)
+      assert get_row!(910_028).status == "running"
+    end
+  end
+
   describe "requeue/1" do
     test "moves a claimed row back to queued and clears the claim binding" do
       account = account_fixture()


### PR DESCRIPTION
A workflow job that GitHub places on a JIT runner minted for a *different* job never leaves `queued`, and stays that way for its entire runtime.

### What was happening

GitHub binds a JIT runner to a label set, not to a job, so it routinely places job B on the Pod we minted for job A — the runner shuffle. On `workflow_job.in_progress`, `Claims.record_execution/3` detected the mismatch and handed A back to the queue, but nothing moved B. `WorkflowJobs.transition_running/3` CASes only the Pod's own `claimed -> running`, guarded on `claimed_at`; B was never claimed by this Pod, so its row sat at `queued` until the `completed` webhook flipped it terminal.

Compounding it, a running job's row could be re-queued mid-flight by `requeue_fields/0` clearing the `runner_name` / `executed_workflow_job_id` that had just been stamped, making an actively-executing job a dispatch candidate again.

### Evidence

Production, account 4094, 2026-09-08 — three jobs with `status='queued'`, `started_at IS NULL`, `claimed_at IS NULL`, each with a live claim in `lifecycle_state='running'` whose `executed_workflow_job_id` pointed at them, and each burning CPU in ClickHouse `runner_job_machine_metrics`:

| workflow_job_id | samples | avg CPU | max CPU |
| --- | --- | --- | --- |
| 102013890822 | 103 | 61.5% | 96.9% |
| 102014186281 | 87 | 66.4% | 97.5% |
| 102014610205 | 33 | 24.5% | 93.0% |

Their `runner_sessions` rows all had `job_started_at IS NULL`, while every healthy session in the preceding 90 minutes reached `job_started_at` within 6-8s of `started_at`. Scale: 690 phantom terminal jobs across two accounts in 24h (`status IN ('completed','cancelled') AND started_at IS NULL AND runner_name IS NOT NULL`), with fleet-wide `tuist_runners_recovery_count{kind="displaced_job_requeued"}` running 20-227/hour.

### Impact

1. The dashboard showed running builds as Queued for their whole runtime.
2. `tuist_runners_queue_length` and `tuist_runners_queue_oldest_dispatchable_age_seconds` counted them; the two were identical for `tuist-tuist-runner-pool-linux-16vcpu-32gb`, so phantoms read as dispatchable.
3. `tuist_runners_autoscaler_queued_jobs` tracks `queue_length` exactly, so the autoscaler provisioned pods for work already running — each reserving 34.5 GiB (32 + 2.5 GiB kata podFixed) on a 4-node OVH RISE-L fleet already at zero free 16x32 slots ~15% of peak hours.
4. `claimed_at - enqueued_at` spanned re-queue cycles, overstating p95 queue time (p50 2s vs p95 2084s on that fleet).

### What changed

**`WorkflowJobs.transition_executing/3`** CASes `queued -> running`, called from inside `Claims.detach_displaced_job/2`'s existing transaction. The Pod's slot moves from one job to the other, so both lifecycle rows move with it: A back to the queue, B started. B has no other way in — no mint will ever transition it, and GitHub announces nothing further about a job it has already placed.

It needs its own guarded path rather than a loosened `transition_running/3`. Guarding on `queued` alone is what keeps it from resurrecting a terminal row *and* from stamping this Pod over a generation another Pod holds: a row already `claimed` or `running` belongs to whichever claim moved it there, and overwriting it would misattribute the next execution.

**The row carries the executing Pod's identity.** `pod_name` is what `list_running_for_pod/1` reads, so the job is recoverable through the orphan sweep's pod-gone arm when the Pod it is actually on disappears. `claimed_at` gives it a release handle of its own — the recovery sweeps take `%DateTime{} = claimed_at` and would raise on a `running` row without one. Both are stamped with the execution's own moment rather than the minting claim's, because the job waited in the queue until GitHub placed it here, not until the Pod that took it was reserved. That also fixes impact 4 directly: `queued_duration_ms` is `claimed_at - enqueued_at`, which was growing unbounded off a NULL.

**`Claims.release/2` now re-queues by handle** (`requeue_by_handle/2` instead of `requeue/1`). A job the shuffle displaced onto another Pod is no longer a dispatch candidate, but ClickHouse dispatch lag can still hand it a second, stale claim; releasing that one would put an actively-running job back in the queue. In the happy path the claim and the lifecycle row are written from the same `DateTime` in one transaction (`insert_claim/5` -> `transition_claimed/3`), so the guard is a no-op there. Where it does bite — `transition_claimed/3` having no-oped, which `log_unmoved_lifecycle_row/2` already warns about — the row is owned by someone else and not re-queueing it is the correct outcome.

**`Claims.release_pod_missing/2` is guarded the same way.** Review caught that the first pass only closed one of two doors: that path still called the unguarded `requeue/1`, so a stale claim whose Pod vanished could put an executing job back in the queue. It now selects the claim's `claimed_at` alongside the job id and re-queues by handle.

`PodReconciliationWorker`'s `claim_fixture` back-dated only the claim's `claimed_at`, leaving the lifecycle row's at its real value — a divergence production cannot reach, since `insert_claim/5` and `transition_claimed/3` write one timestamp in one transaction. The fixture now ages both, which is what surfaced the guard working.

**`WorkflowJobs.start_executing_queued/1`** (cron `* * * * *` via `UnstartedExecutionsWorker`) is the backstop for rows already stuck and for adopt CASes that missed. One bounded candidate read, then one guarded statement:

```sql
UPDATE runner_workflow_jobs AS r0
   SET status = 'running', runner_name = r1.runner_name, pod_name = r1.pod_name, ...
  FROM runner_claims AS r1
 WHERE r1.executed_workflow_job_id = r0.workflow_job_id AND r1.account_id = r0.account_id
   AND r0.workflow_job_id = ANY($4) AND r0.status = 'queued'
   AND r1.lifecycle_state = 'running' AND r1.runner_name != ''
 RETURNING ...
```

plus one `insert_all` for the batch's outbox events, in a single transaction. The values come from the claim, so Postgres copies them across rather than the sweep issuing a transaction per row. Guards are re-applied in the write, so a row that moved between the read and the update is left alone.

The claim is the whole evidence, and an earlier version of this query got that wrong by also requiring the lifecycle row's `runner_name` to equal the claim's. `executed_workflow_job_id` is written only from a delivery where GitHub named that runner running that job, scoped to the account, and a claim is deleted on completion — a live claim naming a `queued` row is proof on its own. The row's own `runner_name` comes from a separate write that a re-queue clears and that never runs at all when the `queued` webhook arrives *after* the execution did, so requiring agreement excluded exactly the rows the sweep exists for.

### Known residual

The sweep cannot reach a dropped `in_progress` delivery. Nothing then writes `executed_workflow_job_id`, so no claim carries the evidence, and `complete_by_runner_name/3` deletes the claim while the row goes terminal. Those end as phantom terminals — `started_at` NULL with a `runner_name` — and they are part of the 690/day count above. Closing that class needs the durable `runner_sessions` binding, which outlives the Pod, rather than this sweep. The worker's moduledoc states the boundary and a test pins it.

### How to test locally

```bash
mix test test/tuist/runners/ test/tuist/runners_test.exs
```

979 passed across the runner suites plus the runner web suites. The two new `Dispatch` cases were confirmed red against the pre-fix tree (implementation reverted, tests run, restored), both failing on `left: "queued"`:

- `moves the job GitHub actually ran to running`
- `keeps an executing job out of the queue when a stale claim is released`

`mix credo` and `mix format --check-formatted` are clean.

Note on CI: `Test`, `Format`, `Security`, `Seed`, `esbuild`, `Docker build`, `Gettext` and the Swift jobs are all gated on `github.event.pull_request.draft == false` in `.github/workflows/server.yml`, which is why only Credo and Image budget have run so far. They will run when this is marked ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
