### PR TITLE
fix(infra): measure the Xcode and Gradle cache share in bytes

### DIFF
--- a/infra/grafana-dashboards/tuist-kura-adoption.json
+++ b/infra/grafana-dashboards/tuist-kura-adoption.json
@@ -27,7 +27,7 @@
       }
     ],
     "cursorSync": "Off",
-    "description": "Production only. Adoption of Kura, the per-account cache mesh, now that the CLI enables it by default (4.207.0-canary.15+). CLI-run panels cover the module cache lane; the per-lane row compares module, Xcode compilation cache and Gradle request rates between the two backends in Prometheus, counting both of Kura's transports on the Xcode lane since the compilation cache runs on REAPI over gRPC as well as the older HTTP cache routes, and expresses the per-lane share in bytes from ClickHouse since request counts are not comparable across the two protocols. Splits hosted cache traffic between Kura (*.kura.tuist.dev) and the legacy hosted cache (cache-*.tuist.dev) using ClickHouse command_events.cache_endpoint, kura_usage_events and cas_events_daily_stats, the Postgres kura_servers / kura_origin_rollups tables, and the live kura_* / cache_* Prometheus series.",
+    "description": "Production only. Adoption of Kura, the per-account cache mesh, now that the CLI enables it by default (4.207.0-canary.15+). CLI-run panels cover the module cache lane; the per-lane row compares module, Xcode compilation cache and Gradle request rates between the two backends in Prometheus, counting both of Kura's transports on the Xcode lane since the compilation cache runs on REAPI over gRPC as well as the older HTTP cache routes, and expresses the Xcode and Gradle share in bytes from ClickHouse, since request counts are not comparable across the two protocols, keeping the module share on requests because the legacy module cache records no bytes. Splits hosted cache traffic between Kura (*.kura.tuist.dev) and the legacy hosted cache (cache-*.tuist.dev) using ClickHouse command_events.cache_endpoint, kura_usage_events and cas_events_daily_stats, the Postgres kura_servers / kura_origin_rollups tables, and the live kura_* / cache_* Prometheus series.",
     "editable": true,
     "elements": {
       "panel-10": {
@@ -1477,6 +1477,30 @@
                     "hidden": false,
                     "query": {
                       "datasource": {
+                        "name": "grafanacloud-prom"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "100 * (sum(increase(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__range])) / (sum(increase(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__range])) + sum(increase(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/module.*\"}[$__range]))))",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "Module (requests)",
+                        "queryType": "instant",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
                         "name": "dexgs9hv7rjswd"
                       },
                       "group": "grafana-clickhouse-datasource",
@@ -1486,11 +1510,11 @@
                         "format": 1,
                         "queryType": "table",
                         "range": true,
-                        "rawSql": "SELECT\n  round(100 * sum(kura_xcode) / nullIf(sum(kura_xcode) + sum(legacy_xcode), 0), 2) AS \"Xcode\",\n  round(100 * sum(kura_gradle) / nullIf(sum(kura_gradle) + sum(legacy_gradle), 0), 2) AS \"Gradle\"\nFROM (\n  SELECT sumIf(bytes, artifact_kind IN ('xcode', 'reapi')) AS kura_xcode,\n    sumIf(bytes, artifact_kind = 'gradle') AS kura_gradle,\n    toUInt64(0) AS legacy_xcode, toUInt64(0) AS legacy_gradle\n  FROM kura_usage_events WHERE $__timeFilter(window_start)\n  UNION ALL\n  SELECT toUInt64(0), toUInt64(0), toUInt64(sum(total_size)), toUInt64(0)\n  FROM cas_events_daily_stats\n  WHERE date BETWEEN toDate(toDateTime(intDiv($__from, 1000))) AND toDate(toDateTime(intDiv($__to, 1000)))\n  UNION ALL\n  SELECT toUInt64(0), toUInt64(0), toUInt64(0), toUInt64(sum(size))\n  FROM gradle_cache_events\n  WHERE $__timeFilter(inserted_at) AND cache_endpoint NOT LIKE '%.kura.tuist.dev'\n)"
+                        "rawSql": "SELECT\n  round(100 * sum(kura_xcode) / nullIf(sum(kura_xcode) + sum(legacy_xcode), 0), 2) AS \"Xcode (bytes)\",\n  round(100 * sum(kura_gradle) / nullIf(sum(kura_gradle) + sum(legacy_gradle), 0), 2) AS \"Gradle (bytes)\"\nFROM (\n  SELECT sumIf(bytes, artifact_kind IN ('xcode', 'reapi')) AS kura_xcode,\n    sumIf(bytes, artifact_kind = 'gradle') AS kura_gradle,\n    toUInt64(0) AS legacy_xcode, toUInt64(0) AS legacy_gradle\n  FROM kura_usage_events WHERE $__timeFilter(window_start)\n  UNION ALL\n  SELECT toUInt64(0), toUInt64(0), toUInt64(sum(total_size)), toUInt64(0)\n  FROM cas_events_daily_stats\n  WHERE date BETWEEN toDate(toDateTime(intDiv($__from, 1000))) AND toDate(toDateTime(intDiv($__to, 1000)))\n  UNION ALL\n  SELECT toUInt64(0), toUInt64(0), toUInt64(0), toUInt64(sum(size))\n  FROM gradle_cache_events\n  WHERE $__timeFilter(inserted_at) AND cache_endpoint NOT LIKE '%.kura.tuist.dev'\n)"
                       },
                       "version": "v0"
                     },
-                    "refId": "A"
+                    "refId": "B"
                   }
                 }
               ],
