### PR TITLE
fix(server): handle corrupt build archives without crashing the processor

### DIFF
--- a/server/lib/tuist/builds/workers/process_build_worker.ex
+++ b/server/lib/tuist/builds/workers/process_build_worker.ex
@@ -72,6 +72,11 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorker do
         Logger.warning("Build processing skipped: project #{project_id} not found for build #{build_id}")
         {:discard, :project_not_found}
 
+      {:error, :bad_zip} ->
+        Logger.warning("Build archive for build #{build_id} is not a valid zip; marking as failed_processing")
+        mark_failed_build_processing(build_id, project_id, account_id, build_metadata)
+        {:discard, :bad_zip}
+
       {:error, :object_not_found} when attempt <= @not_visible_snoozes ->
         {:snooze, @not_visible_snooze_seconds}
 

--- a/server/lib/tuist/processor/build_processor.ex
+++ b/server/lib/tuist/processor/build_processor.ex
@@ -12,6 +12,8 @@ defmodule Tuist.Processor.BuildProcessor do
   same BEAM as the rest of the server.
   """
 
+  require Logger
+
   @apple_reference_date_offset 978_307_200
 
   def process_build(build_zip_path, xcode_cache_upload_enabled) do
@@ -28,8 +30,23 @@ defmodule Tuist.Processor.BuildProcessor do
     end
   end
 
+  # `:zip.unzip/2` fails with `:bad_eocd`, `:data_error`, or similar when the
+  # uploaded archive is truncated or corrupt. Retrying does not fix the bytes
+  # on disk, so we surface a discrete `:bad_zip` tag and let the worker skip
+  # straight to the `failed_processing` marker instead of raising a MatchError
+  # that reruns four more times before Oban gives up.
   defp process_zip(zip_path, temp_dir, xcode_cache_upload_enabled) do
-    {:ok, _} = :zip.unzip(~c"#{zip_path}", [{:cwd, ~c"#{temp_dir}"}])
+    case :zip.unzip(~c"#{zip_path}", [{:cwd, ~c"#{temp_dir}"}]) do
+      {:ok, _} ->
+        parse_unzipped(temp_dir, xcode_cache_upload_enabled)
+
+      {:error, reason} ->
+        Logger.warning("Rejecting build archive: :zip.unzip returned #{inspect(reason)}")
+        {:error, :bad_zip}
+    end
+  end
+
+  defp parse_unzipped(temp_dir, xcode_cache_upload_enabled) do
     xcactivitylog_path = find_xcactivitylog(temp_dir)
     cas_analytics_db_path = Path.join(temp_dir, "cas_analytics.db")
     legacy_cas_metadata_path = Path.join(temp_dir, "cas_metadata")

--- a/server/test/tuist/builds/workers/process_build_worker_test.exs
+++ b/server/test/tuist/builds/workers/process_build_worker_test.exs
@@ -230,6 +230,24 @@ defmodule Tuist.Builds.Workers.ProcessBuildWorkerTest do
       assert {:discard, :project_not_found} =
                ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, "999999")))
     end
+
+    test "discards the job and marks the build as failed when the archive is not a valid zip", %{
+      account: account,
+      project: project,
+      build: build
+    } do
+      expect(Tuist.Storage, :download_to_file, fn _, _, _ -> {:ok, :done} end)
+      expect(BuildProcessor, :process_build, fn _path, _ -> {:error, :bad_zip} end)
+
+      expect(Builds, :create_build, fn attrs ->
+        assert attrs.id == build.id
+        assert attrs.status == "failed_processing"
+        {:ok, %{id: build.id}}
+      end)
+
+      assert {:discard, :bad_zip} =
+               ProcessBuildWorker.perform(oban_job(job_args(build.id, account.id, project.id), 1, 5))
+    end
   end
 
   describe "perform/1 VCS comment" do

--- a/server/test/tuist/processor/build_processor_test.exs
+++ b/server/test/tuist/processor/build_processor_test.exs
@@ -1,0 +1,21 @@
+defmodule Tuist.Processor.BuildProcessorTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.Processor.BuildProcessor
+
+  @tag :tmp_dir
+  test "returns {:error, :bad_zip} when the archive is not a valid zip", %{tmp_dir: tmp_dir} do
+    zip_path = Path.join(tmp_dir, "corrupt.zip")
+    File.write!(zip_path, "not a zip file")
+
+    assert {:error, :bad_zip} = BuildProcessor.process_build(zip_path, false)
+  end
+
+  @tag :tmp_dir
+  test "returns {:error, :bad_zip} when the archive is truncated", %{tmp_dir: tmp_dir} do
+    zip_path = Path.join(tmp_dir, "empty.zip")
+    File.write!(zip_path, "")
+
+    assert {:error, :bad_zip} = BuildProcessor.process_build(zip_path, false)
+  end
+end


### PR DESCRIPTION
Resolves the recurring Hive error [23aaf744](https://hive.tuist.dev/errors/23aaf744-b1f5-55ff-b84d-3062b3a62417) (`MatchError: no match of right hand side value: {:error, :bad_eocd}` at `server/lib/tuist/processor/build_processor.ex:32`).

## What changed

- `Tuist.Processor.BuildProcessor.process_zip/3` now wraps `:zip.unzip/2` in a `case` and returns `{:error, :bad_zip}` on any failure, after logging the underlying zip reason once. It no longer pattern-matches strictly on `{:ok, _}`.
- `Tuist.Builds.Workers.ProcessBuildWorker.perform/1` gains an explicit `{:error, :bad_zip}` branch that mirrors the existing `:project_not_found` handling: log a warning, write the `failed_processing` build placeholder via `mark_failed_build_processing/4`, and `{:discard, :bad_zip}` so Oban stops retrying.
- New `server/test/tuist/processor/build_processor_test.exs` covers both a non-zip payload and a 0-byte input against the real `:zip.unzip/2`.
- Extended `server/test/tuist/builds/workers/process_build_worker_test.exs` with a case that stubs `BuildProcessor.process_build/2 -> {:error, :bad_zip}` and asserts the discard plus `failed_processing` write.

## Why

`:zip.unzip/2` returns `{:error, :bad_eocd}` when the archive has no valid End Of Central Directory record, i.e. the uploaded `build.zip` is truncated or was never a real zip. The old strict match turned that into an uncaught `MatchError`, which:

- Ran to full Oban retry (5 attempts) even though the bytes on disk cannot fix themselves between attempts.
- Sent Hive a fresh event on every attempt (roughly 215 events over 27 hours by the time we caught it).
- Left the build stuck in `processing` until the last attempt happened to hit the generic `{:error, reason}` branch.

## Root cause

Two-part root cause:

1. **Immediate cause (server side).** Line 32 asserted `{:ok, _} = :zip.unzip(...)`. Any non-`:ok` return raised before the worker's `{:error, reason}` branch could classify it, so all bad-zip cases went through Oban's uncaught-exception path.
2. **Upstream cause (why we see bad zips at all).** The command-line tool's upload flow in `UploadBuildRunService.bundleBuild` zips the artifact directory into a temp file and then multipart-uploads it without validating the archive. The most plausible sources of the corrupted uploads:
   - The tool is killed after the zip stream started but before the End Of Central Directory footer is flushed (SIGKILL, machine sleep, canceled Xcode invocation, terminal window closed). A 0-byte or truncated `build.zip` is then uploaded verbatim.
   - `fileSystem.zipFileOrDirectoryContent` errors quietly (permission on a source file, temp dir wiped early) and leaves the target as an empty file.
   - Neither S3 multipart nor the download path corrupts the bytes: S3 verifies part ETags, and the server writes the download to disk before `:zip.unzip` sees it. So this really is a source-side archive problem.

This pull request only fixes the server-side handling. Sanity-checking the archive in the tool before upload is a good follow-up.

## Approach

Return a discrete `:bad_zip` tag from the processor and handle it explicitly in the worker. Alternatives considered:

- **Swallow the error silently.** Rejected: we still want the build to move out of `processing` and into `failed_processing` so users see a clear terminal state.
- **Let Oban retry to exhaustion.** Rejected: retrying a bad archive is pointless and generates one Hive event per attempt.
- **Rescue the raise generically in the worker.** Rejected: hides the specific case behind an opaque `rescue`, and the codebase already uses discrete error tags (`:project_not_found`, `:object_not_found`) for the same shape of concern (see [feedback_no_rescue_pattern_match](https://github.com/tuist)).

## Impact

- Users whose builds ship a corrupt archive now see the build as `failed_processing` after the first attempt instead of waiting through five Oban retries.
- The processor no longer pages Hive on bad archives, so real signal is no longer buried under this class of events.
- No behavioral change for healthy archives: the happy path is unchanged.

## Validation

- `mix format --check-formatted` on the four changed files: clean.
- `MIX_ENV=test mix compile` (existing pre-existing warnings in `lib/tuist/locale.ex` unrelated to this change; no new warnings).
- `mix run --no-start` executing the new `BuildProcessorTest`: both cases pass against the real `:zip.unzip/2` with a non-zip and a 0-byte file input.
- The worker test could not be run locally because the pre-`mix test` migration validator opens ClickHouse→Postgres connections and my Postgres was saturated at 81/100 from other local development processes. The new case follows the existing `:project_not_found` discard pattern in the same file, so CI will verify it.

### How to test locally

```elixir
zip = "/tmp/broken.zip"
File.write!(zip, "not a zip")
Tuist.Processor.BuildProcessor.process_build(zip, false)
# {:error, :bad_zip}
```

Then, in `ProcessBuildWorker`, stubbing `BuildProcessor.process_build/2` to return `{:error, :bad_zip}` should produce `{:discard, :bad_zip}` and write a `failed_processing` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
