### PR TITLE
fix(infra): keep hcloud-csi-node off the Vultr kura fleet

### DIFF
--- a/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
+++ b/infra/k8s/mgmt/bootstrap/hcloud-csi-values.yaml
@@ -94,6 +94,9 @@ node:
   # hcloud-csi-node landed on the new bare-metal boxes and
   # CrashLoopBackOff'd (hcloud Volumes can't attach off Hetzner).
   # A new kura region on an existing provider now needs no edit here.
+  # A new *provider* does: its `instance-type` value has to join the
+  # list below. Adding the Vultr fleet missed that, and
+  # hcloud-csi-node crash-looped on `sa-west` exactly as #11346 had.
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -119,7 +122,7 @@ node:
                   - clickhouse
               # Nodes the in-house CAPI provider brings up on
               # non-Hetzner infrastructure (OVHcloud, Dedibox,
-              # Scaleway) for the kura cache fleets. hcloud Volumes
+              # Scaleway, Vultr) for the kura cache fleets. hcloud Volumes
               # can't attach anywhere off Hetzner, so the driver only
               # crash-loops there; the server provisions those PVCs
               # from local NVMe instead. Keying on the provider label
@@ -133,6 +136,7 @@ node:
                   - ovh
                   - dedibox
                   - scaleway
+                  - vultr
               - key: kubernetes.io/os
                 operator: NotIn
                 values:


### PR DESCRIPTION
## What changed

Adds `vultr` to the `node.cluster.x-k8s.io/instance-type` exclusion in the `hcloud-csi-node` node affinity, alongside `ovh`, `dedibox` and `scaleway`.

## Why

`hcloud-csi-node` has been in `CrashLoopBackOff` on the `sa-west` Vultr node since it joined, 371 restarts by the time this was written. The driver container's own log says it plainly:

```
msg="unable to connect to the metadata service"
msg="failed to setup CSI driver" error="could not determine default volume location:
  failed to get location from metadata service: response status was 404"
```

It is looking for Hetzner Cloud's metadata service to resolve a default volume location. A Vultr box has no such endpoint, so the driver exits before it ever creates `/run/csi/socket`, and `csi-node-driver-registrar` and `liveness-probe` then sit logging `Still connecting` until the pod is restarted. hcloud Volumes cannot attach off Hetzner regardless, so there is nothing for it to do on this node.

## Root cause

This is the same failure as #11346, which is what `hcloud-csi-values.yaml` exists to prevent, and the file already explains the rule it is built on: exclude by provider rather than by enumerating pool names, so that "a new kura region on an existing provider now needs no edit here."

Vultr is not a new region on an existing provider. It is a new provider, and a new provider's `instance-type` value does have to be added to that list. Adding the Vultr machine kind and fleet missed it. The comment now says that explicitly, since the existing wording emphasises the case that needs no edit and reads as though the list is self-maintaining.

## Why not exclude by pool

Enumerating pools is precisely what caused #11346. Keying on the provider label keeps every future `kura-*` region on Vultr excluded with no further edits, which is the property the rest of the list already has.

## Impact

Ends a permanent crash loop on every Vultr fleet node, present and future. No effect on any other node: the rule is `NotIn`, and only nodes that explicitly advertise `instance-type: vultr` are filtered out.

Worth noting what this does not fix. The pod's restarts are cosmetic in the sense that nothing on the node depends on it, but a DaemonSet that can never converge is permanent noise in pod-health views and in any alert that counts restarting containers.

## Validation

Confirmed on the live node that the label the rule keys on is present and that the current affinity does not cover it:

```
node.cluster.x-k8s.io/instance-type=vultr
instance-type NotIn [ovh dedibox scaleway]     <- before
instance-type NotIn [ovh dedibox scaleway vultr]  <- after
```

Read the three container logs off the running pod to confirm the metadata service is the cause rather than a transient, and that `csi-node-driver-registrar` and `liveness-probe` are downstream of the driver's exit rather than failing independently.

Parsed the edited file with `yq` and read back the resulting `values` list.

`csi-deployment.yml` triggers on pushes to main touching this file and applies it to canary, staging and production in parallel, so merging is the whole rollout.