### PR TITLE
fix(infra): take a full when the week's ClickHouse backup base is missing

### DIFF
--- a/infra/helm/tuist/templates/clickhouse-backup.yaml
+++ b/infra/helm/tuist/templates/clickhouse-backup.yaml
@@ -27,9 +27,30 @@ Tuesday through Sunday resolves to the full taken at the start of its own
 week. Moving the full to Sunday would silently pair each incremental with the
 previous week's full.
 
-If a full fails, that week's incrementals fail too, because their base is
-missing. That is deliberate. The alternative is an "incremental" that quietly
-promotes itself to a full and takes a terabyte by surprise.
+## When the week's full is missing
+
+An incremental whose base does not exist takes a full instead, under the same
+`full/$WEEK` path, and says so in its log.
+
+This reverses an earlier decision here, which was to let those incrementals
+fail on the grounds that the alternative is an "incremental" that quietly
+promotes itself to a full and takes a terabyte by surprise. The surprise is
+real. It is the smaller problem.
+
+What the earlier reasoning covered was a failed Monday, where an operator is
+already being paged and can re-run the full the same day. What it did not
+cover is an environment enabled on any day other than Monday: its first full
+is not due until the following Monday, so every incremental until then fails
+against a base that was never taken, and the environment holds no backup at
+all for up to six days while alerting daily in a way that reads like a
+credentials fault. That happened to canary and staging in 2026-W37, and it
+would have happened to production on whichever weekday it was enabled, during
+the part of the migration where the in-cluster server is least proven.
+
+So the trade is an unplanned full against no backup at all, and it resolves
+the same way in both the cases above. It is bounded by the same
+`timeoutSeconds` and by `concurrencyPolicy: Forbid`, and the log line names it
+rather than leaving a full to be inferred from the object store.
 
 ## Restoring
 
@@ -63,7 +84,9 @@ the log collector entirely, so the object itself is the record.
   (dict "suffix" "full" "schedule" $m.backup.fullSchedule "query" (printf "BACKUP DATABASE \\`%s\\` TO Disk('backups', 'full/$WEEK')" $m.database)
         "describe" "a full backup for ISO week $WEEK")
   (dict "suffix" "incremental" "schedule" $m.backup.incrementalSchedule "query" (printf "BACKUP DATABASE \\`%s\\` TO Disk('backups', 'incremental/$WEEK/$DAY') SETTINGS base_backup = Disk('backups', 'full/$WEEK')" $m.database)
-        "describe" "an incremental backup for $DAY against the full for ISO week $WEEK")
+        "describe" "an incremental backup for $DAY against the full for ISO week $WEEK"
+        "fallbackQuery" (printf "BACKUP DATABASE \\`%s\\` TO Disk('backups', 'full/$WEEK')" $m.database)
+        "fallbackDescribe" "a full backup for ISO week $WEEK")
 }}
 {{- range $job := $jobs }}
 ---
@@ -127,14 +150,38 @@ spec:
                 - |
                   WEEK=$(date -u +%G-W%V)
                   DAY=$(date -u +%F)
+                  ch() {
+                    clickhouse-client \
+                      --host {{ $chName }} \
+                      --port 9000 \
+                      --user default \
+                      --password "$CLICKHOUSE_PASSWORD" \
+                      --receive_timeout {{ $m.backup.timeoutSeconds }} \
+                      --query "$1"
+                  }
                   echo "Taking {{ $job.describe }}"
