### PR TITLE
feat(cli): change the Xcode cache upload policy without reinstalling the agent

### DIFF
--- a/cli/Sources/TuistKit/Commands/Setup/SetupCacheCommand.swift
+++ b/cli/Sources/TuistKit/Commands/Setup/SetupCacheCommand.swift
@@ -1,12 +1,35 @@
 import ArgumentParser
 import Foundation
 
+extension XcodeCacheUploadPolicy: ExpressibleByArgument {}
+
 struct SetupCacheCommand: AsyncParsableCommand {
     static var configuration: CommandConfiguration {
         CommandConfiguration(
             commandName: "cache",
             _superCommandName: "setup",
-            abstract: "Set up the Tuist Xcode cache"
+            abstract: "Set up the Tuist Xcode cache",
+            discussion: """
+            Run without options, this installs the cache agent for the project and records \
+            the `xcodeCache(upload:)` policy from 'Tuist.swift'.
+
+            `--upload-policy` changes only that policy, for this machine, and leaves the agent \
+            running. The cache proxy re-reads it within 15 seconds. It does not set the cache \
+            up, and a plain `tuist setup cache` records the policy from 'Tuist.swift' again, so \
+            run the two in that order.
+
+            Two caveats worth knowing before you rely on it:
+
+            - The policy is recorded per machine and per project, not per build. Two lanes \
+            building the same project at once on one machine both see whichever policy was \
+            written last.
+
+            - `--upload-policy disabled` stops every upload on its own. `--upload-policy \
+            enabled` does not start Swift uploads again if the project was generated with \
+            `xcodeCache(upload: false)`: `tuist generate` bakes that into the project as a \
+            build setting the cache plugin gates on by itself, so the project has to be \
+            regenerated with `xcodeCache(upload: true)`.
+            """
         )
     }
 
@@ -17,9 +40,16 @@ struct SetupCacheCommand: AsyncParsableCommand {
     )
     var path: String?
 
+    @Option(
+        name: .long,
+        help: "Change only whether this machine uploads Xcode cache artifacts for the project, without reinstalling the cache agent."
+    )
+    var uploadPolicy: XcodeCacheUploadPolicy?
+
     func run() async throws {
         try await SetupCacheCommandService().run(
-            path: path
+            path: path,
+            uploadPolicy: uploadPolicy
         )
     }
 }

