### PR TITLE
fix(infra): call the Xcode cache lane by its name and share it in bytes

### DIFF
--- a/infra/grafana-dashboards/tuist-kura-adoption.json
+++ b/infra/grafana-dashboards/tuist-kura-adoption.json
@@ -27,7 +27,7 @@
       }
     ],
     "cursorSync": "Off",
-    "description": "Production only. Adoption of Kura, the per-account cache mesh, now that the CLI enables it by default (4.207.0-canary.15+). CLI-run panels cover the module cache lane; the per-lane row compares module, legacy Swift CAS daemon and Gradle traffic on the same HTTP route families in Prometheus, and shows the Xcode compilation cache (REAPI over gRPC) as a Kura-only rate, since the legacy cache service has no REAPI endpoint to compare against. Splits hosted cache traffic between Kura (*.kura.tuist.dev) and the legacy hosted cache (cache-*.tuist.dev) using ClickHouse command_events.cache_endpoint, kura_usage_events and cas_events_daily_stats, the Postgres kura_servers / kura_origin_rollups tables, and the live kura_* / cache_* Prometheus series.",
+    "description": "Production only. Adoption of Kura, the per-account cache mesh, now that the CLI enables it by default (4.207.0-canary.15+). CLI-run panels cover the module cache lane; the per-lane row compares module, Xcode compilation cache and Gradle request rates between the two backends in Prometheus, counting both of Kura's transports on the Xcode lane since the compilation cache runs on REAPI over gRPC as well as the older HTTP cache routes, and expresses the Xcode and Gradle share in bytes from ClickHouse, since request counts are not comparable across the two protocols, keeping the module share on requests because the legacy module cache records no bytes. Splits hosted cache traffic between Kura (*.kura.tuist.dev) and the legacy hosted cache (cache-*.tuist.dev) using ClickHouse command_events.cache_endpoint, kura_usage_events and cas_events_daily_stats, the Postgres kura_servers / kura_origin_rollups tables, and the live kura_* / cache_* Prometheus series.",
     "editable": true,
     "elements": {
       "panel-10": {
@@ -1483,10 +1483,10 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(increase(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__range])) / (sum(increase(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__range])) + sum(increase(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/module.*\"}[$__range])))",
+                        "expr": "100 * (sum(increase(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__range])) / (sum(increase(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__range])) + sum(increase(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/module.*\"}[$__range]))))",
                         "format": "time_series",
                         "instant": true,
-                        "legendFormat": "Module",
+                        "legendFormat": "Module (requests)",
                         "queryType": "instant",
                         "range": false
                       },
@@ -1501,46 +1501,20 @@
                     "hidden": false,
                     "query": {
                       "datasource": {
-                        "name": "grafanacloud-prom"
+                        "name": "dexgs9hv7rjswd"
                       },
-                      "group": "prometheus",
+                      "group": "grafana-clickhouse-datasource",
                       "kind": "DataQuery",
                       "spec": {
-                        "editorMode": "code",
-                        "expr": "sum(increase(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/(cas|keyvalue).*\"}[$__range])) / (sum(increase(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/(cas|keyvalue).*\"}[$__range])) + sum(increase(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/(cas|keyvalue).*\"}[$__range])))",
-                        "format": "time_series",
-                        "instant": true,
-                        "legendFormat": "Legacy CAS daemon",
-                        "queryType": "instant",
-                        "range": false
+                        "editorType": "sql",
+                        "format": 1,
+                        "queryType": "table",
+                        "range": true,
+                        "rawSql": "SELECT\n  round(100 * sum(kura_xcode) / nullIf(sum(kura_xcode) + sum(legacy_xcode), 0), 2) AS \"Xcode (bytes)\",\n  round(100 * sum(kura_gradle) / nullIf(sum(kura_gradle) + sum(legacy_gradle), 0), 2) AS \"Gradle (bytes)\"\nFROM (\n  SELECT sumIf(bytes, artifact_kind IN ('xcode', 'reapi')) AS kura_xcode,\n    sumIf(bytes, artifact_kind = 'gradle') AS kura_gradle,\n    toUInt64(0) AS legacy_xcode, toUInt64(0) AS legacy_gradle\n  FROM kura_usage_events WHERE $__timeFilter(window_start)\n  UNION ALL\n  SELECT toUInt64(0), toUInt64(0), toUInt64(sum(total_size)), toUInt64(0)\n  FROM cas_events_daily_stats\n  WHERE date BETWEEN toDate(toDateTime(intDiv($__from, 1000))) AND toDate(toDateTime(intDiv($__to, 1000)))\n  UNION ALL\n  SELECT toUInt64(0), toUInt64(0), toUInt64(0), toUInt64(sum(size))\n  FROM gradle_cache_events\n  WHERE $__timeFilter(inserted_at) AND cache_endpoint NOT LIKE '%.kura.tuist.dev'\n)"
                       },
                       "version": "v0"
                     },
                     "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "grafanacloud-prom"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "sum(increase(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/gradle.*\"}[$__range])) / (sum(increase(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/gradle.*\"}[$__range])) + sum(increase(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/gradle.*\"}[$__range])))",
-                        "format": "time_series",
-                        "instant": true,
-                        "legendFormat": "Gradle",
-                        "queryType": "instant",
-                        "range": false
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
                   }
                 }
               ],
@@ -1548,7 +1522,7 @@
               "transformations": []
             }
           },
