### PR TITLE
fix(cli): warn at generate time when the CAS proxy is not reachable

### DIFF
--- a/cli/Sources/TuistGenerator/Mappers/XcodeCacheSettingsProjectMapper.swift
+++ b/cli/Sources/TuistGenerator/Mappers/XcodeCacheSettingsProjectMapper.swift
@@ -17,17 +17,20 @@ public struct XcodeCacheSettingsProjectMapper: ProjectMapping {
     private let kuraEnabled: Bool
     private let casPluginCandidates: [AbsolutePath]
     private let fileSystem: FileSysteming
+    private let cacheSocketService: CacheSocketServicing
 
     public init(
         tuist: Tuist,
         kuraEnabled: Bool = false,
         casPluginCandidates: [AbsolutePath] = [],
-        fileSystem: FileSysteming = FileSystem()
+        fileSystem: FileSysteming = FileSystem(),
+        cacheSocketService: CacheSocketServicing = CacheSocketService()
     ) {
         self.tuist = tuist
         self.kuraEnabled = kuraEnabled
         self.casPluginCandidates = casPluginCandidates
         self.fileSystem = fileSystem
+        self.cacheSocketService = cacheSocketService
     }
 
     public func map(project: Project) async throws -> (Project, [SideEffectDescriptor]) {
@@ -103,6 +106,7 @@ public struct XcodeCacheSettingsProjectMapper: ProjectMapping {
                     baseSettings["COMPILATION_CACHE_REMOTE_SERVICE_PATH"] = .string(
                         Environment.current.casProxySocketPathString()
                     )
+                    warnIfCASProxyIsUnreachable(fullHandle: fullHandle)
                 } else {
                     // Kura is enabled but the bundled dylib is absent, so the build
                     // silently falls back to local-only caching (no remote). Warn
@@ -131,6 +135,16 @@ public struct XcodeCacheSettingsProjectMapper: ProjectMapping {
         )
 
         return (project, [])
+    }
+
+    /// The proxy unlinks its socket at bind and never at exit, so the file on disk
+    /// outlives the process and only a `connect()` tells a live proxy from a dead one.
+    private func warnIfCASProxyIsUnreachable(fullHandle: String) {
+        let socketPath = Environment.current.casProxySocketPath()
+        guard !cacheSocketService.canConnect(to: socketPath) else { return }
+        Logger.current.warning(
+            "Xcode Cache is enabled for \(fullHandle) but nothing is listening on the CAS proxy socket at \(socketPath.pathString). This build will use local-only compilation caching with no remote cache. Run `tuist setup cache` to start the proxy."
+        )
     }
 
     /// Whether the selected Xcode's build system implements the source/build

--- a/cli/Sources/TuistSupport/AGENTS.md
+++ b/cli/Sources/TuistSupport/AGENTS.md
@@ -7,6 +7,7 @@ This module provides low-level helpers and shared infrastructure used across the
 - Error modeling (`FatalError`) and common system helpers (process, environment, Xcode detection).
 - Shared constants and utilities used across CLI modules.
 - Caller-owned scratch directory preparation and validation for cache warming.
+- Unix socket reachability probing for the Xcode Cache daemon and CAS proxy sockets.
 
 ## Boundaries
 - Keep this module dependency-light; it should not depend on higher-level feature modules.

--- a/cli/Sources/TuistSupport/Utils/CacheSocketService.swift
+++ b/cli/Sources/TuistSupport/Utils/CacheSocketService.swift
@@ -8,17 +8,22 @@ import Mockable
 import Path
 
 @Mockable
-protocol CacheSocketServicing {
+public protocol CacheSocketServicing {
+    /// Whether something is accepting connections on the unix socket at `path`. A
+    /// socket file outlives the process that bound it, so only a `connect()` answers.
+    func canConnect(to path: AbsolutePath) -> Bool
     func waitUntilListening(at path: AbsolutePath, timeout: Duration) async -> Bool
 }
 
-struct CacheSocketService: CacheSocketServicing {
-    func waitUntilListening(at path: AbsolutePath, timeout: Duration) async -> Bool {
+public struct CacheSocketService: CacheSocketServicing {
+    public init() {}
+
+    public func waitUntilListening(at path: AbsolutePath, timeout: Duration) async -> Bool {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: timeout)
 
         repeat {
-            if canConnect(to: path.pathString) {
+            if canConnect(to: path) {
                 return true
             }
             if clock.now >= deadline || Task.isCancelled {
@@ -28,7 +33,9 @@ struct CacheSocketService: CacheSocketServicing {
         } while true
     }
 
-    private func canConnect(to path: String) -> Bool {
+    public func canConnect(to path: AbsolutePath) -> Bool {
+        let path = path.pathString
+
         #if canImport(Darwin)
             let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
         #else

--- a/cli/Tests/TuistGeneratorTests/Mappers/XcodeCacheSettingsProjectMapperTests.swift
+++ b/cli/Tests/TuistGeneratorTests/Mappers/XcodeCacheSettingsProjectMapperTests.swift
@@ -10,6 +10,8 @@ import TuistConstants
 import TuistCore
 import TuistEnvironment
 import TuistEnvironmentTesting
+import TuistLoggerTesting
+import TuistLogging
 import TuistSupport
 import TuistTesting
 import XcodeGraph
@@ -539,5 +541,85 @@ struct XcodeCacheSettingsProjectMapperTests {
             mappedProject.settings.base["COMPILATION_CACHE_PLUGIN_PATH"]
                 == .string(casPluginPath.pathString)
         )
+    }
+
+    /// The proxy owns the remote half of the kura path, and a machine without one
+    /// caches only locally. The socket file alone proves nothing: the proxy unlinks
+    /// it at bind and never at exit, so a dead proxy leaves the file behind.
+    @Test(.inTemporaryDirectory, .withMockedXcodeController, .withMockedEnvironment(), .withMockedLogger())
+    func map_whenProxyIsNotReachable_warnsAndKeepsCachingSettings() async throws {
+        // Given
+        try stubXcodeVersion(Version(26, 0, 0))
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let casPluginPath = temporaryDirectory.appending(component: "libtuist_cas_plugin.dylib")
+        try await FileSystem().touch(casPluginPath)
+        let tuist = Tuist(
+            project: .generated(
+                .test(
+                    generationOptions: .test(enableCaching: true)
+                )
+            ),
+            fullHandle: "test-org/test-project",
+            inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
+            url: Constants.URLs.production
+        )
+        let subject = XcodeCacheSettingsProjectMapper(
+            tuist: tuist,
+            kuraEnabled: true,
+            casPluginCandidates: [casPluginPath]
+        )
+        let project = Project.test(name: "TestProject", settings: .test(base: [:]))
+
+        // When
+        let (mappedProject, _) = try await subject.map(project: project)
+
+        // Then
+        let warnings = Logger.testingLogHandler.collected[.warning, ==]
+        #expect(warnings.contains(Environment.current.casProxySocketPath().pathString) == true)
+        #expect(warnings.contains("local-only compilation caching") == true)
+
+        // Not fatal: the build still gets every caching setting, it just has no
+        // remote to reach.
+        #expect(mappedProject.settings.base["COMPILATION_CACHE_ENABLE_PLUGIN"] == .string("YES"))
+        #expect(
+            mappedProject.settings.base["COMPILATION_CACHE_REMOTE_SERVICE_PATH"]
+                == .string(Environment.current.casProxySocketPathString())
+        )
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedXcodeController, .withMockedEnvironment(), .withMockedLogger())
+    func map_whenProxyIsReachable_doesNotWarn() async throws {
+        // Given
+        try stubXcodeVersion(Version(26, 0, 0))
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let casPluginPath = temporaryDirectory.appending(component: "libtuist_cas_plugin.dylib")
+        try await FileSystem().touch(casPluginPath)
+        let cacheSocketService = MockCacheSocketServicing()
+        given(cacheSocketService)
+            .canConnect(to: .value(Environment.current.casProxySocketPath()))
+            .willReturn(true)
+        let tuist = Tuist(
+            project: .generated(
+                .test(
+                    generationOptions: .test(enableCaching: true)
+                )
+            ),
+            fullHandle: "test-org/test-project",
+            inspectOptions: .init(redundantDependencies: .init(ignoreTagsMatching: [])),
+            url: Constants.URLs.production
+        )
+        let subject = XcodeCacheSettingsProjectMapper(
+            tuist: tuist,
+            kuraEnabled: true,
+            casPluginCandidates: [casPluginPath],
+            cacheSocketService: cacheSocketService
+        )
+        let project = Project.test(name: "TestProject", settings: .test(base: [:]))
+
+        // When
+        _ = try await subject.map(project: project)
+
+        // Then
+        #expect(Logger.testingLogHandler.collected[.warning, ==].isEmpty == true)
     }
 }

--- a/cli/Tests/TuistSupportTests/Utils/CacheSocketServiceTests.swift
+++ b/cli/Tests/TuistSupportTests/Utils/CacheSocketServiceTests.swift
@@ -5,7 +5,7 @@ import Foundation
 import Path
 import Testing
 
-@testable import TuistKit
+@testable import TuistSupport
 
 struct CacheSocketServiceTests {
     private let fileSystem = FileSystem()
@@ -65,5 +65,46 @@ struct CacheSocketServiceTests {
                 timeout: .zero
             )
         )
+    }
+
+    /// A socket file left behind by a process that exited is not a reachable peer:
+    /// `connect()` answers `ECONNREFUSED` where an existence check reports healthy.
+    @Test(.inTemporaryDirectory)
+    func canConnect_returnsFalseForAStaleSocketFile() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let shortDirectoryPath = try AbsolutePath(validating: "/tmp/\(UUID().uuidString)")
+        try await fileSystem.createSymbolicLink(from: shortDirectoryPath, to: temporaryDirectory)
+        let socketPath = shortDirectoryPath.appending(component: "stale.sock")
+        defer {
+            unlink(socketPath.pathString)
+            unlink(shortDirectoryPath.pathString)
+        }
+        try bindAndClose(at: socketPath)
+        try #require(await fileSystem.exists(socketPath))
+
+        #expect(subject.canConnect(to: socketPath) == false)
+    }
+
+    /// Binds a listening socket and closes it, leaving the socket file on disk the
+    /// way the CAS proxy does when it exits.
+    private func bindAndClose(at socketPath: AbsolutePath) throws {
+        let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        try #require(descriptor >= 0)
+        var address = sockaddr_un()
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        address.sun_family = sa_family_t(AF_UNIX)
+        try #require(socketPath.pathString.utf8.count < MemoryLayout.size(ofValue: address.sun_path))
+        withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+            buffer.initializeMemory(as: UInt8.self, repeating: 0)
+            buffer.copyBytes(from: socketPath.pathString.utf8)
+        }
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                Darwin.bind(descriptor, socketAddress, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        try #require(bindResult == 0)
+        try #require(Darwin.listen(descriptor, 1) == 0)
+        close(descriptor)
     }
 }


### PR DESCRIPTION
## What changed

`XcodeCacheSettingsProjectMapper` now probes the machine-wide CAS proxy socket when it wires up the kura Xcode Cache path, and warns when nothing is listening:

```
Xcode Cache is enabled for my-org/my-project but nothing is listening on the CAS proxy
socket at /Users/me/.local/state/tuist/cas-proxy.sock. This build will use local-only
compilation caching with no remote cache. Run `tuist setup cache` to start the proxy.
```

The probe is `CacheSocketService`, moved from `TuistKit` to `TuistSupport` so both the setup command that already used it and the generator can reach it. It gained a public one-shot `canConnect(to:)`; the existing `waitUntilListening(at:timeout:)` is now written in terms of it.

## Why

On the kura path the CAS plugin owns remote read/write-through, and it reaches the remote only through the per-machine proxy. When no proxy is bootstrapped, the plugin degrades to local misses per operation and records that only in the file named by `TUIST_CAS_LOG` (`crate::log_line`, defaulting to `default_log_path` in `cas-plugin/src/lib.rs`). Nothing reaches the build output.

The consequence is that a build with no remote cache at all looks exactly like a build with a cold one. Both are slow, both succeed, and the only evidence lives in a log file you have to already know about. A customer hit a setup bug that left no proxy bootstrapped and ran a full CI job against no remote cache. Their own preflight could not catch it: it checked for the plugin dylib, which was present. The missing piece was the proxy, and nothing anywhere said so.

## Why this shape

The generator already warns for the sibling failure. `XcodeCacheSettingsProjectMapper` warns when kura is enabled but `libtuist_cas_plugin.dylib` cannot be found, with the reasoning stated inline: warn rather than let a cold cache be the first symptom. Two lines earlier it has already computed the proxy socket path via `Environment.current.casProxySocketPathString()`, so the symmetric check belongs in the same branch with a warning of the same shape. A reader who has seen one message needs no new vocabulary for the other.

It stays a warning, not an error. A machine without a proxy still builds correctly, it just builds without a remote cache, so failing would break every legitimate local-only build. Teams that want it fatal can promote the warning, the same as for the dylib warning today.

## Why a connect(), not a file check

The proxy calls `remove_file` on its socket path immediately before `UnixListener::bind` and never unlinks at exit (`cas-plugin/src/bin/tuist-cas-proxy.rs`). A proxy that died therefore leaves the socket file sitting on disk, so an existence check reports a healthy cache in precisely the case this change exists to catch. A `connect()` against that stale file gives `ECONNREFUSED`. `CacheSocketServiceTests.canConnect_returnsFalseForAStaleSocketFile` pins this: it binds a listening socket, closes it, asserts the file still exists, and asserts the probe says false.

## What this check does and does not cover

Generate is the earliest point where we know a build is meant to use the proxy, which is where the reported failure lives: a proxy that never started, or that died during setup. It cannot catch a proxy that dies between generate and build.

I considered a second probe in the `tuist xcodebuild` wrapper and decided against it. That wrapper (`cli/Sources/TuistKit/Services/XcodeBuild/`) has no knowledge of Xcode Cache today, so the check would mean teaching a passthrough command to load config and resolve the kura client feature flag just to decide whether a proxy is even expected. It would also narrow the window rather than close it, and it would still miss the largest uncovered case, an Xcode command-B build, which never goes through the CLI at all. Closing the gap properly means the plugin itself surfacing the degradation into the build output, which is a change on the plugin side rather than another CLI-side probe.

## Impact

Anyone generating a project with Xcode Cache on the kura path now learns at generate time that their remote cache is unreachable, instead of inferring it later from build times or finding it in `TUIST_CAS_LOG`. No behavior change when a proxy is running, and no build setting changes in either case.

## Validation

Written red first: the unreachable-proxy test failed on both warning assertions against the unmodified mapper, then passed after the change.

- `TuistGeneratorTests/XcodeCacheSettingsProjectMapperTests`, 15 tests pass. Two are new: one asserts the warning names the socket path and says the build falls back to local-only caching, and that the caching settings are still applied so the warning is not fatal. The other asserts a reachable proxy produces no warning.
- `TuistSupportTests/CacheSocketServiceTests`, 3 tests pass, including the new stale-socket-file case.
- `TuistKitTests/SetupCacheCommandServiceTests`, 25 tests pass, confirming the move did not disturb the existing consumer.
- `swiftformat --lint` and `swiftlint` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
