### PR TITLE
fix(server): scope the storage multipart telemetry refutation to its own emitter

### DIFF
--- a/server/test/AGENTS.md
+++ b/server/test/AGENTS.md
@@ -8,6 +8,7 @@ This directory contains ExUnit tests for the Tuist Server.
 - Audit-event assertions should compare contents without assuming chronological order from second-precision timestamps or UUIDv7 IDs generated in the same millisecond.
 - Never modify System environment variables in tests (shared state).
 - Use mocks/stubs/DI for environment-dependent behavior.
+- Telemetry handlers are global: `:telemetry_test.attach_event_handlers/2` also delivers an event a concurrently running test emitted, tagged with this test's own ref. Use `TuistTestSupport.TelemetryCapture.attach_event_handlers/1`, which forwards only what the attaching process emits.
 
 ## Related Context
 - Business logic: `server/lib/tuist/AGENTS.md`

--- a/server/test/support/tuist_test_support/telemetry_capture.ex
+++ b/server/test/support/tuist_test_support/telemetry_capture.ex
@@ -1,0 +1,40 @@
+defmodule TuistTestSupport.TelemetryCapture do
+  @moduledoc """
+  `:telemetry_test.attach_event_handlers/2` narrowed to the events the calling
+  test emits itself.
+
+  Telemetry handlers are global and the suite runs its async files
+  concurrently, so a handler one test attaches also fires for the same event
+  emitted by any other test running beside it. The message carries the
+  attaching test's own ref either way, because the ref identifies the handler
+  rather than the emitter, so pinning it does not tell the two apart: a test
+  that refutes an event fails on another test's, and a test that asserts one
+  can pass on it.
+
+  Handlers run in the process that called `:telemetry.execute/3`, which is the
+  one thing that does separate them. Only events emitted from the attaching
+  process are forwarded, so an event emitted by a task or a worker the test
+  starts is dropped, and a test that needs one of those wants
+  `:telemetry_test.attach_event_handlers/2` and metadata narrow enough to
+  identify itself.
+  """
+
+  def attach_event_handlers(event_names) when is_list(event_names) do
+    ref = make_ref()
+
+    :telemetry.attach_many(ref, event_names, &__MODULE__.handle_event/4, %{emitter: self(), ref: ref})
+
+    ExUnit.Callbacks.on_exit(fn -> :telemetry.detach(ref) end)
+
+    ref
+  end
+
+  @doc false
+  def handle_event(event_name, measurements, metadata, %{emitter: emitter, ref: ref}) do
+    if self() == emitter do
+      send(emitter, {event_name, ref, measurements, metadata})
+    end
+
+    :ok
+  end
+end

--- a/server/test/tuist/kura/account_policies_test.exs
+++ b/server/test/tuist/kura/account_policies_test.exs
@@ -16,6 +16,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
   alias Tuist.Repo
   alias TuistTestSupport.Fixtures.AccountsFixtures
   alias TuistTestSupport.Fixtures.BillingFixtures
+  alias TuistTestSupport.TelemetryCapture
 
   setup :set_mimic_from_context
 
@@ -765,7 +766,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       serving(["us-east", "us-west", "eu-central"])
       seed_origin(account, "US-VA")
       room(%{"us-east" => false, "us-west" => true})
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       assert AccountPolicies.resolve(account) == {:ok, %{plan: :enterprise, service_region: "us-west"}}
 
@@ -804,7 +805,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       serving(["us-east", "us-west", "eu-central"])
       seed_origin(account, "US-VA")
       room(%{"us-east" => false, "us-west" => false, "eu-central" => true})
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       assert AccountPolicies.resolve(account) == {:ok, %{plan: :enterprise, service_region: "us-east"}}
 
@@ -834,7 +835,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       BillingFixtures.subscription_fixture(account_id: account.id, plan: :pro)
       serving(["us-east", "us-west", "eu-central"])
       room(%{"us-east" => false, "us-west" => true, "eu-central" => true})
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       assert AccountPolicies.resolve(account) == {:ok, %{plan: :pro, service_region: "us-west"}}
 
