### PR TITLE
chore(infra): enable the sa-west Vultr fleet

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -827,14 +827,17 @@ vultrFleet:
     item: VULTR_API
 
 vultrFleets:
-  # South America West (Santiago). DISABLED until the region is switched on:
-  # an enabled fleet whose box the controller cannot adopt sits at MD 0/1 and
-  # wedges `helm --wait` for every production deploy, not just this region.
-  # Turning it on is: confirm the box carries the adoptTag and has been through
-  # `mise run baremetal:prep-vultr`, flip this to true, then add sa-west to
-  # TUIST_KURA_AVAILABLE_REGIONS once the node reports Ready.
+  # South America West (Santiago). Enabled: the box is pre-ordered, carries the
+  # adoptTag, and has been through `mise run baremetal:prep-vultr`, so the
+  # controller has something to claim. That matters because an enabled fleet with
+  # no adoptable box sits at MD 0/1 and wedges `helm --wait` for every production
+  # deploy, not just this region; flipping this back to false is the rollback.
+  #
+  # The region is still not served. sa-west stays out of
+  # TUIST_KURA_AVAILABLE_REGIONS and its ingress controller stays disabled until
+  # the node reports Ready and kura_volume_quota_enforced reads 1 on it.
   sa-west:
-    enabled: false
+    enabled: true
     replicas: 1
     nodePool: kura-sa-west
     machine:

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -827,15 +827,22 @@ vultrFleet:
     item: VULTR_API
 
 vultrFleets:
-  # South America West (Santiago). Enabled: the box is pre-ordered, carries the
-  # adoptTag, and has been through `mise run baremetal:prep-vultr`, so the
-  # controller has something to claim. That matters because an enabled fleet with
-  # no adoptable box sits at MD 0/1 and wedges `helm --wait` for every production
-  # deploy, not just this region; flipping this back to false is the rollback.
+  # South America West (Santiago), on Vultr because no other provider in the
+  # fleet sells bare metal in South America.
   #
-  # The region is still not served. sa-west stays out of
-  # TUIST_KURA_AVAILABLE_REGIONS and its ingress controller stays disabled until
-  # the node reports Ready and kura_volume_quota_enforced reads 1 on it.
+  # Every box counted by replicas must already carry the adoptTag and have been
+  # through `mise run baremetal:prep-vultr`. Vultr's installer cannot lay down
+  # the mirrored root plus separate XFS /data the self-join gates on, so an
+  # unconverted box is never adopted, and a fleet whose replicas exceed the
+  # adoptable boxes sits at MD 0/1 and wedges `helm --wait` for every production
+  # deploy rather than just this region.
+  #
+  # Running a box here is not the same as serving the region: that is decided by
+  # sa-west's presence in TUIST_KURA_AVAILABLE_REGIONS and by its ingress
+  # controller in the platform chart, and both are worth leaving closed until
+  # kura_volume_quota_enforced reads 1 on the node. It is 0 on a box whose /data
+  # cannot bound anything, which is otherwise invisible right up to the point one
+  # account fills the box and kubelet evicts every tenant on it.
   sa-west:
     enabled: true
     replicas: 1


### PR DESCRIPTION
One line: `vultrFleets.sa-west.enabled: false` to `true`. This is the first of three gates for the Santiago region.

Follows [#12962](https://github.com/tuist/tuist/pull/12962), which shipped the region and the Vultr machine kind deliberately inert.

## What this does

Renders a `VultrMachineTemplate` and `MachineDeployment` for the `kura-sa-west` pool, which lets the controller claim the Santiago box, convert its disk layout if needed, and self-join it as a node.

## Why it is safe now and was not before

The operator running in production is `capi-scaleway@0.30.0`, and `git merge-base --is-ancestor` confirms that tag contains #12962, so the `VultrMachine` reconciler is in the running image. The CRDs are installed and the ClusterRole carries the `vultrmachines` permissions.

That matters because an enabled fleet that nothing reconciles, or that has no box to claim, sits at MD 0/1 and blocks `helm --wait` for **every** production deploy, not just this region. Both conditions are now satisfied:

| | |
|---|---|
| Reconciler in the running image | `capi-scaleway@0.30.0`, rolled 11:28 |
| CRDs | `vultrmachines`, `vultrmachinetemplates` installed |
| RBAC | present in the ClusterRole |
| Box | `active`, tagged `tuist-kura-vultr-production`, converted |

## The region is still not served

Two gates stay closed on purpose, so no account can resolve into `sa-west` while the node proves itself:

- `sa-west` is absent from `TUIST_KURA_AVAILABLE_REGIONS`
- `kura-sa-west-ingress-nginx.enabled: false`

They move once the node is Ready and `kura_volume_quota_enforced` reads 1 on it. That metric is the one that matters here: this is the first node whose `/data` came from a post-install conversion rather than from the installer, and a box whose `/data` cannot bound anything looks healthy right up to the point one account fills it and kubelet evicts every tenant.

## What to watch

The adoption path has never run against real hardware. Expect: claim, then `Converting` short-circuiting because the box is already converted, then the self-join, then Ready. Roughly two to five minutes, matching the other bare-metal fleets.

`kubectl -n tuist get vultrmachines` shows the phase.

## Rollback

Flip this back to `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)