-          "description": "Share of `/api/cache/*` requests served by production Kura nodes rather than the production legacy cache service, per lane, over the selected range. Lanes are the HTTP route families both backends expose: module cache (`/api/cache/module/*`), the legacy per-project Swift CAS daemon (`/api/cache/cas/*` and `/api/cache/keyvalue*`), Gradle (`/api/cache/gradle/*`). The Xcode compilation cache is not here: it speaks REAPI over gRPC, the legacy cache service has no REAPI endpoint, so there is no share to compute. Its volume is on the REAPI rate panel instead.",
+          "description": "Share of each cache lane served by production Kura nodes rather than the legacy hosted cache, over the selected range. The module lane is a request share and the other two are byte shares, which the series names carry. Bytes are the better measure, since REAPI batches many blobs into one call while the HTTP cache lanes are one request per object, so a request ratio understates Kura on the Xcode lane. Module stays on requests because legacy module cache bytes are not recorded in ClickHouse (`module_cache_outputs` is empty), so that lane has no byte denominator. Xcode counts Kura's REAPI and HTTP bytes together (`kura_usage_events` `reapi` plus `xcode`) against `cas_events_daily_stats`, which holds no Kura-endpoint rows. Gradle counts `kura_usage_events` `gradle` against the `gradle_cache_events` rows that did not go to a Kura endpoint. Module reads the live Prometheus request counters on `/api/cache/module.*`. The two byte arms come from ClickHouse and lag the live rate panels above; legacy Xcode bytes are stored daily, which sets the floor on their granularity.",
           "id": 40,
           "links": [],
           "title": "Kura share per cache lane",
@@ -1562,7 +1536,7 @@
                     "mode": "thresholds"
                   },
                   "decimals": 1,
-                  "max": 1,
+                  "max": 100,
                   "min": 0,
                   "thresholds": {
                     "mode": "absolute",
@@ -1581,7 +1555,7 @@
                       }
                     ]
                   },
-                  "unit": "percentunit"
+                  "unit": "percent"
                 },
                 "overrides": []
               },