--- a/cli/Sources/TuistKit/Services/Setup/CacheSourcesRegistry.swift
+++ b/cli/Sources/TuistKit/Services/Setup/CacheSourcesRegistry.swift
@@ -1,0 +1,157 @@
+import FileSystem
+import Foundation
+import Path
+import TuistEnvironment
+
+/// What setup knows about a project that the proxy cannot work out for itself
+/// (see `load_sources` in cas-plugin).
+///
+/// The registry is a JSON object of instance -> this. JSON because we write it
+/// and the proxy reads it from another language: a format each side hand-rolls
+/// is one each side can drift on, and every value here is optional, which is the
+/// shape a hand-rolled one gets wrong first.
+struct RegisteredSource: Codable {
+    /// The project's configured default branch, which is a server-side decision.
+    /// The proxy would otherwise have to guess it from the local clone's
+    /// `origin/HEAD`, a property of how this machine cloned rather than of the
+    /// project.
+    let trunk: String?
+    /// Recorded only on CI. See `ciBranch`.
+    let branch: String?
+    /// The project's `xcodeCache.upload`. The proxy is the only place that can
+    /// enforce this: the plugin reads it as a compiler option, which reaches
+    /// Swift, while the build system's Clang caching runs in its own process
+    /// with no plugin options at all. Recorded here so one answer covers both.
+    let upload: Bool
+
+    init(trunk: String?, branch: String?, upload: Bool) {
+        self.trunk = trunk
+        self.branch = branch
+        self.upload = upload
+    }
+
+    /// Hand-written rather than synthesized, so that an absent field means here
+    /// what it means to the proxy. The synthesized one requires every
+    /// non-optional, which would make this side reject a registry the proxy
+    /// reads happily: the drift that using one format on both sides exists to
+    /// prevent.
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        trunk = try container.decodeIfPresent(String.self, forKey: .trunk)
+        branch = try container.decodeIfPresent(String.self, forKey: .branch)
+        // Nothing recorded is nothing to withhold (`uploads_by_default` there).
+        upload = try container.decodeIfPresent(Bool.self, forKey: .upload) ?? true
+    }
+}
+
+/// The cache proxy's sources registry: one row per project set up on this
+/// machine, holding what `tuist setup cache` knows that the proxy cannot work
+/// out for itself.
+///
+/// The one writer of the file, so that every entry point gets the same lock and
+/// the same atomic swap. A policy flip races a concurrent setup exactly as two
+/// setups race each other, and both windows are closed here or nowhere.
+struct CacheSourcesRegistry {
+    private let fileSystem: FileSysteming
+
+    init(fileSystem: FileSysteming = FileSystem()) {
+        self.fileSystem = fileSystem
+    }
+
+    /// Rewrites this project's row in the proxy's sources registry
+    /// (`<state>/cas-proxy.sock.registry.sources`, honoring the same
+    /// `TUIST_CAS_PROXY_REGISTRY` override the proxy reads), handing `mutate` the
+    /// row recorded for it today (`nil` when it has none) and storing what comes
+    /// back.
+    func update(
+        fullHandle: String,
+        _ mutate: (RegisteredSource?) -> RegisteredSource
+    ) async throws {
+        // Derived from the proxy's OWN socket, not from `stateDirectory`. The two
+        // agree by default and diverge under `XDG_STATE_HOME`, which the socket
+        // deliberately ignores (see `casProxySocketPath`) because the plugin must
+        // resolve it from HOME alone. Writing this file where the proxy is not
+        // reading loses the trunk silently: unscoped snapshots and untagged
+        // publishes, with nothing to show for it.
+        let sourcesPath: AbsolutePath
+        if let registry = Environment.current.variables["TUIST_CAS_PROXY_REGISTRY"] {
+            sourcesPath = try AbsolutePath(validating: registry + ".sources")
+        } else {
+            sourcesPath = try AbsolutePath(
+                validating: Environment.current.casProxySocketPath().pathString + ".registry.sources"
+            )
+        }
+
+        if try await !fileSystem.exists(sourcesPath.parentDirectory, isDirectory: true) {
+            try await fileSystem.makeDirectory(at: sourcesPath.parentDirectory)
+        }
+
+        // The whole read-modify-write is serialized across processes. Atomic
+        // rename gives a READER the old file or the new one, never a torn one,
+        // but it does nothing for two setups racing: both read the registry
+        // before either renames, and the later rename drops the project the
+        // earlier one added, silently losing its trunk and upload policy. An
+        // exclusive lock on a sidecar file makes the second setup wait for the
+        // first, so it reads the already-updated registry and upserts onto it.
+        let lockPath = sourcesPath.parentDirectory
+            .appending(component: "\(sourcesPath.basename).lock")
+        try await withRegistryLock(at: lockPath) {
+            // Read every other project back: this rewrites the whole file, so
+            // anything lost here is a project silently losing its policy. A
+            // registry we cannot decode therefore fails the command rather than
+            // being written over with just this project, which would erase every
+            // other one's.
+            var entries: [String: RegisteredSource] = [:]
+            if try await fileSystem.exists(sourcesPath) {
+                let contents = try await fileSystem.readTextFile(at: sourcesPath)
+                entries = try JSONDecoder().decode([String: RegisteredSource].self, from: Data(contents.utf8))
+            }
+            entries[fullHandle] = mutate(entries[fullHandle])
+
+            let encoder = JSONEncoder()
+            // Sorted so a rewrite that changes nothing produces the same bytes,
+            // and unescaped because every key here is an `account/project`.
+            encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
+            let body = String(decoding: try encoder.encode(entries), as: UTF8.self)
+
+            // Swapped in, never rewritten in place, and `rename` rather than a
+            // remove followed by a write or a move: it is the only one of the
+            // three that leaves no instant where the file is missing or
+            // half-written.
+            //
+            // The proxy re-reads this on a timer while we write it, and it
+            // carries the upload policy. A reader that finds no file sees no
+            // projects, and an unknown project has to be allowed to upload, so
+            // any gap here hands an opted-out project a window in which its Clang
+            // outputs are published. `rename` gives every reader either the whole
+            // old file or the whole new one, and both are answers we can live
+            // with.
+            let staged = sourcesPath.parentDirectory
+                .appending(component: "\(sourcesPath.basename).\(UUID().uuidString)")
+            try await fileSystem.writeText(body, at: staged)
+            guard rename(staged.pathString, sourcesPath.pathString) == 0 else {
+                let code = errno
+                try? await fileSystem.remove(staged)
+                throw SetupCacheCommandServiceError.registryNotReplaced(sourcesPath.pathString, code)
+            }
+        }
+    }
+
+    /// Runs `body` while holding an exclusive advisory lock on `lockPath`, so two
+    /// `tuist setup cache` processes cannot interleave a read-modify-write of the
+    /// registry. The lock file is created on demand and never removed: deleting
+    /// it would reopen the race it closes. `flock` is released when the descriptor
+    /// closes, including on a crash, so a killed setup cannot wedge the next one.
+    private func withRegistryLock(at lockPath: AbsolutePath, _ body: () async throws -> Void) async throws {
+        let descriptor = open(lockPath.pathString, O_CREAT | O_RDWR, 0o644)
+        guard descriptor >= 0 else {
+            throw SetupCacheCommandServiceError.registryNotLocked(lockPath.pathString, errno)
+        }
+        defer { close(descriptor) }
+        guard flock(descriptor, LOCK_EX) == 0 else {
+            throw SetupCacheCommandServiceError.registryNotLocked(lockPath.pathString, errno)
+        }
+        defer { flock(descriptor, LOCK_UN) }
+        try await body()
+    }
+}

