### PR TITLE
fix(server): give a stalled Kura provision a terminal state and a signal

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -3243,7 +3243,7 @@ on which is authoritative.
 ### Kura instance provisioned but not serving
 
 ```promql
-sum(tuist_kura_lifecycle_unroutable_instances_count{cluster="tuist-production"})
+max by (region) (tuist_kura_lifecycle_unroutable_instances_count{cluster="tuist-production"})
 ```
 
 - Threshold: `> 0`, so the alert value is how many instances are unroutable
@@ -3251,15 +3251,37 @@ sum(tuist_kura_lifecycle_unroutable_instances_count{cluster="tuist-production"})
 - Severity: warning
 - Production only. Folder `Alerts`, group `Cache`, receiver
   `Slack #notifications 2`; **No Data: Alerting**, **Error: Alerting**.
-- Summary: `{{ $values.A.Value }} Kura instance(s) have been provisioned but
-  are not serving their account`
-- Description: `Cache resolution offers an account only its active instances,
-  so an instance that never reaches active is one the account is allocated,
-  is paying for, and is not being routed to; it keeps building against the
-  legacy cache lane and nothing errors. Read the instance status on /ops/kura
-  and the reconciler log for "could not converge server". Instances pass
-  through provisioning for a minute or two on creation, so a count that clears
-  on its own is normal and this fires only on one that does not.`
+- Live: rule `dfxnedzs40i68f`, created 2026-09-08.
+- Summary and description: see the deployed rule, which carries the full
+  triage text.
+
+**This rule was documented here for weeks before it existed.** It was written
+up in this file and never created in Grafana, so the 2026-09-08 stall ran for
+over three hours against a rule that looked specified and was not deployed.
+That is the reason nothing fired. Treat a section in this file as a claim
+about intent, not as evidence a rule exists: check
+`alerting_manage_rules` before concluding a rule is broken or missing, and
+record the uid here when one is created.
+
+**Read it with `max`, not `sum`.** Adaptive Metrics has aggregated `instance`
+and `pod` away from this gauge, which a bare selector now reports as an error
+rather than silently. `region` and `cluster` both survive. Every
+`tuist-tuist-server` replica polls the same fleet-wide count, so the reducer
+has to be one that collapses identical values rather than adding them.
+Measured on 2026-09-08 against a ground truth of two stuck instances in
+us-east and one in eu-central:
+
+| query | us-east | eu-central |
+| --- | --- | --- |
+| `sum by (region)` | 10 | 5 |
+| `max by (region)` | 2 | 1 |
+| Postgres | 2 | 1 |
+
+`sum` returns the truth multiplied by the five web replicas, so it tracks
+replica count rather than anything about the fleet. `max` is exact. No
+Adaptive Metrics change is needed for this: the aggregation keeps a max
+variant and rewrites the query onto it, so the correct reducer recovers the
+correct number today.
 
 **Summed rather than read per region.** The gauge carries a `region` label and
 the underlying series is per region, but Adaptive Metrics has already
@@ -3291,33 +3313,22 @@ unroutable for as long as about 52 days while their pods answered `/up` the
 whole time. Nothing errored, no queue grew, and no existing rule moved, so it
 was found by reading the database rather than by an alert.
 
-**The value in the summary is inflated, the firing is not.** This is a PromEx
-polling gauge, so all five `tuist-tuist-server` replicas report the same
-fleet-wide count once a minute, and Adaptive Metrics aggregates the `pod` label
-away by summing them. On 2026-09-08 the rule read 5 while Postgres held exactly
-one non-active instance. `> 0` is unaffected, because five times a true zero is
-still zero, so the rule fires and clears correctly; what is wrong is
-`{{ $values.A.Value }}` in the summary, which reports the replica count times
-the truth. Read the count off `/ops/kura` rather than off the Slack message
-until the aggregation is fixed.
-
-The fix is a Grafana Cloud one and does not live in this repo. Nothing in
-`values.yaml` touches this metric: the drop rules there are anchored on
-`_bucket` and the `labeldrop` list is
+**Nothing in `values.yaml` is involved, and nothing needs excluding.** The
+first instinct on finding an inflated count is to look for a drop or
+aggregation rule in `infra/helm/k8s-monitoring/values.yaml`. There is none that
+touches this metric: the drop rules there are anchored on `_bucket`, which a
+gauge never matches, and the `labeldrop` list is
 `container_id|uid|pod_ip|image_id|image_spec|k8s_pod_uid`, which does not