@@ -1633,9 +1607,9 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__rate_interval])) / (sum(rate(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__rate_interval])) + sum(rate(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/module.*\"}[$__rate_interval])))",
+                        "expr": "100 * (sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__rate_interval])) / (sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__rate_interval])) + sum(rate(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/module.*\"}[$__rate_interval]))))",
                         "instant": false,
-                        "legendFormat": "Module",
+                        "legendFormat": "Module (requests)",
                         "queryType": "range",
                         "range": true
                       },
@@ -1650,44 +1624,20 @@
                     "hidden": false,
                     "query": {
                       "datasource": {
-                        "name": "grafanacloud-prom"
+                        "name": "dexgs9hv7rjswd"
                       },
-                      "group": "prometheus",
+                      "group": "grafana-clickhouse-datasource",
                       "kind": "DataQuery",
                       "spec": {
-                        "editorMode": "code",
-                        "expr": "sum(rate(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/(cas|keyvalue).*\"}[$__rate_interval])) / (sum(rate(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/(cas|keyvalue).*\"}[$__rate_interval])) + sum(rate(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/(cas|keyvalue).*\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "Legacy CAS daemon",
-                        "queryType": "range",
-                        "range": true
+                        "editorType": "sql",
+                        "format": 1,
+                        "queryType": "table",
+                        "range": true,
+                        "rawSql": "SELECT time,\n  round(100 * sum(kura_xcode) / nullIf(sum(kura_xcode) + sum(legacy_xcode), 0), 2) AS \"Xcode (bytes)\",\n  round(100 * sum(kura_gradle) / nullIf(sum(kura_gradle) + sum(legacy_gradle), 0), 2) AS \"Gradle (bytes)\"\nFROM (\n  SELECT toStartOfInterval(window_start, INTERVAL 1 $bucket) AS time,\n    sumIf(bytes, artifact_kind IN ('xcode', 'reapi')) AS kura_xcode,\n    sumIf(bytes, artifact_kind = 'gradle') AS kura_gradle,\n    toUInt64(0) AS legacy_xcode, toUInt64(0) AS legacy_gradle\n  FROM kura_usage_events WHERE $__timeFilter(window_start) GROUP BY time\n  UNION ALL\n  SELECT toStartOfInterval(toDateTime(date), INTERVAL 1 $bucket) AS time,\n    toUInt64(0), toUInt64(0), toUInt64(sum(total_size)), toUInt64(0)\n  FROM cas_events_daily_stats\n  WHERE date BETWEEN toDate(toDateTime(intDiv($__from, 1000))) AND toDate(toDateTime(intDiv($__to, 1000))) GROUP BY time\n  UNION ALL\n  SELECT toStartOfInterval(inserted_at, INTERVAL 1 $bucket) AS time,\n    toUInt64(0), toUInt64(0), toUInt64(0), toUInt64(sum(size))\n  FROM gradle_cache_events\n  WHERE $__timeFilter(inserted_at) AND cache_endpoint NOT LIKE '%.kura.tuist.dev' GROUP BY time\n)\nGROUP BY time ORDER BY time"
                       },
                       "version": "v0"
                     },
                     "refId": "B"
-                  }
-                },
-                {
-                  "kind": "PanelQuery",
-                  "spec": {
-                    "hidden": false,
-                    "query": {
-                      "datasource": {
-                        "name": "grafanacloud-prom"
-                      },
-                      "group": "prometheus",
-                      "kind": "DataQuery",
-                      "spec": {
-                        "editorMode": "code",
-                        "expr": "sum(rate(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/gradle.*\"}[$__rate_interval])) / (sum(rate(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/gradle.*\"}[$__rate_interval])) + sum(rate(cache_prom_ex_phoenix_http_requests_total{instance=~\"cache-.*\", instance!~\".*-(canary|staging).*\", path=~\"/api/cache/gradle.*\"}[$__rate_interval])))",
-                        "instant": false,
-                        "legendFormat": "Gradle",
-                        "queryType": "range",
-                        "range": true
-                      },
-                      "version": "v0"
-                    },
-                    "refId": "C"
                   }
                 }
               ],
@@ -1695,7 +1645,7 @@
               "transformations": []
             }
           },
-          "description": "Kura requests over Kura + legacy requests on each lane's HTTP route family, from Prometheus. The Xcode compilation cache is absent for the same reason as on the summary panel: it is REAPI over gRPC and Kura-only, so it has no share. Gaps mean neither backend saw traffic on that lane in the interval.",
+          "description": "Kura's share of each cache lane per bucket. The module lane is a request share and the other two are byte shares, which the series names carry. Bytes are the better measure, since REAPI batches many blobs into one call while the HTTP cache lanes are one request per object, so a request ratio understates Kura on the Xcode lane. Module stays on requests because legacy module cache bytes are not recorded in ClickHouse (`module_cache_outputs` is empty), so that lane has no byte denominator. Xcode counts Kura's REAPI and HTTP bytes together (`kura_usage_events` `reapi` plus `xcode`) against `cas_events_daily_stats`, which holds no Kura-endpoint rows. Gradle counts `kura_usage_events` `gradle` against the `gradle_cache_events` rows that did not go to a Kura endpoint. Module reads the live Prometheus request counters on `/api/cache/module.*`. The two byte arms come from ClickHouse and lag the live rate panels above; legacy Xcode bytes are stored daily, which sets the floor on their granularity. Gaps mean neither backend saw traffic on that lane in the interval.",
           "id": 41,
           "links": [],
           "title": "Kura share per cache lane over time",
