### PR TITLE
fix(server): isolate Kura telemetry assertions from concurrently running tests

### DIFF
--- a/server/test/AGENTS.md
+++ b/server/test/AGENTS.md
@@ -8,6 +8,7 @@ This directory contains ExUnit tests for the Tuist Server.
 - Audit-event assertions should compare contents without assuming chronological order from second-precision timestamps or UUIDv7 IDs generated in the same millisecond.
 - Never modify System environment variables in tests (shared state).
 - Use mocks/stubs/DI for environment-dependent behavior.
+- Telemetry handlers are global: `:telemetry_test.attach_event_handlers/2` also delivers an event a concurrently running test emitted, tagged with this test's own ref. Use `TuistTestSupport.TelemetryCapture.attach_event_handlers/1`, which forwards only what the attaching process emits.
 
 ## Related Context
 - Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/test/support/tuist_test_support/telemetry_capture.ex
+++ b/server/test/support/tuist_test_support/telemetry_capture.ex
@@ -1,0 +1,40 @@
+defmodule TuistTestSupport.TelemetryCapture do
+  @moduledoc """
+  `:telemetry_test.attach_event_handlers/2` narrowed to the events the calling
+  test emits itself.
+
+  Telemetry handlers are global and the suite runs its async files
+  concurrently, so a handler one test attaches also fires for the same event
+  emitted by any other test running beside it. The message carries the
+  attaching test's own ref either way, because the ref identifies the handler
+  rather than the emitter, so pinning it does not tell the two apart: a test
+  that refutes an event fails on another test's, and a test that asserts one
+  can pass on it.
+
+  Handlers run in the process that called `:telemetry.execute/3`, which is the
+  one thing that does separate them. Only events emitted from the attaching
+  process are forwarded, so an event emitted by a task or a worker the test
+  starts is dropped, and a test that needs one of those wants
+  `:telemetry_test.attach_event_handlers/2` and metadata narrow enough to
+  identify itself.
+  """
+
+  def attach_event_handlers(event_names) when is_list(event_names) do
+    ref = make_ref()
+
+    :telemetry.attach_many(ref, event_names, &__MODULE__.handle_event/4, %{emitter: self(), ref: ref})
+
+    ExUnit.Callbacks.on_exit(fn -> :telemetry.detach(ref) end)
+
+    ref
+  end
+
+  @doc false
+  def handle_event(event_name, measurements, metadata, %{emitter: emitter, ref: ref}) do
+    if self() == emitter do
+      send(emitter, {event_name, ref, measurements, metadata})
+    end
+
+    :ok
+  end
+end

--- a/server/test/tuist/kura/account_policies_test.exs
+++ b/server/test/tuist/kura/account_policies_test.exs
@@ -16,6 +16,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
   alias Tuist.Repo
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.BillingFixtures
+  alias TuistTestSupport.TelemetryCapture
 
   setup :set_mimic_from_context
 
@@ -765,7 +766,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       serving(["us-east", "us-west", "eu-central"])
       seed_origin(account, "US-VA")
       room(%{"us-east" => false, "us-west" => true})
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       assert AccountPolicies.resolve(account) == {:ok, %{plan: :enterprise, service_region: "us-west"}}
 
@@ -804,7 +805,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       serving(["us-east", "us-west", "eu-central"])
       seed_origin(account, "US-VA")
       room(%{"us-east" => false, "us-west" => false, "eu-central" => true})
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       assert AccountPolicies.resolve(account) == {:ok, %{plan: :enterprise, service_region: "us-east"}}
 
@@ -834,7 +835,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       BillingFixtures.subscription_fixture(account_id: account.id, plan: :pro)
       serving(["us-east", "us-west", "eu-central"])
       room(%{"us-east" => false, "us-west" => true, "eu-central" => true})
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       assert AccountPolicies.resolve(account) == {:ok, %{plan: :pro, service_region: "us-west"}}
 
