### PR TITLE
fix(infra): disable the Vultr image's host firewall during conversion

### DIFF
--- a/infra/cluster-api-provider-tuist/controllers/linux/vultr_convert.sh
+++ b/infra/cluster-api-provider-tuist/controllers/linux/vultr_convert.sh
@@ -7,6 +7,25 @@ set -euo pipefail
 
 log() { echo "prep-vultr: $*"; }
 
+# The Vultr image ships ufw enabled and default-deny; the OVH and Dedibox images
+# ship no host firewall at all. It admits only SSH, so the box joins and reports
+# Ready -- the kubelet's outbound path to the apiserver is untouched -- while
+# every pod on it is cut off: Cilium's VXLAN (8472/udp) and health probes
+# (4240/tcp) are dropped on arrival from the other nodes, and the apiserver
+# cannot reach the kubelet on 10250 for logs, exec or metrics. Cilium already
+# programs this node's iptables, so a second filtering layer it does not know
+# about turns every future cluster port into a Vultr-only outage. Runs ahead of
+# the conversion so a box that fails the disk gates still ends up reachable.
+if command -v ufw >/dev/null 2>&1; then
+  if ufw status | grep '^Status: active' >/dev/null; then
+    ufw disable >/dev/null
+    log "disabled ufw"
+  else
+    log "ufw already inactive"
+  fi
+  ufw status | grep '^Status: inactive' >/dev/null || { log "ufw is still active"; exit 1; }
+fi
+
 # An existing /data is not proof of a good /data: one that is ext4, or mounted
 # without project quotas, would leave every cache volume unbounded. So skip the
 # conversion but always fall through to the gates below, which decide.


### PR DESCRIPTION
## What changed

`vultr_convert.sh` now disables `ufw` before it touches the disk. The check is idempotent, is a no-op where `ufw` is not installed, and fails the run if the firewall is still active afterwards, matching how the rest of the script verifies rather than assumes.

It runs ahead of the conversion deliberately: the conversion has several `exit 1` paths, and a box that fails a disk gate should still end up reachable so the failure can be diagnosed over the cluster rather than only over SSH.

Both callers pick this up from the one file. The reconciler embeds it with `go:embed` as its `Converting` stage, and `mise run baremetal:prep-vultr` ships the same bytes, so out-of-band prep and the controller cannot drift.

## Why

The Vultr image ships `ufw` enabled and default-deny. The OVH and Dedibox images ship no host firewall at all, so nothing in the fleet bootstrap expected one.

Its only rule is `22/tcp ALLOW`. That is enough for the node to look completely healthy: the kubelet's outbound path to the apiserver is unaffected, so it joins, passes its gates, gets adopted by CAPI, and reports `Ready`. Meanwhile every pod on it is severed from the cluster. The kernel log on `sa-west` showed the drops arriving from the control plane and from the other fleet nodes:

- `8472/udp`, Cilium's VXLAN overlay
- `4240/tcp`, Cilium health probes
- `10250/tcp`, the kubelet API, so no logs, exec or metrics for the node

The packets reach the host before `ufw` drops them, so the provider network is not involved and there is nothing to change on the Vultr side.

## Root cause

A `Ready` node whose pod network is dead is the worst shape this can fail in, because the scheduler will place Kura pods on it. On `sa-west` the visible symptom was three DaemonSets in `CrashLoopBackOff` (`alloy-logs`, `alloy-metrics`, `hcloud-csi-node`) while the node itself reported healthy.

The failure did not look like a firewall at first. `alloy` was not failing on the kubelet port at all, it died on `Get https://10.128.0.1:443/.../secrets/k8s-monitoring-grafana-cloud: context deadline exceeded`. The same request from the host's own network namespace returns `200`. Host netns fine, overlay dead, which is what pinned it to the tunnel ports rather than to anything about the workload.

This is also why it is not the known three-layer fleet kubelet problem documented in the provider's runbook. That one presents as `tls: internal error` or `401`; this presents as `i/o timeout`, because the packets are dropped rather than rejected.

## Why disable rather than allow the ports

Opening `8472/udp`, `4240/tcp` and `10250/tcp` would fix today's symptom and leave the mechanism in place. Cilium already programs this node's iptables, and a second filtering layer it does not know about turns every future cluster port into a failure that appears only on Vultr and only as a timeout. The rest of the fleet runs no host firewall, so neither should this. Uniformity across the fleet is worth more here than a redundant layer that has now cost one outage.

## Impact

New Vultr boxes get a working pod network at bootstrap. Without this, any box added to the fleet joins in the same broken state and looks healthy while doing it.

## Validation

Applied to the live `sa-west` node by re-running `mise run baremetal:prep-vultr`, which is the same bytes the reconciler runs:

```
prep-vultr: disabled ufw
prep-vultr: /data already mounted from /dev/nvme0n1p2 (xfs); skipping the conversion
prep-vultr: RESULT device=/dev/nvme0n1p2 fstype=xfs quota=true size=894G
prep-vultr: all four gates pass
```

After that, on the previously severed node:

- `10250` reachable, and `kubectl logs` against a pod on the node returns output where it previously returned `i/o timeout`
- `kubectl top node` reports `124m CPU / 745Mi`, previously unavailable
- all three crash-looping DaemonSets recovered without intervention: `alloy-logs` 2/2, `alloy-metrics` 2/2, `hcloud-csi-node` 3/3
- the `/data` gates still pass, so the conversion result is unchanged

`bash -n` clean. The disk conversion path is untouched.