@@ -1742,7 +1692,7 @@
                       "mode": "off"
                     }
                   },
-                  "max": 1,
+                  "max": 100,
                   "min": 0,
                   "thresholds": {
                     "mode": "absolute",
@@ -1753,13 +1703,13 @@
                       }
                     ]
                   },
-                  "unit": "percentunit"
+                  "unit": "percent"
                 },
                 "overrides": [
                   {
                     "matcher": {
                       "id": "byName",
-                      "options": "Module"
+                      "options": "Module (requests)"
                     },
                     "properties": [
                       {
@@ -1774,7 +1724,7 @@
                   {
                     "matcher": {
                       "id": "byName",
-                      "options": "Legacy CAS daemon"
+                      "options": "Xcode (bytes)"
                     },
                     "properties": [
                       {
@@ -1789,7 +1739,7 @@
                   {
                     "matcher": {
                       "id": "byName",
-                      "options": "Gradle"
+                      "options": "Gradle (bytes)"
                     },
                     "properties": [
                       {
@@ -1840,7 +1790,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__rate_interval]))",
+                        "expr": "sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/module.*\"}[$__rate_interval]))",
                         "instant": false,
                         "legendFormat": "Kura",
                         "queryType": "range",
@@ -1879,7 +1829,7 @@
               "transformations": []
             }
           },
-          "description": "Requests per second on `/api/cache/module.*` routes: production Kura nodes versus production legacy cache service instances (canary and staging excluded by instance name).",
+          "description": "Requests per second on `/api/cache/module.*` routes: production Kura nodes versus production legacy cache service instances (canary and staging excluded by instance name)). Kura arms read `kura_public_request_latency_seconds_count`, the only Kura series that covers both transports: `kura_http_requests_total_total` is HTTP-only and carries no REAPI routes at all.",
           "id": 42,
           "links": [],
           "title": "Module lane request rate by backend",
@@ -2007,7 +1957,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/(cas|keyvalue).*\"}[$__rate_interval]))",
+                        "expr": "sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/(cas|keyvalue).*|/build.bazel.*|/google.bytestream.*\"}[$__rate_interval]))",
                         "instant": false,
                         "legendFormat": "Kura",
                         "queryType": "range",
@@ -2046,10 +1996,10 @@
               "transformations": []
             }
           },
-          "description": "Requests per second on `/api/cache/(cas|keyvalue).*`: production Kura nodes versus production legacy cache service instances (canary and staging excluded by instance name). This is the legacy per-project Swift CAS daemon lane (`ArtifactProducer::Xcode`, mapped in `kura/src/accelerated_file_serving.rs`), not the Xcode compilation cache. The compilation cache runs on REAPI over gRPC and has its own panel. The daemon lane is winding down, so a low Kura share here says nothing about Xcode adoption.",
+          "description": "Requests per second for the Xcode compilation cache. Kura serves it over two transports and both are counted here: the REAPI gRPC routes (the cas-plugin lane) and the older `/api/cache/(cas|keyvalue).*` HTTP routes. The legacy cache service has no REAPI endpoint, so its arm is the HTTP routes alone (canary and staging excluded by instance name). Kura arms read `kura_public_request_latency_seconds_count`, the only Kura series that covers both transports: `kura_http_requests_total_total` is HTTP-only and carries no REAPI routes at all. REAPI batches many blobs into one request, so this request ratio reads lower than the byte ratio on the bytes panel.",
           "id": 43,
           "links": [],
-          "title": "Legacy CAS daemon lane request rate by backend",
+          "title": "Xcode cache request rate by backend",
           "vizConfig": {
             "group": "timeseries",
             "kind": "VizConfig",
@@ -2174,7 +2124,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "sum(rate(kura_http_requests_total_total{cluster=\"tuist-production\", route=~\"/api/cache/gradle.*\"}[$__rate_interval]))",
+                        "expr": "sum(rate(kura_public_request_latency_seconds_count{cluster=\"tuist-production\", route=~\"/api/cache/gradle.*\"}[$__rate_interval]))",
                         "instant": false,
                         "legendFormat": "Kura",
                         "queryType": "range",
@@ -2213,7 +2163,7 @@
               "transformations": []
             }
           },
-          "description": "Requests per second on `/api/cache/gradle.*` routes: production Kura nodes versus production legacy cache service instances (canary and staging excluded by instance name).",
+          "description": "Requests per second on `/api/cache/gradle.*` routes: production Kura nodes versus production legacy cache service instances (canary and staging excluded by instance name)). Kura arms read `kura_public_request_latency_seconds_count`, the only Kura series that covers both transports: `kura_http_requests_total_total` is HTTP-only and carries no REAPI routes at all.",
           "id": 44,
           "links": [],
           "title": "Gradle lane request rate by backend",
@@ -2813,10 +2763,10 @@
               "transformations": []
             }
           },