@@ -856,7 +857,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       BillingFixtures.subscription_fixture(account_id: account.id, plan: :pro)
       serving(["us-east", "us-west", "eu-central"])
       seed_origin(account, "US-VA")
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       # The other node records eu-central while this one is still reading room.
       room(%{"us-east" => false, "us-west" => true, "eu-central" => true},
@@ -883,7 +884,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       serving(["us-east", "us-west", "eu-central"])
       seed_origin(account, "US-VA")
       room(%{"us-east" => false, "us-west" => true})
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       assert AccountPolicies.resolve(account) == {:ok, %{plan: :pro, service_region: "us-west"}}
 
@@ -918,7 +919,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       serving(["us-east", "us-west"])
       seed_origin(account, "US-VA")
       unreadable_cluster()
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       assert AccountPolicies.resolve(account) == {:ok, %{plan: :enterprise, service_region: "us-east"}}
 
@@ -943,7 +944,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       live_instance(account, "us-east")
       seed_origin(account, "US-VA")
       room(%{"us-east" => false, "us-west" => true})
-      event_ref = :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_placement_capacity_spill()])
+      event_ref = TelemetryCapture.attach_event_handlers([Telemetry.event_name_placement_capacity_spill()])
 
       assert AccountPolicies.resolve(account) == {:ok, %{plan: :enterprise, service_region: "us-east"}}
 
@@ -1039,7 +1040,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       BillingFixtures.subscription_fixture(account_id: account.id, plan: :open_source)
 
       event_ref =
-        :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_resolution_refused()])
+        TelemetryCapture.attach_event_handlers([Telemetry.event_name_resolution_refused()])
 
       assert AccountPolicies.resolve(account) == {:error, :plan_not_supported}
 
@@ -1053,7 +1054,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       deploy_regions(["us-east"])
 
       event_ref =
-        :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_resolution_refused()])
+        TelemetryCapture.attach_event_handlers([Telemetry.event_name_resolution_refused()])
 
       assert AccountPolicies.resolve(account) == {:error, :service_region_unavailable}
 
@@ -1071,7 +1072,7 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       accounts = Enum.map([first, second], &Repo.preload(&1, :subscriptions))
 
       event_ref =
-        :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_resolution_refused()])
+        TelemetryCapture.attach_event_handlers([Telemetry.event_name_resolution_refused()])
 
       AccountPolicies.resolve_all(accounts)
 
@@ -1085,14 +1086,13 @@ defmodule Tuist.Kura.AccountPoliciesTest do
       account = organization_account()
 
       event_ref =
-        :telemetry_test.attach_event_handlers(self(), [Telemetry.event_name_resolution_refused()])
+        TelemetryCapture.attach_event_handlers([Telemetry.event_name_resolution_refused()])
 
       assert {:ok, %{plan: :air}} = AccountPolicies.resolve(account)
 
-      # `refute_received` rather than `refute_receive`: the handler is global,
-      # so its 100ms wait is a window for any async test file that refuses a
-      # resolution to deliver into this mailbox. `resolve/1` emits
-      # synchronously, so an event from this call is already here.
+      # `refute_received` rather than `refute_receive`: `resolve/1` emits
+      # synchronously, so an event from this call is already in the mailbox
+      # and the 100ms wait would buy nothing.
       refute_received {_event_name, ^event_ref, _measurements, _metadata}
     end
   end

--- a/server/test/tuist/storage_test.exs
+++ b/server/test/tuist/storage_test.exs
@@ -8,6 +8,7 @@ defmodule Tuist.StorageTest do
   alias Tuist.Environment
   alias Tuist.Storage
   alias Tuist.Storage.AzureBlob
+  alias TuistTestSupport.TelemetryCapture
 
   setup do
     # Mock ExAws.Config.new to return a proper config that won't try to access instance metadata
@@ -647,7 +648,7 @@ defmodule Tuist.StorageTest do
     test "returns an error and reports it when the object storage rejects the request" do
       # Given
       event_name = Tuist.Telemetry.event_name_storage_multipart_start_upload()
-      event_ref = :telemetry_test.attach_event_handlers(self(), [event_name])
+      event_ref = TelemetryCapture.attach_event_handlers([event_name])
 
       object_key = UUIDv7.generate()
       bucket_name = UUIDv7.generate()

