### PR TITLE
fix(infra): stop the Kura wildcard certificate from blocking deploys

### DIFF
--- a/infra/helm/tuist/values-managed-common.yaml
+++ b/infra/helm/tuist/values-managed-common.yaml
@@ -40,8 +40,13 @@ kuraController:
   # chart. The controller uses it for the shared wildcard below, and for the
   # per-instance certificate of any instance that wildcard does not cover.
   tlsClusterIssuer: "letsencrypt-cloudflare"
+  # Disabled until the wildcard can be issued without blocking a release.
+  # `--rollback-on-failure` defaults Helm 4's wait strategy to `watcher`, which
+  # waits on every resource in the release including cert-manager Certificates,
+  # so a wildcard held in ACME backoff fails the whole deploy and rolls it back.
+  # Re-enable once the Certificate is created outside the release.
   publicWildcardCertificate:
-    enabled: true
+    enabled: false
     dnsNames:
       - "*.kura.tuist.dev"
   telemetry:


### PR DESCRIPTION
Unblocks the production cascade, which is red and skipping production since #13006.

## What happened

The canary deploy failed and rolled back:

```
Upgrade "tuist" failed: resource Certificate/kura/kura-public-wildcard-tls not ready.
status: InProgress, message: Issuing certificate as Secret does not exist
```

Acceptance tests, the Kura canary rollout gate, and production were all skipped as a result. Canary is healthy on the rolled-back release and production never deployed, so no environment is broken; nothing can ship.

## Root cause

`server-deployment.yml` passes `--rollback-on-failure`. In Helm 4 that defaults the wait strategy to `watcher`, which waits on every resource in the release rather than only hooks, and that includes custom resources. A cert-manager `Certificate` therefore counts toward release readiness.

The wildcard cannot be issued yet. Its ACME order is refused with exactly the limit the wildcard exists to escape:

```
429 rateLimited: too many certificates (50) already issued for "tuist.dev"
in the last 168h0m0s, retry after 2026-09-09 10:49:00 UTC
```

So the Certificate sits `InProgress`, the release exceeds its timeout, and every deploy to that environment rolls back. This is not specific to the rate limit: any first issuance that takes longer than the release timeout blocks the deploy, so a new environment would hit it too.

I missed it because I validated with `helm template` and `helm lint`, neither of which models the wait, and the staging run that would have caught it failed earlier on an unrelated immutable ClickHouse PV.

## What this changes

Renders the wildcard disabled on managed clusters. The controller flag is gated on the same value, so instances stay on their per-instance certificates, which is what the fleet runs today. Verified the production overlay now renders zero references to `kura-public-wildcard-tls`.

## Follow-up

The real fix is to create the wildcard outside the release so no deploy ever waits on an ACME order. Helm offers no per-resource opt-out from the wait, and moving it to the platform chart inherits the same `--wait`, so it belongs in the kura-controller as an unowned cluster singleton, which also keeps it free of any `KuraInstance` owner reference. The controller already holds RBAC for Certificates. I will open that separately.

Worth keeping in view: production is still minting one per-tenant certificate roughly every 90 minutes against a saturated window, and 43 of the existing certificates renew in the same week about eight weeks out, so the underlying problem is still live and on a clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