@@ -1498,10 +1522,10 @@
               "transformations": []
             }
           },
-          "description": "Share of cache bytes served by production Kura nodes rather than the legacy hosted cache, per lane, over the selected range. Bytes rather than requests because REAPI batches many blobs into one call while the HTTP cache lanes are one request per object, so counting requests understates Kura on the Xcode lane. Xcode counts Kura's REAPI and HTTP bytes together (`kura_usage_events` `reapi` plus `xcode`) against `cas_events_daily_stats`, which holds no Kura-endpoint rows. Gradle counts `kura_usage_events` `gradle` against the `gradle_cache_events` rows that did not go to a Kura endpoint. The module lane has no share here: legacy module cache bytes are not recorded in ClickHouse (`module_cache_outputs` is empty), so there is no denominator to divide by. Module adoption is tracked by CLI runs on the module cache row instead. ClickHouse rather than Prometheus, because the legacy byte totals only exist here, so this lags the live rate panels above. Legacy Xcode bytes are stored daily, which sets the floor on granularity.",
+          "description": "Share of each cache lane served by production Kura nodes rather than the legacy hosted cache, over the selected range. The module lane is a request share and the other two are byte shares, which the series names carry. Bytes are the better measure, since REAPI batches many blobs into one call while the HTTP cache lanes are one request per object, so a request ratio understates Kura on the Xcode lane. Module stays on requests because legacy module cache bytes are not recorded in ClickHouse (`module_cache_outputs` is empty), so that lane has no byte denominator. Xcode counts Kura's REAPI and HTTP bytes together (`kura_usage_events` `reapi` plus `xcode`) against `cas_events_daily_stats`, which holds no Kura-endpoint rows. Gradle counts `kura_usage_events` `gradle` against the `gradle_cache_events` rows that did not go to a Kura endpoint. Module reads the live Prometheus request counters on `/api/cache/module.*`. The two byte arms come from ClickHouse and lag the live rate panels above; legacy Xcode bytes are stored daily, which sets the floor on their granularity.",
           "id": 40,
           "links": [],