@@ -856,7 +857,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       BillingFixtures.subscription_fixture(account_id: account.id, plan: :pro)
       serving(["us-east", "us-west", "eu-central"])
       seed_origin(account, "US-VA")
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       # The other node records eu-central while this one is still reading room.
       room(%{"us-east" => false, "us-west" => true, "eu-central" => true},
@@ -883,7 +884,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       serving(["us-east", "us-west", "eu-central"])
       seed_origin(account, "US-VA")
       room(%{"us-east" => false, "us-west" => true})
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       assert AccountPolicies.resolve(account) == {:ok, %{plan: :pro, service_region: "us-west"}}
 
@@ -918,7 +919,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       serving(["us-east", "us-west"])
       seed_origin(account, "US-VA")
       unreadable_cluster()
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       assert AccountPolicies.resolve(account) == {:ok, %{plan: :enterprise, service_region: "us-east"}}
 
@@ -943,7 +944,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       live_instance(account, "us-east")
       seed_origin(account, "US-VA")
       room(%{"us-east" => false, "us-west" => true})
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       assert AccountPolicies.resolve(account) == {:ok, %{plan: :enterprise, service_region: "us-east"}}
 
@@ -1039,7 +1040,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       BillingFixtures.subscription_fixture(account_id: account.id, plan: :open_source)
 
       event_ref =
-        :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_resolution_refused()])
+        TelemetryCapture.attach_event_handlers([Telemetry.event_name_resolution_refused()])
 
       assert AccountPolicies.resolve(account) == {:error, :plan_not_supported}
 
@@ -1053,7 +1054,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       deploy_regions(["us-east"])
 
       event_ref =
-        :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_resolution_refused()])
+        TelemetryCapture.attach_event_handlers([Telemetry.event_name_resolution_refused()])
 
       assert AccountPolicies.resolve(account) == {:error, :service_region_unavailable}
 
@@ -1071,7 +1072,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       accounts = Enum.map([first, second], &Repo.preload(&1, :subscriptions))
 
       event_ref =
-        :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_resolution_refused()])
+        TelemetryCapture.attach_event_handlers([Telemetry.event_name_resolution_refused()])
 
       AccountPolicies.resolve_all(accounts)
 
@@ -1085,14 +1086,13 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       account = organization_account()
 
       event_ref =
-        :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_resolution_refused()])
+        TelemetryCapture.attach_event_handlers([Telemetry.event_name_resolution_refused()])
 
       assert {:ok, %{plan: :air}} = AccountPolicies.resolve(account)
 
-      # `refute_received` rather than `refute_receive`: the handler is global,
-      # so its 100ms wait is a window for any async test file that refuses a
-      # resolution to deliver into this mailbox. `resolve/1` emits
-      # synchronously, so an event from this call is already here.
+      # `refute_received` rather than `refute_receive`: `resolve/1` emits
+      # synchronously, so an event from this call is already in the mailbox
+      # and the 100ms wait would buy nothing.
       refute_received {_event_name, ^event_ref, _measurements, _metadata}
     end
   end

--- a/server/test/tuist_test_support/telemetry_capture_test.exs
+++ b/server/test/tuist_test_support/telemetry_capture_test.exs
@@ -1,0 +1,42 @@
+defmodule TuistTestSupport.TelemetryCaptureTest do
+  use ExUnit.Case, async: true
+
+  alias TuistTestSupport.TelemetryCapture
+
+  @event [:tuist_test_support, :telemetry_capture_test, :event]
+
+  test "forwards an event the attaching process emits" do
+    event_ref = TelemetryCapture.attach_event_handlers([@event])
+
+    :telemetry.execute(@event, %{count: 1}, %{source: "self"})
+
+    assert_received {@event, ^event_ref, %{count: 1}, %{source: "self"}}
+  end
+
+  test "drops an event another process emits" do
+    event_ref = TelemetryCapture.attach_event_handlers([@event])
+
+    emit_from_another_process(%{source: "elsewhere"})
+
+    refute_received {@event, ^event_ref, _measurements, _metadata}
+  end
+
+  test "drops the event a global handler delivers under this test's own ref" do
+    # What `:telemetry_test.attach_event_handlers/2` does with the same event,
+    # stated so the difference is visible: the ref identifies the handler, so a
+    # concurrent emitter's event arrives carrying this process's own ref.
+    global_ref = :telemetry_test.attach_event_handlers(self(), [@event])
+    on_exit(fn -> :telemetry.detach(global_ref) end)
+    scoped_ref = TelemetryCapture.attach_event_handlers([@event])
+
+    emit_from_another_process(%{source: "elsewhere"})
+
+    assert_receive {@event, ^global_ref, _measurements, %{source: "elsewhere"}}
+    refute_received {@event, ^scoped_ref, _measurements, _metadata}
+  end
+
+  defp emit_from_another_process(metadata) do
+    task = Task.async(fn -> :telemetry.execute(@event, %{count: 1}, metadata) end)
+    Task.await(task)
+  end
+end