-                  clickhouse-client \
-                    --host {{ $chName }} \
-                    --port 9000 \
-                    --user default \
-                    --password "$CLICKHOUSE_PASSWORD" \
-                    --receive_timeout {{ $m.backup.timeoutSeconds }} \
-                    --query "{{ $job.query }}"
+                  if out=$(ch "{{ $job.query }}" 2>&1); then
+                    printf '%s\n' "$out"
+                    exit 0
+                  fi
+                  printf '%s\n' "$out" >&2
+{{- if $job.fallbackQuery }}
+                  # Only a missing base falls back. Every other failure is a
+                  # real one and must stay a failure: promoting a permission
+                  # error or an unreachable server into a full backup attempt
+                  # would turn one alert into two and still leave no backup.
+                  case "$out" in
+                    *BACKUP_NOT_FOUND*)
+                      echo "No full backup exists for ISO week $WEEK, so taking {{ $job.fallbackDescribe }} instead of an incremental."
+                      ch "{{ $job.fallbackQuery }}"
+                      ;;
+                    *)
+                      exit 1
+                      ;;
+                  esac
+{{- else }}
+                  exit 1
+{{- end }}
               resources:
                 {{- toYaml $m.backup.resources | nindent 16 }}
 {{- end }}


### PR DESCRIPTION
## What changed

The ClickHouse incremental backup now takes a full, under the same `full/$WEEK` path, when the full it would have been based on does not exist. It logs that it did so. Any other failure still fails.

## The incident

Canary and staging both alerted on a failed incremental in 2026-W37. From the failed pod's log:

```
Code: 599. DB::Exception: Backup Disk('backups', 'full/2026-W37') not found. (BACKUP_NOT_FOUND)
(query: BACKUP DATABASE `tuist` TO Disk('backups', 'incremental/2026-W37/2026-09-09')
        SETTINGS base_backup = Disk('backups', 'full/2026-W37'))
```

Neither environment had failed a backup. Both had their backup CronJobs created after Monday 01:00, so that week's full was never due: `LAST SCHEDULE` on `backup-full` was `<none>` in both, with the CronJobs 19h and 9h old respectively.

The alert's own runbook lists "a full backup missing, when an incremental fails" among the likely causes, but the first two it names are credentials and an unreachable server, so the failure reads like a credentials fault until you pull the log.

## Why this is worth changing rather than re-running by hand

It is not a one-off. Every environment whose backups are enabled on a day other than Monday has no full until the following Monday, and every incremental until then fails. That is up to six days with no backup and a daily alert.

Production is the case that matters. Enabling it on a weekday would leave the in-cluster server with no second copy exactly while it is least proven, and the migration's whole argument for the machine is that a RAID mirror survives a dead disk but not a dropped table or a bad migration.

## This reverses a documented decision

The file said, in as many words, that a failed full failing that week's incrementals was deliberate, because the alternative is an "incremental" that quietly promotes itself to a full and takes a terabyte by surprise.

That surprise is real, and it is the smaller problem. The original reasoning covered a **failed Monday**, where an operator is already being paged and can re-run the full the same day. It did not cover a **first enablement**, where nothing is due for days and no one is paged into a state that self-corrects. The trade is an unplanned full against no backup at all.

The note in the template has been rewritten to carry both the original argument and why it changed, rather than deleting it.

## Scope of the fallback

Only `BACKUP_NOT_FOUND` falls back. Every other failure exits non-zero as before, because promoting a permission error or an unreachable server into a full backup attempt would turn one alert into two and still leave no backup. The fallback is bounded by the same `timeoutSeconds` and `activeDeadlineSeconds`, and by `concurrencyPolicy: Forbid`.

The full backup job is unchanged apart from sharing the new `ch` helper.

## Validation

Rendered canary with `values-managed-common.yaml` plus the overlay and read the generated script, then ran that emitted shell against a stubbed `clickhouse-client` for all three outcomes:

| First attempt | Result |
|---|---|
| succeeds | prints output, exits 0, no fallback |
| fails `BACKUP_NOT_FOUND` | logs the reason, takes the full, exits 0 |
| fails `Access Denied` | exits 1, no fallback |

The `set -e` interaction is the part worth checking and is covered: the attempt runs inside an `if` condition, so it does not abort the script, and the fallback runs unguarded so a failing full still fails the job.

## Already done by hand

The immediate gap is closed. A full was seeded in both environments before this PR, so tonight's incrementals have a base:

- staging `ch-backup-w37`: `BACKUP_CREATED` in 11s
- canary `ch-backup-w37`: `BACKUP_CREATED` in 6s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