-          "title": "Kura share of cache bytes per lane",
+          "title": "Kura share per cache lane",
           "vizConfig": {
             "group": "bargauge",
             "kind": "VizConfig",
@@ -1577,6 +1601,29 @@
                     "hidden": false,
                     "query": {
                       "datasource": {
+                        "name": "grafanacloud-prom"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "100 * (sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__rate_interval])) / (sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__rate_interval])) + sum(rate(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/module.*\"}[$__rate_interval]))))",
+                        "instant": false,
+                        "legendFormat": "Module (requests)",
+                        "queryType": "range",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
                         "name": "dexgs9hv7rjswd"
                       },
                       "group": "grafana-clickhouse-datasource",
@@ -1586,11 +1633,11 @@
                         "format": 1,
                         "queryType": "table",
                         "range": true,
-                        "rawSql": "SELECT time,\n  round(100 * sum(kura_xcode) / nullIf(sum(kura_xcode) + sum(legacy_xcode), 0), 2) AS \"Xcode\",\n  round(100 * sum(kura_gradle) / nullIf(sum(kura_gradle) + sum(legacy_gradle), 0), 2) AS \"Gradle\"\nFROM (\n  SELECT toStartOfInterval(window_start, INTERVAL 1 $bucket) AS time,\n    sumIf(bytes, artifact_kind IN ('xcode', 'reapi')) AS kura_xcode,\n    sumIf(bytes, artifact_kind = 'gradle') AS kura_gradle,\n    toUInt64(0) AS legacy_xcode, toUInt64(0) AS legacy_gradle\n  FROM kura_usage_events WHERE $__timeFilter(window_start) GROUP BY time\n  UNION ALL\n  SELECT toStartOfInterval(toDateTime(date), INTERVAL 1 $bucket) AS time,\n    toUInt64(0), toUInt64(0), toUInt64(sum(total_size)), toUInt64(0)\n  FROM cas_events_daily_stats\n  WHERE date BETWEEN toDate(toDateTime(intDiv($__from, 1000))) AND toDate(toDateTime(intDiv($__to, 1000))) GROUP BY time\n  UNION ALL\n  SELECT toStartOfInterval(inserted_at, INTERVAL 1 $bucket) AS time,\n    toUInt64(0), toUInt64(0), toUInt64(0), toUInt64(sum(size))\n  FROM gradle_cache_events\n  WHERE $__timeFilter(inserted_at) AND cache_endpoint NOT LIKE '%.kura.tuist.dev' GROUP BY time\n)\nGROUP BY time ORDER BY time"
+                        "rawSql": "SELECT time,\n  round(100 * sum(kura_xcode) / nullIf(sum(kura_xcode) + sum(legacy_xcode), 0), 2) AS \"Xcode (bytes)\",\n  round(100 * sum(kura_gradle) / nullIf(sum(kura_gradle) + sum(legacy_gradle), 0), 2) AS \"Gradle (bytes)\"\nFROM (\n  SELECT toStartOfInterval(window_start, INTERVAL 1 $bucket) AS time,\n    sumIf(bytes, artifact_kind IN ('xcode', 'reapi')) AS kura_xcode,\n    sumIf(bytes, artifact_kind = 'gradle') AS kura_gradle,\n    toUInt64(0) AS legacy_xcode, toUInt64(0) AS legacy_gradle\n  FROM kura_usage_events WHERE $__timeFilter(window_start) GROUP BY time\n  UNION ALL\n  SELECT toStartOfInterval(toDateTime(date), INTERVAL 1 $bucket) AS time,\n    toUInt64(0), toUInt64(0), toUInt64(sum(total_size)), toUInt64(0)\n  FROM cas_events_daily_stats\n  WHERE date BETWEEN toDate(toDateTime(intDiv($__from, 1000))) AND toDate(toDateTime(intDiv($__to, 1000))) GROUP BY time\n  UNION ALL\n  SELECT toStartOfInterval(inserted_at, INTERVAL 1 $bucket) AS time,\n    toUInt64(0), toUInt64(0), toUInt64(0), toUInt64(sum(size))\n  FROM gradle_cache_events\n  WHERE $__timeFilter(inserted_at) AND cache_endpoint NOT LIKE '%.kura.tuist.dev' GROUP BY time\n)\nGROUP BY time ORDER BY time"
                       },
                       "version": "v0"
                     },
-                    "refId": "A"
+                    "refId": "B"
                   }
                 }
               ],
@@ -1598,10 +1645,10 @@
               "transformations": []
             }
           },