--- a/server/test/tuist_test_support/telemetry_capture_test.exs
+++ b/server/test/tuist_test_support/telemetry_capture_test.exs
@@ -1,0 +1,42 @@
+defmodule TuistTestSupport.TelemetryCaptureTest do
+  use ExUnit.Case, async: true
+
+  alias TuistTestSupport.TelemetryCapture
+
+  @event [:tuist_test_support, :telemetry_capture_test, :event]
+
+  test "forwards an event the attaching process emits" do
+    event_ref = TelemetryCapture.attach_event_handlers([@event])
+
+    :telemetry.execute(@event, %{count: 1}, %{source: "self"})
+
+    assert_received {@event, ^event_ref, %{count: 1}, %{source: "self"}}
+  end
+
+  test "drops an event another process emits" do
+    event_ref = TelemetryCapture.attach_event_handlers([@event])
+
+    emit_from_another_process(%{source: "elsewhere"})
+
+    refute_received {@event, ^event_ref, _measurements, _metadata}
+  end
+
+  test "drops the event a global handler delivers under this test's own ref" do
+    # What `:telemetry_test.attach_event_handlers/2` does with the same event,
+    # stated so the difference is visible: the ref identifies the handler, so a
+    # concurrent emitter's event arrives carrying this process's own ref.
+    global_ref = :telemetry_test.attach_event_handlers(self(), [@event])
+    on_exit(fn -> :telemetry.detach(global_ref) end)
+    scoped_ref = TelemetryCapture.attach_event_handlers([@event])
+
+    emit_from_another_process(%{source: "elsewhere"})
+
+    assert_receive {@event, ^global_ref, _measurements, %{source: "elsewhere"}}
+    refute_received {@event, ^scoped_ref, _measurements, _metadata}
+  end
+
+  defp emit_from_another_process(metadata) do
+    task = Task.async(fn -> :telemetry.execute(@event, %{count: 1}, metadata) end)
+    Task.await(task)
+  end
+end


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #13009, which this branch is based on. Its commit is included in the diff below and will disappear once #13009 merges. **Merge #13009 first.** `TuistTestSupport.TelemetryCapture` does not exist on `main` yet, so this change cannot compile without it.

## Purpose

`server/test/tuist/storage_test.exs:680` refutes a `storage.multipart.start_upload` telemetry event on a handler attached with `:telemetry_test.attach_event_handlers/2`. That handler is global and forwards an event to the attaching test whichever process emitted it. The ref the message carries identifies the handler rather than the emitter, so pinning it does not tell a foreign emission apart from the test's own.

This swaps that one call site to `TuistTestSupport.TelemetryCapture.attach_event_handlers/1`, which forwards only the events the attaching process emits.

## Why the reasoning here differs from #13009

This started from the assumption that `storage_test.exs` carried the same exposure as `account_policies_test.exs`. It does not, and the difference is worth recording, because it changes what this fix is actually for.

`account_policies_test.exs` is `async: true`. `storage_test.exs` is `async: false`. ExUnit drains every async module before it starts a sync one and then runs sync modules one at a time (`ExUnit.Runner.async_loop/4`, the `# Wait for all async modules` branch that asserts `0 = ... map_size()`). **No concurrently running test can reach this file.**

The verification confirms it. A temporary `async: true` file emitting the event in a loop for 20s, run beside `storage_test.exs` against the unchanged code, passes:

```
Finished in 20.6 seconds (20.0s async, 0.6s sync)
Result: 53 passed
```

The `20.0s async` / `0.6s sync` split is the proof: the pressure loop finished in the async phase, then `storage_test.exs` ran alone. They never overlapped.

What *can* overlap a sync file is any process other than the test emitting while the test is in flight, because the handler runs in the emitting process and sends onward unconditionally. That is the exposure this closes, along with the file later being flipped to `async: true`.

## Validation

Same pressure file, but emitting from a process that outlives its own case so the emissions span the sync phase. Against the unchanged code it fails, at the line in question, on a message the test could not have produced:

```
1) test multipart_start/1 returns an error and reports it when the object storage rejects the request (Tuist.StorageTest)
   test/tuist/storage_test.exs:647
   Unexpectedly received message {[:tuist, :storage, :multipart, :start_upload], #Reference<0.3564325360.2543583233.55260>, %{duration: 1}, %{object_key: "pressure"}} (which matched {^event_name, ^event_ref, _measurements, _metadata})
   code: refute_received {^event_name, ^event_ref, _measurements, _metadata}
   stacktrace:
     test/tuist/storage_test.exs:680: (test)
```

`object_key: "pressure"` is the pressure file's, delivered under this test's own ref. With the change, five consecutive runs pass. The pressure file was temporary and is not part of this PR.

`mix format --check-formatted` and `mix credo` both pass on the changed file.

## Scope

The file's other 18 `:telemetry_test` call sites are left alone. They all assert positively, where a foreign event can only mask a failure rather than invent one, and their metadata already pins the emission to the case at hand. Converting them would be a separate, deliberate call rather than a blanket sweep.

### How to test locally

```
cd server && mix test test/tuist/storage_test.exs
```

To reproduce the leak, add an `async: true` test file that emits `Tuist.Telemetry.event_name_storage_multipart_start_upload()` from a `spawn`ed process outliving its own case, and run it alongside `test/tuist/storage_test.exs`. It fails at `storage_test.exs:680` before this change and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