--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -20,6 +20,7 @@ enum SetupCacheCommandServiceError: Equatable, LocalizedError {
     case cacheDaemonNotReady(label: String, socketPath: String, logPath: String)
     case registryNotReplaced(String, Int32)
     case registryNotLocked(String, Int32)
+    case uploadPolicyRequiresProxy
 
     var errorDescription: String? {
         switch self {
@@ -36,49 +37,24 @@ enum SetupCacheCommandServiceError: Equatable, LocalizedError {
             return "Could not update the cache proxy's registry at \(path) (errno \(code))."
         case let .registryNotLocked(path, code):
             return "Could not lock the cache proxy's registry at \(path) (errno \(code))."
+        case .uploadPolicyRequiresProxy:
+            return
+                "The upload policy is read from the cache proxy's registry, and this machine runs the per-project cache daemon instead (`TUIST_FEATURE_FLAG_KURA` is off). Change `xcodeCache(upload:)` in 'Tuist.swift' and run `tuist setup cache` again."
         }
     }
 }
 
-/// What setup knows about a project that the proxy cannot work out for itself
-/// (see `load_sources` in cas-plugin).
+/// Which way `tuist setup cache --upload-policy` moves a project's recorded
+/// Xcode cache upload policy.
 ///
-/// The registry is a JSON object of instance -> this. JSON because we write it
-/// and the proxy reads it from another language: a format each side hand-rolls
-/// is one each side can drift on, and every value here is optional, which is the
-/// shape a hand-rolled one gets wrong first.
-private struct RegisteredSource: Codable {
-    /// The project's configured default branch, which is a server-side decision.
-    /// The proxy would otherwise have to guess it from the local clone's
-    /// `origin/HEAD`, a property of how this machine cloned rather than of the
-    /// project.
-    let trunk: String?
-    /// Recorded only on CI. See `ciBranch`.
-    let branch: String?
-    /// The project's `xcodeCache.upload`. The proxy is the only place that can
-    /// enforce this: the plugin reads it as a compiler option, which reaches
-    /// Swift, while the build system's Clang caching runs in its own process
-    /// with no plugin options at all. Recorded here so one answer covers both.
-    let upload: Bool
+/// Not a `Bool` on the command line: the flag stands in for `xcodeCache(upload:)`
+/// for one machine, and `--upload-policy disabled` says in a CI file what
+/// `--upload-policy false` would leave the reader to work out.
+enum XcodeCacheUploadPolicy: String, CaseIterable, Sendable {
+    case enabled
+    case disabled
 
-    init(trunk: String?, branch: String?, upload: Bool) {
-        self.trunk = trunk
-        self.branch = branch
-        self.upload = upload
-    }
-
-    /// Hand-written rather than synthesized, so that an absent field means here
-    /// what it means to the proxy. The synthesized one requires every
-    /// non-optional, which would make this side reject a registry the proxy
-    /// reads happily: the drift that using one format on both sides exists to
-    /// prevent.
-    init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        trunk = try container.decodeIfPresent(String.self, forKey: .trunk)
-        branch = try container.decodeIfPresent(String.self, forKey: .branch)
-        // Nothing recorded is nothing to withhold (`uploads_by_default` there).
-        upload = try container.decodeIfPresent(Bool.self, forKey: .upload) ?? true
-    }
+    var upload: Bool { self == .enabled }
 }
 
 struct SetupCacheCommandService {
@@ -87,7 +63,7 @@ struct SetupCacheCommandService {
     private let serverEnvironmentService: ServerEnvironmentServicing
     private let serverAuthenticationController: ServerAuthenticationControlling
     private let manifestLoader: ManifestLoading
-    private let fileSystem: FileSysteming
+    private let sourcesRegistry: CacheSourcesRegistry
     private let getProjectService: GetProjectServicing
     private let gitController: GitControlling
     private let cacheSocketService: CacheSocketServicing
@@ -110,7 +86,7 @@ struct SetupCacheCommandService {
         self.serverEnvironmentService = serverEnvironmentService
         self.serverAuthenticationController = serverAuthenticationController
         self.manifestLoader = manifestLoader
-        self.fileSystem = fileSystem
+        sourcesRegistry = CacheSourcesRegistry(fileSystem: fileSystem)
         self.getProjectService = getProjectService
         self.gitController = gitController
         self.cacheSocketService = cacheSocketService
@@ -154,8 +130,7 @@ struct SetupCacheCommandService {
     }
 
     /// Records a `RegisteredSource` for this project in the proxy's sources
-    /// registry (`<state>/cas-proxy.sock.registry.sources`, honoring the same
-    /// `TUIST_CAS_PROXY_REGISTRY` override the proxy reads).
+    /// registry.
     ///
     /// Upserts, so setting up a second project does not clobber the first.
     private func registerSource(
@@ -164,92 +139,64 @@ struct SetupCacheCommandService {
         branch: String?,
         upload: Bool
     ) async throws {
-        // Derived from the proxy's OWN socket, not from `stateDirectory`. The two
-        // agree by default and diverge under `XDG_STATE_HOME`, which the socket
-        // deliberately ignores (see `casProxySocketPath`) because the plugin must
-        // resolve it from HOME alone. Writing this file where the proxy is not
-        // reading loses the trunk silently: unscoped snapshots and untagged
-        // publishes, with nothing to show for it.
-        let sourcesPath: AbsolutePath
-        if let registry = Environment.current.variables["TUIST_CAS_PROXY_REGISTRY"] {
-            sourcesPath = try AbsolutePath(validating: registry + ".sources")
-        } else {
-            sourcesPath = try AbsolutePath(
-                validating: Environment.current.casProxySocketPath().pathString + ".registry.sources"
-            )
-        }
-
-        if try await !fileSystem.exists(sourcesPath.parentDirectory, isDirectory: true) {
-            try await fileSystem.makeDirectory(at: sourcesPath.parentDirectory)
-        }
-
-        // The whole read-modify-write is serialized across processes. Atomic
-        // rename gives a READER the old file or the new one, never a torn one,
-        // but it does nothing for two setups racing: both read the registry
-        // before either renames, and the later rename drops the project the
-        // earlier one added, silently losing its trunk and upload policy. An
-        // exclusive lock on a sidecar file makes the second setup wait for the
-        // first, so it reads the already-updated registry and upserts onto it.
-        let lockPath = sourcesPath.parentDirectory
-            .appending(component: "\(sourcesPath.basename).lock")
-        try await withRegistryLock(at: lockPath) {
-            // Read every other project back: this rewrites the whole file, so
-            // anything lost here is a project silently losing its policy. A
-            // registry we cannot decode therefore fails the command rather than
-            // being written over with just this project, which would erase every
-            // other one's.
-            var entries: [String: RegisteredSource] = [:]
-            if try await fileSystem.exists(sourcesPath) {
-                let contents = try await fileSystem.readTextFile(at: sourcesPath)
-                entries = try JSONDecoder().decode([String: RegisteredSource].self, from: Data(contents.utf8))
-            }
-            entries[fullHandle] = RegisteredSource(trunk: trunk, branch: branch, upload: upload)
-
-            let encoder = JSONEncoder()
-            // Sorted so a rewrite that changes nothing produces the same bytes,
-            // and unescaped because every key here is an `account/project`.
-            encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
-            let body = String(decoding: try encoder.encode(entries), as: UTF8.self)
-
-            // Swapped in, never rewritten in place, and `rename` rather than a
-            // remove followed by a write or a move: it is the only one of the
-            // three that leaves no instant where the file is missing or
-            // half-written.
-            //
-            // The proxy re-reads this on a timer while we write it, and it
-            // carries the upload policy. A reader that finds no file sees no
-            // projects, and an unknown project has to be allowed to upload, so
-            // any gap here hands an opted-out project a window in which its Clang
-            // outputs are published. `rename` gives every reader either the whole
-            // old file or the whole new one, and both are answers we can live
-            // with.
-            let staged = sourcesPath.parentDirectory
-                .appending(component: "\(sourcesPath.basename).\(UUID().uuidString)")
-            try await fileSystem.writeText(body, at: staged)
-            guard rename(staged.pathString, sourcesPath.pathString) == 0 else {
-                let code = errno
-                try? await fileSystem.remove(staged)
-                throw SetupCacheCommandServiceError.registryNotReplaced(sourcesPath.pathString, code)
-            }
+        try await sourcesRegistry.update(fullHandle: fullHandle) { _ in
+            RegisteredSource(trunk: trunk, branch: branch, upload: upload)
         }
     }
 
-    /// Runs `body` while holding an exclusive advisory lock on `lockPath`, so two
-    /// `tuist setup cache` processes cannot interleave a read-modify-write of the
-    /// registry. The lock file is created on demand and never removed: deleting
-    /// it would reopen the race it closes. `flock` is released when the descriptor
-    /// closes, including on a crash, so a killed setup cannot wedge the next one.
-    private func withRegistryLock(at lockPath: AbsolutePath, _ body: () async throws -> Void) async throws {
-        let descriptor = open(lockPath.pathString, O_CREAT | O_RDWR, 0o644)
-        guard descriptor >= 0 else {
-            throw SetupCacheCommandServiceError.registryNotLocked(lockPath.pathString, errno)
+    /// Rewrites nothing but this project's upload policy in the proxy's sources
+    /// registry, leaving the launch agent running.
+    ///
+    /// `Proxy::upload_enabled` re-reads the registry on a fifteen second memo, and
+    /// every publication from both lanes and from the background sweeper passes
+    /// through it, so the file is the whole mechanism. Reinstalling the agent to
+    /// change one boolean would tear down and bootstrap the machine's only cache
+    /// proxy for a change it never sees.
+    ///
+    /// The trunk and the CI branch are carried over rather than re-resolved. Neither
+    /// is a policy decision: the trunk is the server's answer to a question this
+    /// command is not asking, and the branch is what the setup that ran inside the
+    /// CI job saw. Re-resolving them would put a server round trip and a git call in
+    /// front of a local file write whose only outcomes are keeping them or losing
+    /// them.
+    private func setUploadPolicy(
+        fullHandle: String,
+        policy: XcodeCacheUploadPolicy,
+        configuredUpload: Bool
+    ) async throws {
+        // The registry is the machine-wide proxy's file and nobody else's. On the
+        // legacy per-project daemon the policy is a `--no-upload` launchd argument,
+        // so writing it here would report success over a lane that keeps publishing.
+        guard ClientFeatureFlags.contains("kura") else {
+            throw SetupCacheCommandServiceError.uploadPolicyRequiresProxy
         }
-        defer { close(descriptor) }
-        guard flock(descriptor, LOCK_EX) == 0 else {
-            throw SetupCacheCommandServiceError.registryNotLocked(lockPath.pathString, errno)
+
+        try await sourcesRegistry.update(fullHandle: fullHandle) { existing in
+            RegisteredSource(trunk: existing?.trunk, branch: existing?.branch, upload: policy.upload)
         }
-        defer { flock(descriptor, LOCK_UN) }
-        try await body()
+
+        // Enabling is not the mirror image of disabling. Disabling holds on its own,
+        // because the proxy gate covers every publication whatever the build settings
+        // say. Enabling only lifts the proxy's half: `tuist generate` bakes
+        // `xcodeCache(upload: false)` into the project as `-cas-plugin-option
+        // tuist-upload=false`, and the plugin's own gate keeps withholding Swift
+        // outputs until the project is regenerated. Left unsaid, that is a flip
+        // someone believes took and half of which did not.
+        if policy == .enabled, !configuredUpload {
+            AlertController.current.warning(
+                "'Tuist.swift' still sets `xcodeCache(upload: false)`, which `tuist generate` bakes into generated projects as a build setting the cache plugin gates on by itself. Swift compilations keep withholding their outputs until the project is regenerated with `xcodeCache(upload: true)`. C, Objective-C and precompiled modules publish from now on."
+            )
+        }
+
+        AlertController.current.success(
+            .alert(
+                "Xcode cache uploads are now \(policy.rawValue) for \(fullHandle)",
+                takeaways: [
+                    "The cache proxy picks this up within 15 seconds; its launch agent was left running",
+                    "The policy is recorded per machine, so it covers every build of \(fullHandle) here",
+                ]
+            )
+        )
     }
 
     private func ensureCacheDaemonIsListening(label: String, socketPath: AbsolutePath) async throws {
@@ -288,13 +235,27 @@ struct SetupCacheCommandService {
     }
 
     func run(
-        path: String?
+        path: String?,
+        uploadPolicy: XcodeCacheUploadPolicy? = nil
     ) async throws {
         let path = try await Environment.current.pathRelativeToWorkingDirectory(path)
         let config = try await configLoader.loadConfig(path: path)
 
         guard let fullHandle = config.fullHandle else {
             throw SetupCacheCommandServiceError.missingFullHandle
+        }
+
+        // Before anything that authenticates or reaches the server. A policy flip
+        // rewrites one field of a local file the proxy already reads; a credential
+        // it does not need is a credential that can fail it, which is exactly the
+        // read-scoped PR lane the flip exists for.
+        if let uploadPolicy {
+            try await setUploadPolicy(
+                fullHandle: fullHandle,
+                policy: uploadPolicy,
+                configuredUpload: config.xcodeCache.upload
+            )
+            return
         }
 
         let serverURL = try serverEnvironmentService.url(configServerURL: config.url)

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -902,6 +902,221 @@ struct SetupCacheCommandServiceTests {
         }
         """)
     }
+
+    /// The policy-only flip is the whole point of `--upload-policy`: it rewrites the
+    /// one field the proxy gates publishes on and leaves the launch agent alone, so
+    /// a team can turn a lane read-only without dragging an agent teardown and
+    /// bootstrap behind it.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment(), .withMockedLogger())
+    func setUploadPolicy_rewritesTheRegistryWithoutTouchingTheAgent() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let registry = temporaryDirectory.appending(component: "cas-proxy.registry")
+        environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
+        let sourcesPath = registry.parentDirectory.appending(component: "cas-proxy.registry.sources")
+        let fileSystem = FileSystem()
+        try await fileSystem.writeText(
+            #"{"tuist/tuist":{"trunk":"main","branch":"feature/tags","upload":true}}"#,
+            at: sourcesPath
+        )
+
+        // When
+        try await subject.run(path: nil, uploadPolicy: .disabled)
+
+        // Then: only `upload` moves. The trunk and the CI branch were recorded by
+        // the setup that installed the agent and are not a policy decision, so
+        // re-resolving them here would be a server round trip that could only lose
+        // them.
+        let sources = try await fileSystem.readTextFile(at: sourcesPath)
+        #expect(sources == """
+        {
+          "tuist/tuist" : {
+            "branch" : "feature/tags",
+            "trunk" : "main",
+            "upload" : false
+          }
+        }
+        """)
+
+        verify(launchAgentService)
+            .setupLaunchAgent(label: .any, plistFileName: .any, programArguments: .any, environmentVariables: .any)
+            .called(0)
+        verify(launchAgentService)
+            .teardownLaunchAgent(label: .any, plistFileName: .any)
+            .called(0)
+    }
+
+    /// Nothing about rewriting one boolean in a local file needs credentials or the
+    /// server. Requiring either would make a policy flip fail exactly where teams
+    /// want it — a PR lane whose token is scoped for reads, or a laptop that is
+    /// offline.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment(), .withMockedLogger())
+    func setUploadPolicy_doesNotAuthenticateOrCallTheServer() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        environment.variables["CI"] = "1"
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let registry = temporaryDirectory.appending(component: "cas-proxy.registry")
+        environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
+
+        serverAuthenticationController.reset()
+        given(serverAuthenticationController)
+            .authenticationToken(serverURL: .any)
+            .willReturn(nil)
+
+        // When
+        try await subject.run(path: nil, uploadPolicy: .disabled)
+
+        // Then
+        let sources = try await FileSystem().readTextFile(
+            at: registry.parentDirectory.appending(component: "cas-proxy.registry.sources")
+        )
+        #expect(sources == """
+        {
+          "tuist/tuist" : {
+            "upload" : false
+          }
+        }
+        """)
+
+        verify(getProjectService)
+            .getProject(fullHandle: .any, serverURL: .any)
+            .called(0)
+        verify(gitController)
+            .gitInfo(workingDirectory: .any)
+            .called(0)
+    }
+
+    /// The registry is machine-wide and a flip rewrites the whole file, so every
+    /// other project's row has to survive one, exactly as it does for a full setup.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment(), .withMockedLogger())
+    func setUploadPolicy_keepsOtherProjectsRows() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let registry = temporaryDirectory.appending(component: "cas-proxy.registry")
+        environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
+        let sourcesPath = registry.parentDirectory.appending(component: "cas-proxy.registry.sources")
+        let fileSystem = FileSystem()
+        try await fileSystem.writeText(
+            #"{"other/project":{"trunk":"trunk","upload":false},"tuist/tuist":{"trunk":"main","upload":true}}"#,
+            at: sourcesPath
+        )
+
+        // When
+        try await subject.run(path: nil, uploadPolicy: .disabled)
+
+        // Then
+        let sources = try await fileSystem.readTextFile(at: sourcesPath)
+        #expect(sources == """
+        {
+          "other/project" : {
+            "trunk" : "trunk",
+            "upload" : false
+          },
+          "tuist/tuist" : {
+            "trunk" : "main",
+            "upload" : false
+          }
+        }
+        """)
+    }
+
+    /// Enabling is not the mirror image of disabling. `tuist generate` bakes
+    /// `xcodeCache(upload:)` into the project as `-cas-plugin-option
+    /// tuist-upload=false`, and the plugin gates on that independently of the
+    /// registry, so a generated project keeps blocking its Swift lane until it is
+    /// regenerated. Saying nothing would leave someone believing a flip that only
+    /// half took.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment(), .withMockedLogger())
+    func setUploadPolicy_warnsWhenEnablingWhileTheConfigurationStillOptsOut() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let registry = temporaryDirectory.appending(component: "cas-proxy.registry")
+        environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
+
+        configLoader.reset()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: "tuist/tuist", xcodeCache: Tuist.XcodeCache(upload: false)))
+
+        let alertController = AlertController()
+
+        // When
+        try await AlertController.$current.withValue(alertController) {
+            try await subject.run(path: nil, uploadPolicy: .enabled)
+        }
+
+        // Then
+        let sources = try await FileSystem().readTextFile(
+            at: registry.parentDirectory.appending(component: "cas-proxy.registry.sources")
+        )
+        #expect(sources.contains(#""upload" : true"#))
+
+        let warning = try #require(alertController.warnings().last)
+        #expect(warning.message.plain().contains("tuist generate"))
+    }
+
+    /// Disabling has no such caveat — the proxy gate covers every publication from
+    /// both lanes — so it must not drag the regeneration warning along with it.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment(), .withMockedLogger())
+    func setUploadPolicy_doesNotWarnWhenDisabling() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let registry = temporaryDirectory.appending(component: "cas-proxy.registry")
+        environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
+
+        configLoader.reset()
+        given(configLoader)
+            .loadConfig(path: .any)
+            .willReturn(.test(fullHandle: "tuist/tuist", xcodeCache: Tuist.XcodeCache(upload: false)))
+
+        let alertController = AlertController()
+
+        // When
+        try await AlertController.$current.withValue(alertController) {
+            try await subject.run(path: nil, uploadPolicy: .disabled)
+        }
+
+        // Then
+        #expect(alertController.warnings().isEmpty)
+    }
+
+    /// The registry is read by the machine-wide proxy and by nothing else. On the
+    /// legacy per-project daemon the policy is a launchd argument, so a flip would
+    /// write a file nothing reads and report success — the quietest way for a lane
+    /// to keep publishing after being told not to.
+    @Test(.inTemporaryDirectory, .withMockedEnvironment(), .withMockedLogger())
+    func setUploadPolicy_failsWhenTheMachineRunsTheLegacyDaemon() async throws {
+        // Given
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "0"
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let registry = temporaryDirectory.appending(component: "cas-proxy.registry")
+        environment.variables["TUIST_CAS_PROXY_REGISTRY"] = registry.pathString
+
+        // When / Then
+        await #expect(throws: SetupCacheCommandServiceError.uploadPolicyRequiresProxy) {
+            try await subject.run(path: nil, uploadPolicy: .disabled)
+        }
+        #expect(try await !FileSystem().exists(
+            registry.parentDirectory.appending(component: "cas-proxy.registry.sources")
+        ))
+    }
 }
 
 private struct TestError: Error {

--- a/server/priv/docs/en/guides/features/cache/xcode-cache.md
+++ b/server/priv/docs/en/guides/features/cache/xcode-cache.md
@@ -141,6 +141,32 @@ let tuist = Tuist(
 
 With this setup, local builds benefit from cached artifacts without uploading, while CI builds populate the cache for the rest of the team.
 
+#### Changing the policy without reinstalling the agent {#changing-the-upload-policy}
+
+`xcodeCache(upload:)` is committed configuration, so it is the same for every machine and every lane that checks the project out. When a single machine or lane needs a different answer, `tuist setup cache --upload-policy` changes it in place:
+
+```bash
+tuist setup cache --upload-policy disabled
+```
+
+This rewrites the policy the cache proxy reads and leaves the proxy's launch agent running, so nothing is torn down or bootstrapped. The proxy picks the new value up within 15 seconds. `--upload-policy enabled` turns uploading back on.
+
+The flag needs neither authentication nor the Tuist server: it writes a local file, which is also why it works on a lane whose token is scoped for reads.
+
+It does not set the cache up, and the ordering matters: `tuist setup cache` records the policy from `Tuist.swift`, so a flip that runs before it is overwritten by it. Run `tuist setup cache` first, then the flip.
+
+> [!IMPORTANT]
+> **Enabling is not the mirror image of disabling**
+>
+> `--upload-policy disabled` stops every upload on its own, because the proxy checks the policy for every publication whatever the project's build settings say.
+>
+> `--upload-policy enabled` is not enough on a generated project that was generated with `xcodeCache(upload: false)`. `tuist generate` bakes that into the project as a build setting the cache plugin gates on by itself, so Swift compilations keep withholding their outputs until the project is regenerated with `xcodeCache(upload: true)`. C, Objective-C and precompiled modules are unaffected and start uploading immediately.
+
+> [!NOTE]
+> **The policy is per machine and per project, not per build**
+>
+> The cache proxy serves every project on the machine and records one policy per project, so a flip covers every build of that project on that machine. Two lanes building the same project at the same time on one machine both see whichever policy was written last. Give each lane its own machine (the usual arrangement on CI) when they need different policies.
+
 ### Continuous integration {#continuous-integration}
 
 To enable caching in your CI environment, you need to run the same command as in local environments: `tuist setup cache`.


### PR DESCRIPTION
## What changed

`tuist setup cache` gains `--upload-policy <enabled|disabled>`. It rewrites the project's Xcode cache upload policy in the cache proxy's sources registry and returns, leaving the launch agent running.

```bash
tuist setup cache --upload-policy disabled
```

The atomic write moved into a new `CacheSourcesRegistry` type with a mutation closure, so the full setup and the policy flip share one implementation.

## Why

Teams that confine cache writes to a single warm lane, with PR lanes read-only, had to re-run `tuist setup cache` on every policy change. On the kura path that command always reinstalls the machine-wide CAS proxy, so a policy flip dragged a full agent teardown and bootstrap behind it. That is far more than the change needs, and it is what exposes those teams to the bootout race being fixed separately in `LaunchAgentService`.

## Root cause, and why this shape

The cheap path was already implemented on the proxy side and simply had no entry point.

- `Proxy::registered_source` re-reads `<socket>.registry.sources` from disk on a memo miss, memoized on `GIT_CONTEXT_TTL` (15 seconds).
- `Proxy::upload_enabled` consults it for every publication, from both the Swift and Clang lanes and from the background sweeper. It is deliberately authoritative rather than trusted from the client, because the client cannot speak for the whole build.

So rewriting that one file is already sufficient to change the policy within about fifteen seconds, with the agent left alone. `SetupCacheCommandService.run` called `registerSource` and then `installProxy` unconditionally; the change is letting a caller ask for the first without the second.

Two things the flip deliberately does not do:

- **It does not re-resolve the trunk or the CI branch.** Neither is a policy decision. The trunk is the server's answer to a question this command is not asking, and the branch is what the setup that ran inside the CI job saw. Re-resolving them would put a server round trip and a git call in front of a local file write whose only outcomes are keeping them or losing them, so the recorded values are carried over instead.
- **It does not check authentication.** Rewriting one boolean in a local file needs no credential, and requiring one would fail the flip exactly where teams want it: a PR lane whose token is scoped for reads, or a laptop that is offline.

A flag on `tuist setup cache` was preferred to a separate command so the registry keeps a single writer and the option is discoverable from the `--help` someone is already reading.

## Atomicity

Unchanged, and now in one place. `CacheSourcesRegistry.update` still stages to a temporary file and `rename`s it under the `flock` held by the lock helper, so:

- Two writers, in any combination of setup and flip, contend on the same lock and neither drops the other's row.
- Every reader gets either the whole old file or the whole new one. A reader that finds no file sees no projects, and an unknown project has to be allowed to upload, so any window where the file is missing or half-written would hand an opted-out project a window in which its Clang outputs are published. `rename` leaves no such window; a remove-then-write or a move would.

## The asymmetry

Disabling and enabling are not symmetric, and this is the part that would make the feature quietly useless if it were left unsaid.

- **Registry `false` is sufficient to stop publishing.** The proxy gate covers every publication regardless of what the build settings say.
- **Registry `true` is not sufficient to start publishing** if the project was generated with `upload: false`. `tuist generate` bakes the policy into the project as `-cas-plugin-option tuist-upload=false`, and the plugin gates on it independently in `resolve_upload`, so the Swift lane stays blocked until the project is regenerated.

The command handles this as far as it can: `--upload-policy enabled` warns when `Tuist.swift` still sets `xcodeCache(upload: false)`, naming the regeneration. It is stated in the help text and in the docs as well. Disabling emits no such warning, since it carries no caveat.

Two more facts surfaced in the docs: the registry entry is keyed by instance and is machine-wide, so a flip applies to every lane on that machine rather than per job (two lanes for the same project on one runner see whichever policy was written last); and `tuist setup cache` records the policy from `Tuist.swift`, so the flip has to run after it, not before.

The flip is refused outright when the machine runs the legacy per-project daemon (`TUIST_FEATURE_FLAG_KURA` off). There the policy is a `--no-upload` launchd argument, so writing the registry would report success over a lane that keeps publishing.

## Impact

CI lanes and developer machines can turn uploading on or off for a project in place, with no agent churn, no credential, and no server round trip. The default behaviour of `tuist setup cache` is unchanged.

## Validation

- Six new tests in `SetupCacheCommandServiceTests`, written and run red against the missing API before the implementation: the registry rewrite with the agent untouched, no authentication or server call, other projects' rows preserved, the enable warning, no warning on disable, and the legacy-daemon refusal. The full suite passes.
- End to end against a built `tuist` on a scratch project with `TUIST_CAS_PROXY_REGISTRY` pointed at a temporary path:
  - `--upload-policy disabled` wrote `{"tuist/uploadpolicy": {"upload": false}}`, left no staging file behind, and left every `~/Library/LaunchAgents/tuist.*` plist byte-identical.
  - `--upload-policy enabled` against a seeded registry preserved another project's row and this project's `trunk` and `branch`, flipped only `upload`, and emitted the regeneration warning.
  - `TUIST_FEATURE_FLAG_KURA=0` failed with the legacy-daemon error and left the file untouched.
  - `tuist setup cache --help` renders the discussion and `(values: enabled, disabled)`.
- `mise run lint` passes. The extraction also brings `SetupCacheCommandService` back under the `type_body_length` error threshold it would otherwise have crossed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