-          "description": "Kura bytes over Kura + legacy bytes on each lane, per bucket. Bytes rather than requests because REAPI batches many blobs into one call while the HTTP cache lanes are one request per object, so counting requests understates Kura on the Xcode lane. Xcode counts Kura's REAPI and HTTP bytes together (`kura_usage_events` `reapi` plus `xcode`) against `cas_events_daily_stats`, which holds no Kura-endpoint rows. Gradle counts `kura_usage_events` `gradle` against the `gradle_cache_events` rows that did not go to a Kura endpoint. The module lane has no share here: legacy module cache bytes are not recorded in ClickHouse (`module_cache_outputs` is empty), so there is no denominator to divide by. Module adoption is tracked by CLI runs on the module cache row instead. ClickHouse rather than Prometheus, because the legacy byte totals only exist here, so this lags the live rate panels above. Legacy Xcode bytes are stored daily, which sets the floor on granularity. Gaps mean neither backend moved bytes on that lane in the interval.",
+          "description": "Kura's share of each cache lane per bucket. The module lane is a request share and the other two are byte shares, which the series names carry. Bytes are the better measure, since REAPI batches many blobs into one call while the HTTP cache lanes are one request per object, so a request ratio understates Kura on the Xcode lane. Module stays on requests because legacy module cache bytes are not recorded in ClickHouse (`module_cache_outputs` is empty), so that lane has no byte denominator. Xcode counts Kura's REAPI and HTTP bytes together (`kura_usage_events` `reapi` plus `xcode`) against `cas_events_daily_stats`, which holds no Kura-endpoint rows. Gradle counts `kura_usage_events` `gradle` against the `gradle_cache_events` rows that did not go to a Kura endpoint. Module reads the live Prometheus request counters on `/api/cache/module.*`. The two byte arms come from ClickHouse and lag the live rate panels above; legacy Xcode bytes are stored daily, which sets the floor on their granularity. Gaps mean neither backend saw traffic on that lane in the interval.",
           "id": 41,
           "links": [],
