### PR TITLE
fix(server): skip Faro on the log in pages

### DIFF
--- a/server/lib/tuist_web/live/sso_login_live.ex
+++ b/server/lib/tuist_web/live/sso_login_live.ex
@@ -12,7 +12,12 @@ defmodule TuistWeb.SSOLoginLive do
     email = Flash.get(socket.assigns.flash, :email)
     form = to_form(%{"email" => email}, as: "user")
 
-    socket = assign(socket, :form, form)
+    socket =
+      socket
+      |> assign(:form, form)
+      # Same rationale as UserLoginLive: skip Faro on the SSO log in page so
+      # crawler visits do not drag the LCP tail metric.
+      |> assign(:analytics_disabled?, true)
 
     {
       :ok,

--- a/server/lib/tuist_web/live/user_login_live.ex
+++ b/server/lib/tuist_web/live/user_login_live.ex
@@ -25,6 +25,10 @@ defmodule TuistWeb.UserLoginLive do
       |> assign(:tuist_hosted?, Environment.tuist_hosted?())
       |> assign(:email_auth_enabled?, Environment.email_auth_enabled?())
       |> assign(:test_user_login_enabled?, Environment.test_user_login_enabled?())
+      # Crawlers following `Log in` links on every localised docs page have
+      # been dominating the tuist-web LCP tail from `/users/log_in`, where
+      # LCP has no product meaning. Skip Faro on this page.
+      |> assign(:analytics_disabled?, true)
 
     {
       :ok,

--- a/server/test/tuist_web/live/login_analytics_opt_out_test.exs
+++ b/server/test/tuist_web/live/login_analytics_opt_out_test.exs
@@ -1,0 +1,51 @@
+defmodule TuistWeb.LoginAnalyticsOptOutTest do
+  # A crawler farm was following `Log in` links on every localised docs page and
+  # landing on `/users/log_in?return_to=/<locale>/docs/...`. Every hit reported a
+  # fresh Faro session with LCP dominated by TTFB, dragging the `tuist-web`
+  # 24h p99 above 17s and firing the pathological-tail alert. The login page
+  # has no product-meaningful LCP anyway (`context_element="#login>div"`), so
+  # the two LiveViews behind that URL opt out of Faro entirely.
+  use ExUnit.Case, async: false
+  use Mimic
+
+  import Phoenix.LiveViewTest
+
+  setup :set_mimic_from_context
+
+  setup do
+    stub(Tuist.Environment, :analytics_enabled?, fn -> true end)
+    stub(Tuist.Environment, :faro_collector_url, fn -> "/-/faro" end)
+    # `UserLoginLive.mount/3` calls `Accounts.sso_configured?/0` which hits the
+    # database. This test doesn't need a real answer; it only asserts on the
+    # `analytics_disabled?` assign.
+    stub(Tuist.Accounts, :sso_configured?, fn -> false end)
+    :ok
+  end
+
+  test "UserLoginLive.mount/3 flags the layout to skip Faro" do
+    socket = build_socket()
+
+    {:ok, socket, _opts} = TuistWeb.UserLoginLive.mount(%{}, %{}, socket)
+
+    assert render_analytics(socket.assigns) =~ ~s("enabled":false)
+  end
+
+  test "SSOLoginLive.mount/3 flags the layout to skip Faro" do
+    socket = build_socket()
+
+    {:ok, socket, _opts} = TuistWeb.SSOLoginLive.mount(%{}, %{}, socket)
+
+    assert render_analytics(socket.assigns) =~ ~s("enabled":false)
+  end
+
+  defp build_socket do
+    %Phoenix.LiveView.Socket{assigns: %{flash: %{}, __changed__: %{}}}
+  end
+
+  defp render_analytics(assigns) do
+    render_component(
+      &TuistWeb.LayoutComponents.head_analytics_scripts/1,
+      Map.put(assigns, :page_section, "dashboard")
+    )
+  end
+end


### PR DESCRIPTION
Resolves the `Web - LCP p99 pathological tail` Grafana alert (`efx5a3mn2fwg0c`), which has been firing since 2026-09-07 19:20 UTC.

### Why

For roughly a day the alert has been reporting `tuist-web` 24h LCP p99 at 17.04s across 1,450 samples, with 39 distinct sessions above 10s. The description of the alert calls for a look at the per-page breakdown, which returned this shape:

```
https://tuist.dev/users/log_in?return_to=%2F<locale>%2Fdocs%2F...
```

Every one of the top ten offenders was a login-page hit whose `return_to` pointed at a localised docs URL (`ko`, `ru`, `ka`, `zh_Hans`, `zh_Hant`, `yue_Hant`). Per-URL p99 ranged from 20s to 48s.

Sampling the raw Faro events made the source obvious: identical UA `Mozilla/5.0 (X11; Linux x86_64) ... Chrome/150.0.0.0` (a version that does not exist), `browser_os="Linux unknown"`, fresh `session_id` on every hit, and the LCP element consistently `#login>div`. The badness is entirely TTFB, not paint:

| lcp | ttfb | render_delay |
| --- | --- | --- |
| 25.3s | 25.1s | 0.24s |
| 21.4s | 21.2s | 0.24s |
| 12.2s | 12.0s | 0.25s |

Real users are not the population that alert is reporting on. LCP on the log-in page has no product meaning anyway; it is a static form, not a Core Web Vitals content page. The client-side guard on `navigator.webdriver` already skips real headless browsers, but this crawler is not setting that flag.

### Root cause

The Faro Web SDK is initialised on every page that renders the shared app layout, including `/users/log_in` and `/users/log_in/sso`. Both routes are the natural landing spot for any crawler that follows a `Log in` link on the localised docs, and the resulting slow-first-byte responses fully dominate the tuist-web LCP distribution over any 24h window.

### Approach

The layout already has a wiring point: `head_analytics_scripts/1` in `TuistWeb.LayoutComponents` reads an `analytics_disabled?` assign from the socket and renders `"enabled":false` when it is `true`. `MarketingBlogIframeController` already uses this to skip Faro for embedded blog visualisations, and the behaviour is covered by `layout_components_test.exs`.

Two other approaches were considered and set aside:

- Client-side UA sniffing. `Chrome/150.0.0.0` is easy to detect today but ages badly, and there is no JavaScript test harness under `server/assets/` to hang a test off.
- Blocking the crawler at Cloudflare. Reasonable as a follow-up, but it does not address the underlying signal quality of the LCP tail alert, and there is no code path to test.

Reusing the existing seam keeps the change to two mount functions and gives the fix a straightforward unit test.

### What changed

- `TuistWeb.UserLoginLive.mount/3` and `TuistWeb.SSOLoginLive.mount/3` now assign `analytics_disabled?: true`, so the layout omits Faro for both `/users/log_in` and `/users/log_in/sso`.
- New `test/tuist_web/live/login_analytics_opt_out_test.exs` invokes each `mount/3` directly and feeds the resulting assigns through `head_analytics_scripts/1`, asserting that the rendered `<script>` contains `"enabled":false`. Written as a plain `ExUnit.Case` so it does not need the database sandbox.

### Impact

- The two login LiveViews stop emitting Faro sessions. Everything else on the site continues to report web vitals as before.
- The alert uses `[24h]` windows, so it will keep firing until the polluted samples roll out of the window after the deploy lands. No metric backfill is possible; time is the only cure.
- No user-visible behaviour changes on the login pages themselves.

### Validation

Local ExUnit run against the new test file:

```
POOL_SIZE=5 MIX_ENV=test mix test test/tuist_web/live/login_analytics_opt_out_test.exs --no-start
# 2 passed
```

Also confirmed the tests fail on the pre-change source: the assertion left side is `"enabled":true` when `analytics_disabled?` is not set, exactly what would let a crawler visit be recorded.
