### PR TITLE
fix(server): tell a repeated module cache miss apart from a first-seen one

### DIFF
--- a/server/assets/app/css/components/widget.css
+++ b/server/assets/app/css/components/widget.css
@@ -239,6 +239,10 @@
       background-color: var(--noora-chart-tertiary);
     }
 
+    &[data-color="quaternary"] {
+      background-color: var(--noora-chart-quaternary);
+    }
+
     &[data-color="destructive"] {
       background-color: var(--noora-chart-destructive);
     }

--- a/server/lib/tuist/builds/analytics.ex
+++ b/server/lib/tuist/builds/analytics.ex
@@ -2257,9 +2257,16 @@ defmodule Tuist.Builds.Analytics do
 
   For each cacheable module (keyed by `name` + `product`) it reports how often the
   module was a cache miss ("invalidated"), how often it appeared, and — by comparing
-  each missed build to the module's previous build on the same branch — whether the
-  invalidation was caused by the module's own content changing (`self_changes`) or
-  only by one of its dependencies changing (`dependency_induced`).
+  each missed build to the module's previous build on the same branch — why it
+  missed: its own content changed (`self_changes`), only one of its dependencies
+  changed (`dependency_induced`), nothing we record changed and it missed anyway
+  (`unchanged`), or there was no previous build to compare against (`cold`).
+
+  `unchanged` is the one that says something is wrong rather than expected: the
+  module's recorded hashing inputs are byte-identical to its previous build, so
+  the cache was asked for a key it had already been asked for and had nothing to
+  return. That points at an artifact that was never stored or has been evicted,
+  or at a hashing input the CLI folds into the key but does not report.
 
   The classification window partitions by branch so a `main` build is never compared
   against a feature-branch build, regardless of the `:git_branch` filter.
@@ -2274,8 +2281,9 @@ defmodule Tuist.Builds.Analytics do
   ## Returns
     A list of maps with `:name`, `:product`, `:appearances`, `:invalidations`,
     `:invalidation_rate` and `:hit_rate` (percentages), `:self_changes`,
-    `:dependency_induced`, and `:unclassified` (misses with no comparable prior
-    build: first-seen / cold / evicted).
+    `:dependency_induced`, `:unchanged` (every recorded input matched the previous
+    build and it missed anyway) and `:cold` (no prior build on the branch within
+    the window to compare against).
   """
   def module_invalidations(opts \\ []) do
     opts
@@ -2286,7 +2294,8 @@ defmodule Tuist.Builds.Analytics do
   @doc """
   Returns, per module and day, how often it was built and why it missed:
   `appearances`, `misses`, `changed` (its own content differed from its previous
-  build) and `upstream` (only a dependency differed). One pass over the window
+  build), `upstream` (only a dependency differed) and `unchanged` (a previous
+  build exists and every recorded input matched it). One pass over the window
   that `module_invalidations/1` and `module_miss_reasons_timeseries/1` both
   derive from, so a page that needs both runs it once.
 