-          "title": "Kura share of cache bytes per lane over time",
+          "title": "Kura share per cache lane over time",
           "vizConfig": {
             "group": "timeseries",
             "kind": "VizConfig",
@@ -1662,7 +1709,22 @@
                   {
                     "matcher": {
                       "id": "byName",
-                      "options": "Xcode"
+                      "options": "Module (requests)"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Xcode (bytes)"
                     },
                     "properties": [
                       {
@@ -1677,7 +1739,7 @@
                   {
                     "matcher": {
                       "id": "byName",
-                      "options": "Gradle"
+                      "options": "Gradle (bytes)"
                     },
                     "properties": [
                       {

--- a/infra/grafana-dashboards/tuist-kura-adoption.json
+++ b/infra/grafana-dashboards/tuist-kura-adoption.json
@@ -27,7 +27,7 @@
       }
     ],
     "cursorSync": "Off",
-    "description": "Production only. Adoption of Kura, the per-account cache mesh, now that the CLI enables it by default (4.207.0-canary.15+). CLI-run panels cover the module cache lane; the per-lane row compares module, Xcode compilation cache and Gradle traffic between the two backends in Prometheus, counting both of Kura's transports on the Xcode lane since the compilation cache runs on REAPI over gRPC as well as the older HTTP cache routes. Splits hosted cache traffic between Kura (*.kura.tuist.dev) and the legacy hosted cache (cache-*.tuist.dev) using ClickHouse command_events.cache_endpoint, kura_usage_events and cas_events_daily_stats, the Postgres kura_servers / kura_origin_rollups tables, and the live kura_* / cache_* Prometheus series.",
+    "description": "Production only. Adoption of Kura, the per-account cache mesh, now that the CLI enables it by default (4.207.0-canary.15+). CLI-run panels cover the module cache lane; the per-lane row compares module, Xcode compilation cache and Gradle request rates between the two backends in Prometheus, counting both of Kura's transports on the Xcode lane since the compilation cache runs on REAPI over gRPC as well as the older HTTP cache routes, and expresses the per-lane share in bytes from ClickHouse since request counts are not comparable across the two protocols. Splits hosted cache traffic between Kura (*.kura.tuist.dev) and the legacy hosted cache (cache-*.tuist.dev) using ClickHouse command_events.cache_endpoint, kura_usage_events and cas_events_daily_stats, the Postgres kura_servers / kura_origin_rollups tables, and the live kura_* / cache_* Prometheus series.",
     "editable": true,
     "elements": {
       "panel-10": {
@@ -1477,70 +1477,20 @@
                     "hidden": false,
                     "query": {
                       "datasource": {
-                        "name": "grafanacloud-prom"
+                        "name": "dexgs9hv7rjswd"
                       },
-                      "group": "prometheus",
+                      "group": "grafana-clickhouse-datasource",
                       "kind": "DataQuery",
                       "spec": {
-                        "editorMode": "code",
-                        "expr": "sum(increase(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__range])) / (sum(increase(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__range])) + sum(increase(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/module.*\"}[$__range])))",
-                        "format": "time_series",
-                        "instant": true,
-                        "legendFormat": "Module",
-                        "queryType": "instant",
-                        "range": false
+                        "editorType": "sql",
+                        "format": 1,
+                        "queryType": "table",
+                        "range": true,
+                        "rawSql": "SELECT\n  round(100 * sum(kura_xcode) / nullIf(sum(kura_xcode) + sum(legacy_xcode), 0), 2) AS \"Xcode\",\n  round(100 * sum(kura_gradle) / nullIf(sum(kura_gradle) + sum(legacy_gradle), 0), 2) AS \"Gradle\"\nFROM (\n  SELECT sumIf(bytes, artifact_kind IN ('xcode', 'reapi')) AS kura_xcode,\n    sumIf(bytes, artifact_kind = 'gradle') AS kura_gradle,\n    toUInt64(0) AS legacy_xcode, toUInt64(0) AS legacy_gradle\n  FROM kura_usage_events WHERE $__timeFilter(window_start)\n  UNION ALL\n  SELECT toUInt64(0), toUInt64(0), toUInt64(sum(total_size)), toUInt64(0)\n  FROM cas_events_daily_stats\n  WHERE date BETWEEN toDate(toDateTime(intDiv($__from, 1000))) AND toDate(toDateTime(intDiv($__to, 1000)))\n  UNION ALL\n  SELECT toUInt64(0), toUInt64(0), toUInt64(0), toUInt64(sum(size))\n  FROM gradle_cache_events\n  WHERE $__timeFilter(inserted_at) AND cache_endpoint NOT LIKE '%.kura.tuist.dev'\n)"
                       },
                       "version": "v0"
                     },
                     "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "grafanacloud-prom"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "sum(increase(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/(cas|keyvalue).*|/build.bazel.*|/google.bytestream.*\"}[$__range])) / (sum(increase(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/(cas|keyvalue).*|/build.bazel.*|/google.bytestream.*\"}[$__range])) + sum(increase(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/(cas|keyvalue).*\"}[$__range])))",
-                        "format": "time_series",
-                        "instant": true,
-                        "legendFormat": "Xcode",
-                        "queryType": "instant",
-                        "range": false
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "grafanacloud-prom"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "sum(increase(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/gradle.*\"}[$__range])) / (sum(increase(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/gradle.*\"}[$__range])) + sum(increase(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/gradle.*\"}[$__range])))",
-                        "format": "time_series",
-                        "instant": true,
-                        "legendFormat": "Gradle",
-                        "queryType": "instant",
-                        "range": false
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
                   }
                 }
               ],
@@ -1548,10 +1498,10 @@
               "transformations": []
             }
           },
-          "description": "Share of requests served by production Kura nodes rather than the production legacy cache service, per lane, over the selected range: module cache (`/api/cache/module/*`), Xcode compilation cache, Gradle (`/api/cache/gradle/*`). The Xcode lane counts both of Kura's transports, REAPI over gRPC plus the older `/api/cache/(cas|keyvalue).*` HTTP routes, against the legacy service's HTTP routes. Kura arms read `kura_public_request_latency_seconds_count`, the only Kura series that covers both transports: `kura_http_requests_total_total` is HTTP-only and carries no REAPI routes at all. REAPI batches many blobs into one request, so this request ratio reads lower than the byte ratio on the bytes panel.",
+          "description": "Share of cache bytes served by production Kura nodes rather than the legacy hosted cache, per lane, over the selected range. Bytes rather than requests because REAPI batches many blobs into one call while the HTTP cache lanes are one request per object, so counting requests understates Kura on the Xcode lane. Xcode counts Kura's REAPI and HTTP bytes together (`kura_usage_events` `reapi` plus `xcode`) against `cas_events_daily_stats`, which holds no Kura-endpoint rows. Gradle counts `kura_usage_events` `gradle` against the `gradle_cache_events` rows that did not go to a Kura endpoint. The module lane has no share here: legacy module cache bytes are not recorded in ClickHouse (`module_cache_outputs` is empty), so there is no denominator to divide by. Module adoption is tracked by CLI runs on the module cache row instead. ClickHouse rather than Prometheus, because the legacy byte totals only exist here, so this lags the live rate panels above. Legacy Xcode bytes are stored daily, which sets the floor on granularity.",
           "id": 40,
           "links": [],
-          "title": "Kura share per cache lane",
+          "title": "Kura share of cache bytes per lane",
           "vizConfig": {
             "group": "bargauge",
             "kind": "VizConfig",
@@ -1562,7 +1512,7 @@
                     "mode": "thresholds"
                   },
                   "decimals": 1,
-                  "max": 1,
+                  "max": 100,
                   "min": 0,
                   "thresholds": {
                     "mode": "absolute",
@@ -1581,7 +1531,7 @@
                       }
                     ]
                   },
-                  "unit": "percentunit"
+                  "unit": "percent"
                 },
                 "overrides": []
               },
