### PR TITLE
feat(infra): mirror ClickHouse writes to canary's in-cluster server

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -279,6 +279,27 @@ clickhouse:
         # not the pool label. The second box is joined, tainted and idle until
         # the two-replica work lands.
         nodeName: bm-tuist-canary-md-clickhouse-zxbdh-hkgcf-nlxk4
+    # Dual writes come before the backfill, not after it. From the moment this
+    # is on, every new row reaches both servers; the backfill then copies what
+    # was written before a stated cutoff. Doing it the other way round leaves
+    # the rows written between the copy finishing and the mirror starting on
+    # Cloud alone, with nothing later looking for them.
+    #
+    # Cloud stays the system of record. Nothing reads from the in-cluster
+    # server yet, so a mirrored write that fails costs a metric and not a
+    # request: inserts are handed to a bounded Task.Supervisor rather than
+    # awaited, and mutations stay synchronous so an `ALTER TABLE ... DELETE`
+    # cannot overtake the inserts it is meant to erase.
+    #
+    # Gate to leave this step: `tuist_clickhouse_shadow_write_count{result}`
+    # settles with no `dropped` once the pods have started. A pod's shadow pool
+    # is not ready for the first seconds of its life, which is what the retry
+    # covers, and retrying is safe because every destination table is
+    # `Replicated*` and deduplicates identical insert blocks by checksum.
+    #
+    # Rollback: turn it off. Nothing has read from that server.
+    shadowWrites:
+      enabled: true
     keeper:
       replicas: 1
     backup:
@@ -298,17 +319,24 @@ clickhouse:
     # makes the destination reject a non-replicated table, so creation
     # succeeding is the proof.
     #
-    # Being a post-upgrade hook, this re-runs on every deploy while it is
-    # enabled. That is harmless for the clone, which creates what is missing
-    # and leaves the rest, but the step after it is not: advance `task` rather
-    # than leaving this armed once the gate is met.
+    # Off, because the clone has run here: 84 tables, 30 views, 245 migration
+    # versions, nothing failed. Each step is a post-upgrade hook, so leaving
+    # one enabled re-runs it on every deploy. That was harmless for the clone,
+    # which creates what is missing and leaves the rest alone, and it is not
+    # harmless for what comes next.
     #
-    # `cutoff` stays unset. It belongs to the backfill, two steps later, and is
-    # read off the completed rollout of the deploy that turns dual writes on.
+    # `name` and `task` are the step this would run if it were enabled, which
+    # is why they name the *next* one rather than the last that ran.
+    #
+    # `cutoff` is deliberately absent, and arming the backfill without it fails
+    # loudly rather than copying to a stale timestamp. Set it to a moment after
+    # the deploy that turns dual writes on above has finished rolling out: the
+    # backfill covers everything before it, the mirror covers everything after,
+    # and naming the boundary is what stops the two from leaving a gap.
     migration:
-      enabled: true
-      name: schema-clone
-      task: Tuist.Release.clone_clickhouse_schema
+      enabled: false
+      name: backfill
+      task: Tuist.Release.backfill_clickhouse
 
   poolSize: "30"
   bufferPoolSize: "30"


### PR DESCRIPTION
## What changed

Canary mirrors every ClickHouse write to the in-cluster server, and the schema clone is stood down in the same change.

```yaml
shadowWrites:
  enabled: true
migration:
  enabled: false          # was: true, schema-clone
  name: backfill          # names the next step, not the last one
  task: Tuist.Release.backfill_clickhouse
```

## Why dual writes come before the backfill

The backfill copies what was written **before a stated cutoff**. If the copy ran first, every row written between it finishing and the mirror starting would exist on Cloud alone, with nothing later looking for them. Turning the mirror on first inverts that: the backfill covers everything before the boundary, the mirror covers everything after, and the cutoff is the name of the boundary.

That cutoff is read off *this* deploy's completed rollout, which is why it cannot be set in this change and why step 5 is a separate one.

## What this does and does not do

Cloud stays the system of record and nothing reads from the in-cluster server, so a mirrored write that fails costs a metric rather than a request. Inserts are handed to a bounded `Task.Supervisor` instead of being awaited. Mutations stay synchronous, because an asynchronous `ALTER TABLE ... DELETE` could overtake the inserts it is meant to erase.

The destination's tables exist and are empty. This makes them start filling from now; it does not backfill history.

## Standing the clone down

The clone has run on canary: 84 tables, 30 views, 245 migration versions, nothing failed.

Every migration step is a `post-upgrade` hook, so leaving one enabled re-runs it on every deploy. Confirmed rather than assumed: the `schema-clone` and `init` Jobs on canary were 83 minutes old when checked, having re-run on the most recent deploy. That is harmless for the clone, which creates what is missing and leaves the rest alone, and it is not harmless for the backfill.

Following the convention already in `values-managed-staging.yaml`, `name` and `task` name the step this *would* run if enabled, so they point at the backfill rather than at the clone that last ran. `cutoff` stays absent, and the backfill refuses to run without one, so arming it without choosing a boundary fails loudly instead of copying up to a stale timestamp.

## Gate and rollback

Leave this step when `tuist_clickhouse_shadow_write_count{result}` settles with no `dropped` once the pods have started. A pod's shadow pool is not ready for the first seconds of its life, which is what the retry covers, and retrying is safe because every destination table is `Replicated*` and deduplicates identical insert blocks by checksum for seven days.

Rollback is turning it off, with no data loss, because nothing has read from that server.

## Validation

Rendered all three environments the way the deploy does, with `values-managed-common.yaml` followed by the per-env overlay:

| | `TUIST_CLICKHOUSE_SHADOW_WRITES_ENABLED` | migration Job |
|---|---|---|
| canary | 4 workloads | none |
| staging | 4 workloads, unchanged | none |
| production | none | none |

The four are `server-deployment`, `server-migration-job`, `processor-deployment` and `xcresult-processor-deployment`, which is the full set that writes ClickHouse. The xcresult processor matters specifically: it writes the test tables, so without it the mirror would cover only what the web pods insert and every row parsed out of an xcresult would reach Cloud alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