-include `pod`. Editing that file would ship a no-op. Exclude
-`tuist_kura_lifecycle_unroutable_instances_count` and
-`tuist_kura_lifecycle_stalled_instances_count` from `pod` aggregation under
-**Metrics > Adaptive Metrics** in Grafana Cloud (the same recommendations the
-two limits above **Critical alerts** describe), then read both with `max`
-rather than `sum`, which is the correct reducer for a gauge every replica
-reports identically. `max` on its own does not repair it: applied to a
-series Adaptive Metrics has already summed, it returns the same inflated value.
+include `pod`. The deployed `k8s-monitoring-alloy-metrics` configmap does not
+mention the metric either, so editing that file would ship a no-op. The
+aggregation is Adaptive Metrics, on the Grafana Cloud side, and the fix is the
+reducer in the query rather than any change to the aggregation. See the
+measured comparison under the rule at the top of this section.
 
 ### Kura instance stalled in provisioning
 
 ```promql
-max(tuist_kura_lifecycle_stalled_instances_count{cluster="tuist-production"})
+max by (region) (tuist_kura_lifecycle_stalled_instances_count{cluster="tuist-production"})
 ```
 
 - Threshold: `> 0`
@@ -3325,8 +3336,11 @@ max(tuist_kura_lifecycle_stalled_instances_count{cluster="tuist-production"})
 - Severity: warning
 - Production only. Folder `Alerts`, group `Cache`, receiver
   `Slack #notifications 2`; **No Data: Alerting**, **Error: Alerting**.
-- Summary: `A Kura instance has been provisioning for over 15 minutes without a
-  routable endpoint`
+- **Not deployed yet.** The metric ships with the reconciler stall escalation;
+  create the rule once a release carrying it is in production, or it evaluates
+  No Data and pages immediately. Record its uid here when you do.
+- Summary: `A Kura instance in {{ $labels.region }} has been provisioning for
+  over 15 minutes without a routable endpoint`
 - Description: `The instance holds an allocation its account cannot use and is
   building against the legacy cache lane. The reconciler has already marked the
   server failed and captured the reason to Sentry under "Kura provisioning

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -3291,6 +3291,73 @@ unroutable for as long as about 52 days while their pods answered `/up` the
 whole time. Nothing errored, no queue grew, and no existing rule moved, so it
 was found by reading the database rather than by an alert.
 
+**The value in the summary is inflated, the firing is not.** This is a PromEx
+polling gauge, so all five `tuist-tuist-server` replicas report the same
+fleet-wide count once a minute, and Adaptive Metrics aggregates the `pod` label
+away by summing them. On 2026-09-08 the rule read 5 while Postgres held exactly
+one non-active instance. `> 0` is unaffected, because five times a true zero is
+still zero, so the rule fires and clears correctly; what is wrong is
+`{{ $values.A.Value }}` in the summary, which reports the replica count times
+the truth. Read the count off `/ops/kura` rather than off the Slack message
+until the aggregation is fixed.
+
+The fix is a Grafana Cloud one and does not live in this repo. Nothing in
+`values.yaml` touches this metric: the drop rules there are anchored on
+`_bucket` and the `labeldrop` list is
+`container_id|uid|pod_ip|image_id|image_spec|k8s_pod_uid`, which does not
+include `pod`. Editing that file would ship a no-op. Exclude
+`tuist_kura_lifecycle_unroutable_instances_count` and
+`tuist_kura_lifecycle_stalled_instances_count` from `pod` aggregation under
+**Metrics > Adaptive Metrics** in Grafana Cloud (the same recommendations the
+two limits above **Critical alerts** describe), then read both with `max`
+rather than `sum`, which is the correct reducer for a gauge every replica
+reports identically. `max` on its own does not repair it: applied to a
+series Adaptive Metrics has already summed, it returns the same inflated value.
+
+### Kura instance stalled in provisioning
+
+```promql
+max(tuist_kura_lifecycle_stalled_instances_count{cluster="tuist-production"})
+```
+
+- Threshold: `> 0`
+- Pending period: 5 minutes
+- Severity: warning
+- Production only. Folder `Alerts`, group `Cache`, receiver
+  `Slack #notifications 2`; **No Data: Alerting**, **Error: Alerting**.
+- Summary: `A Kura instance has been provisioning for over 15 minutes without a
+  routable endpoint`
+- Description: `The instance holds an allocation its account cannot use and is
+  building against the legacy cache lane. The reconciler has already marked the
+  server failed and captured the reason to Sentry under "Kura provisioning
+  stalled"; read it there for which of DNS, the public endpoint or the
+  node-port chain never came up, and check the account's Certificate in the
+  kura namespace, which is the usual cause.`
+
+**Why this exists next to the rule above.** The unroutable gauge counts every
+instance that is not `:active`, so a healthy cold provision is in it for a
+couple of minutes and the rule can only ask how long a count persisted, which
+is what the 30-minute pending period is buying. This gauge counts only
+instances whose open deployment has run past
+`Tuist.Kura.provisioning_stall_seconds/0`, so a fleet with nothing stuck reads
+zero and the question becomes whether the value is non-zero at all. That is
+also what makes it survive the aggregation described above: a threshold that
+only asks non-zero does not care what the true count is multiplied by.
+
+**Why 5 minutes.** The 15-minute stall threshold is already the patience, and
+it is measured against a fleet whose instances reach `:active` in about 105
+seconds on average. A second long pending period on top would only delay a
+signal that has already waited seven times the normal provisioning time.
+
+**What it would have caught.** The 2026-09-08 stall, where one account's
+instance sat in `:provisioning` for over three hours with its `updated_at`
+byte-identical to its `inserted_at`. Let's Encrypt had refused the certificate
+for its host under the 50-per-registered-domain weekly rate limit, so the
+ingress served its default self-signed certificate, the reconciler's `/up`
+probe failed TLS verification every tick, and the endpoint-not-ready branch
+logged at info and returned `:ok` without writing anything. The instance was
+indistinguishable from one thirty seconds old.
+
 ### Kura region has room for one more instance
 
 The `ceiling` and `memory` rows of **Kura region cannot place another