@@ -2319,7 +2328,10 @@ defmodule Tuist.Builds.Analytics do
       countIf(hit = 'miss' AND rn > 1 AND own != prev_own) AS changed,
       countIf(
         hit = 'miss' AND rn > 1 AND own = prev_own AND (deps != prev_deps OR ext != prev_ext)
-      ) AS upstream
+      ) AS upstream,
+      countIf(
+        hit = 'miss' AND rn > 1 AND own = prev_own AND deps = prev_deps AND ext = prev_ext
+      ) AS unchanged
     FROM (
       SELECT
         day, name, product, hit, own, deps, ext,
@@ -2356,7 +2368,7 @@ defmodule Tuist.Builds.Analytics do
 
     %{rows: rows} = ClickHouseRepo.query!(query, params)
 
-    Enum.map(rows, fn [day, name, product, appearances, misses, changed, upstream] ->
+    Enum.map(rows, fn [day, name, product, appearances, misses, changed, upstream, unchanged] ->
       %{
         day: normalize_date(day),
         name: name,
@@ -2364,7 +2376,8 @@ defmodule Tuist.Builds.Analytics do
         appearances: appearances,
         misses: misses,
         changed: changed,
-        upstream: upstream
+        upstream: upstream,
+        unchanged: unchanged
       }
     end)
   end
@@ -2384,6 +2397,7 @@ defmodule Tuist.Builds.Analytics do
       invalidations = rows |> Enum.map(& &1.misses) |> Enum.sum()
       self_changes = rows |> Enum.map(& &1.changed) |> Enum.sum()
       dependency_induced = rows |> Enum.map(& &1.upstream) |> Enum.sum()
+      unchanged = rows |> Enum.map(& &1.unchanged) |> Enum.sum()
 
       %{
         name: name,
@@ -2394,7 +2408,8 @@ defmodule Tuist.Builds.Analytics do
         hit_rate: percentage(appearances - invalidations, appearances),
         self_changes: self_changes,
         dependency_induced: dependency_induced,
-        unclassified: max(invalidations - (self_changes + dependency_induced), 0),
+        unchanged: unchanged,
+        cold: max(invalidations - (self_changes + dependency_induced + unchanged), 0),
         # nil when the latest graph carries no dependency edges (older CLI);
         # an integer (0 for a leaf) once edges are present.
         blast_radius: Map.get(radii, name)
@@ -2422,7 +2437,15 @@ defmodule Tuist.Builds.Analytics do
         misses = rows |> Enum.map(& &1.misses) |> Enum.sum()
         changed = rows |> Enum.map(& &1.changed) |> Enum.sum()
         upstream = rows |> Enum.map(& &1.upstream) |> Enum.sum()
-        {day, %{changed: changed, upstream: upstream, cold: max(misses - changed - upstream, 0)}}
+        unchanged = rows |> Enum.map(& &1.unchanged) |> Enum.sum()
+
+        {day,
+         %{
+           changed: changed,
+           upstream: upstream,
+           unchanged: unchanged,
+           cold: max(misses - changed - upstream - unchanged, 0)
+         }}
       end)
 
     dates =
@@ -2435,6 +2458,7 @@ defmodule Tuist.Builds.Analytics do
       dates: Enum.map(dates, &Date.to_iso8601/1),
       changed: Enum.map(dates, fn d -> get_in(by_day, [d, :changed]) || 0 end),
       upstream: Enum.map(dates, fn d -> get_in(by_day, [d, :upstream]) || 0 end),
+      unchanged: Enum.map(dates, fn d -> get_in(by_day, [d, :unchanged]) || 0 end),
       cold: Enum.map(dates, fn d -> get_in(by_day, [d, :cold]) || 0 end)
     }
   end
@@ -2596,7 +2620,8 @@ defmodule Tuist.Builds.Analytics do
     * `:is_ci` - When set, restricts to CI (`true`) or local (`false`) runs
     * `:git_branch` - When set, restricts to a single branch
     * `:commit_sha` - When set, matches commit shas starting with it
-    * `:reason` - When set, restricts to `"hit"`, `"changed"`, `"upstream"` or `"cold"`
+    * `:reason` - When set, restricts to `"hit"`, `"changed"`, `"upstream"`,
+      `"unchanged"` or `"cold"`
     * `:order` - `"desc"` (default, newest first) or `"asc"`
     * `:limit` - Rows per page (default 25)
 
@@ -2605,7 +2630,7 @@ defmodule Tuist.Builds.Analytics do
     start_cursor: binary | nil, end_cursor: binary | nil}`, where each row has
     `:id` (the command event), `:scheme`, `:ran_at`, `:branch`, `:commit_sha`,
     `:hit` (`"miss"`, `"local"` or `"remote"`) and `:reason` (`"hit"`,
-    `"changed"`, `"upstream"` or `"cold"`).
+    `"changed"`, `"upstream"`, `"unchanged"` or `"cold"`).
 
     `:scheme` comes from the build run the command event belongs to and is
     empty for the commands that produce no activity log, such as `generate` and
@@ -2657,7 +2682,7 @@ defmodule Tuist.Builds.Analytics do
           rn = 1, 'cold',
           own != prev_own, 'changed',
           deps != prev_deps OR ext != prev_ext, 'upstream',
-          'cold'
+          'unchanged'
         ) AS reason
       FROM (
         SELECT
@@ -2738,8 +2763,11 @@ defmodule Tuist.Builds.Analytics do
 
   defp build_history_reason_filter(opts) do
     case Keyword.get(opts, :reason) do
-      reason when reason in ~w(hit changed upstream cold) -> {"reason = {reason:String}", %{reason: reason}}
-      _ -> {"", %{}}
+      reason when reason in ~w(hit changed upstream unchanged cold) ->
+        {"reason = {reason:String}", %{reason: reason}}
+
+      _ ->
+        {"", %{}}
     end
   end
 
@@ -3061,8 +3089,10 @@ defmodule Tuist.Builds.Analytics do
 
   @doc """
   Returns a daily breakdown of why a module missed: `changed` (its own content
-  differed from its previous build), `upstream` (only a dependency differed), and
-  `cold` (a miss with no comparable prior build — first-seen or evicted).
+  differed from its previous build), `upstream` (only a dependency differed),
+  `unchanged` (a previous build exists and every recorded input matched it, so
+  the cache had nothing for a key nothing changed in) and `cold` (no prior build
+  on the branch within the window to compare against).
 
   Uses the same branch-partitioned window as `module_invalidations/1`, grouped by
   day instead of by module. Requires `:name`.

--- a/server/lib/tuist_web/live/module_cache_module_live.ex
+++ b/server/lib/tuist_web/live/module_cache_module_live.ex
@@ -90,7 +90,8 @@ defmodule TuistWeb.ModuleCacheModuleLive do
      |> push_event("replace-url", %{url: "?" <> query})}
   end
 
-  def handle_event("select_miss_reason", %{"type" => type}, socket) when type in ~w(all changed upstream cold) do
+  def handle_event("select_miss_reason", %{"type" => type}, socket)
+      when type in ~w(all changed upstream unchanged cold) do
     query = Query.put(socket.assigns.uri.query, "miss-reason", type)
 
     {:noreply,
@@ -217,7 +218,8 @@ defmodule TuistWeb.ModuleCacheModuleLive do
       hit_rate: rate(reuses, appearances),
       self_changes: 0,
       dependency_induced: 0,
-      unclassified: invalidations,
+      unchanged: 0,
+      cold: invalidations,
       # A module with no misses still has dependents; the graph knows them even
       # though there is no invalidation row to read them from.
       blast_radius: Analytics.module_dependents_count(Keyword.put(opts, :name, name))
@@ -296,33 +298,39 @@ defmodule TuistWeb.ModuleCacheModuleLive do
   def builds_reason_label("hit"), do: dgettext("dashboard_cache", "Cached")
   def builds_reason_label("changed"), do: dgettext("dashboard_cache", "Changed")
   def builds_reason_label("upstream"), do: dgettext("dashboard_cache", "Upstream")
-  def builds_reason_label("cold"), do: dgettext("dashboard_cache", "Cold")
+  def builds_reason_label("unchanged"), do: dgettext("dashboard_cache", "Unchanged")
+  def builds_reason_label("cold"), do: dgettext("dashboard_cache", "First seen")
   def builds_reason_label(_), do: dgettext("dashboard_cache", "Any")
 
   def miss_reason_value(module, "changed"), do: module.self_changes
   def miss_reason_value(module, "upstream"), do: module.dependency_induced
-  def miss_reason_value(module, "cold"), do: module.unclassified
+  def miss_reason_value(module, "unchanged"), do: module.unchanged
+  def miss_reason_value(module, "cold"), do: module.cold
   def miss_reason_value(module, _all), do: module.invalidations
 
   def miss_reason_title("changed"), do: dgettext("dashboard_cache", "Changed misses")
   def miss_reason_title("upstream"), do: dgettext("dashboard_cache", "Upstream misses")
-  def miss_reason_title("cold"), do: dgettext("dashboard_cache", "Cold misses")
+  def miss_reason_title("unchanged"), do: dgettext("dashboard_cache", "Unchanged misses")
+  def miss_reason_title("cold"), do: dgettext("dashboard_cache", "First-seen misses")
   def miss_reason_title(_all), do: dgettext("dashboard_cache", "Misses")
 
   def miss_reason_legend("changed"), do: "primary"
   def miss_reason_legend("upstream"), do: "secondary"
+  def miss_reason_legend("unchanged"), do: "quaternary"
   def miss_reason_legend("cold"), do: "tertiary"
   def miss_reason_legend(_all), do: "destructive"
 
   def build_reason_label("changed"), do: dgettext("dashboard_cache", "Changed")
   def build_reason_label("upstream"), do: dgettext("dashboard_cache", "Upstream")
-  def build_reason_label("cold"), do: dgettext("dashboard_cache", "Cold")
+  def build_reason_label("unchanged"), do: dgettext("dashboard_cache", "Unchanged")
+  def build_reason_label("cold"), do: dgettext("dashboard_cache", "First seen")
   def build_reason_label(_), do: dgettext("dashboard_cache", "Cached")
 
   # The colours the miss-reason widget and its chart already use, so a row reads
   # the same way as the breakdown above it.
   def build_reason_color("changed"), do: "primary"
   def build_reason_color("upstream"), do: "secondary"
+  def build_reason_color("unchanged"), do: "destructive"
   def build_reason_color("cold"), do: "attention"
   def build_reason_color(_), do: "neutral"
 

--- a/server/lib/tuist_web/live/module_cache_module_live.html.heex
+++ b/server/lib/tuist_web/live/module_cache_module_live.html.heex
@@ -167,7 +167,7 @@
         description={
           dgettext(
             "dashboard_cache",
-            "Builds where this module was a cache miss: its own content changed, only an upstream dependency changed, or it had never been cached."
+            "Builds where this module was a cache miss: its own content changed, only an upstream dependency changed, nothing we record changed and it missed anyway, or it was seen for the first time."
           )
         }
         value={
@@ -185,7 +185,8 @@
                 {"all", dgettext("dashboard_cache", "All"), "destructive"},
                 {"changed", dgettext("dashboard_cache", "Changed"), "primary"},
                 {"upstream", dgettext("dashboard_cache", "Upstream"), "secondary"},
-                {"cold", dgettext("dashboard_cache", "Cold"), "tertiary"}
+                {"unchanged", dgettext("dashboard_cache", "Unchanged"), "quaternary"},
+                {"cold", dgettext("dashboard_cache", "First seen"), "tertiary"}
               ]
             }
             value={value}
@@ -400,7 +401,15 @@
             barMaxWidth: 18
           },
           %{
-            name: dgettext("dashboard_cache", "Cold"),
+            name: dgettext("dashboard_cache", "Unchanged"),
+            data: @miss_reasons_series.result.unchanged,
+            type: "bar",
+            stack: "total",
+            color: "var:noora-chart-quaternary",
+            barMaxWidth: 18
+          },
+          %{
+            name: dgettext("dashboard_cache", "First seen"),
             data: @miss_reasons_series.result.cold,
             type: "bar",
             stack: "total",
@@ -464,7 +473,7 @@
           secondary_text={dgettext("dashboard_cache", "Reason:")}
         >
           <.dropdown_item
-            :for={value <- ~w(any hit changed upstream cold)}
+            :for={value <- ~w(any hit changed upstream unchanged cold)}
             value={value}
             label={builds_reason_label(value)}
             patch={builds_filter_patch(@uri, "builds-reason", value)}

--- a/server/lib/tuist_web/live/modules_live.ex
+++ b/server/lib/tuist_web/live/modules_live.ex
@@ -78,7 +78,7 @@ defmodule TuistWeb.ModulesLive do
   end
 
   def handle_event("select_miss_reason", %{"type" => type}, %{assigns: assigns} = socket)
-      when type in ~w(all changed upstream cold) do
+      when type in ~w(all changed upstream unchanged cold) do
     query_params = Query.put(assigns.uri.query, "miss-reason", type)
     path = "/#{assigns.selected_account.name}/#{assigns.selected_project.name}/module-cache/modules"
 
@@ -195,22 +195,26 @@ defmodule TuistWeb.ModulesLive do
       misses: Enum.sum(timeseries.invalidations),
       changed: Enum.sum(miss_reasons.changed),
       upstream: Enum.sum(miss_reasons.upstream),
+      unchanged: Enum.sum(miss_reasons.unchanged),
       cold: Enum.sum(miss_reasons.cold)
     }
   end
 
   def miss_reason_value(totals, "changed"), do: totals.changed
   def miss_reason_value(totals, "upstream"), do: totals.upstream
+  def miss_reason_value(totals, "unchanged"), do: totals.unchanged
   def miss_reason_value(totals, "cold"), do: totals.cold
   def miss_reason_value(totals, _all), do: totals.misses
 
   def miss_reason_title("changed"), do: dgettext("dashboard_cache", "Changed misses")
   def miss_reason_title("upstream"), do: dgettext("dashboard_cache", "Upstream misses")
-  def miss_reason_title("cold"), do: dgettext("dashboard_cache", "Cold misses")
+  def miss_reason_title("unchanged"), do: dgettext("dashboard_cache", "Unchanged misses")
+  def miss_reason_title("cold"), do: dgettext("dashboard_cache", "First-seen misses")
   def miss_reason_title(_all), do: dgettext("dashboard_cache", "Misses")
 
   def miss_reason_color("changed"), do: "primary"
   def miss_reason_color("upstream"), do: "secondary"
+  def miss_reason_color("unchanged"), do: "quaternary"
   def miss_reason_color("cold"), do: "tertiary"
   def miss_reason_color(_all), do: "destructive"
 

--- a/server/lib/tuist_web/live/modules_live.html.heex
+++ b/server/lib/tuist_web/live/modules_live.html.heex
@@ -127,7 +127,7 @@
         description={
           dgettext(
             "dashboard_cache",
-            "Module builds that were a cache miss: the module's own content changed, only an upstream dependency changed, or it had never been cached."
+            "Module builds that were a cache miss: the module's own content changed, only an upstream dependency changed, nothing we record changed and it missed anyway, or it was seen for the first time."
           )
         }
         value={if totals, do: format_number(miss_reason_value(totals, @selected_miss_reason))}
@@ -142,7 +142,8 @@
                 {"all", dgettext("dashboard_cache", "All"), "destructive"},
                 {"changed", dgettext("dashboard_cache", "Changed"), "primary"},
                 {"upstream", dgettext("dashboard_cache", "Upstream"), "secondary"},
-                {"cold", dgettext("dashboard_cache", "Cold"), "tertiary"}
+                {"unchanged", dgettext("dashboard_cache", "Unchanged"), "quaternary"},
+                {"cold", dgettext("dashboard_cache", "First seen"), "tertiary"}
               ]
             }
             value={value}
@@ -306,7 +307,15 @@
             barMaxWidth: 18
           },
           %{
-            name: dgettext("dashboard_cache", "Cold"),
+            name: dgettext("dashboard_cache", "Unchanged"),
+            data: @miss_reasons_series.result.unchanged,
+            type: "bar",
+            stack: "total",
+            color: "var:noora-chart-quaternary",
+            barMaxWidth: 18
+          },
+          %{
+            name: dgettext("dashboard_cache", "First seen"),
             data: @miss_reasons_series.result.cold,
             type: "bar",
             stack: "total",

--- a/server/priv/gettext/dashboard_cache.pot
+++ b/server/priv/gettext/dashboard_cache.pot
@@ -82,12 +82,12 @@ msgstr ""
 #: lib/tuist_web/live/module_cache_live.ex:410
 #: lib/tuist_web/live/module_cache_live.html.heex:10
 #: lib/tuist_web/live/module_cache_live.html.heex:40
-#: lib/tuist_web/live/module_cache_module_live.ex:293
-#: lib/tuist_web/live/module_cache_module_live.ex:300
-#: lib/tuist_web/live/module_cache_module_live.ex:331
+#: lib/tuist_web/live/module_cache_module_live.ex:295
+#: lib/tuist_web/live/module_cache_module_live.ex:303
+#: lib/tuist_web/live/module_cache_module_live.ex:339
 #: lib/tuist_web/live/module_cache_module_live.html.heex:41
-#: lib/tuist_web/live/module_cache_module_live.html.heex:443
-#: lib/tuist_web/live/modules_live.ex:325
+#: lib/tuist_web/live/module_cache_module_live.html.heex:452
+#: lib/tuist_web/live/modules_live.ex:329
 #: lib/tuist_web/live/modules_live.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "Any"
@@ -149,14 +149,14 @@ msgstr ""
 #: lib/tuist_web/live/bundles_live.html.heex:362
 #: lib/tuist_web/live/cache_runs_live.ex:60
 #: lib/tuist_web/live/cache_runs_live.html.heex:93
-#: lib/tuist_web/live/module_cache_module_live.html.heex:540
+#: lib/tuist_web/live/module_cache_module_live.html.heex:549
 #, elixir-autogen, elixir-format
 msgid "Branch"
 msgstr ""
 
 #: lib/tuist_web/live/bundles_live.html.heex:43
 #: lib/tuist_web/live/module_cache_live.html.heex:36
-#: lib/tuist_web/live/module_cache_module_live.html.heex:439
+#: lib/tuist_web/live/module_cache_module_live.html.heex:448
 #, elixir-autogen, elixir-format
 msgid "Branch:"
 msgstr ""
@@ -195,9 +195,9 @@ msgstr ""
 #: lib/tuist_web/live/module_cache_live.ex:412
 #: lib/tuist_web/live/module_cache_live.ex:413
 #: lib/tuist_web/live/module_cache_live.html.heex:26
-#: lib/tuist_web/live/module_cache_module_live.ex:330
+#: lib/tuist_web/live/module_cache_module_live.ex:338
 #: lib/tuist_web/live/module_cache_module_live.html.heex:43
-#: lib/tuist_web/live/modules_live.ex:324
+#: lib/tuist_web/live/modules_live.ex:328
 #: lib/tuist_web/live/modules_live.html.heex:13
 #: lib/tuist_web/live/xcode_cache_live.ex:425
 #, elixir-autogen, elixir-format
@@ -221,8 +221,8 @@ msgstr ""
 #: lib/tuist_web/live/module_cache_live.html.heex:140
 #: lib/tuist_web/live/module_cache_live.html.heex:669
 #: lib/tuist_web/live/module_cache_module_live.html.heex:130
-#: lib/tuist_web/live/module_cache_module_live.html.heex:296
-#: lib/tuist_web/live/modules_live.ex:319
+#: lib/tuist_web/live/module_cache_module_live.html.heex:297
+#: lib/tuist_web/live/modules_live.ex:323
 #: lib/tuist_web/live/xcode_cache_live.ex:304
 #: lib/tuist_web/live/xcode_cache_live.html.heex:109
 #: lib/tuist_web/live/xcode_cache_live.html.heex:786
@@ -275,7 +275,7 @@ msgstr ""
 
 #: lib/tuist_web/live/bundle_live.html.heex:160
 #: lib/tuist_web/live/bundles_live.html.heex:392
-#: lib/tuist_web/live/module_cache_module_live.html.heex:548
+#: lib/tuist_web/live/module_cache_module_live.html.heex:557
 #, elixir-autogen, elixir-format
 msgid "Commit SHA"
 msgstr ""
@@ -401,9 +401,9 @@ msgstr ""
 
 #: lib/tuist_web/live/module_cache_live.html.heex:229
 #: lib/tuist_web/live/module_cache_module_live.html.heex:117
-#: lib/tuist_web/live/module_cache_module_live.html.heex:251
+#: lib/tuist_web/live/module_cache_module_live.html.heex:252
 #: lib/tuist_web/live/modules_live.html.heex:112
-#: lib/tuist_web/live/modules_live.html.heex:249
+#: lib/tuist_web/live/modules_live.html.heex:250
 #, elixir-autogen, elixir-format
 msgid "Hits"
 msgstr ""
@@ -441,10 +441,10 @@ msgstr ""
 #: lib/tuist_web/live/module_cache_live.ex:411
 #: lib/tuist_web/live/module_cache_live.ex:414
 #: lib/tuist_web/live/module_cache_live.html.heex:18
-#: lib/tuist_web/live/module_cache_module_live.ex:329
+#: lib/tuist_web/live/module_cache_module_live.ex:337
 #: lib/tuist_web/live/module_cache_module_live.html.heex:42
-#: lib/tuist_web/live/module_cache_module_live.html.heex:522
-#: lib/tuist_web/live/modules_live.ex:323
+#: lib/tuist_web/live/module_cache_module_live.html.heex:531
+#: lib/tuist_web/live/modules_live.ex:327
 #: lib/tuist_web/live/modules_live.html.heex:12
 #: lib/tuist_web/live/xcode_cache_live.ex:426
 #, elixir-autogen, elixir-format
@@ -464,9 +464,9 @@ msgstr ""
 
 #: lib/tuist_web/components/module_invalidations_table.ex:33
 #: lib/tuist_web/live/module_cache_live.html.heex:249
-#: lib/tuist_web/live/module_cache_module_live.ex:310
-#: lib/tuist_web/live/modules_live.ex:210
-#: lib/tuist_web/live/modules_live.ex:321
+#: lib/tuist_web/live/module_cache_module_live.ex:315
+#: lib/tuist_web/live/modules_live.ex:213
+#: lib/tuist_web/live/modules_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "Misses"
 msgstr ""
@@ -570,7 +570,7 @@ msgstr ""
 #: lib/tuist_web/live/cache_runs_live.html.heex:34
 #: lib/tuist_web/live/cache_runs_live.html.heex:117
 #: lib/tuist_web/live/module_cache_live.html.heex:772
-#: lib/tuist_web/live/module_cache_module_live.html.heex:553
+#: lib/tuist_web/live/module_cache_module_live.html.heex:562
 #: lib/tuist_web/live/xcode_cache_live.html.heex:893
 #, elixir-autogen, elixir-format
 msgid "Ran at"
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Run the following command to analyze a bundle."
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.html.heex:508
+#: lib/tuist_web/live/module_cache_module_live.html.heex:517
 #: lib/tuist_web/live/xcode_cache_live.ex:419
 #: lib/tuist_web/live/xcode_cache_live.html.heex:494
 #: lib/tuist_web/live/xcode_cache_live.html.heex:859
@@ -642,7 +642,7 @@ msgstr ""
 #: lib/tuist_web/live/bundle_live.html.heex:650
 #: lib/tuist_web/live/bundles_live.html.heex:310
 #: lib/tuist_web/live/cache_runs_live.html.heex:14
-#: lib/tuist_web/live/modules_live.html.heex:345
+#: lib/tuist_web/live/modules_live.html.heex:354
 #, elixir-autogen, elixir-format
 msgid "Sort by:"
 msgstr ""
@@ -1036,36 +1036,20 @@ msgstr ""
 msgid "%{share}%"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.ex:297
-#: lib/tuist_web/live/module_cache_module_live.ex:317
+#: lib/tuist_web/live/module_cache_module_live.ex:299
+#: lib/tuist_web/live/module_cache_module_live.ex:323
 #: lib/tuist_web/live/module_cache_module_live.html.heex:186
-#: lib/tuist_web/live/module_cache_module_live.html.heex:387
+#: lib/tuist_web/live/module_cache_module_live.html.heex:388
 #: lib/tuist_web/live/modules_live.html.heex:143
-#: lib/tuist_web/live/modules_live.html.heex:293
+#: lib/tuist_web/live/modules_live.html.heex:294
 #, elixir-autogen, elixir-format
 msgid "Changed"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.ex:299
-#: lib/tuist_web/live/module_cache_module_live.ex:319
-#: lib/tuist_web/live/module_cache_module_live.html.heex:188
-#: lib/tuist_web/live/module_cache_module_live.html.heex:403
-#: lib/tuist_web/live/modules_live.html.heex:145
-#: lib/tuist_web/live/modules_live.html.heex:309
-#, elixir-autogen, elixir-format
-msgid "Cold"
-msgstr ""
-
-#: lib/tuist_web/live/module_cache_module_live.ex:309
-#: lib/tuist_web/live/modules_live.ex:209
-#, elixir-autogen, elixir-format
-msgid "Cold misses"
-msgstr ""
-
 #: lib/tuist_web/components/module_invalidations_table.ex:49
 #: lib/tuist_web/live/module_cache_module_live.html.heex:149
-#: lib/tuist_web/live/module_cache_module_live.html.heex:343
-#: lib/tuist_web/live/modules_live.ex:320
+#: lib/tuist_web/live/module_cache_module_live.html.heex:344
+#: lib/tuist_web/live/modules_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "Dependents"
 msgstr ""
@@ -1084,8 +1068,8 @@ msgstr ""
 #: lib/tuist_web/live/module_cache_module_live.html.heex:3
 #: lib/tuist_web/live/modules_live.ex:27
 #: lib/tuist_web/live/modules_live.html.heex:96
-#: lib/tuist_web/live/modules_live.html.heex:206
-#: lib/tuist_web/live/modules_live.html.heex:324
+#: lib/tuist_web/live/modules_live.html.heex:207
+#: lib/tuist_web/live/modules_live.html.heex:333
 #, elixir-autogen, elixir-format
 msgid "Modules"
 msgstr ""
@@ -1101,7 +1085,7 @@ msgstr ""
 msgid "Most missed"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.html.heex:203
+#: lib/tuist_web/live/module_cache_module_live.html.heex:204
 #, elixir-autogen, elixir-format
 msgid "N/A"
 msgstr ""
@@ -1112,12 +1096,12 @@ msgid "Needs CLI graph edges"
 msgstr ""
 
 #: lib/tuist_web/live/module_cache_live.html.heex:642
-#: lib/tuist_web/live/modules_live.html.heex:371
+#: lib/tuist_web/live/modules_live.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "No cache misses yet"
 msgstr ""
 
-#: lib/tuist_web/live/modules_live.html.heex:407
+#: lib/tuist_web/live/modules_live.html.heex:416
 #, elixir-autogen, elixir-format
 msgid "No modules match your search"
 msgstr ""
@@ -1127,7 +1111,7 @@ msgstr ""
 msgid "Product: %{product}"
 msgstr ""
 
-#: lib/tuist_web/live/modules_live.html.heex:336
+#: lib/tuist_web/live/modules_live.html.heex:345
 #, elixir-autogen, elixir-format
 msgid "Search modules"
 msgstr ""
@@ -1147,18 +1131,18 @@ msgstr ""
 msgid "The module that was a cache miss most often during the period. Reducing how often it rebuilds has the largest direct payoff."
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.ex:298
-#: lib/tuist_web/live/module_cache_module_live.ex:318
+#: lib/tuist_web/live/module_cache_module_live.ex:300
+#: lib/tuist_web/live/module_cache_module_live.ex:324
 #: lib/tuist_web/live/module_cache_module_live.html.heex:187
-#: lib/tuist_web/live/module_cache_module_live.html.heex:395
+#: lib/tuist_web/live/module_cache_module_live.html.heex:396
 #: lib/tuist_web/live/modules_live.html.heex:144
-#: lib/tuist_web/live/modules_live.html.heex:301
+#: lib/tuist_web/live/modules_live.html.heex:302
 #, elixir-autogen, elixir-format
 msgid "Upstream"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.ex:308
-#: lib/tuist_web/live/modules_live.ex:208
+#: lib/tuist_web/live/module_cache_module_live.ex:312
+#: lib/tuist_web/live/modules_live.ex:210
 #, elixir-autogen, elixir-format
 msgid "Upstream misses"
 msgstr ""
@@ -1178,54 +1162,54 @@ msgstr ""
 msgid "The module that invalidates the most other modules when it changes. It is the highest-impact target for better boundaries."
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.html.heex:418
+#: lib/tuist_web/live/module_cache_module_live.html.heex:427
 #, elixir-autogen, elixir-format
 msgid "Builds"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.html.heex:510
-#: lib/tuist_web/live/module_cache_module_live.html.heex:544
+#: lib/tuist_web/live/module_cache_module_live.html.heex:519
+#: lib/tuist_web/live/module_cache_module_live.html.heex:553
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.ex:296
-#: lib/tuist_web/live/module_cache_module_live.ex:320
+#: lib/tuist_web/live/module_cache_module_live.ex:298
+#: lib/tuist_web/live/module_cache_module_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "Cached"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.html.heex:490
+#: lib/tuist_web/live/module_cache_module_live.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "No builds match these filters"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.html.heex:430
+#: lib/tuist_web/live/module_cache_module_live.html.heex:439
 #, elixir-autogen, elixir-format
 msgid "Search commit sha"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.html.heex:513
+#: lib/tuist_web/live/module_cache_module_live.html.heex:522
 #, elixir-autogen, elixir-format
 msgid "Hit"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.html.heex:528
+#: lib/tuist_web/live/module_cache_module_live.html.heex:537
 #, elixir-autogen, elixir-format
 msgid "Missed"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.html.heex:516
+#: lib/tuist_web/live/module_cache_module_live.html.heex:525
 #, elixir-autogen, elixir-format
 msgid "Remote"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.html.heex:533
+#: lib/tuist_web/live/module_cache_module_live.html.heex:542
 #, elixir-autogen, elixir-format
 msgid "Reason"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.html.heex:464
+#: lib/tuist_web/live/module_cache_module_live.html.heex:473
 #, elixir-autogen, elixir-format
 msgid "Reason:"
 msgstr ""
@@ -1241,25 +1225,15 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: lib/tuist_web/live/module_cache_module_live.ex:307
-#: lib/tuist_web/live/modules_live.ex:207
+#: lib/tuist_web/live/module_cache_module_live.ex:311
+#: lib/tuist_web/live/modules_live.ex:209
 #, elixir-autogen, elixir-format
 msgid "Changed misses"
-msgstr ""
-
-#: lib/tuist_web/live/modules_live.html.heex:128
-#, elixir-autogen, elixir-format
-msgid "Module builds that were a cache miss: the module's own content changed, only an upstream dependency changed, or it had never been cached."
 msgstr ""
 
 #: lib/tuist_web/live/modules_live.html.heex:115
 #, elixir-autogen, elixir-format
 msgid "Module builds served from cache instead of being rebuilt."
-msgstr ""
-
-#: lib/tuist_web/live/module_cache_module_live.html.heex:168
-#, elixir-autogen, elixir-format
-msgid "Builds where this module was a cache miss: its own content changed, only an upstream dependency changed, or it had never been cached."
 msgstr ""
 
 #: lib/tuist_web/live/module_cache_module_live.html.heex:120
@@ -1270,4 +1244,46 @@ msgstr ""
 #: lib/tuist_web/live/bundle_live.html.heex:469
 #, elixir-autogen, elixir-format
 msgid "and %{count} more"
+msgstr ""
+
+#: lib/tuist_web/live/module_cache_module_live.html.heex:168
+#, elixir-autogen, elixir-format
+msgid "Builds where this module was a cache miss: its own content changed, only an upstream dependency changed, nothing we record changed and it missed anyway, or it was seen for the first time."
+msgstr ""
+
+#: lib/tuist_web/live/module_cache_module_live.ex:302
+#: lib/tuist_web/live/module_cache_module_live.ex:326
+#: lib/tuist_web/live/module_cache_module_live.html.heex:189
+#: lib/tuist_web/live/module_cache_module_live.html.heex:412
+#: lib/tuist_web/live/modules_live.html.heex:146
+#: lib/tuist_web/live/modules_live.html.heex:318
+#, elixir-autogen, elixir-format
+msgid "First seen"
+msgstr ""
+
+#: lib/tuist_web/live/module_cache_module_live.ex:314
+#: lib/tuist_web/live/modules_live.ex:212
+#, elixir-autogen, elixir-format
+msgid "First-seen misses"
+msgstr ""
+
+#: lib/tuist_web/live/modules_live.html.heex:128
+#, elixir-autogen, elixir-format
+msgid "Module builds that were a cache miss: the module's own content changed, only an upstream dependency changed, nothing we record changed and it missed anyway, or it was seen for the first time."
+msgstr ""
+
+#: lib/tuist_web/live/module_cache_module_live.ex:301
+#: lib/tuist_web/live/module_cache_module_live.ex:325
+#: lib/tuist_web/live/module_cache_module_live.html.heex:188
+#: lib/tuist_web/live/module_cache_module_live.html.heex:404
+#: lib/tuist_web/live/modules_live.html.heex:145
+#: lib/tuist_web/live/modules_live.html.heex:310
+#, elixir-autogen, elixir-format
+msgid "Unchanged"
+msgstr ""
+
+#: lib/tuist_web/live/module_cache_module_live.ex:313
+#: lib/tuist_web/live/modules_live.ex:211
+#, elixir-autogen, elixir-format
+msgid "Unchanged misses"
 msgstr ""

--- a/server/test/tuist/builds/analytics_test.exs
+++ b/server/test/tuist/builds/analytics_test.exs
@@ -2043,6 +2043,7 @@ defmodule Tuist.Builds.AnalyticsTest do
       assert series.cold == [2, 0]
       assert series.changed == [0, 1]
       assert series.upstream == [0, 1]
+      assert series.unchanged == [0, 0]
     end
   end
 
@@ -2091,8 +2092,9 @@ defmodule Tuist.Builds.AnalyticsTest do
 
       assert core.self_changes == 1
       assert core.dependency_induced == 0
-      # The first build has nothing before it, so exactly one miss is cold.
-      assert core.unclassified == 1
+      # The first build has nothing before it, so exactly one miss is first-seen.
+      assert core.cold == 1
+      assert core.unchanged == 0
     end
 
     test "the branch filter reaches the hit rate analytics, not just the module table", %{
@@ -2261,7 +2263,7 @@ defmodule Tuist.Builds.AnalyticsTest do
       page = Analytics.module_build_history(project_id: project.id, name: "Core")
 
       # Newest first.
-      assert Enum.map(page.rows, & &1.reason) == ["cold", "upstream", "changed", "hit", "cold"]
+      assert Enum.map(page.rows, & &1.reason) == ["unchanged", "upstream", "changed", "hit", "cold"]
       assert Enum.map(page.rows, & &1.hit) == ["miss", "miss", "miss", "remote", "miss"]
       assert Enum.all?(page.rows, &(&1.branch == "main"))
       refute page.has_previous_page
@@ -2379,6 +2381,18 @@ defmodule Tuist.Builds.AnalyticsTest do
       cold = Analytics.module_build_history(project_id: project.id, name: "Core", reason: "cold")
       assert Enum.all?(cold.rows, &(&1.reason == "cold"))
       refute Enum.empty?(cold.rows)
+    end
+
+    test "filters the history down to the misses nothing explains", %{project: project, build: build} do
+      build.(~N[2024-04-01 10:00:00], :miss, "s1", "d1")
+      build.(~N[2024-04-02 10:00:00], :miss, "s1", "d1")
+      build.(~N[2024-04-03 10:00:00], :miss, "s2", "d1")
+
+      page = Analytics.module_build_history(project_id: project.id, name: "Core", reason: "unchanged")
+
+      assert Enum.map(page.rows, & &1.reason) == ["unchanged"]
+      assert [%{ran_at: ran_at}] = page.rows
+      assert NaiveDateTime.to_date(ran_at) == ~D[2024-04-02]
     end
 
     test "orders oldest first and pages through it", %{project: project, build: build} do
@@ -2559,7 +2573,8 @@ defmodule Tuist.Builds.AnalyticsTest do
       assert core.invalidations == 3
       assert core.self_changes == 2
       assert core.dependency_induced == 0
-      assert core.unclassified == 1
+      assert core.unchanged == 0
+      assert core.cold == 1
       assert_in_delta core.invalidation_rate, 75.0, 0.1
       # No dependency edges in this graph -> blast radius is unknown.
       assert core.blast_radius == nil
@@ -2569,8 +2584,51 @@ defmodule Tuist.Builds.AnalyticsTest do
       assert networking.invalidations == 3
       assert networking.self_changes == 0
       assert networking.dependency_induced == 2
-      assert networking.unclassified == 1
+      assert networking.unchanged == 0
+      assert networking.cold == 1
       assert_in_delta networking.invalidation_rate, 100.0, 0.1
+    end
+
+    test "separates a miss that repeats identical inputs from a first-seen one", %{project: project} do
+      build = fn created_at, hit, sources ->
+        event =
+          CommandEventsFixtures.command_event_fixture(
+            project_id: project.id,
+            git_branch: "main",
+            created_at: created_at
+          )
+
+        XcodeFixtures.xcode_target_fixture(
+          command_event_id: event.id,
+          name: "Core",
+          product: "framework",
+          binary_cache_hash: "h-#{sources}",
+          binary_cache_hit: hit,
+          sources_hash: sources,
+          dependencies_hash: "d1"
+        )
+      end
+
+      # Only the first build is genuinely first-seen. The next three ask the
+      # cache for a key nothing changed in and get nothing back, which is what
+      # an artifact that was never stored (or has been evicted) looks like.
+      build.(~N[2024-04-01 10:00:00], :miss, "s1")
+      build.(~N[2024-04-02 10:00:00], :miss, "s1")
+      build.(~N[2024-04-03 10:00:00], :miss, "s1")
+      build.(~N[2024-04-04 10:00:00], :miss, "s1")
+
+      [core] =
+        Analytics.module_invalidations(
+          project_id: project.id,
+          start_datetime: ~U[2024-04-01 00:00:00Z],
+          end_datetime: ~U[2024-04-30 23:59:59Z]
+        )
+
+      assert core.invalidations == 4
+      assert core.self_changes == 0
+      assert core.dependency_induced == 0
+      assert core.unchanged == 3
+      assert core.cold == 1
     end
 
     test "compares builds within the same branch only", %{project: project} do
@@ -2610,7 +2668,8 @@ defmodule Tuist.Builds.AnalyticsTest do
       # interleaved feature-branch build (which would look like a self-change).
       assert core.dependency_induced == 1
       assert core.self_changes == 0
-      assert core.unclassified == 2
+      assert core.unchanged == 0
+      assert core.cold == 2
     end
 
     test "filters by branch", %{project: project} do

--- a/server/test/tuist_web/live/module_cache_module_live_test.exs
+++ b/server/test/tuist_web/live/module_cache_module_live_test.exs
@@ -120,7 +120,7 @@ defmodule TuistWeb.ModuleCacheModuleLiveTest do
         row |> Floki.find("td") |> Enum.at(2) |> Floki.text() |> String.trim()
       end)
 
-    assert reasons == ["Changed", "Cached", "Cold"]
+    assert reasons == ["Changed", "Cached", "First seen"]
 
     results =
       document

--- a/server/test/tuist_web/live/modules_live_test.exs
+++ b/server/test/tuist_web/live/modules_live_test.exs
@@ -183,7 +183,7 @@ defmodule TuistWeb.ModulesLiveTest do
     # view and the markup is checked separately.
     html = render(lv)
 
-    for reason <- ~w(all changed upstream cold) do
+    for reason <- ~w(all changed upstream unchanged cold) do
       assert html =~ ~s(phx-click="select_miss_reason" phx-value-type="#{reason}")
     end
 
@@ -197,8 +197,14 @@ defmodule TuistWeb.ModulesLiveTest do
     render_click(lv, "select_miss_reason", %{"type" => "cold"})
     render_async(lv, 2000)
 
-    assert has_element?(lv, "#widget-misses", "Cold misses")
+    assert has_element?(lv, "#widget-misses", "First-seen misses")
     assert has_element?(lv, "#widget-misses", "1")
+
+    render_click(lv, "select_miss_reason", %{"type" => "unchanged"})
+    render_async(lv, 2000)
+
+    assert has_element?(lv, "#widget-misses", "Unchanged misses")
+    assert has_element?(lv, "#widget-misses", "0")
   end
 
   test "pages through the modules table", %{


### PR DESCRIPTION
## What changed

The module cache miss classifier advertised three reasons but only computed two of them. `changed` and `upstream` were derived by comparing a missed build's recorded hashing inputs against the module's previous build on the same branch. Everything left over fell into a single `cold` bucket, labelled **Cold** in the dashboard and documented as *"a miss with no comparable prior build — first-seen or evicted"*.

That bucket conflated two outcomes with nothing in common:

- the module genuinely had no earlier build to compare against, and
- the module's recorded inputs were **byte-identical** to its previous build and it missed anyway.

This splits them:

| reason | meaning |
| --- | --- |
| `changed` | the module's own content differed from its previous build |
| `upstream` | only a dependency or the external project differed |
| `unchanged` | a previous build exists, every recorded input matched it, and it missed anyway |
| `cold` | no previous build on the branch within the window |

Both the aggregate breakdown (`module_invalidation_breakdown/1` → `module_invalidations/1`, `module_miss_reasons_timeseries/1`) and the per-build history (`module_build_history/1`) carry the distinction, so the misses widget, the stacked miss-reasons chart, the reason filters and the build-history badges all say which of the two a miss is. `cold` is now shown as **First seen** so the label matches what it counts.

## Why

This came out of a support report: a team looking at their most-missed CI modules found the list dominated by third-party package targets they had not touched in months, all attributed to `cold`. "Cold" reads as *your cache was empty*, which is not what was happening and gives nobody anything to do.

Working through their data, the shape was unambiguous. For an untouched external module:

- Its recorded hashing inputs — own content, dependency hash, external project hash, settings, destinations, configuration, Swift version, cache version — never moved across weeks of CI.
- Its cache keys split into two stable families. One is written by the cache-warming job and hits every single time. The other is looked up by the consuming builds and **has never hit once**, over thousands of lookups.
- Because the recorded inputs are identical on both sides of that split, every one of those misses landed in the residual bucket. The overwhelming majority of that module's misses were of this kind; only a handful were genuinely first-seen.

So the dashboard was reporting an empty cache for a module that was being warmed and consumed under two different keys. `unchanged` is the signal that says so: *nothing we record changed, and the cache still had nothing.* That points at an artifact that was never stored, has been evicted, or is keyed on a hashing input the CLI folds into the key but does not report.

## Root cause of the mislabelling

`module_invalidation_breakdown/1` computed only `changed` and `upstream`, and every consumer derived the third bucket by subtraction:

```elixir
cold: max(misses - changed - upstream, 0)
```

Subtraction cannot distinguish "no prior row to compare" (`rn = 1`) from "prior row compared equal", so the two collapsed. `module_build_history/1` had the same shape, with `'cold'` as both the `rn = 1` case and the `multiIf` fallback — the existing test for it even carried the comment *"Nothing changed but it still missed, so the entry was gone"* while asserting the reason was `cold`.

The fix adds one `countIf` for the equal-inputs case over rows the query already scans and derives `cold` from what is left, so the two are computed independently instead of one absorbing the other.

## Why this shape over the alternatives

- **Renaming "Cold" to something vaguer.** Rejected: the bucket really does hold two different things; a better word for a mixture is still a mixture.
- **Widening the comparison baseline** so a module's first build on a branch falls back to its most recent build on any branch. This would shrink `cold` further (with many short-lived CI branches, every branch's first build is currently unclassifiable) and is a real improvement, but it needs a second window function partitioned differently from the first, roughly doubling the sort work in the heaviest query on a page that is already slow for large projects. Left out deliberately — see below.
- **Reporting the missing hashing input.** `TargetContentHashSubhashes.embeddedProductReferences` is folded into the cache key by the CLI but is absent from the analytics payload, the OpenAPI schema and the server schema, so the dashboard's subhash list is incomplete by construction. Worth closing, but it needs an API regeneration and a ClickHouse column, and it is not what produced the split described above.

## Impact

- Users get a fourth miss reason that separates "the cache had nothing for a key nothing changed in" from "we had never seen this module before". The first is a cache problem to chase; the second is expected.
- `module_invalidations/1` rows now expose `:unchanged` and `:cold` instead of `:unclassified`, and `module_miss_reasons_timeseries/1` gains an `unchanged` series. Both are internal to the server; no public API or CLI surface changes.
- `module_build_history/1` accepts `reason: "unchanged"` as a filter.
- Query cost is unchanged: one extra `countIf` over rows already being scanned, no extra scan, join, sort or window.

## Not included

Two follow-ups this investigation surfaced, left out on purpose so this change stays cheap and reviewable:

1. **Branch-first-build baseline.** A module's first build on a branch is still unclassifiable and counts as `cold`. On a repo with many short-lived branches that is a meaningful share of the bucket. Fixing it costs a second window function in the heaviest query on the Modules page, which is exactly the page reported as struggling at the 30-day default; it deserves to be measured on its own rather than bundled here.
2. **`embedded_product_references` is never reported.** The CLI hashes it into the module cache key (`TargetContentHasher`, external and local branches) but `CreateCommandEventService` does not send it, the OpenAPI schema has no field for it, and `xcode_targets` has no column. Until that is closed, the dashboard's subhash list cannot fully explain a hash, and the classifier is blind to changes in a target's embedded product closure.

## Validation

- `mix test test/tuist/builds/analytics_test.exs` — 102 passing, including two new cases: one asserting that four consecutive misses with identical inputs classify as 3 `unchanged` + 1 `cold` rather than 4 `cold`, and one covering the `reason: "unchanged"` history filter. The existing `module_build_history/1` case that asserted `cold` for a repeated identical miss now asserts `unchanged`.
- `mix test test/tuist_web/live/{modules,module_cache_module,module_cache}_live_test.exs` — 25 passing, extended to exercise the new widget reason end to end.
- `mix credo --strict` clean on the touched modules; `mix format` applied; `mix gettext.extract` run (`.pot` only).
- Verified in the local dashboard against seeded data. The Modules page breakdown reads `Changed 912 · Upstream 37 · Unchanged 653 · First seen 31` where it previously showed a single `Cold 684`, and the module build history renders **Unchanged** badges and filters on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
