### PR TITLE
fix(cli): require a fresh process before calling a refused bootstrap a success

### DIFF
--- a/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/SetupCacheCommandService.swift
@@ -252,11 +252,12 @@ struct SetupCacheCommandService {
         try await body()
     }
 
-    private func ensureCacheDaemonIsListening(label: String, socketPath: AbsolutePath) async throws {
-        if await cacheSocketService.waitUntilListening(
-            at: socketPath,
-            timeout: cacheDaemonStartupTimeout
-        ) {
+    private func ensureCacheDaemonIsListening(
+        label: String,
+        socketPath: AbsolutePath,
+        displacing displacedProcessIdentifier: Int32?
+    ) async throws {
+        if await isCacheDaemonReady(label: label, socketPath: socketPath, displacing: displacedProcessIdentifier) {
             return
         }
 
@@ -265,10 +266,7 @@ struct SetupCacheCommandService {
         )
         do {
             try await launchAgentService.restartLaunchAgent(label: label)
-            if await cacheSocketService.waitUntilListening(
-                at: socketPath,
-                timeout: cacheDaemonStartupTimeout
-            ) {
+            if await isCacheDaemonReady(label: label, socketPath: socketPath, displacing: displacedProcessIdentifier) {
                 return
             }
         } catch {
@@ -285,6 +283,20 @@ struct SetupCacheCommandService {
             socketPath: socketPath.pathString,
             logPath: logPath.pathString
         )
+    }
+
+    /// The socket answering is not on its own evidence that the daemon this setup
+    /// installed is the one serving it: a daemon booted out moments ago goes on
+    /// accepting connections until it leaves, so its socket confirms a
+    /// configuration that never took effect. Pairing the socket with the process
+    /// behind the label is what tells the two apart, and what lets a connection
+    /// answered by the outgoing daemon reach the restart above instead of being
+    /// reported as success.
+    private func isCacheDaemonReady(label: String, socketPath: AbsolutePath, displacing displaced: Int32?) async -> Bool {
+        guard await cacheSocketService.waitUntilListening(at: socketPath, timeout: cacheDaemonStartupTimeout) else {
+            return false
+        }
+        return await launchAgentService.runningProcessIdentifier(label: label) != displaced
     }
 
     func run(
@@ -531,7 +543,7 @@ struct SetupCacheCommandService {
         )
 
         let label = Environment.current.casProxyLaunchAgentLabel()
-        try await launchAgentService.setupLaunchAgent(
+        let displacedProcessIdentifier = try await launchAgentService.setupLaunchAgent(
             label: label,
             plistFileName: "\(label).plist",
             programArguments: programArguments,
@@ -539,7 +551,8 @@ struct SetupCacheCommandService {
         )
         try await ensureCacheDaemonIsListening(
             label: label,
-            socketPath: Environment.current.casProxySocketPath()
+            socketPath: Environment.current.casProxySocketPath(),
+            displacing: displacedProcessIdentifier
         )
     }
 
@@ -578,7 +591,7 @@ struct SetupCacheCommandService {
         )
 
         let label = Environment.current.cacheLaunchAgentLabel(for: fullHandle)
-        try await launchAgentService.setupLaunchAgent(
+        let displacedProcessIdentifier = try await launchAgentService.setupLaunchAgent(
             label: label,
             plistFileName: "\(label).plist",
             programArguments: programArguments,
@@ -586,7 +599,8 @@ struct SetupCacheCommandService {
         )
         try await ensureCacheDaemonIsListening(
             label: label,
-            socketPath: Environment.current.cacheSocketPath(for: fullHandle)
+            socketPath: Environment.current.cacheSocketPath(for: fullHandle),
+            displacing: displacedProcessIdentifier
         )
     }
 }

--- a/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
+++ b/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
@@ -8,12 +8,15 @@ import TuistLogging
 
 public enum LaunchAgentServiceError: Equatable, LocalizedError {
     case failedToLoadLaunchAgent(String)
+    case failedToBootOutLaunchAgent(String)
     case missingExecutablePath
 
     public var errorDescription: String? {
         switch self {
         case let .failedToLoadLaunchAgent(error):
             return "Failed to load LaunchAgent: \(error)"
+        case let .failedToBootOutLaunchAgent(error):
+            return "Failed to boot out the LaunchAgent that is already running: \(error)"
         case .missingExecutablePath:
             return "Failed to determine the current tuist executable path"
         }
@@ -22,12 +25,20 @@ public enum LaunchAgentServiceError: Equatable, LocalizedError {
 
 @Mockable
 public protocol LaunchAgentServicing {
+    /// Bootstraps the agent, returning the process it displaced when a job was
+    /// already running under the label.
+    ///
+    /// A caller that goes on to check the agent's readiness needs it: whatever
+    /// answers on the agent's endpoint straight afterwards can still be the
+    /// displaced process, serving out its last moments from the configuration
+    /// this call replaced.
+    @discardableResult
     func setupLaunchAgent(
         label: String,
         plistFileName: String,
         programArguments: [String],
         environmentVariables: [String: String]
-    ) async throws
+    ) async throws -> Int32?
 
     func teardownLaunchAgent(
         label: String,
@@ -35,6 +46,11 @@ public protocol LaunchAgentServicing {
     ) async throws
 
     func restartLaunchAgent(label: String) async throws
+
+    /// The process currently running the agent, or `nil` when the label is not in
+    /// the domain, when launchd holds it without a process, or when launchd
+    /// cannot be asked.
+    func runningProcessIdentifier(label: String) async -> Int32?
 }
 
 public struct LaunchAgentService: LaunchAgentServicing {
@@ -52,12 +68,13 @@ public struct LaunchAgentService: LaunchAgentServicing {
         self.bootoutTimeout = bootoutTimeout
     }
 
+    @discardableResult
     public func setupLaunchAgent(
         label: String,
         plistFileName: String,
         programArguments: [String],
         environmentVariables: [String: String] = [:]
-    ) async throws {
+    ) async throws -> Int32? {
         let tuistBinaryPath = try await determineTuistBinaryPath()
 
         let launchAgentsDir = Environment.current.homeDirectory.appending(
@@ -69,9 +86,18 @@ public struct LaunchAgentService: LaunchAgentServicing {
             try await fileSystem.makeDirectory(at: launchAgentsDir)
         }
 
-        if try await launchctlController.isLoaded(label: label) {
+        let outgoingJob = try await launchctlController.job(label: label)
+        if outgoingJob != nil {
             Logger.current.debug("Existing LaunchAgent found. Booting out...")
-            try await launchctlController.bootout(label: label)
+            do {
+                try await launchctlController.bootout(label: label)
+            } catch {
+                // A job on its way out is exactly what makes launchctl refuse a
+                // bootout, so this failure reaches the user on an ordinary setup.
+                // Typed rather than the raw launchctl termination, which surfaces
+                // as an unreadable `CommandError` dump.
+                throw LaunchAgentServiceError.failedToBootOutLaunchAgent(String(describing: error))
+            }
             await waitUntilBootedOut(label: label)
         }
 
@@ -107,19 +133,27 @@ public struct LaunchAgentService: LaunchAgentServicing {
         } catch let commandError as CommandError {
             // `5` is launchd's catch-all, covering both a label that is already
             // bootstrapped and a plist it cannot load at all, so the code alone
-            // cannot decide. Ask the domain instead: the label being there means
-            // the bootstrap was redundant and setup has what it wanted.
+            // cannot decide. Ask the domain instead — and ask which PROCESS holds
+            // the label, not merely whether the label is there.
+            //
+            // The label alone answers "yes" for the job booted out above that has
+            // not finished leaving, which is the case where the plist just written
+            // is precisely what is NOT bootstrapped. Reading that as success hands
+            // the caller a proxy that exits moments later, and a readiness check
+            // against its socket confirms it. Only a process launchd spawned after
+            // the bootout means this configuration is live.
             //
             // Deliberately narrower than the blanket tolerance this replaces
             // (removed in #12014), which reported success for an agent that had
             // genuinely failed to load. Do not widen it back to every `5`.
             if case .terminated(5, _, _) = commandError,
-               await isLoadedIgnoringFailures(label: label)
+               let liveProcessIdentifier = await jobIgnoringFailures(label: label)?.processIdentifier,
+               liveProcessIdentifier != outgoingJob?.processIdentifier
             {
                 Logger.current.debug(
-                    "launchctl refused to bootstrap \(label), which is already loaded: \(commandError)"
+                    "launchctl refused to bootstrap \(label), which is already loaded under \(liveProcessIdentifier): \(commandError)"
                 )
-                return
+                return outgoingJob?.processIdentifier
             }
             var message = String(describing: commandError)
             if let stderrContent = try? await fileSystem.readTextFile(at: stderrLogPath),
@@ -139,6 +173,12 @@ public struct LaunchAgentService: LaunchAgentServicing {
         }
 
         Logger.current.debug("LaunchAgent configured and loaded successfully")
+
+        return outgoingJob?.processIdentifier
+    }
+
+    public func runningProcessIdentifier(label: String) async -> Int32? {
+        await jobIgnoringFailures(label: label).flatMap(\.processIdentifier)
     }
 
     /// `bootout` returns once launchd has accepted the removal, not once the job
@@ -147,23 +187,24 @@ public struct LaunchAgentService: LaunchAgentServicing {
     /// passing against the previous daemon, which would report success for a
     /// configuration that never took effect.
     ///
-    /// Gives up rather than throwing: a label that outlives the wait leaves the
-    /// bootstrap facing the same ambiguity it already resolves against the
-    /// domain.
+    /// Gives up rather than throwing: a label that outlives the wait is not itself
+    /// a failure, and the bootstrap after it settles the question anyway by
+    /// requiring a process other than the one being booted out.
     private func waitUntilBootedOut(label: String) async {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: bootoutTimeout)
 
         while clock.now < deadline, !Task.isCancelled {
-            if await !isLoadedIgnoringFailures(label: label) { return }
+            if await jobIgnoringFailures(label: label) == nil { return }
             try? await Task.sleep(for: .milliseconds(100))
         }
 
         Logger.current.debug("\(label) is still loaded after booting it out. Continuing.")
     }
 
-    private func isLoadedIgnoringFailures(label: String) async -> Bool {
-        (try? await launchctlController.isLoaded(label: label)) ?? false
+    private func jobIgnoringFailures(label: String) async -> LaunchAgentJob? {
+        guard let job = try? await launchctlController.job(label: label) else { return nil }
+        return job
     }
 
     public func restartLaunchAgent(label: String) async throws {
@@ -179,7 +220,7 @@ public struct LaunchAgentService: LaunchAgentServicing {
             components: "Library", "LaunchAgents", plistFileName
         )
 
-        if try await launchctlController.isLoaded(label: label) {
+        if try await launchctlController.job(label: label) != nil {
             try await launchctlController.bootout(label: label)
             Logger.current.debug("Booted out LaunchAgent")
         }

--- a/cli/Sources/TuistLaunchctl/LaunchctlController.swift
+++ b/cli/Sources/TuistLaunchctl/LaunchctlController.swift
@@ -3,6 +3,19 @@ import Foundation
 import Mockable
 import Path
 
+/// A job in the current user's GUI domain, as `launchctl print` reports it.
+public struct LaunchAgentJob: Equatable, Sendable {
+    /// The process running the job, absent while launchd holds the label without
+    /// one. A job waiting on its respawn throttle prints that way, and so does an
+    /// outgoing job whose process has already been reaped but whose record has
+    /// not yet left the domain.
+    public let processIdentifier: Int32?
+
+    public init(processIdentifier: Int32?) {
+        self.processIdentifier = processIdentifier
+    }
+}
+
 /// Utility to interact with the `launchctl` CLI.
 @Mockable
 public protocol LaunchctlControlling {
@@ -15,9 +28,14 @@ public protocol LaunchctlControlling {
     /// Restarts a LaunchAgent by label in the current user's GUI domain.
     func kickstart(label: String) async throws
 
-    /// Returns whether a LaunchAgent with the given label is currently loaded in the
-    /// current user's GUI domain.
-    func isLoaded(label: String) async throws -> Bool
+    /// Returns the job the given label names in the current user's GUI domain, or
+    /// `nil` when the label is not in the domain.
+    ///
+    /// The process and not merely the label, because the two answer different
+    /// questions: a label is in the domain from the moment it is bootstrapped
+    /// until the moment its last job leaves, which spans two different jobs
+    /// across a bootout, and only the process tells them apart.
+    func job(label: String) async throws -> LaunchAgentJob?
 }
 
 public struct LaunchctlController: LaunchctlControlling {
@@ -65,23 +83,39 @@ public struct LaunchctlController: LaunchctlControlling {
         .awaitCompletion()
     }
 
-    public func isLoaded(label: String) async throws -> Bool {
+    public func job(label: String) async throws -> LaunchAgentJob? {
         let uid = getuid()
         do {
-            _ = try await commandRunner.run(
+            let output = try await commandRunner.run(
                 arguments: [
                     "/bin/launchctl",
                     "print",
                     "gui/\(uid)/\(label)",
                 ]
             )
-            .awaitCompletion()
-            return true
+            .concatenatedString(including: [.standardOutput])
+            return LaunchAgentJob(processIdentifier: Self.processIdentifier(in: output))
         } catch let error as CommandError {
             guard case let .terminated(code, stderr, _) = error else { throw error }
             guard Self.describesAMissingService(code: code, stderr: stderr) else { throw error }
-            return false
+            return nil
         }
+    }
+
+    /// The `pid` `launchctl print` reports for the job itself. Only the first
+    /// match qualifies: the nested dictionaries that follow it in the report
+    /// describe endpoints and spawn records, which carry PIDs of their own.
+    ///
+    /// A report without one is not a parse failure. It is how launchd describes a
+    /// label it holds with no process behind it, which is a state the callers have
+    /// to keep apart from a running job rather than round to one.
+    private static func processIdentifier(in output: String) -> Int32? {
+        for line in output.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("pid = ") else { continue }
+            return Int32(trimmed.dropFirst("pid = ".count).trimmingCharacters(in: .whitespaces))
+        }
+        return nil
     }
 
     /// `launchctl print` exits non-zero both for a service that is not there and

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupCacheCommandServiceTests.swift
@@ -75,7 +75,7 @@ struct SetupCacheCommandServiceTests {
 
         given(launchAgentService)
             .setupLaunchAgent(label: .any, plistFileName: .any, programArguments: .any, environmentVariables: .any)
-            .willReturn()
+            .willReturn(nil)
 
         given(launchAgentService)
             .teardownLaunchAgent(label: .any, plistFileName: .any)
@@ -84,6 +84,11 @@ struct SetupCacheCommandServiceTests {
         given(cacheSocketService)
             .waitUntilListening(at: .any, timeout: .any)
             .willReturn(true)
+
+        // A daemon serving the socket under a process this setup did not displace.
+        given(launchAgentService)
+            .runningProcessIdentifier(label: .any)
+            .willReturn(4242)
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment(), .withMockedLogger()) func setupCache_withTuistProject() async throws {
@@ -702,6 +707,43 @@ struct SetupCacheCommandServiceTests {
                 timeout: .value(.zero)
             )
             .called(2)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupCache_restartsTheAgentWhenTheSocketIsAnsweredByTheDisplacedDaemon() async throws {
+        // Given: the socket answers on the first check, but from the very process
+        // this setup displaced. On the socket alone that is indistinguishable from
+        // a healthy new daemon, and setup used to report success for it moments
+        // before the process exited leaving nothing bootstrapped.
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        environment.variables["TUIST_FEATURE_FLAG_KURA"] = "1"
+
+        launchAgentService.reset()
+        given(launchAgentService)
+            .setupLaunchAgent(label: .any, plistFileName: .any, programArguments: .any, environmentVariables: .any)
+            .willReturn(4242)
+        given(launchAgentService)
+            .teardownLaunchAgent(label: .any, plistFileName: .any)
+            .willReturn()
+        given(launchAgentService)
+            .restartLaunchAgent(label: .value("tuist.cas-proxy"))
+            .willReturn()
+        var identityChecks = 0
+        given(launchAgentService)
+            .runningProcessIdentifier(label: .value("tuist.cas-proxy"))
+            .willProduce { _ in
+                identityChecks += 1
+                return identityChecks == 1 ? 4242 : 5555
+            }
+
+        // When
+        try await subject.run(path: nil)
+
+        // Then: the restart the socket check alone would have skipped.
+        verify(launchAgentService)
+            .restartLaunchAgent(label: .value("tuist.cas-proxy"))
+            .called(1)
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment())

--- a/cli/Tests/TuistKitTests/Services/Setup/SetupInsightsCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/SetupInsightsCommandServiceTests.swift
@@ -24,7 +24,7 @@ struct SetupInsightsCommandServiceTests {
                 programArguments: .any,
                 environmentVariables: .any
             )
-            .willReturn()
+            .willReturn(nil)
     }
 
     @Test(.withMockedEnvironment(), .withMockedLogger()) func setupInsights() async throws {

--- a/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
+++ b/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
@@ -15,12 +15,12 @@ import TuistTesting
 /// Hands out one answer per call so a test can drive a poll to completion. The
 /// last answer repeats, so an over-eager poll fails on `consumed` rather than
 /// running off the end.
-private final class AnswerSequence: @unchecked Sendable {
+private final class AnswerSequence<Answer: Sendable>: @unchecked Sendable {
     private let lock = NSLock()
-    private let answers: [Bool]
+    private let answers: [Answer]
     private var index = 0
 
-    init(answers: [Bool]) {
+    init(answers: [Answer]) {
         self.answers = answers
     }
 
@@ -28,7 +28,7 @@ private final class AnswerSequence: @unchecked Sendable {
         lock.withLock { index }
     }
 
-    func next() -> Bool {
+    func next() -> Answer {
         lock.withLock {
             defer { index += 1 }
             return answers[min(index, answers.count - 1)]
@@ -48,8 +48,8 @@ struct LaunchAgentServiceTests {
             bootoutTimeout: .milliseconds(500)
         )
         given(launchctlController)
-            .isLoaded(label: .any)
-            .willReturn(false)
+            .job(label: .any)
+            .willReturn(nil)
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment())
@@ -159,8 +159,8 @@ struct LaunchAgentServiceTests {
 
         launchctlController.reset()
         given(launchctlController)
-            .isLoaded(label: .value("tuist.test"))
-            .willReturn(true)
+            .job(label: .value("tuist.test"))
+            .willReturn(LaunchAgentJob(processIdentifier: 4242))
 
         given(launchctlController)
             .bootout(label: .value("tuist.test"))
@@ -200,14 +200,17 @@ struct LaunchAgentServiceTests {
 
         launchctlController.reset()
         given(launchctlController)
-            .isLoaded(label: .value("tuist.test"))
-            .willReturn(true)
+            .job(label: .value("tuist.test"))
+            .willReturn(LaunchAgentJob(processIdentifier: 4242))
 
         given(launchctlController)
             .bootout(label: .any)
             .willThrow(NSError(domain: "test", code: 1))
 
-        await #expect(throws: NSError.self) {
+        // Typed, not the raw launchctl failure: `bootout` fails for benign reasons
+        // (the job already leaving, a removal still in progress) that reach the
+        // user as an unreadable `CommandError` dump otherwise.
+        await #expect(throws: LaunchAgentServiceError.self) {
             try await subject.setupLaunchAgent(
                 label: "tuist.test",
                 plistFileName: "tuist.test.plist",
@@ -228,8 +231,8 @@ struct LaunchAgentServiceTests {
 
         launchctlController.reset()
         given(launchctlController)
-            .isLoaded(label: .value("tuist.test"))
-            .willReturn(true)
+            .job(label: .value("tuist.test"))
+            .willReturn(LaunchAgentJob(processIdentifier: 4242))
         given(launchctlController)
             .bootout(label: .value("tuist.test"))
             .willReturn()
@@ -332,8 +335,8 @@ struct LaunchAgentServiceTests {
 
         launchctlController.reset()
         given(launchctlController)
-            .isLoaded(label: .value("tuist.test"))
-            .willReturn(true)
+            .job(label: .value("tuist.test"))
+            .willReturn(LaunchAgentJob(processIdentifier: 4242))
 
         given(launchctlController)
             .bootout(label: .value("tuist.test"))
@@ -361,8 +364,8 @@ struct LaunchAgentServiceTests {
 
         launchctlController.reset()
         given(launchctlController)
-            .isLoaded(label: .value("tuist.test"))
-            .willReturn(false)
+            .job(label: .value("tuist.test"))
+            .willReturn(nil)
 
         try await subject.teardownLaunchAgent(
             label: "tuist.test",
@@ -392,8 +395,8 @@ struct LaunchAgentServiceTests {
 
         launchctlController.reset()
         given(launchctlController)
-            .isLoaded(label: .value("tuist.test"))
-            .willReturn(true)
+            .job(label: .value("tuist.test"))
+            .willReturn(LaunchAgentJob(processIdentifier: 4242))
 
         given(launchctlController)
             .bootout(label: .value("tuist.test"))
@@ -414,8 +417,8 @@ struct LaunchAgentServiceTests {
     func teardownLaunchAgent_succeedsWhenPlistIsMissing() async throws {
         launchctlController.reset()
         given(launchctlController)
-            .isLoaded(label: .value("tuist.test"))
-            .willReturn(false)
+            .job(label: .value("tuist.test"))
+            .willReturn(nil)
 
         try await subject.teardownLaunchAgent(
             label: "tuist.test",
@@ -456,14 +459,16 @@ struct LaunchAgentServiceTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedEnvironment())
-    func setupLaunchAgent_succeedsWhenBootstrapIsRefusedAndTheLabelIsInTheDomain() async throws {
+    func setupLaunchAgent_succeedsWhenBootstrapIsRefusedAndAFreshProcessOwnsTheLabel() async throws {
         let environment = try #require(Environment.mocked)
         environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
 
+        // A process launchd spawned after this setup booted nothing out owns the
+        // label, so the refusal really is the redundant bootstrap it looks like.
         launchctlController.reset()
-        let answers = AnswerSequence(answers: [false, true])
+        let answers = AnswerSequence<LaunchAgentJob?>(answers: [nil, LaunchAgentJob(processIdentifier: 7)])
         given(launchctlController)
-            .isLoaded(label: .value("tuist.test"))
+            .job(label: .value("tuist.test"))
             .willProduce { _ in answers.next() }
         given(launchctlController)
             .bootstrap(plistPath: .any)
@@ -514,9 +519,11 @@ struct LaunchAgentServiceTests {
         environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
 
         launchctlController.reset()
-        let answers = AnswerSequence(answers: [true, true, false])
+        let answers = AnswerSequence<LaunchAgentJob?>(
+            answers: [LaunchAgentJob(processIdentifier: 4242), LaunchAgentJob(processIdentifier: 4242), nil]
+        )
         given(launchctlController)
-            .isLoaded(label: .value("tuist.test"))
+            .job(label: .value("tuist.test"))
             .willProduce { _ in answers.next() }
         given(launchctlController)
             .bootout(label: .value("tuist.test"))
@@ -548,9 +555,9 @@ struct LaunchAgentServiceTests {
             bootoutTimeout: .milliseconds(250)
         )
         launchctlController.reset()
-        let answers = AnswerSequence(answers: [true])
+        let answers = AnswerSequence<LaunchAgentJob?>(answers: [LaunchAgentJob(processIdentifier: 4242)])
         given(launchctlController)
-            .isLoaded(label: .value("tuist.test"))
+            .job(label: .value("tuist.test"))
             .willProduce { _ in answers.next() }
         given(launchctlController)
             .bootout(label: .value("tuist.test"))
@@ -581,5 +588,123 @@ struct LaunchAgentServiceTests {
         verify(launchctlController)
             .kickstart(label: .value("tuist.test"))
             .called(1)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupLaunchAgent_throwsWhenBootstrapIsRefusedAndTheOutgoingAgentStillOwnsTheLabel() async throws {
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+
+        // Given: the agent booted out above outlives the wait, so the label is
+        // still in the domain under the SAME process when the bootstrap is
+        // refused. Nothing bootstrapped the plist just written, and the outgoing
+        // process is about to exit.
+        launchctlController.reset()
+        given(launchctlController)
+            .job(label: .value("tuist.test"))
+            .willReturn(LaunchAgentJob(processIdentifier: 4242))
+        given(launchctlController)
+            .bootout(label: .value("tuist.test"))
+            .willReturn()
+        let bootstrapError = CommandError.terminated(
+            5,
+            stderr: "Bootstrap failed: 5: Input/output error",
+            command: ["/bin/launchctl", "bootstrap", "gui/501", "/Users/test/Library/LaunchAgents/tuist.test.plist"]
+        )
+        given(launchctlController)
+            .bootstrap(plistPath: .any)
+            .willThrow(bootstrapError)
+
+        // When / Then
+        await #expect(throws: LaunchAgentServiceError.self) {
+            try await subject.setupLaunchAgent(
+                label: "tuist.test",
+                plistFileName: "tuist.test.plist",
+                programArguments: ["test-start"]
+            )
+        }
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupLaunchAgent_throwsWhenBootstrapIsRefusedAndLaunchdHoldsTheLabelWithoutAProcess() async throws {
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+
+        // Given: the label is in the domain but nothing is running under it. The
+        // presence of the label says the bootstrap was redundant; the missing
+        // process says no configuration is serving anything.
+        launchctlController.reset()
+        let answers = AnswerSequence<LaunchAgentJob?>(
+            answers: [nil, LaunchAgentJob(processIdentifier: nil)]
+        )
+        given(launchctlController)
+            .job(label: .value("tuist.test"))
+            .willProduce { _ in answers.next() }
+        given(launchctlController)
+            .bootstrap(plistPath: .any)
+            .willThrow(
+                CommandError.terminated(
+                    5,
+                    stderr: "Bootstrap failed: 5: Input/output error",
+                    command: ["/bin/launchctl", "bootstrap", "gui/501", "/Users/test/Library/LaunchAgents/tuist.test.plist"]
+                )
+            )
+
+        // When / Then
+        await #expect(throws: LaunchAgentServiceError.self) {
+            try await subject.setupLaunchAgent(
+                label: "tuist.test",
+                plistFileName: "tuist.test.plist",
+                programArguments: ["test-start"]
+            )
+        }
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupLaunchAgent_returnsTheProcessItDisplaced() async throws {
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+
+        launchctlController.reset()
+        let answers = AnswerSequence<LaunchAgentJob?>(answers: [LaunchAgentJob(processIdentifier: 4242), nil])
+        given(launchctlController)
+            .job(label: .value("tuist.test"))
+            .willProduce { _ in answers.next() }
+        given(launchctlController)
+            .bootout(label: .value("tuist.test"))
+            .willReturn()
+        given(launchctlController)
+            .bootstrap(plistPath: .any)
+            .willReturn()
+
+        let displaced = try await subject.setupLaunchAgent(
+            label: "tuist.test",
+            plistFileName: "tuist.test.plist",
+            programArguments: ["test-start"]
+        )
+
+        // The caller's readiness check needs it: whatever answers on the agent's
+        // endpoint right after setup could still be this process.
+        #expect(displaced == 4242)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func runningProcessIdentifier_reportsTheProcessBehindTheLabel() async throws {
+        launchctlController.reset()
+        given(launchctlController)
+            .job(label: .value("tuist.test"))
+            .willReturn(LaunchAgentJob(processIdentifier: 7))
+
+        #expect(await subject.runningProcessIdentifier(label: "tuist.test") == 7)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func runningProcessIdentifier_isNilWhenTheLabelIsNotInTheDomain() async throws {
+        launchctlController.reset()
+        given(launchctlController)
+            .job(label: .value("tuist.test"))
+            .willReturn(nil)
+
+        #expect(await subject.runningProcessIdentifier(label: "tuist.test") == nil)
     }
 }

--- a/cli/Tests/TuistLaunchctlTests/LaunchctlControllerTests.swift
+++ b/cli/Tests/TuistLaunchctlTests/LaunchctlControllerTests.swift
@@ -114,7 +114,7 @@ struct LaunchctlControllerTests {
             .called(1)
     }
 
-    @Test func isLoaded_returnsTrueWhenLaunchctlPrintSucceeds() async throws {
+    @Test func job_returnsTheRunningProcessWhenLaunchctlPrintReportsOne() async throws {
         // Given
         let label = "tuist.cache.org_project"
         let uid = getuid()
@@ -125,14 +125,15 @@ struct LaunchctlControllerTests {
                 workingDirectory: .any
             )
             .willReturn(AsyncThrowingStream { continuation in
+                continuation.yield(.standardOutput(Array(Self.printOutput(processIdentifier: 4242).utf8)))
                 continuation.finish()
             })
 
         // When
-        let isLoaded = try await subject.isLoaded(label: label)
+        let job = try await subject.job(label: label)
 
         // Then
-        #expect(isLoaded == true)
+        #expect(job == LaunchAgentJob(processIdentifier: 4242))
         verify(commandRunner)
             .run(
                 arguments: .value(
@@ -148,7 +149,7 @@ struct LaunchctlControllerTests {
             .called(1)
     }
 
-    @Test func isLoaded_returnsFalseWhenLaunchctlPrintTerminatesNonZero() async throws {
+    @Test func job_returnsNilWhenLaunchctlPrintTerminatesNonZero() async throws {
         // Given
         let label = "tuist.cache.org_project"
         given(commandRunner)
@@ -166,13 +167,13 @@ struct LaunchctlControllerTests {
             })
 
         // When
-        let isLoaded = try await subject.isLoaded(label: label)
+        let job = try await subject.job(label: label)
 
         // Then
-        #expect(isLoaded == false)
+        #expect(job == nil)
     }
 
-    @Test func isLoaded_returnsFalseWhenLaunchctlPrintCannotFindTheServiceUnderAnotherCode() async throws {
+    @Test func job_returnsNilWhenLaunchctlPrintCannotFindTheServiceUnderAnotherCode() async throws {
         // Given
         let label = "tuist.cache.org_project"
         given(commandRunner)
@@ -190,13 +191,13 @@ struct LaunchctlControllerTests {
             })
 
         // When
-        let isLoaded = try await subject.isLoaded(label: label)
+        let job = try await subject.job(label: label)
 
         // Then
-        #expect(isLoaded == false)
+        #expect(job == nil)
     }
 
-    @Test func isLoaded_propagatesTerminationsThatAreNotAMissingService() async throws {
+    @Test func job_propagatesTerminationsThatAreNotAMissingService() async throws {
         // Given
         let label = "tuist.cache.org_project"
         given(commandRunner)
@@ -215,11 +216,11 @@ struct LaunchctlControllerTests {
 
         // When / Then
         await #expect(throws: CommandError.self) {
-            _ = try await subject.isLoaded(label: label)
+            _ = try await subject.job(label: label)
         }
     }
 
-    @Test func isLoaded_propagatesNonTerminatedErrors() async throws {
+    @Test func job_propagatesNonTerminatedErrors() async throws {
         // Given
         let label = "tuist.cache.org_project"
         struct BoomError: Error {}
@@ -235,7 +236,79 @@ struct LaunchctlControllerTests {
 
         // When / Then
         await #expect(throws: BoomError.self) {
-            _ = try await subject.isLoaded(label: label)
+            _ = try await subject.job(label: label)
         }
+    }
+
+    @Test func job_reportsNoProcessWhenLaunchdHoldsTheLabelWithoutOne() async throws {
+        // Given: launchd prints a loaded job that is waiting to be spawned. It has
+        // no `pid` line at all, which is a different answer from "not loaded" and
+        // has to survive as one.
+        let label = "tuist.cache.org_project"
+        given(commandRunner)
+            .run(
+                arguments: .any,
+                environment: .any,
+                workingDirectory: .any
+            )
+            .willReturn(AsyncThrowingStream { continuation in
+                continuation.yield(.standardOutput(Array("""
+                gui/501/\(label) = {
+                \tactive count = 0
+                \tpath = /Users/test/Library/LaunchAgents/\(label).plist
+                \ttype = LaunchAgent
+                \tstate = spawn scheduled
+                }
+                """.utf8)))
+                continuation.finish()
+            })
+
+        // When
+        let job = try await subject.job(label: label)
+
+        // Then
+        #expect(job == LaunchAgentJob(processIdentifier: nil))
+    }
+
+    @Test func job_readsTheJobsOwnProcessAndNotANestedOne() async throws {
+        // Given: the endpoint dictionaries launchd prints after the job carry PIDs
+        // of their own, so only the first `pid` in the report is the job's.
+        let label = "tuist.cache.org_project"
+        given(commandRunner)
+            .run(
+                arguments: .any,
+                environment: .any,
+                workingDirectory: .any
+            )
+            .willReturn(AsyncThrowingStream { continuation in
+                continuation.yield(.standardOutput(Array("""
+                gui/501/\(label) = {
+                \tstate = running
+                \tpid = 4242
+                \tendpoints = {
+                \t\t"com.example" = {
+                \t\t\tpid = 99
+                \t\t}
+                \t}
+                }
+                """.utf8)))
+                continuation.finish()
+            })
+
+        // When
+        let job = try await subject.job(label: label)
+
+        // Then
+        #expect(job == LaunchAgentJob(processIdentifier: 4242))
+    }
+
+    private static func printOutput(processIdentifier: Int32) -> String {
+        """
+        gui/501/tuist.cache.org_project = {
+        \tactive count = 1
+        \tstate = running
+        \tpid = \(processIdentifier)
+        }
+        """
     }
 }


### PR DESCRIPTION
## What changed

`tuist setup cache` could report success while leaving no CAS proxy bootstrapped, and the build after it degraded silently to local-only caching. Three defects in [LaunchAgentService.swift](cli/Sources/TuistLaunchctl/LaunchAgentService.swift) shared one root cause, and this fixes them together.

- `LaunchctlControlling.isLoaded(label:)` is replaced by `job(label:)`, which returns the job's `pid` parsed out of the same `launchctl print` call `isLoaded` already made and threw away.
- The `terminated(5)` bootstrap tolerance now requires the label to be held by a process *other* than the one just booted out.
- `setupLaunchAgent` returns the process it displaced, and `ensureCacheDaemonIsListening` pairs the socket check with that identity.
- A failed `bootout` becomes a typed `LaunchAgentServiceError` instead of a raw `CommandError`.

## Why

All three failures come from the same conflation: **the label belongs to both jobs across a bootout, so "the label is there" cannot mean "my configuration is live."**

The sequence:

1. The label is loaded, so `bootout` runs, then `waitUntilBootedOut` polls for at most `bootoutTimeout` (default 3s) and gives up.
2. If the outgoing job outlives that wait, `bootstrap` is refused with `terminated(5)`.
3. The guard asks "is the label loaded?", gets `true` from the **outgoing** job, and returns as if the bootstrap succeeded. The plist just written is never bootstrapped.
4. Readiness confirms it: [`CacheSocketService.canConnect`](cli/Sources/TuistKit/Services/Setup/CacheSocketService.swift) is a bare unix-socket `connect()`, and the outgoing proxy is still listening on that path.
5. Setup prints `Xcode Cache has been enabled 🎉` and the outgoing proxy exits with nothing bootstrapped behind it.

The self-heal in `ensureCacheDaemonIsListening` only restarts the agent when the socket does **not** answer. Here it answers, from the doomed process, so the one recovery path never ran. The readiness check had no identity: "the proxy I just configured is up" and "some proxy is up for another two seconds" were indistinguishable.

Separately, `bootout`'s result was propagated raw. A job on its way out is exactly what makes launchctl refuse a bootout, so that same condition hard-failed setup with an unreadable `CommandError` dump.

## Why this solution over the obvious alternatives

Lengthening `bootoutTimeout` or escalating to a forced kill only narrows the window; neither makes the refusal readable. Rejecting the refusal is what actually closes it, so neither knob is changed and the `terminated(5)` tolerance is **not** widened. The existing comment warning against exactly that widening is preserved and extended.

The PID is the minimal signal that closes all three: it distinguishes the outgoing job from a freshly bootstrapped one, and it gives the readiness check something to assert beyond "something is listening".

## Provenance

The tolerance was introduced in tuist/tuist#12437 (`9ce674f2df`) and shipped in 4.206.0. Before that a refused bootstrap failed loudly, so it converted a loud failure into a silent one. `git diff 4.207.0 HEAD` on the file was empty, so it is live on main.

## Investigation: there is no second bug underneath

The report described the proxy taking roughly five seconds to exit, which could not be explained from the code — there is no SIGTERM handler anywhere in the `cas-plugin` crate, and a handler-less process dies on the first signal. This was checked on real hardware (macOS 26.3) before writing the fix, because it changed how much of the change was needed.

- A launch agent whose process ignores SIGTERM stays in the domain for **5.26s**. That is launchd's SIGTERM-to-SIGKILL escalation window, and it matches the reported "~5 second" exit. It is a property of launchd, not of proxy shutdown logic.
- **The proxy is not slow to leave the domain.** It leaves in ~0.6s idle, and in ~0.6s again with 14 threads mid-network-call. The launchd job's `Program` is the Swift CLI, which `execv`s into the Rust proxy, and neither installs a SIGTERM handler or blocks the signal. Loading Apple's `libToolchainCASPlugin` and creating a CAS leaves SIGTERM at `SIG_DFL` and unblocked.

So the timeout is not the issue and the PID check is the whole fix. Crucially, the failure does not need a slow proxy at all: while a booted-out job is still draining, `launchctl bootstrap` exits `5` while `launchctl print` reports the label loaded under the **unchanged** pid. That is the exact input the old guard read as success.

## Impact

A `tuist setup cache` whose bootstrap does not take now fails loudly instead of printing success over a proxy that is about to exit. Where a stale daemon is still answering the socket, the restart path that was previously unreachable now runs and recovers. `LaunchAgentServicing.setupLaunchAgent` gains a `@discardableResult` return, so the insights setup path is unchanged.

## Validation

Red before green: the three new/updated tests were run against the unfixed logic first and failed exactly as expected (`setupLaunchAgent_throwsWhenBootstrapIsRefusedAndTheOutgoingAgentStillOwnsTheLabel`, `setupLaunchAgent_throwsWhenBootstrapIsRefusedAndLaunchdHoldsTheLabelWithoutAProcess`, `setupLaunchAgent_preservesExistingPlistAndThrowsWhenUnloadFails`), with the other 31 passing.

- `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist` — BUILD SUCCEEDED
- `xcodebuild test -only-testing TuistLaunchctlTests` — 34 tests, all pass
- `xcodebuild test -only-testing TuistKitTests/SetupCacheCommandServiceTests -only-testing TuistKitTests/SetupInsightsCommandServiceTests` — 27 tests, all pass
- `xcodebuild test -only-testing TuistKitTests/TeardownCacheCommandServiceTests -only-testing TuistKitTests/TeardownInsightsCommandServiceTests` — 7 tests, all pass
- `mise run lint` — no errors. The `type_body_length` limit on `SetupCacheCommandService` was hit at 358 lines while writing this and the addition was compacted back to 343 (it was 337 before, already over the 250-line warning threshold).

Against real `launchctl`, not just the mocks:

- The refusal input was reproduced end to end: bootstrap during a drain returns `rc=5` with the pid unchanged, so the new code rejects where the old code accepted.
- The `pid` parse was checked against real `launchctl print` output for three live services and matched `launchctl list` on each. A loaded-but-not-running job (`state = spawn scheduled`) prints no `pid` line at all, which is why `LaunchAgentJob.processIdentifier` is optional and why that state is rejected rather than rounded to "running".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
