### PR TITLE
fix(infra): stop enrolled minis idle-sleeping before bootstrap runs

### DIFF
--- a/infra/mdm/pkg/postinstall.tmpl
+++ b/infra/mdm/pkg/postinstall.tmpl
@@ -18,6 +18,13 @@ SVC_ACCOUNT="@SVC_ACCOUNT@"
 # remote reboot.
 /usr/bin/pmset autorestart 1
 
+# Never idle-sleep. A mini ships defaulting to a one-minute idle sleep,
+# and a sleeping headless host in a rack is indistinguishable from a dead
+# one until someone power-cycles it. macos-host-bootstrap disables this
+# too, but not until it runs: without it here, a machine can fall asleep
+# in the window between enrolling and being bootstrapped.
+/usr/bin/pmset -a sleep 0 displaysleep 0 disksleep 0
+
 # The AccountConfiguration command that creates the service account is
 # queued ahead of this package, but give directory services a moment in
 # case the install is retried out of order.


### PR DESCRIPTION
## What

One line in the MDM bootstrap package's postinstall, next to the existing `pmset autorestart 1`:

```sh
/usr/bin/pmset -a sleep 0 displaysleep 0 disksleep 0
```

## Why

A Mac mini ships with a **one-minute idle sleep**. A sleeping headless host in a rack is indistinguishable from a dead one — no SSH, no scrape, no MDM push — until someone power-cycles the outlet.

`macos-host-bootstrap` already disables sleep, but not until it runs. Between finishing enrollment and being bootstrapped, a machine is supposed to sit there waiting to be picked up, and that is precisely the window in which it can fall asleep. Closing it in the package means a mini is never asleep from the moment it finishes enrolling.

Observed on the prototype M1, which came up with `sleep 1` after a clean zero-touch enrollment.

## Note on scope

The MDM's footprint on a host is deliberately tiny and I did not want to widen it casually. This belongs here on the same grounds as `pmset autorestart 1`, which is already in this file: both are power behaviours the fleet depends on being true from first boot rather than from first convergence, and both are one line.

## Validation

Rebuilt and re-signed the package with the Developer ID Installer identity (`pkgutil --check-signature` passes, 15848 bytes), stored in the `MDM` item in both vaults, and confirmed serving from `mdm.tuist.dev/static/bootstrap.pkg` — no pod restart needed, since the enroller re-reads the asset per request after tuist/tuist#13014.

Not yet exercised end to end on hardware: the prototype enrolled with the previous package, and its sleep settings were corrected afterwards by the host-prep step instead. The next erase-and-enroll cycle covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)