-          "description": "Requests per second on the REAPI gRPC routes, broken out by method: ActionCache, ContentAddressableStorage, ByteStream and Capabilities. This is the lane the Xcode compilation cache runs on (the cas-plugin), shared with any Bazel client pointed at Kura; Kura records both under `ArtifactProducer::Reapi`, so they are not separable here. Kura-only, so this is a raw rate rather than a share: the legacy cache service has no REAPI endpoint. Sourced from `kura_public_request_latency_seconds_count` because `kura_http_requests_total_total` is HTTP-only and carries none of these routes; `_count` rather than `_bucket` because the adaptive-metrics drop rules in `infra/helm/k8s-monitoring/values.yaml` are anchored on `_bucket`. Build event streaming (`/google.devtools.build.v1.PublishBuildEvent/*`) is excluded because it is not cache traffic.",
+          "description": "The gRPC half of the Xcode cache lane, broken out by method: ActionCache, ContentAddressableStorage, ByteStream and Capabilities. Shown per method rather than as a share because the legacy cache service has no REAPI endpoint to compare against. `_count` rather than `_bucket` because the adaptive-metrics drop rules in `infra/helm/k8s-monitoring/values.yaml` are anchored on `_bucket`. Build event streaming (`/google.devtools.build.v1.PublishBuildEvent/*`) is excluded because it is not cache traffic.",
           "id": 47,
           "links": [],