--- a/server/lib/tuist/kura.ex
+++ b/server/lib/tuist/kura.ex
@@ -96,6 +96,27 @@ defmodule Tuist.Kura do
   @doc "Seconds a draining server keeps serving before teardown."
   def drain_seconds, do: @drain_seconds
 
+  # How long a provisioning attempt may go without producing a routable
+  # endpoint before the wait stops being a startup delay and starts being a
+  # stall. Every wait the reconciler treats as benign (DNS that has not
+  # propagated, a workload whose endpoint is not serving yet) is benign for
+  # seconds, not for hours: instances reach `:active` in about two minutes, so
+  # this sits far enough past that to never fire on a slow start and close
+  # enough to surface a stall inside a build cycle.
+  #
+  # The clock is the open deployment's `inserted_at`, not the server's
+  # `updated_at`. A stalled server is precisely one nothing writes to, so its
+  # `updated_at` is frozen at the moment the attempt began and cannot say how
+  # long the attempt has run. Exactly one deployment is open per server at a
+  # time (`ensure_no_open_deployment/1`), it is inserted when the attempt
+  # starts (a first provision and a cold return out of `:archived` both go
+  # through `insert_initial_deployment/3`), and it closes when the server
+  # activates, which makes it the one clock that measures the attempt itself.
+  @provisioning_stall_seconds 900
+
+  @doc "Seconds a provisioning attempt may run without a routable endpoint before it counts as stalled."
+  def provisioning_stall_seconds, do: @provisioning_stall_seconds
+
   # How long a client may hold an endpoint answer before it has to ask again.
   # Lives here rather than on the controller that sets the header because the
   # drain below has to outlast it, and two numbers that must agree should not
@@ -2088,6 +2109,36 @@ defmodule Tuist.Kura do
     |> where([s], s.status in ^@unroutable_statuses and s.region in ^region_ids)
     |> group_by([s], s.region)
     |> select([s], {s.region, count(s.id)})
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @open_deployment_statuses [:pending, :running]
+
+  @doc """
+  Counts, per region, the instances whose provisioning attempt has run past
+  `provisioning_stall_seconds/0` without producing a routable endpoint.
+
+  The subset of `unroutable_instance_counts/1` that is actually wrong. That
+  count includes every instance still starting, so it is only readable as "how
+  long did it persist"; this one excludes them by construction, because a
+  healthy attempt closes its deployment in about two minutes and leaves. A
+  fleet with nothing stuck reads zero, which is what makes it alertable on the
+  value rather than on the duration.
+
+  Counting the deployment rather than the server status is deliberate: it
+  covers a stall in any of the non-serving states, `:replicating` included,
+  without depending on which one the projection last derived.
+  """
+  def stalled_instance_counts(region_ids) do
+    cutoff = DateTime.add(DateTime.utc_now(), -@provisioning_stall_seconds, :second)
+
+    Server
+    |> join(:inner, [s], d in Deployment, on: d.kura_server_id == s.id)
+    |> where([s, d], s.status in ^@unroutable_statuses and s.region in ^region_ids)
+    |> where([_s, d], d.status in ^@open_deployment_statuses and d.inserted_at <= ^cutoff)
+    |> group_by([s], s.region)
+    |> select([s], {s.region, count(s.id, :distinct)})
     |> Repo.all()
     |> Map.new()
   end

--- a/server/lib/tuist/kura/prom_ex_plugin.ex
+++ b/server/lib/tuist/kura/prom_ex_plugin.ex
@@ -7,7 +7,7 @@ defmodule Tuist.Kura.PromExPlugin do
   reclaimed bytes, archive cancellations, refused provisions, and the accounts
   refused a service region before they reach any transition at all.
 