@@ -1627,67 +1577,20 @@
                     "hidden": false,
                     "query": {
                       "datasource": {
-                        "name": "grafanacloud-prom"
+                        "name": "dexgs9hv7rjswd"
                       },
-                      "group": "prometheus",
+                      "group": "grafana-clickhouse-datasource",
                       "kind": "DataQuery",
                       "spec": {
-                        "editorMode": "code",
-                        "expr": "sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__rate_interval])) / (sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__rate_interval])) + sum(rate(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/module.*\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "Module",
-                        "queryType": "range",
-                        "range": true
+                        "editorType": "sql",
+                        "format": 1,
+                        "queryType": "table",
+                        "range": true,
+                        "rawSql": "SELECT time,\n  round(100 * sum(kura_xcode) / nullIf(sum(kura_xcode) + sum(legacy_xcode), 0), 2) AS \"Xcode\",\n  round(100 * sum(kura_gradle) / nullIf(sum(kura_gradle) + sum(legacy_gradle), 0), 2) AS \"Gradle\"\nFROM (\n  SELECT toStartOfInterval(window_start, INTERVAL 1 $bucket) AS time,\n    sumIf(bytes, artifact_kind IN ('xcode', 'reapi')) AS kura_xcode,\n    sumIf(bytes, artifact_kind = 'gradle') AS kura_gradle,\n    toUInt64(0) AS legacy_xcode, toUInt64(0) AS legacy_gradle\n  FROM kura_usage_events WHERE $__timeFilter(window_start) GROUP BY time\n  UNION ALL\n  SELECT toStartOfInterval(toDateTime(date), INTERVAL 1 $bucket) AS time,\n    toUInt64(0), toUInt64(0), toUInt64(sum(total_size)), toUInt64(0)\n  FROM cas_events_daily_stats\n  WHERE date BETWEEN toDate(toDateTime(intDiv($__from, 1000))) AND toDate(toDateTime(intDiv($__to, 1000))) GROUP BY time\n  UNION ALL\n  SELECT toStartOfInterval(inserted_at, INTERVAL 1 $bucket) AS time,\n    toUInt64(0), toUInt64(0), toUInt64(0), toUInt64(sum(size))\n  FROM gradle_cache_events\n  WHERE $__timeFilter(inserted_at) AND cache_endpoint NOT LIKE '%.kura.tuist.dev' GROUP BY time\n)\nGROUP BY time ORDER BY time"
                       },
                       "version": "v0"
                     },
                     "refId": "A"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "grafanacloud-prom"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/(cas|keyvalue).*|/build.bazel.*|/google.bytestream.*\"}[$__rate_interval])) / (sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/(cas|keyvalue).*|/build.bazel.*|/google.bytestream.*\"}[$__rate_interval])) + sum(rate(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/(cas|keyvalue).*\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "Xcode",
-                        "queryType": "range",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "grafanacloud-prom"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/gradle.*\"}[$__rate_interval])) / (sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/gradle.*\"}[$__rate_interval])) + sum(rate(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/gradle.*\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "Gradle",
-                        "queryType": "range",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
                   }
                 }
               ],
@@ -1695,10 +1598,10 @@
               "transformations": []
             }
           },
