### PR TITLE
chore(infra): run the fleet MDM in the production cluster

### DIFF
--- a/.github/workflows/mdm-deployment.yml
+++ b/.github/workflows/mdm-deployment.yml
@@ -4,8 +4,11 @@ name: MDM Deployment
 #
 # There is one MDM instance and it owns every Mac we own, whatever
 # cluster that Mac ends up serving — the MDM manages a host before it
-# joins anything. The cluster named below is where the server is hosted,
-# not an environment tier, and there is no per-cluster MDM.
+# joins anything. There is no per-cluster MDM.
+#
+# It runs in the production cluster, in its own namespace, alongside
+# tuist-ops: this is the plane that provisions the fleet, so it does not
+# belong in the cluster we treat as disposable.
 #
 # The `ref` input exists so a branch can be deployed WITHOUT
 # merging it: the workflow definition is taken from the ref this workflow
@@ -99,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment:
-      name: server-k8s-staging
+      name: server-k8s-production
     env:
       KUBECONFIG: ${{ github.workspace }}/.kube/config
     steps:
@@ -117,8 +120,8 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
           mkdir -p "$(dirname "$KUBECONFIG")"
-          op document get "kubeconfig: tuist-staging" \
-            --vault "tuist-k8s-staging" --output "$KUBECONFIG"
+          op document get "kubeconfig: tuist-production" \
+            --vault "tuist-k8s-production" --output "$KUBECONFIG"
           chmod 600 "$KUBECONFIG"
       - name: Verify cluster reachability
         run: |


### PR DESCRIPTION
## What

Points the MDM deploy workflow at the production cluster: the `server-k8s-production` environment and the `tuist-production` kubeconfig from the production vault. No other change.

## Why

The MDM is the plane that provisions the Mac fleet. Staging is explicitly disposable — a deploy from an unrelated branch can delete workloads there — which is fine for a spike and disqualifying for the server that has to be reachable when a mini needs reprovisioning at 3am. It belongs in the production cluster in its own namespace, the same place and for the same reason as `tuist-ops`.

The chart changes that go with this (tailnet tag and backup bucket, both of which follow the hosting cluster rather than the instance) are in tuist/tuist#12749.

## Why now

**Nothing is enrolled yet.** The hostname is unchanged, so no device would re-enroll even if one existed, and there is no accumulated state worth migrating — the prototype's ABM token exchange takes about five minutes to redo and is documented in the runbook.

Doing this after real hardware enrols would mean either restoring the database into a new cluster or repeating the ceremony with machines already depending on it. Same reasoning as fixing `ServerCapabilities` before first enrollment: the cheap moment is now.

## Note on the `ref` input

The workflow can still deploy a branch, which now means deploying unmerged code into the production cluster. That is deliberate for the duration of the prototype gauntlet, where the enroller is expected to change repeatedly against physical hardware, and the blast radius is one namespace with its own database that touches no customer workload. It is worth removing once the fleet is live and iteration stops.

## Validation

Workflow parses; the production cluster has the CNPG CRD and a ready `onepassword` ClusterSecretStore, and its Tailscale operator is scoped to `tag:tuist-k8s-production`. I also verified the production Tigris credentials can write under the `mdm` prefix before pointing backups there, rather than discovering it from a failed WAL archive — which is exactly how the staging misconfiguration surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)