-  Three polled gauges cover what a transition cannot see:
+  Four polled gauges cover what a transition cannot see:
 
     * per-region occupancy — the forecast enforced warm quota against what is
       installed. This is the number that decides whether another machine is
@@ -20,8 +20,20 @@ defmodule Tuist.Kura.PromExPlugin do
       `:active`, so the CLI cannot be handed them. The account holds an
       allocation and builds against the legacy cache lane, and nothing errors,
       so there is no transition to hang this off and no failure to count.
+    * stalled instances: the subset of the above whose provisioning attempt has
+      run past `Tuist.Kura.provisioning_stall_seconds/0`. Unroutable counts
+      every instance still starting, so it is only readable as how long a count
+      persisted; this one is zero on a healthy fleet and non-zero only when
+      something is genuinely stuck, which is what makes it alertable on its
+      value.
 
-  All three are tagged by region only. Account never appears as a tag.
+  All four are tagged by region only. Account never appears as a tag.
+
+  These are polled per web pod, so every replica reports the same fleet-wide
+  count. Alert on whether the value is non-zero, never on how large it is: a
+  count that has had its `pod` label aggregated away by summing reads as the
+  true count multiplied by the replica count, so any absolute threshold tracks
+  how many web pods are running rather than how many instances are stuck.
   """
 
   use PromEx.Plugin
@@ -226,6 +238,17 @@ defmodule Tuist.Kura.PromExPlugin do
                 "cache lane instead of the instance the account is paying for. Provisioning passes " <>
                 "through here for a minute or two, so what matters is how long a count persists.",
             tags: [:region]
+          ),
+          last_value(
+            @metric_prefix ++ [:stalled_instances, :count],
+            event_name: [:tuist, :kura, :lifecycle, :instance_routability],
+            measurement: :stalled,
+            description:
+              "Instances whose provisioning attempt has run past the stall threshold without a " <>
+                "routable endpoint. Unlike unroutable_instances this excludes instances that are " <>
+                "merely starting, so a healthy fleet reads zero and any non-zero value is an " <>
+                "account holding an allocation it cannot use.",
+            tags: [:region]
           )
         ]
       )
@@ -256,6 +279,7 @@ defmodule Tuist.Kura.PromExPlugin do
   def execute_unroutable_instances_telemetry_event do
     region_ids = Enum.map(lifecycle_regions(), & &1.id)
     counts = Kura.unroutable_instance_counts(region_ids)
+    stalled = Kura.stalled_instance_counts(region_ids)
 
     # Emitted for every region, not only the ones with a count, so a region
     # whose instances stop reaching `:active` is a series moving off zero
@@ -264,7 +288,7 @@ defmodule Tuist.Kura.PromExPlugin do
     Enum.each(region_ids, fn region_id ->
       :telemetry.execute(
         [:tuist, :kura, :lifecycle, :instance_routability],
-        %{unroutable: Map.get(counts, region_id, 0)},
+        %{unroutable: Map.get(counts, region_id, 0), stalled: Map.get(stalled, region_id, 0)},
         %{region: region_id}
       )
     end)

--- a/server/lib/tuist/kura/reconciler.ex
+++ b/server/lib/tuist/kura/reconciler.ex
@@ -364,19 +364,18 @@ defmodule Tuist.Kura.Reconciler do
         {:error, status} when status in [:server_destroying, :server_destroyed, :server_reclaimed] ->
           cancel(deployment, "server #{server.id} became #{server_status(status)} during rollout; skipping activation")
 
-        {:error, {:public_host_not_resolvable, host, reason}} ->
+        {:error, {:public_host_not_resolvable, host, reason} = detail} ->
           # external-dns has not propagated yet. Leave the deployment in
           # `:running` so the next reconciler tick retries instead of
           # marking the server failed for what's a benign delay.
-          Logger.info("[Kura.Reconciler] waiting on DNS for server #{server.id} (#{host}): #{inspect(reason)}")
-
-          :ok
-
-        {:error, {:public_endpoint_not_ready, host, reason}} ->
-          Logger.info(
-            "[Kura.Reconciler] waiting on public endpoint for server #{server.id} (#{host}): #{inspect(reason)}"
+          wait_or_stall(
+            server,
+            deployment,
+            detail,
+            "waiting on DNS for server #{server.id} (#{host}): #{inspect(reason)}"
           )
 
+        {:error, {:public_endpoint_not_ready, host, reason} = detail} ->
           # The workload is up on the desired image but the endpoint is not
           # serving yet: the pod is typically still replicating from mesh peers
           # behind the /ready backfill gate, so it offers no healthy upstream to
@@ -388,19 +387,27 @@ defmodule Tuist.Kura.Reconciler do
           # attribute the wait to a catch-up that can never complete and leave
           # the instance sitting there. Those are cold starts and stay
           # `:provisioning` until the endpoint answers.
+          #
+          # A catch-up has a peer feeding it and a size that justifies a long
+          # wait, so it is left to run and the stalled gauge is what reports it
+          # if it never finishes. A cold start has neither, so it is the one
+          # this escalates.
           if Kura.replication_source?(server) do
             record(server, :replicating, deployment.image_tag, now())
           else
-            :ok
+            wait_or_stall(
+              server,
+              deployment,
+              detail,
+              "waiting on public endpoint for server #{server.id} (#{host}): #{inspect(reason)}"
+            )
           end
 
-        {:error, :node_port_endpoint_not_ready} ->
+        {:error, :node_port_endpoint_not_ready = detail} ->
           # The controller has not yet observed the full node-port
           # chain (Service ports allocated, primary pod placed on a
           # labeled node). Benign startup delay, same as DNS.
-          Logger.info("[Kura.Reconciler] waiting on node-port endpoint for server #{server.id}")
-
-          :ok
+          wait_or_stall(server, deployment, detail, "waiting on node-port endpoint for server #{server.id}")
 
         {:error, reason} ->
           fail(deployment, server, reason)
@@ -714,6 +721,80 @@ defmodule Tuist.Kura.Reconciler do
     :ok
   end
 
+  # Every readiness wait above is benign at first and indistinguishable from a
+  # permanent one afterwards: the branch logs at info, returns `:ok` and writes
+  # nothing, so the row keeps the `:provisioning` it was inserted with and its
+  # `updated_at` stays at its insert time. That shape is identical whether the
+  # endpoint is thirty seconds from serving or will never serve at all (an ACME
+  # order that errored, a host that never got a certificate, a node-port chain
+  # that never completes), which is how an instance can hold an
+  # allocation for hours while its account silently builds against the legacy
+  # cache lane, looking exactly like one that is half a minute old.
+  #
+  # Past the stall threshold the wait is recorded instead of swallowed: the
+  # server goes `:failed`, which the dashboard renders as a failure with a
+  # Retry rather than an endless "Deploying", and the reason reaches Sentry.
+  #
+  # The deployment is deliberately left open. `:failed` is a projection here,
+  # not a terminal sink (see the module doc), so the fast path keeps probing
+  # every tick and the instance still activates on its own the moment its
+  # endpoint comes up, with no operator retry.
+  defp wait_or_stall(%Server{} = server, %Deployment{} = deployment, reason, message) do
+    cond do
+      not stalled?(deployment) ->
+        Logger.info("[Kura.Reconciler] #{message}")
+        :ok
+
+      # Already reported. Keep retrying quietly rather than re-reporting the
+      # same stall every tick for as long as it lasts.
+      server.status == :failed ->
+        Logger.info("[Kura.Reconciler] #{message}")
+        :ok
+
+      true ->
+        report_stall(server, deployment, reason, message)
+    end
+  end
+
+  defp stalled?(%Deployment{inserted_at: inserted_at}) do
+    stalled_seconds(inserted_at) >= Kura.provisioning_stall_seconds()
+  end
+
+  defp stalled_seconds(inserted_at), do: DateTime.diff(DateTime.utc_now(), inserted_at)
+
+  defp report_stall(%Server{} = server, %Deployment{} = deployment, reason, message) do
+    age = stalled_seconds(deployment.inserted_at)
+    kind = failure_kind(reason)
+
+    Logger.error(
+      "[Kura.Reconciler] server #{server.id} has been provisioning for #{age}s with no routable endpoint: #{message}"
+    )
+
+    Sentry.capture_message("Kura provisioning stalled",
+      level: :error,
+      tags: %{failure_kind: kind, region: server.region},
+      extra: %{
+        account_id: server.account_id,
+        deployment_id: deployment.id,
+        failure_detail: message,
+        failure_kind: kind,
+        region: server.region,
+        server_id: server.id,
+        stalled_seconds: age
+      }
+    )
+
+    case Kura.fail_server(server) do
+      {:ok, _server} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("[Kura.Reconciler] could not record stall for server #{server.id}: #{inspect(reason)}")
+
+        :ok
+    end
+  end
+
   defp fail(deployment, server, reason) do
     message = if is_binary(reason), do: reason, else: inspect(reason)
 
@@ -749,6 +830,7 @@ defmodule Tuist.Kura.Reconciler do
   end
 
   defp failure_kind(:not_found), do: "not_found"
+  defp failure_kind(kind) when is_atom(kind) and not is_nil(kind), do: Atom.to_string(kind)
   defp failure_kind({kind, _}) when is_atom(kind), do: Atom.to_string(kind)
   defp failure_kind({kind, _, _}) when is_atom(kind), do: Atom.to_string(kind)
   defp failure_kind(%{__struct__: module}), do: module |> Module.split() |> List.last() |> Macro.underscore()

--- a/server/test/tuist/kura/prom_ex_plugin_test.exs
+++ b/server/test/tuist/kura/prom_ex_plugin_test.exs
@@ -7,7 +7,9 @@ defmodule Tuist.Kura.PromExPluginTest do
   alias Tuist.IngestRepo
   alias Tuist.KeyValueStore
   alias Tuist.Kubernetes.Client
+  alias Tuist.Kura
   alias Tuist.Kura.Demand
+  alias Tuist.Kura.Deployment
   alias Tuist.Kura.PromExPlugin
   alias Tuist.Kura.Regions
   alias Tuist.Kura.Server
@@ -71,6 +73,18 @@ defmodule Tuist.Kura.PromExPluginTest do
       region: @region,
       status: :active,
       provisioner_node_ref: "kura-#{account.id}-us-east"
+    })
+  end
+
+  # The stall clock is the open deployment's age, so a stalled instance is one
+  # whose attempt started before the threshold and never closed.
+  defp open_deployment(server, age_seconds: age_seconds) do
+    Repo.insert!(%Deployment{
+      cluster_id: "test-cluster",
+      image_tag: "0.5.2",
+      kura_server_id: server.id,
+      status: :running,
+      inserted_at: DateTime.add(DateTime.utc_now(), -age_seconds, :second)
     })
   end
 
@@ -190,6 +204,52 @@ defmodule Tuist.Kura.PromExPluginTest do
       PromExPlugin.execute_unroutable_instances_telemetry_event()
 
       assert_received {[:tuist, :kura, :lifecycle, :instance_routability], ^ref, %{unroutable: 0}, %{region: @region}}
+    end
+
+    test "counts an instance whose provisioning attempt has run past the stall threshold as stalled" do
+      account()
+      |> instance()
+      |> Ecto.Changeset.change(status: :provisioning, url: nil, current_image_tag: nil)
+      |> Repo.update!()
+      |> open_deployment(age_seconds: Kura.provisioning_stall_seconds() + 60)
+
+      ref = :telemetry_test.attach_event_handlers(self(), [[:tuist, :kura, :lifecycle, :instance_routability]])
+
+      PromExPlugin.execute_unroutable_instances_telemetry_event()
+
+      assert_received {[:tuist, :kura, :lifecycle, :instance_routability], ^ref, %{unroutable: 1, stalled: 1},
+                       %{region: @region}}
+    end
+
+    test "does not count an instance that is merely starting as stalled" do
+      account()
+      |> instance()
+      |> Ecto.Changeset.change(status: :provisioning, url: nil, current_image_tag: nil)
+      |> Repo.update!()
+      |> open_deployment(age_seconds: 30)
+
+      ref = :telemetry_test.attach_event_handlers(self(), [[:tuist, :kura, :lifecycle, :instance_routability]])
+
+      PromExPlugin.execute_unroutable_instances_telemetry_event()
+
+      assert_received {[:tuist, :kura, :lifecycle, :instance_routability], ^ref, %{unroutable: 1, stalled: 0},
+                       %{region: @region}}
+    end
+
+    test "stops counting an instance as stalled once its deployment closes" do
+      account()
+      |> instance()
+      |> Ecto.Changeset.change(status: :provisioning, url: nil, current_image_tag: nil)
+      |> Repo.update!()
+      |> open_deployment(age_seconds: Kura.provisioning_stall_seconds() + 60)
+      |> Ecto.Changeset.change(status: :succeeded)
+      |> Repo.update!()
+
+      ref = :telemetry_test.attach_event_handlers(self(), [[:tuist, :kura, :lifecycle, :instance_routability]])
+
+      PromExPlugin.execute_unroutable_instances_telemetry_event()
+
+      assert_received {[:tuist, :kura, :lifecycle, :instance_routability], ^ref, %{stalled: 0}, %{region: @region}}
     end
   end
 

--- a/server/test/tuist/kura/reconciler_test.exs
+++ b/server/test/tuist/kura/reconciler_test.exs
@@ -790,6 +790,89 @@ defmodule Tuist.Kura.ReconcilerTest do
     end
   end
 
+  describe "provisioning stalls" do
+    setup do
+      # A host that resolves but whose endpoint never answers: exactly the
+      # shape of an instance whose certificate was never issued, so the
+      # workload is up and the ingress serves something the probe rejects.
+      stub(Provisioner, :public_url, fn _account, _server -> "https://localhost:4100" end)
+      stub(Req, :get, fn _url, _opts -> {:error, :econnrefused} end)
+      :ok
+    end
+
+    test "keeps waiting while the attempt is younger than the stall threshold" do
+      {_account, server, deployment} = create_server()
+      {:ok, deployment} = Kura.mark_running(deployment)
+
+      stub(Provisioner, :current_image_tag, fn _server -> {:ok, deployment.image_tag} end)
+
+      assert :ok = Reconciler.reconcile()
+
+      assert %Server{status: :provisioning, url: nil} = Repo.get!(Server, server.id)
+      assert %Deployment{status: :running} = Repo.get!(Deployment, deployment.id)
+    end
+
+    test "marks the server failed once the attempt runs past the stall threshold" do
+      {_account, server, deployment} = create_server()
+      {:ok, deployment} = Kura.mark_running(deployment)
+      backdate_deployment(deployment, Kura.provisioning_stall_seconds() + 60)
+
+      stub(Provisioner, :current_image_tag, fn _server -> {:ok, deployment.image_tag} end)
+
+      assert :ok = Reconciler.reconcile()
+
+      assert %Server{status: :failed, url: nil} = Repo.get!(Server, server.id)
+
+      # The deployment stays open on purpose: the fast path keeps probing every
+      # tick, so the instance activates by itself when its endpoint comes up.
+      assert %Deployment{status: :running} = Repo.get!(Deployment, deployment.id)
+    end
+
+    test "activates a stalled server once its endpoint starts serving" do
+      {_account, server, deployment} = create_server()
+      {:ok, deployment} = Kura.mark_running(deployment)
+      backdate_deployment(deployment, Kura.provisioning_stall_seconds() + 60)
+
+      stub(Provisioner, :current_image_tag, fn _server -> {:ok, deployment.image_tag} end)
+
+      assert :ok = Reconciler.reconcile()
+      assert %Server{status: :failed} = Repo.get!(Server, server.id)
+
+      stub(Req, :get, fn _url, _opts -> {:ok, %Req.Response{status: 200}} end)
+
+      assert :ok = Reconciler.reconcile()
+
+      assert %Server{status: :active, url: "https://localhost:4100"} = Repo.get!(Server, server.id)
+      assert %Deployment{status: :succeeded} = Repo.get!(Deployment, deployment.id)
+    end
+
+    test "leaves a stalled server failed without re-reporting it every tick" do
+      {_account, server, deployment} = create_server()
+      {:ok, deployment} = Kura.mark_running(deployment)
+      backdate_deployment(deployment, Kura.provisioning_stall_seconds() + 60)
+
+      stub(Provisioner, :current_image_tag, fn _server -> {:ok, deployment.image_tag} end)
+
+      assert :ok = Reconciler.reconcile()
+      failed = Repo.get!(Server, server.id)
+      assert failed.status == :failed
+
+      # Only the first crossing reports; afterwards the row is already recorded
+      # and is left untouched, so a stall does not rewrite the row once a
+      # minute for as long as it lasts.
+      assert :ok = Reconciler.reconcile()
+
+      assert %Server{status: :failed, updated_at: updated_at} = Repo.get!(Server, server.id)
+      assert updated_at == failed.updated_at
+    end
+  end
+
+  defp backdate_deployment(deployment, seconds) do
+    deployment
+    |> Ecto.Changeset.change(inserted_at: DateTime.add(DateTime.utc_now(), -seconds, :second))
+    |> Repo.update!()
+  end
+
   defp create_server do
     user = AccountsFixtures.user_fixture()
     account = Accounts.get_account_from_user(user)


### PR DESCRIPTION
An account's Kura instance sat in `:provisioning` for over three hours against a
two minute norm, with its `updated_at` byte-identical to its `inserted_at`. By
the end of the investigation three accounts were in the same state, two of them
minutes old.

Nothing errored, no queue grew, and no alert moved. The account holds an
allocation it cannot use and silently builds against the legacy
`cache-*.tuist.dev` lane the whole time. This is the same silent-fallback shape
as the endpoint-publication bug fixed in #12960, reached by a different route.

## Root cause

Let's Encrypt refused the certificate for the instance's host under its
50-certificates-per-registered-domain weekly limit for `tuist.dev`. The ACME
order errored with `429 rateLimited`, so the ingress served its default
self-signed certificate.

Everything in front of that looked healthy, which is what made it invisible:

| Layer | State |
| --- | --- |
| KuraInstance CR | `Ready`, 2/2 replicas on the desired image |
| DNS | resolves to the same ingress IP as healthy peers |
| `curl /up` | `http=000 tls=20`, a certificate verification failure |
| Served certificate | `CN=Kubernetes Ingress Controller Fake Certificate` |
| ACME order | `errored`, 429 rate limited |

`Kura.activate_server/2` gates on the public endpoint answering `/up` over
HTTPS, so the probe failed TLS verification on every reconciler tick.
`Tuist.Kura.Reconciler` treats that as a benign startup wait: it logs at info
and returns `:ok` without writing anything. For a cold start there is no
replication source either, so not even `:replicating` was recorded.

That is why the row was never touched. The reconciler was **not** filtering it
out and it was not slow progress; the row was processed on all ~180 passes and
the code deliberately wrote nothing each time. The frozen `updated_at` is the
signature of the silent branch, not of a skipped row. Worth stating explicitly
because the obvious hypotheses are all wrong here: `create_server_transaction`
inserts the server and its deployment atomically so an orphaned row is
impossible, and the CR being `Ready` rules out both admission refusal and a
resource that was never created.

The rate limit is domain-wide, so it strands every newly provisioned tenant at
once. 40 Kura certificates had been issued inside the 168h window while the
fleet grew from roughly 23 to 64 tenants.

## What changed

**A stalled provision now reaches a terminal state.** Past 15 minutes the wait
is recorded instead of swallowed: the server goes `:failed`, which the dashboard
renders as a failure with a Retry rather than an endless "Deploying", and the
reason reaches Sentry as `Kura provisioning stalled` with the region and the
failure kind. Only the first crossing reports, so a stall does not rewrite the
row every tick for as long as it lasts.

**The clock is the open deployment's `inserted_at`, not the server's
`updated_at`.** A stalled server is precisely one nothing writes to, so its own
timestamp cannot say how long the attempt has run. Exactly one deployment is
open per server (`ensure_no_open_deployment/1`), it is inserted when the attempt
starts (a first provision and a cold return out of `:archived` both go through
`insert_initial_deployment/3`), and it closes when the server activates. That
makes it the one clock measuring the attempt itself.

**The deployment is deliberately left open.** `:failed` is a projection in this
loop, not a terminal sink, so the fast path keeps probing every tick and the
instance still activates on its own the moment its endpoint comes up, with no
operator retry. Marking the deployment failed as well would have closed the fast
path and pushed recovery onto the slower projection pass for no benefit.

**A catch-up behind the backfill gate is left alone.** It has a peer feeding it
and a size that justifies a long wait, so escalating it would fire on healthy
replication. The new gauge still reports it if it never finishes.

Adds `tuist_kura_lifecycle_stalled_instances_count`, the subset of
`unroutable_instances` that is actually wrong. Unroutable counts every instance
still starting, so it is only readable as how long a count persisted; this one
is zero on a healthy fleet, which is what makes it alertable on its value.

## Alerting

The alert this class needed was already written up in `alerts.md` and had never
been created in Grafana. That is why nothing fired. It now exists as rule
`dfxnedzs40i68f` in folder `Alerts`, group `Cache`, and was verified evaluating
against the live incident: the two affected regions went `Pending`, the two
healthy regions stayed `Normal`.

The documented expression was also wrong. It used `sum`, which for a PromEx
polling gauge that every web replica reports identically returns the true count
multiplied by the replica count, because Adaptive Metrics has aggregated
`instance` and `pod` away. Measured against a Postgres ground truth of two stuck
instances in one region and one in another:

| query | region A | region B |
| --- | --- | --- |
| `sum by (region)` | 10 | 5 |
| `max by (region)` | 2 | 1 |
| Postgres | 2 | 1 |

`max` is exact, and `region` and `cluster` both survive the aggregation, so the
rule reports per region. No Grafana Cloud change is needed: the aggregation keeps
a max variant and rewrites the query onto it. An earlier revision of this branch
claimed the opposite, that `max` could not repair a pre-summed series and the
metric had to be excluded from aggregation; that was wrong and is corrected in
the same file. What does hold is that nothing in `values.yaml` is involved, since
its drop rules are anchored on `_bucket` and its labeldrop list has no `pod`.

## Impact

A provisioning failure of any kind (certificate, DNS, node-port chain) now
becomes visible within 15 minutes in Sentry and on the instance's own row,
instead of being indistinguishable from a thirty-second-old provision. Healthy
provisioning is untouched: nothing changes below the threshold, and the "keeps
waiting" behaviour is covered by a test.

## Follow-ups, not in this PR

- The durable infrastructure fix is a wildcard certificate for
  `*.kura.tuist.dev`, which removes per-tenant issuance and therefore the rate
  limit entirely. Tracked separately.
- The companion rule on `tuist_kura_lifecycle_stalled_instances_count` is
  documented but intentionally not deployed, because the metric ships with this
  PR and the rule would otherwise evaluate No Data and page on creation. Create
  it once a release carrying the metric is in production and record its uid in
  `alerts.md`.

### How to test locally

```bash
mise run install
mix test test/tuist/kura/ test/tuist/kura_test.exs
```

857 tests pass. The four new reconciler tests were verified red before green by
neutering `stalled?/1` to always return `false`: exactly the three escalation
tests failed, and the "keeps waiting while the attempt is younger than the stall
threshold" test kept passing, which is the one asserting preserved behaviour.

The stall path is driven by stubbing `Provisioner.public_url/2` to an `https`
host and `Req.get/2` to an error, which is the shape of an instance whose
certificate was never issued: the workload is up and the ingress serves
something the probe rejects.