-          "description": "Kura requests over Kura + legacy requests on each lane, from Prometheus. The Xcode lane counts Kura's REAPI gRPC routes alongside its `/api/cache/(cas|keyvalue).*` HTTP routes, since the compilation cache runs on both. Gaps mean neither backend saw traffic on that lane in the interval. REAPI batches many blobs into one request, so this request ratio reads lower than the byte ratio on the bytes panel.",
+          "description": "Kura bytes over Kura + legacy bytes on each lane, per bucket. Bytes rather than requests because REAPI batches many blobs into one call while the HTTP cache lanes are one request per object, so counting requests understates Kura on the Xcode lane. Xcode counts Kura's REAPI and HTTP bytes together (`kura_usage_events` `reapi` plus `xcode`) against `cas_events_daily_stats`, which holds no Kura-endpoint rows. Gradle counts `kura_usage_events` `gradle` against the `gradle_cache_events` rows that did not go to a Kura endpoint. The module lane has no share here: legacy module cache bytes are not recorded in ClickHouse (`module_cache_outputs` is empty), so there is no denominator to divide by. Module adoption is tracked by CLI runs on the module cache row instead. ClickHouse rather than Prometheus, because the legacy byte totals only exist here, so this lags the live rate panels above. Legacy Xcode bytes are stored daily, which sets the floor on granularity. Gaps mean neither backend moved bytes on that lane in the interval.",
           "id": 41,
           "links": [],
-          "title": "Kura share per cache lane over time",
+          "title": "Kura share of cache bytes per lane over time",
           "vizConfig": {
             "group": "timeseries",
             "kind": "VizConfig",
@@ -1742,7 +1645,7 @@
                       "mode": "off"
                     }
                   },
-                  "max": 1,
+                  "max": 100,
                   "min": 0,
                   "thresholds": {
                     "mode": "absolute",
@@ -1753,24 +1656,9 @@
                       }
                     ]
                   },
