### PR TITLE
feat(infra): serve the sa-west Kura region

### DIFF
--- a/infra/helm/platform/values-tuist.yaml
+++ b/infra/helm/platform/values-tuist.yaml
@@ -169,12 +169,8 @@ kura-ap-southeast-ingress-nginx:
 # South America West (Santiago, Vultr). Same host-network shape as the other
 # bare-metal regions: the region's gateway binds the box's public IP, and Vultr
 # has no cloud LoadBalancer to put in front of it.
-#
-# Disabled until the region is served. It flips to true alongside
-# vultrFleets.sa-west and the TUIST_KURA_AVAILABLE_REGIONS entry; until the pool
-# has a node this would schedule nothing anyway.
 kura-sa-west-ingress-nginx:
-  enabled: false
+  enabled: true
   controller:
     kind: DaemonSet
     hostNetwork: true

--- a/infra/helm/tuist/templates/kura-fleet-storage.yaml
+++ b/infra/helm/tuist/templates/kura-fleet-storage.yaml
@@ -496,6 +496,19 @@ node for a metrics endpoint.
 {{- end }}
 {{- end }}
 {{- end }}
+{{- /* vultrFleets carries the same shape and the same taint default, so a Vultr
+   cache pool qualifies on the same test. Without this the exporter never lands
+   on the pool and kura_volume_quota_enforced has no series for it at all, which
+   reads as "no data" rather than as an unbounded volume. */ -}}
+{{- range $key, $fleet := .Values.vultrFleets }}
+{{- if $fleet.enabled }}
+{{- range $taint := dig "machine" "nodeTaints" (list (dict "key" "tuist.dev/kura-cache")) $fleet }}
+{{- if eq $taint.key "tuist.dev/kura-cache" }}
+{{- $pools = append $pools ($fleet.nodePool | default (printf "kura-%s" $key)) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -192,7 +192,7 @@ server:
     # per-account cache pods and dispatch routes the Mac fleet's build
     # cache to it over the Private Network.
     - name: TUIST_KURA_AVAILABLE_REGIONS
-      value: eu-central,us-east,us-west,ap-southeast,scw-fr-par-runners
+      value: eu-central,us-east,us-west,ap-southeast,sa-west,scw-fr-par-runners
     # Wave 0 (canary) of a progressive Kura runtime rollout: Tuist-owned
     # accounts, and only those (spec #79).
     - name: TUIST_KURA_CANARY_ACCOUNT_HANDLES
@@ -839,10 +839,8 @@ vultrFleets:
   #
   # Running a box here is not the same as serving the region: that is decided by
   # sa-west's presence in TUIST_KURA_AVAILABLE_REGIONS and by its ingress
-  # controller in the platform chart, and both are worth leaving closed until
-  # kura_volume_quota_enforced reads 1 on the node. It is 0 on a box whose /data
-  # cannot bound anything, which is otherwise invisible right up to the point one
-  # account fills the box and kubelet evicts every tenant on it.
+  # controller in the platform chart. Both are open. Closing either one takes the
+  # region out of service without touching the box.
   sa-west:
     enabled: true
     replicas: 1


### PR DESCRIPTION
## What changed

Three things, which together put Santiago into service:

1. `kura-sa-west-ingress-nginx` goes to `enabled: true` in the platform chart.
2. `sa-west` joins `TUIST_KURA_AVAILABLE_REGIONS` in the production values.
3. The `kura-volume-quota-exporter` DaemonSet's node affinity now includes the Vultr cache pools, on the same taint test already used for `ovhFleets`.

## Why

The box has been adopted and healthy since yesterday. `values-managed-production.yaml` already said what serving the region requires, and set the bar for opening it: `kura_volume_quota_enforced` reading 1 on the node, because a 0 there means a `/data` that cannot bound anything, which stays invisible until one account fills the box and kubelet evicts every tenant on it.

That bar could not be met as written. The exporter that emits the metric is scoped by node affinity to an enumerated pool list built from `kuraFleet`, `dediboxFleet`, `ovhFleet` and `ovhFleets`. There is no `vultrFleets` branch, so the exporter never scheduled onto `kura-sa-west` and the metric had no series for the node at all. Absent series reads as "no data", not as "unbounded", so the gate would have looked unmet forever while actually being unmeasured.

Item 3 closes that. This is the third enumeration in this repo that a new provider has to be added to, after the CAPI CRD contract labels and the hcloud-csi exclusion in #13023.

## How the precondition was met

Rather than open the region on an unmeasured node, the underlying fact was verified directly on the box, since that is what the exporter reports:

```
Project quota state on /data (/dev/nvme0n1p2)
  Accounting: ON
  Enforcement: ON

/dev/nvme0n1p2 xfs rw,...,prjquota
```

That is the same condition `kura_volume_quota_enforced=1` encodes, read at the source instead of through the exporter. It also agrees with the `QUOTA true` column the reconciler already reports on the VultrMachine, which comes from the conversion result and the self-join gates. Once this deploys the exporter lands on the node and the metric appears alongside the other four production series, which all read 1.

## Impact

Santiago starts serving. `Tuist.Kura.OriginMap` already prefers `sa-west` for the `south_america` zone, so accounts originating there get placed on it; production placement is propose-only, so nothing moves existing accounts on its own.

Closing either gate takes the region back out of service without touching the box, and the comment in the values file now says that rather than describing a pre-service state that no longer holds.

## Validation

Rendered the production chart and read the results back rather than trusting the edits:

```
kura-volume-quota-exporter nodeAffinity values:
  "kura-scw-fr-par" "kura-dedibox" "kura-ap-southeast" "kura-us-east" "kura-us-west" "kura-sa-west"

TUIST_KURA_AVAILABLE_REGIONS:
  eu-central,us-east,us-west,ap-southeast,sa-west,scw-fr-par-runners
```

Confirmed the platform chart's `condition: kura-sa-west-ingress-nginx.enabled` matches the value now set to true, and confirmed on the node that project quota accounting and enforcement are both ON.