### PR TITLE
fix(infra): regenerate the drifted CAPI provider CRDs and enforce it in CI

### DIFF
--- a/.github/workflows/capi-provider-scaleway-applesilicon-image.yml
+++ b/.github/workflows/capi-provider-scaleway-applesilicon-image.yml
@@ -8,6 +8,8 @@ on:
       - infra/macos-host-bootstrap/**
       - infra/macos-log-shipper/**
       - infra/tart-kubelet/**
+      - infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_*.yaml
+      - mise/tasks/capi-scaleway-applesilicon/**
       - .github/workflows/capi-provider-scaleway-applesilicon-image.yml
   pull_request:
     paths:
@@ -15,6 +17,8 @@ on:
       - infra/macos-host-bootstrap/**
       - infra/macos-log-shipper/**
       - infra/tart-kubelet/**
+      - infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_*.yaml
+      - mise/tasks/capi-scaleway-applesilicon/**
       - .github/workflows/capi-provider-scaleway-applesilicon-image.yml
   workflow_dispatch: {}
 
@@ -135,8 +139,42 @@ jobs:
         working-directory: infra/macos-log-shipper
         run: GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build ./cmd/tuist-log-shipper
 
+  generated:
+    # The CRDs the apiserver enforces in every environment are generated from
+    # the annotated Go types, but they land in the Helm chart's `crds/`
+    # directory rather than beside the types. Nothing else ties a `*_types.go`
+    # edit to its regenerated manifest, and nothing else catches a manifest
+    # edited by hand.
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
+    runs-on: tuist-linux
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: infra/cluster-api-provider-tuist/go.mod
+          cache-dependency-path: infra/cluster-api-provider-tuist/go.sum
+      - uses: ./.github/actions/mise
+        with:
+          # The task stamps the CAPI contract label onto each generated CRD
+          # with yq. controller-gen comes in through `go run`.
+          install_args: "--locked yq"
+          cache: "false"
+      - name: Regenerate DeepCopy + CRDs
+        run: mise run --skip-tools capi-scaleway-applesilicon:generate
+      - name: Check for uncommitted changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error title=Generated CAPI artefacts out of sync::The committed CRDs and DeepCopy methods do not match the API types. Run 'mise run capi-scaleway-applesilicon:generate' and commit the result."
+            echo "Changed files:"
+            git status --porcelain
+            echo "Diff:"
+            git diff
+            exit 1
+          fi
+          echo "Generated CAPI artefacts are up to date"
+
   build:
-    needs: [test, test-macos-host-bootstrap, test-macos-log-shipper, test-tart-kubelet]
+    needs: [test, test-macos-host-bootstrap, test-macos-log-shipper, test-tart-kubelet, generated]
     if: github.event_name != 'pull_request'
     runs-on: tuist-linux
     steps:

--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -41,9 +41,20 @@ Linux kinds share. Until it exists, the `sa-west` box is hand-joined.
 | `DediboxMachine` (+ `…Template`) | One Scaleway Dedibox bare-metal server (eu-central): adopts a pre-prepped box by tag, `fleetName`. Reinstall-on-release. |
 | `OVHDedicatedMachine` (+ `…Template`) | One OVHcloud US bare-metal server (the us-east / us-west / ap-southeast cache regions and the Gravelines runner pool): adopts a pre-prepped box by displayName prefix, `fleetName`, `nodeTaints`. Reinstall-on-release. |
 | `TuistCluster` | Cluster-level stub (CAPI core requires it for the parent Cluster to validate). Sets `Status.Ready=true` once it exists. Shared by all machine kinds. |
+| `FailoverIP` | One vendor failover/additional IP kept routed to a healthy box of a Kura bare-metal pool, draining off a box whose peer demux is rolling. Cluster-scoped, not a CAPI machine kind. |
 
 API group: `infrastructure.cluster.x-k8s.io/v1alpha1`. Short names:
 `samm`, `sammt`, `sasc`.
+
+Every kind above is generated from the annotated types in
+[`api/v1alpha1/`](api/v1alpha1/) by
+`mise run capi-scaleway-applesilicon:generate`, which also writes
+`zz_generated.deepcopy.go` and stamps the `cluster.x-k8s.io/v1beta1` contract
+label CAPI core discovers providers by. Schema, printer columns, and the status
+subresource all come from `+kubebuilder:` markers, so a manifest edited by hand
+is reverted by the next run. The `generated` job in
+[`capi-provider-scaleway-applesilicon-image.yml`](../../.github/workflows/capi-provider-scaleway-applesilicon-image.yml)
+re-runs the task and fails on a diff.
 
 ## Architecture
 

--- a/infra/cluster-api-provider-tuist/api/v1alpha1/failoverip_types.go
+++ b/infra/cluster-api-provider-tuist/api/v1alpha1/failoverip_types.go
@@ -49,6 +49,9 @@ type FailoverIPStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="IP",type=string,JSONPath=".spec.ip"
+// +kubebuilder:printcolumn:name="Vendor",type=string,JSONPath=".spec.vendor"
+// +kubebuilder:printcolumn:name="ActiveNode",type=string,JSONPath=".status.activeNode"
 
 // FailoverIP is the placement of one provider failover IP onto a healthy box of
 // a Kura bare-metal pool.

--- a/infra/cluster-api-provider-tuist/api/v1alpha1/zz_generated.deepcopy_test.go
+++ b/infra/cluster-api-provider-tuist/api/v1alpha1/zz_generated.deepcopy_test.go
@@ -7,14 +7,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// controller-tools is not a dependency of this module, so zz_generated.deepcopy.go
-// is maintained by hand. A pointer field added to the status without a matching
-// block there is shallow-copied by `*out = *in`, so the copy aliases the
-// original — which silently breaks controller-runtime's cache isolation: a
-// reconciler mutating what it believes is its own copy corrupts the cached
-// object and the patch baseline computed from it. The compiler cannot catch it,
-// so assert it here: every pointer must survive a round trip through DeepCopy
-// with its own backing memory.
+// zz_generated.deepcopy.go is written by controller-gen through
+// `mise run capi-scaleway-applesilicon:generate`. A pointer field added to a
+// status without a matching block there is shallow-copied by `*out = *in`, so
+// the copy aliases the original, which silently breaks controller-runtime's
+// cache isolation: a reconciler mutating what it believes is its own copy
+// corrupts the cached object and the patch baseline computed from it. The
+// generator gets this right; a type declaring its own DeepCopyInto, which the
+// generator then skips entirely, does not. The compiler catches neither, so
+// assert it here: every pointer must survive a round trip through DeepCopy with
+// its own backing memory.
 func TestScalewayAppleSiliconMachineStatusDeepCopyDoesNotAliasPointers(t *testing.T) {
 	reason := "TartKubeletUpdateExceededRetries"
 	message := "tart-kubelet update failed 5 times"

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_dediboxmachines.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_dediboxmachines.yaml
@@ -61,8 +61,8 @@ spec:
               description: |-
                 DediboxMachineSpec is the desired state of one Scaleway Dedibox dedicated
                 server. Structurally it mirrors the OVH kind — a customer-facing public box
-                that adopts a pre-ordered server, installs on claim, self-joins over its
-                public IP, and (monthly contract) is not terminated on delete. It is driven
+                that adopts a pre-ordered, installed server, self-joins over its public IP,
+                and is reinstalled back to a clean, claimable state on delete. It is driven
                 through the Scaleway Dedibox API with a default-project IAM key (every Dedibox
                 in the org shares the default project — a Dedibox cannot be assigned to
                 another one — so the project can't isolate environments; a per-fleet tag

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_dediboxmachinetemplates.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_dediboxmachinetemplates.yaml
@@ -58,8 +58,8 @@ spec:
                       description: |-
                         DediboxMachineSpec is the desired state of one Scaleway Dedibox dedicated
                         server. Structurally it mirrors the OVH kind — a customer-facing public box
-                        that adopts a pre-ordered server, installs on claim, self-joins over its
-                        public IP, and (monthly contract) is not terminated on delete. It is driven
+                        that adopts a pre-ordered, installed server, self-joins over its public IP,
+                        and is reinstalled back to a clean, claimable state on delete. It is driven
                         through the Scaleway Dedibox API with a default-project IAM key (every Dedibox
                         in the org shares the default project — a Dedibox cannot be assigned to
                         another one — so the project can't isolate environments; a per-fleet tag

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_failoverips.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_failoverips.yaml
@@ -1,11 +1,12 @@
-# Hand-maintained (no controller-gen in this repo, matching the other provider
-# CRDs here). FailoverIP keeps one vendor failover/additional IP routed to a
-# healthy box of a Kura bare-metal pool, so the region's host-network public peer
-# plane survives a box loss (and a demux roll) without a cloud LoadBalancer.
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: failoverips.infrastructure.cluster.x-k8s.io
+  labels:
+    cluster.x-k8s.io/v1beta1: v1alpha1
 spec:
   group: infrastructure.cluster.x-k8s.io
   names:
@@ -15,61 +16,103 @@ spec:
     singular: failoverip
   scope: Cluster
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      additionalPrinterColumns:
-        - name: IP
+    - additionalPrinterColumns:
+        - jsonPath: .spec.ip
+          name: IP
           type: string
-          jsonPath: .spec.ip
-        - name: Vendor
+        - jsonPath: .spec.vendor
+          name: Vendor
           type: string
-          jsonPath: .spec.vendor
-        - name: ActiveNode
+        - jsonPath: .status.activeNode
+          name: ActiveNode
           type: string
-          jsonPath: .status.activeNode
+      name: v1alpha1
       schema:
         openAPIV3Schema:
-          type: object
+          description: |-
+            FailoverIP is the placement of one provider failover IP onto a healthy box of
+            a Kura bare-metal pool.
           properties:
             apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             spec:
-              type: object
-              required: [ip, vendor, nodePoolSelector]
+              description: |-
+                FailoverIPSpec keeps a provider failover/additional IP routed to a healthy box
+                of a Kura bare-metal pool, so the region's host-network public peer plane
+                survives a box loss (and a demux roll) without a cloud LoadBalancer.
               properties:
+                demuxNamespace:
+                  description: DemuxNamespace is the namespace the demux pods run in (default "kura").
+                  type: string
+                demuxSelector:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    DemuxSelector selects the peer-demux pods whose readiness additionally
+                    gates a box's eligibility, so the IP drains off a box whose demux is
+                    rolling. When empty, node Readiness alone gates eligibility.
+                  type: object
                 ip:
-                  type: string
-                vendor:
-                  type: string
-                  enum: [ovh, dedibox]
-                region:
+                  description: IP is the failover/additional IP (or CIDR) kept routed to a healthy box.
                   type: string
                 nodePoolSelector:
-                  type: object
                   additionalProperties:
                     type: string
-                demuxSelector:
+                  description: |-
+                    NodePoolSelector selects the candidate boxes the IP may route to (the pool
+                    label).
                   type: object
-                  additionalProperties:
-                    type: string
-                demuxNamespace:
+                region:
+                  description: |-
+                    Region is the Kura region this IP fronts (informational; matches the pool
+                    and the peer demux).
                   type: string
-            status:
+                vendor:
+                  description: Vendor is the provider whose API moves the IP.
+                  enum:
+                    - ovh
+                    - dedibox
+                  type: string
+              required:
+                - ip
+                - nodePoolSelector
+                - vendor
               type: object
+            status:
+              description: FailoverIPStatus reports where the IP is currently routed.
               properties:
                 activeNode:
-                  type: string
-                target:
-                  type: string
-                message:
+                  description: ActiveNode is the node the IP is currently routed to.
                   type: string
                 lastReconciledAt:
-                  type: string
                   format: date-time
+                  type: string
+                message:
+                  description: Message surfaces the last reconcile outcome (e.g. "no eligible box").
+                  type: string
+                target:
+                  description: |-
+                    Target is the vendor-opaque destination (OVH service name, or Dedibox
+                    "zone/server-id") the IP routes to.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml
@@ -440,12 +440,48 @@ spec:
                       - type
                     type: object
                   type: array
+                failedHostConfigHash:
+                  description: |-
+                    FailedHostConfigHash records the desired HostConfigHash that
+                    exhausted its update-retry budget and drove the CR into the terminal
+                    Failed state. A broken config can never be applied, so HostConfigHash
+                    never advances to it and comparing desired-vs-last-applied would see
+                    drift forever and reset the retry cap every reconcile. Comparing
+                    desired-vs-FailedHostConfigHash instead keeps the cap for an unchanged
+                    broken config while still retrying a genuinely new one.
+                  type: string
                 failureMessage:
                   type: string
                 failureReason:
                   description: |-
                     FailureReason / FailureMessage are set on terminal failures. CAPI
                     core surfaces them on the Machine object and prevents auto-retry.
+                  type: string
+                hostConfigHash:
+                  description: |-
+                    HostConfigHash is the fleet-wide canonical hash of every host
+                    config the operator pushes — the rendered install scripts plus the
+                    embedded binaries (bootstrap.HostConfigHash). Drift between this
+                    and the operator's own computed hash re-pushes the host config on
+                    the next reconcile, so a change to ANY pushed config (a script
+                    tweak, a fleet CIDR, or a re-baked binary) rolls to existing hosts
+                    instead of only a tart-kubelet binary change.
+                  type: string
+                lastUpdateFailureTime:
+                  description: |-
+                    LastUpdateFailureTime is when the drift loop last recorded an
+                    update failure for this host. It exists so the terminal Failed
+                    state can expire: FailedHostConfigHash alone only lifts it when a
+                    NEW config ships, which is right for a config the host rejected
+                    but wrong for the far more common verdict — the host was simply
+                    unreachable (`dial tcp ...:22: i/o timeout`). Those hosts stayed
+                    terminal indefinitely while remaining Ready and schedulable, so
+                    they kept running jobs on a host config frozen at whatever the
+                    operator last managed to push. Re-arming after a cooldown lets a
+                    host that has since come back take the current config on its own,
+                    while a genuinely broken config still backs off to a handful of
+                    attempts per cooldown instead of hammering every reconcile.
+                  format: date-time
                   type: string
                 phase:
                   description: |-
@@ -464,43 +500,6 @@ spec:
                     ServerID is the Scaleway-assigned UUID for the underlying Mac
                     mini. The Machine reconciler uses this for delete + status
                     polling against Scaleway's API.
-                  type: string
-                failedHostConfigHash:
-                  description: |-
-                    FailedHostConfigHash records the desired HostConfigHash that
-                    exhausted its update-retry budget and drove the CR into the
-                    terminal Failed state. A broken config can never be applied, so
-                    HostConfigHash never advances to it and comparing
-                    desired-vs-last-applied would see drift forever and reset the
-                    retry cap every reconcile. Comparing desired-vs-FailedHostConfigHash
-                    instead keeps the cap for an unchanged broken config while still
-                    retrying a genuinely new one.
-                  type: string
-                lastUpdateFailureTime:
-                  description: |-
-                    LastUpdateFailureTime is when the drift loop last recorded an
-                    update failure for this host. It exists so the terminal Failed
-                    state can expire: FailedHostConfigHash alone only lifts it when a
-                    NEW config ships, which is right for a config the host rejected
-                    but wrong for the far more common verdict — the host was simply
-                    unreachable (`dial tcp ...:22: i/o timeout`). Those hosts stayed
-                    terminal indefinitely while remaining Ready and schedulable, so
-                    they kept running jobs on a host config frozen at whatever the
-                    operator last managed to push. Re-arming after a cooldown lets a
-                    host that has since come back take the current config on its own,
-                    while a genuinely broken config still backs off to a handful of
-                    attempts per cooldown instead of hammering every reconcile.
-                  format: date-time
-                  type: string
-                hostConfigHash:
-                  description: |-
-                    HostConfigHash is the fleet-wide canonical hash of every host
-                    config the operator pushes — the rendered install scripts plus
-                    the embedded binaries (bootstrap.HostConfigHash). Drift between
-                    this and the operator's own computed hash re-pushes the host
-                    config on the next reconcile, so a change to ANY pushed config (a
-                    script tweak, a fleet CIDR, or a re-baked binary) rolls to
-                    existing hosts instead of only a tart-kubelet binary change.
                   type: string
                 tartKubeletBinarySHA:
                   description: |-

--- a/mise/tasks/capi-scaleway-applesilicon/generate.sh
+++ b/mise/tasks/capi-scaleway-applesilicon/generate.sh
@@ -6,11 +6,14 @@
 # infra/cluster-api-provider-tuist/api/v1alpha1/.
 # This task runs controller-gen to regenerate
 #   - api/v1alpha1/zz_generated.deepcopy.go
-#   - infra/helm/tuist/crds/scalewayapplesilicon*.yaml
-# from those types' `+kubebuilder:` markers.
+#   - infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_*.yaml
+# from those types' `+kubebuilder:` markers. Every kind in that API
+# group is generated, not a subset.
 #
 # Run it whenever you touch a *_types.go file. Generated artefacts
-# are committed; CI re-runs the same task to detect drift.
+# are committed; the `generated` job in
+# .github/workflows/capi-provider-scaleway-applesilicon-image.yml
+# re-runs this task and fails on a diff.
 #
 # controller-gen is invoked via `go run @<version>`: no install
 # step, version pinned by string. Go's module cache makes the


### PR DESCRIPTION
Running `mise run capi-scaleway-applesilicon:generate` on a clean checkout of `main` rewrites CRDs that are live in staging, canary and production. The committed manifests had drifted from the annotated Go types they are generated from, and nothing was checking.

### What changed

**The four drifted CRDs are regenerated.** The report that prompted this named three; there was a fourth.

- `infrastructure.cluster.x-k8s.io_failoverips.yaml` carried a header comment claiming it was hand-maintained because there was "no controller-gen in this repo". That has not been true since the generate task landed. controller-gen runs over `./api/...`, which includes `FailoverIP`, so the task already emitted this CRD and the hand-written file was simply being overwritten by anyone who ran it.
- `infrastructure.cluster.x-k8s.io_dediboxmachines.yaml` and `..._dediboxmachinetemplates.yaml` had description-only drift: the `DediboxMachineSpec` doc comment was reworded for reinstall-on-release without regenerating.
- `infrastructure.cluster.x-k8s.io_scalewayapplesiliconmachines.yaml` had drifted too, in the opposite direction: `hostConfigHash` and `failedHostConfigHash` were added to the committed manifest by hand, out of the alphabetical order controller-gen emits and with different line wrapping.

**A `generated` CI job now reruns the task and fails on a diff**, in `capi-provider-scaleway-applesilicon-image.yml`.

**Three stale statements about generation are corrected**, in the generate task header, the provider's `AGENTS.md`, and `zz_generated.deepcopy_test.go`.

### Why FailoverIP is generated rather than excluded

Excluding it would mean teaching the generator to skip one kind, since `crd paths=./api/...` covers everything in the package and there is no per-type opt-out short of deleting `+kubebuilder:object:root=true`, which the type needs to be a runtime object. Any exclusion would have to be a post-generation delete or restore step, which is fragile and leaves the kind permanently outside the drift check.

The real gap was three missing markers. `FailoverIP` had no `+kubebuilder:printcolumn` markers, so a plain regeneration would have dropped the `IP` / `Vendor` / `ActiveNode` columns the live CRD serves. Those markers are now on the type, so the generated CRD keeps `kubectl get failoverips` output identical. The `status` subresource and `scope: Cluster` come from markers that were already there.

### Impact on the live CRDs

These manifests are live. Helm skips `crds/` on upgrade, so the deploy workflow re-applies the directory on every run, which means a schema change ships with the deploy that carries it. Checked before changing them:

- Nothing the apiserver enforces changes. Normalising both sides (stripping descriptions, annotations and labels) leaves all four schemas byte-identical apart from FailoverIP's `required` list, which controller-gen alphabetises to `[ip, nodePoolSelector, vendor]` from `[ip, vendor, nodePoolSelector]`. Same set, same meaning.
- All three environments have the FailoverIP CRD installed with exactly the three printer columns preserved here, and **zero FailoverIP objects exist in any of them**. `server.kuraPeerFailoverIps` is `[]` in the default values and no environment overrides it, so the kind is parked and no stored object can fail validation on the next apply. The empty result was positive-controlled against the CRD's presence, so it is a genuine zero rather than a silent query failure.
- The patch kubectl computes for the new manifest is additive: annotations, the CAPI contract label, and descriptions, with `additionalPrinterColumns` retained.

FailoverIP also gains the `cluster.x-k8s.io/v1beta1` contract label, because the task labels every generated CRD in the group. It is not a CAPI machine kind so nothing consults the label for it, and the alternative, a list of name prefixes, is exactly the design the task moved away from after a missing label left a MachineDeployment at no replicas with `InternalError`.

### Why the CI job is shaped this way

The task header claimed "Generated artefacts are committed; CI re-runs the same task to detect drift". No workflow referenced `capi-scaleway-applesilicon:generate`, so nothing did. Rather than water the claim down, this makes it true, since a drift check is what would have caught all four manifests.

`setup-go` is already the pattern in this workflow, and mise installs only `yq`, which the task uses to stamp the contract label. `mise run --skip-tools` then keeps it from pulling the rest of the repo toolchain in for a lint-shaped check, which matters because the root `mise.toml` pins Erlang and Elixir among others.

The workflow's path filters covered only the provider module, so a hand-edit to a CRD, the case that produced the Apple Silicon drift, would not have triggered the check that catches it. They now also cover the generated manifests and the generate task itself. The manifest filter is scoped to `infrastructure.cluster.x-k8s.io_*.yaml` rather than the whole `crds/` directory, so a kura or runner-pool CRD change does not trigger a provider image build.

### Docs

The claim about CI lived only in the generate script, not in `AGENTS.md`. Two further inaccuracies in the same family are fixed:

- The task header named `crds/scalewayapplesilicon*.yaml` as its output, when controller-gen runs over the whole API group and writes all twelve `infrastructure.cluster.x-k8s.io` CRDs. That understatement is part of why FailoverIP looked like it sat outside the generator.
- `zz_generated.deepcopy_test.go` opened by asserting "controller-tools is not a dependency of this module, so `zz_generated.deepcopy.go` is maintained by hand". That file carries a `Code generated by controller-gen. DO NOT EDIT.` header and 116 generated methods.

The provider's `AGENTS.md` CRD table omitted `FailoverIP` entirely and never said the CRDs were generated at all. It now lists the kind and points at the task and the new job.

### Known follow-up, deliberately not in this PR

`FailoverIP` hand-writes its own DeepCopy methods, which makes controller-gen skip the type: it is the only kind absent from `zz_generated.deepcopy.go`. A new pointer or map field there would be shallow-copied by `*out = *in`, aliasing the cached object, and the new drift check cannot catch it because regenerating produces no diff for a skipped type. That is a behavioural change to a live controller rather than manifests, CI and docs, so it is tracked separately. The rewritten test comment records the hazard in the meantime.

Also noticed and not touched: `AGENTS.md` lists a short name `sasc` that no type declares (the real ones are `samm`, `sammt`, `semm`, `semmt`, `dbm`, `dbmt`, `odm`, `odmt`, `vum`, `vumt`, `tcl`), and the CRD table omits `VultrMachine`.

### How to test locally

From the repo root, confirm a clean checkout now stays clean, which is exactly what the new CI job asserts:

```
mise run capi-scaleway-applesilicon:generate && git status --porcelain
```

To see the check fail, edit any doc comment in `infra/cluster-api-provider-tuist/api/v1alpha1/*_types.go`, rerun the task, and observe both the types file and its CRD show as modified.

Provider tests: from `infra/cluster-api-provider-tuist`, run `go test ./...`, `go vet ./...` and `gofmt -l .`.

### Validation run

- `go test ./...`, `go vet ./...` and `gofmt -l .` in the provider module, all green.
- `helm lint` on the tuist chart.
- `actionlint` on the workflow, which reports only the pre-existing unknown-runner-label warnings that every job in the file already produces.
- A normalised semantic diff of every changed CRD against HEAD, as described above.
- The generate task run twice to confirm it is idempotent, which the drift check depends on.
- The drift check exercised in both directions: clean tree passes, and a types-only edit is caught.
- Live state read from staging, canary and production: CRD present with three printer columns, zero FailoverIP objects. A server-side dry-run apply was RBAC-forbidden, but the patch kubectl computed before the refusal is visible and additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