-                  "unit": "percentunit"
+                  "unit": "percent"
                 },
                 "overrides": [
-                  {
-                    "matcher": {
-                      "id": "byName",
-                      "options": "Module"
-                    },
-                    "properties": [
-                      {
-                        "id": "color",
-                        "value": {
-                          "fixedColor": "green",
-                          "mode": "fixed"
-                        }
-                      }
-                    ]
-                  },
                   {
                     "matcher": {
                       "id": "byName",


### PR DESCRIPTION
Stacked on tuist/tuist#12990, which is where the Xcode lane got its REAPI half. Base that first; this PR is the one-file follow-up that changes what the share is measured in.

## What changed

"Kura share per cache lane" and "Kura share per cache lane over time" (panels 40 and 41) now measure the Xcode and Gradle lanes in **bytes** instead of requests. The module lane stays on requests. Each series says which it is:

| Series | Measure | Source |
|---|---|---|
| Module (requests) | requests | Prometheus, live |
| Xcode (bytes) | bytes | ClickHouse |
| Gradle (bytes) | bytes | ClickHouse |

The Prometheus arm is scaled by 100 so all three land on the same 0 to 100 axis, and the panel unit moves from `percentunit` to `percent`, matching the other ClickHouse share panel already on this dashboard. Both panels now carry per-query datasources, the same way "Account migration status" and "Kura usage by account and lane" already mix ClickHouse and Postgres.

Nothing else moves. The request-rate panels stay on Prometheus and stay live.

## Why

Request counts are not comparable across the two protocols. REAPI batches many blobs into one call (`BatchReadBlobs`, `BatchUpdateBlobs`, `FindMissingBlobs`); the HTTP cache lanes are one request per object. So a request ratio systematically understates Kura on the Xcode lane, which is the lane that matters most for the migration.

Production, 7 days:

| Xcode lane | Kura | Legacy | Share |
|---|---|---|---|
| Requests | 1,207,640 | 33,337,224 | 3.50% |
| Bytes | 491.2 GB | 2,791.3 GB | **14.96%** |

The byte number is the honest one.

## Why the module lane stays on requests

There is no legacy module cache byte source to divide by. `module_cache_outputs` exists in ClickHouse but is empty (0 rows, 0 B), as is `reapi_cache_events`; the legacy module cache only records events in Postgres `cache_events`, which is too large to scan from Grafana.

A mixed panel is the right trade here. Module is the lane with the most accounts on it and it currently reads 51.4% over 7 days, so dropping it to keep the panel unit-pure would have hidden the best-performing lane behind a data-availability detail. The series names carry the unit of measure, which is what keeps the comparison honest.

## Why the byte arms are ClickHouse and not Prometheus

I tried to keep these panels live before moving them. It is not possible today:

- Kura has what is needed. `kura_artifact_read_bytes_total_total` and `kura_artifact_write_bytes_total_total` are labelled by `producer` (`module`, `xcode`, `gradle`, `reapi`), which is exactly the lane dimension and covers both transports.
- The legacy side does not. The only byte series it exports is `cache_prom_ex_phoenix_http_response_size_bytes_sum`, and Adaptive Metrics has aggregated it: querying it returns `Can't query aggregated metric ... the following labels are aggregated: instance, method, path, status_class`. Without `path` there is no way to split legacy bytes by lane, and without `instance` there is no way to exclude canary and staging. It is also response bytes only, so uploads would be missing even if the labels were intact.

Restoring `path` would mean editing the Adaptive Metrics rule set, which is a change to metric ingestion rather than to a dashboard, and `auto_apply` is on so the recommendation would come back. Out of scope here. Worth doing separately if a live byte share is wanted, and it would also need an upload-side series to be a complete measure.

## Sources

- **Xcode**: `kura_usage_events` `reapi` plus `xcode` bytes, against `cas_events_daily_stats.total_size`. Verified the denominator is clean: `cas_events` has 0 rows and 0 bytes with a `.kura.tuist.dev` endpoint over the last 3 days, so the legacy arm is not double counting Kura's own CAS traffic.
- **Gradle**: `kura_usage_events` `gradle` bytes, against `gradle_cache_events.size` restricted to rows whose `cache_endpoint` is not a Kura endpoint. Kura-endpoint Gradle bytes in that table are currently 0.
- **Module**: unchanged, the live Prometheus request counters on `/api/cache/module.*`.

The two byte queries follow the union-with-zero-columns shape the neighbouring "Cache bytes by lane and backend" panel already uses, so the three ClickHouse byte panels read the same way. `sum(...) / nullIf(sum(...) + sum(...), 0)` leaves a gap rather than dividing by zero when neither backend moved bytes in a bucket.

`kura_usage_events` is a ReplacingMergeTree, so I checked whether the sums need `FINAL`: they do not. Identical totals with and without it for all four lanes over 7 days, which is why these queries match the existing panels in not using it.

## Validation

Production ClickHouse and Prometheus, 2026-09-08. The ClickHouse queries were run verbatim with the Grafana macros substituted by hand.

Panel 40 over 2026-09-01 to 2026-09-09: Module 51.38%, Xcode 13.11%, Gradle 0.02%. All three on the same 0 to 100 scale.

Panel 41, `$bucket = day`, same range:

| Day | Xcode (bytes) | Gradle (bytes) |
|---|---|---|
| 09-01 | 4.39% | 0.06% |
| 09-02 | 21.48% | 0.04% |
| 09-03 | 13.76% | 0% |
| 09-04 | 10.87% | 0% |
| 09-05 | 18.43% | 0% |
| 09-06 | 12.64% | 0% |
| 09-07 | 9.89% | 0.01% |
| 09-08 | 11.05% | 0% |

Panel 41, `$bucket = week`: 13.83% and 10.36%. `$bucket` only offers `day` and `week`, so the daily granularity of `cas_events_daily_stats` is never the limiting factor. A sub-day bucket would have put a whole day of legacy bytes in one bucket and read 100% Kura in the rest, which is worth stating in case that variable ever gains an hour option.

An earlier hand-test with deliberately misaligned range predicates produced a 100% first bucket. With the macros aligned the way the panel actually renders them, that bucket reads 4.39%, which confirms the two arms cover the same window.

The 16 Prometheus queries on the dashboard were re-run after the change and all return series, including the rescaled module arm on both panels. Structural checks on the file: parses as JSON, `metadata.name` still `defx5dvim5ro5cf`, 18 elements and 18 layout references with no dangling or duplicate reference, unique refIds per panel, field-color overrides realigned to the new series names, and it round-trips byte-identically through Grafana Git Sync's serialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