-          "title": "REAPI lane request rate (Xcode compilation cache)",
+          "title": "Xcode cache REAPI methods on Kura",
           "vizConfig": {
             "group": "timeseries",
             "kind": "VizConfig",


### PR DESCRIPTION
## Why this PR exists

tuist/tuist#12990 was squash-merged at 12:31 UTC carrying **only its first commit**. The two follow-up commits that were already on its branch never reached main, and tuist/tuist#12993 then merged into that branch rather than into main, so it did not reach main either.

The result is visible on the live dashboard right now: the share panel reads "Legacy CAS daemon", which was the wrong name and was corrected on the branch minutes after it was pushed. `main` and commit 1 of #12990 are byte-identical, so nothing else edited the file in between and there is no competing Grafana UI save to preserve.

This PR carries the remaining work against main. It is the same dashboard file the merged branch already ends at.

## What changed relative to main

1. **The Xcode lane keeps its product name and measures the whole lane.** "Legacy CAS daemon lane request rate by backend" becomes **"Xcode cache request rate by backend"**, and its Kura arm covers the REAPI gRPC routes plus the older `/api/cache/(cas|keyvalue).*` HTTP routes. The legacy cache service has no REAPI endpoint, so its arm stays on the HTTP routes. The `Legacy CAS daemon` series on both share panels goes away with it.
2. **Every Kura arm reads `kura_public_request_latency_seconds_count`**, the one Kura series that covers both transports, so no panel is split across two request metrics.
3. **The Xcode and Gradle shares move to bytes**, from ClickHouse. Module stays on the live Prometheus request ratio. Each series names its own unit: `Module (requests)`, `Xcode (bytes)`, `Gradle (bytes)`, all scaled to a 0 to 100 axis.
4. **The REAPI methods panel** ("Xcode cache REAPI methods on Kura") is unchanged from what merged, other than its title and description.

## Why bytes for Xcode and Gradle

Request counts are not comparable across the two protocols. REAPI batches many blobs into one call (`BatchReadBlobs`, `BatchUpdateBlobs`, `FindMissingBlobs`); the HTTP cache lanes are one request per object, so a request ratio systematically understates Kura on the lane that matters most for the migration.

Production, 7 days, Xcode lane:

| Measure | Kura | Legacy | Share |
|---|---|---|---|
| Requests | 1,207,640 | 33,337,224 | 3.50% |
| Bytes | 491.2 GB | 2,791.3 GB | **14.96%** |

For reference, what main shows today for the same lane is 0.07%, because it matches only the HTTP routes and misses the 98% of the lane that is gRPC.

## Why module stays on requests

There is no legacy module cache byte source. `module_cache_outputs` exists in ClickHouse but is empty (0 rows, 0 B), as is `reapi_cache_events`; the legacy module cache only records events in Postgres `cache_events`, which is too large to scan from Grafana.

Module is the lane with the most accounts on it and reads 52.97% over 30 days, so dropping it to keep the panel unit-pure would have hidden the best-performing lane behind a data-availability detail. The series names carry the unit, which is what keeps the comparison honest.

## Why the byte arms are ClickHouse and not Prometheus

Kura has what is needed: `kura_artifact_read_bytes_total_total` and `kura_artifact_write_bytes_total_total` are labelled by `producer` (`module`, `xcode`, `gradle`, `reapi`), which is exactly the lane dimension and covers both transports.

The legacy side does not. Its only byte series, `cache_prom_ex_phoenix_http_response_size_bytes_sum`, has been aggregated by Adaptive Metrics: querying it returns `Can't query aggregated metric ... the following labels are aggregated: instance, method, path, status_class`. Without `path` there is no per-lane split, without `instance` canary and staging cannot be excluded, and it is response bytes only so uploads would be missing anyway. Restoring `path` means editing the Adaptive Metrics rule set, which is a metric-ingestion change rather than a dashboard change, and `auto_apply` is on so the recommendation would come back.

## Sources

- **Xcode bytes**: `kura_usage_events` `reapi` plus `xcode`, against `cas_events_daily_stats.total_size`. The denominator is clean: `cas_events` has 0 rows and 0 bytes with a `.kura.tuist.dev` endpoint over the last 3 days.
- **Gradle bytes**: `kura_usage_events` `gradle`, against `gradle_cache_events.size` restricted to rows whose `cache_endpoint` is not a Kura endpoint. Kura-endpoint Gradle bytes there are currently 0.
- **Module requests**: unchanged, the live Prometheus counters on `/api/cache/module.*`.

Both byte queries follow the union-with-zero-columns shape the neighbouring "Cache bytes by lane and backend" panel already uses. `nullIf(...)` on the denominator leaves a gap rather than dividing by zero. `kura_usage_events` is a ReplacingMergeTree; sums are identical with and without `FINAL` over 7 days on all four lanes, which is why these queries match the existing panels in not using it.

## Validation

Production Prometheus and ClickHouse, 2026-09-08.

All 16 Prometheus queries in the file were extracted, macro-substituted at the dashboard's default 30d range and executed: all successful, all returning series. Panel 47 returns exactly the 8 expected REAPI methods. `Module (requests)` evaluates to 52.97 on the 0 to 100 axis.

ClickHouse queries run verbatim with macros substituted. Panel 40 over 2026-09-01 to 09-09: Xcode 13.11%, Gradle 0.02%. Panel 41 at `$bucket = day` ranges 4.39% to 21.48% across that week; at `$bucket = week`, 13.83% and 10.36%. `$bucket` only offers `day` and `week`, so the daily granularity of `cas_events_daily_stats` is never the limiting factor; a sub-day bucket would put a whole day of legacy bytes in one bucket and read 100% Kura in the rest, worth knowing if that variable ever gains an hour option.

Structural checks: parses as JSON, `apiVersion` `dashboard.grafana.app/v2`, `metadata.name` still `defx5dvim5ro5cf`, 18 elements and 18 layout references with no dangling or duplicate reference, unique refIds per panel, field-color overrides aligned to the new series names, no occurrence of the old wording left, and the file round-trips byte-identically through Grafana Git Sync's serialization so the next UI save will not produce a whitespace-only diff.

## Note

Please merge this one with all of its commits, or squash it. The earlier partial merge is what left the wrong label live for the last hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