### PR DESCRIPTION
## What changed

`server/test/tuist/kura/account_policies_test.exs` no longer attaches global telemetry handlers. All eleven `:telemetry_test.attach_event_handlers/2` call sites now use a new `TuistTestSupport.TelemetryCapture.attach_event_handlers/1`, which forwards only the events the attaching process emits and detaches on exit.

## Why

`test/tuist/kura/account_policies_test.exs:1084` ("leaves a resolved account uncounted") fails intermittently in CI on unrelated pull requests, most recently on [#13003](https://github.com/tuist/tuist/pull/13003) (run 34250993484):

```
Unexpectedly received message {[:tuist, :kura, :lifecycle, :resolution_refused], #Reference<...>, %{count: 1}, %{reason: "service_region_unavailable", plan: "enterprise"}}
code: refute_received {_event_name, ^event_ref, _measurements, _metadata}
```

## Root cause

`:telemetry_test.attach_event_handlers/2` attaches a handler on the global telemetry bus, and ExUnit runs async files concurrently. Any other test that emits the same event delivers it into this test's mailbox, tagged with this test's own `event_ref`, because the ref identifies the handler rather than the emitter. Pinning `^event_ref` therefore does not isolate the test. The leaked event in the CI failure carries `plan: "enterprise"`, while the test's own account resolves as `:air`, so it cannot have come from the `resolve/1` call under test.

The existing `refute_received` (rather than `refute_receive`) narrowed the window to the gap between attach and assertion, but did not close it.

## Why this fix over the alternatives

Two other fixes were considered and rejected:

- Tagging the refusal event with the account id and refuting only this account's events. `Tuist.Kura.Telemetry`'s moduledoc states the contract this would break: `plan` and `reason` are tagged because they are bounded, and "Account is never a tag." A per-account tag puts unbounded cardinality into a metrics series.
- Filtering the assertion on `plan: "air"`. That narrows the leak rather than removing it: a concurrent test refusing an Air account still lands.

Telemetry handlers run in the process that called `:telemetry.execute/3`, so the emitting process is the one thing that does separate a foreign event from this test's own. `TelemetryCapture` filters on it. `async: false` was not used: ExUnit runs sync tests after async ones but does not stop async files from emitting during the transition, and it would cost the whole file's parallelism to fix an assertion problem.

## Scope: seven assertions, not one

The reported failure was one of seven exposed assertions in the file. The `placement by capacity` describe block has six more `refute_receive`s on `placement_capacity_spill`, each holding a 100ms window on a global handler. Under a concurrent emitter of that event, all six fail. All eleven call sites in the file were converted.

## Validation

A temporary `async: true` file emitting `resolution_refused(:enterprise, :service_region_unavailable)` in a loop for the duration of the suite reproduces the CI failure exactly, byte for byte including the metadata:

- With `:telemetry_test`, `mix test test/tuist/kura/`: 763/764, failing on `leaves a resolved account uncounted` with the message quoted above.
- Extending the pressure file to `placement_capacity_spill` and reverting the seven placement call sites: 758/764, failing on all six `refute_receive` tests.
- With `TelemetryCapture` and both events under pressure: 764 passed.
- Kura suite plus the new helper tests, three runs: 766 passed each.
- `mix test test/tuist/ test/tuist_test_support/`, three runs: 5876 passed each.
- `mix format`, `mix credo`: clean.

`test/tuist_test_support/telemetry_capture_test.exs` covers the helper itself, including a test that emits from another process through a global handler and a scoped one at once and asserts only the global one delivers.

## Impact

Developer-facing only. No production code changes. `server/test/AGENTS.md` records the rule so new telemetry assertions do not reintroduce it.

Note: `server/test/tuist/storage_test.exs:680` has the same latent flake and is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)