### PR TITLE
feat(infra): clone the ClickHouse schema onto canary's in-cluster server

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -283,6 +283,32 @@ clickhouse:
       replicas: 1
     backup:
       enabled: true
+    # One step of the migration, run as a Job by the chart. The sequence is
+    # advanced by changing `task` and deploying, so each step is a reviewed
+    # change in the release history rather than a command typed at a database.
+    #
+    # Step 3 of the rollout: clone the schema onto the empty server. Unlike the
+    # deploy that first introduced the workload, this one has somewhere to
+    # clone to. The Job is a post-upgrade hook, so it runs once the release is
+    # applied and the StatefulSet is up, and the `-credentials` Secret it reads
+    # the destination from already exists.
+    #
+    # Gate: table, view and migration-version counts match the source. Engines
+    # need no assertion, because `database_replicated_allow_only_replicated_engine`
+    # makes the destination reject a non-replicated table, so creation
+    # succeeding is the proof.
+    #
+    # Being a post-upgrade hook, this re-runs on every deploy while it is
+    # enabled. That is harmless for the clone, which creates what is missing
+    # and leaves the rest, but the step after it is not: advance `task` rather
+    # than leaving this armed once the gate is met.
+    #
+    # `cutoff` stays unset. It belongs to the backfill, two steps later, and is
+    # read off the completed rollout of the deploy that turns dual writes on.
+    migration:
+      enabled: true
+      name: schema-clone
+      task: Tuist.Release.clone_clickhouse_schema
 
   poolSize: "30"
   bufferPoolSize: "30"


### PR DESCRIPTION
## What changed

Canary's `clickhouse.managed.migration` is armed with the schema clone:

```yaml
migration:
  enabled: true
  name: schema-clone
  task: Tuist.Release.clone_clickhouse_schema
```

One values file, no template changes.

## Why now

The previous step brought canary's in-cluster ClickHouse up empty, and it has been Running since with its volume pinned to `bm-tuist-canary-md-clickhouse-zxbdh-hkgcf-nlxk4`. This is step 3 of the rollout: create the tables, views and migration-version rows on the destination so there is something for the backfill to copy into.

Nothing is mirrored or read as a result. Dual writes, the backfill and the read flag are three separate deploys after this, each with its own gate.

## Why this deploy will actually clone, unlike staging's first one

On staging, the deploy that introduced the workload logged a warning and skipped, because there was no destination to reach yet. Canary is in the opposite position, and both preconditions were checked rather than assumed:

- The chart's ClickHouse migration Job is a **post-upgrade, post-install** hook (`helm.sh/hook: post-upgrade,post-install`, weight 5), so it runs after the release is applied, not before. The pre-upgrade hook that the `optional: true` on `TUIST_CLICKHOUSE_BARE_METAL_URL` was written for is the *server* migration Job, a different template.
- The `tuist-tuist-clickhouse-credentials` Secret exists. `kubectl get secret` is not permitted for this identity in that namespace, and an empty grep there is a swallowed permission error rather than evidence, so this was established differently: the ClickHouse StatefulSet mounts that Secret as a **non-optional** volume, and its pod is `Ready 1/1`. A missing required Secret volume would hold the pod in `ContainerCreating`.

## Gate

Table, view and migration-version counts match the source. Engines need no separate assertion: `database_replicated_allow_only_replicated_engine` makes the destination reject a non-replicated table with `Code: 56`, so creation succeeding is itself the proof that every table landed on a replicated engine.

The release task logs a structured report, which is the only instrument available here. `kubectl exec` and port-forward are both blocked by the Pomerium gateway, so the destination cannot be inspected directly.

## One property worth knowing

A post-upgrade hook re-runs on every deploy for as long as it is enabled. For the clone that is harmless, since it creates what is missing and leaves the rest alone, and it doubles as schema reconciliation. It is not harmless for the steps after it, so the task should be advanced rather than left armed once the gate is met. That is written next to the values.

`cutoff` stays unset. It belongs to the backfill, two steps later, and is read off the completed rollout of the deploy that turns dual writes on.

## Validation

Rendered all three environments the way the deploy does, with `values-managed-common.yaml` followed by the per-env overlay:

- canary renders one Job, `tuist-tuist-clickhouse-schema-clone`, as `post-upgrade,post-install`, `backoffLimit: 0`, `activeDeadlineSeconds: 21600`, `restartPolicy: Never`, running `eval "Tuist.Release.clone_clickhouse_schema"` with `TUIST_CLICKHOUSE_BARE_METAL_URL` in its environment.
- staging renders no migration Job, since its own step is disabled pending a backfill with a fresh cutoff.
- production renders no managed ClickHouse at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
