### PR TITLE
fix(server): expand the Linux runner fleet to six RISE-L hosts

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -980,11 +980,11 @@ ovhFleets:
     # adopting it. Growing the fleet is `baremetal:prep-ovh` on each new box,
     # then this number.
     #
-    # Four boxes carry the Linux runner fleet: 128 GB each is 32 slots at the
-    # chart's 1 vCPU / 4 GB slot size, so 128 in total. Slots and threads are 1:1
+    # Six boxes carry the Linux runner fleet: 128 GB each is 32 slots at the
+    # chart's 1 vCPU / 4 GB slot size, so 192 in total. Slots and threads are 1:1
     # on this shape, so there is no oversubscription headroom to absorb a burst;
     # capacity grows by box count rather than by packing slots tighter.
-    replicas: 4
+    replicas: 6
     # The OVHcloud entity holding the account, not the box's geography: the RISE
     # range's EU-datacenter plan codes are orderable under OVHcloud US. Every OVH
     # fleet must share one value, because the reconciler resolves a single

--- a/infra/k8s/clusters/README.md
+++ b/infra/k8s/clusters/README.md
@@ -67,7 +67,7 @@ the tenant-repo copies are then retired to a pointer.
 |---|---|---|
 | `tuist-staging` | 3× cpx22 | md-0: 2× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); md-clickhouse: 1× AX42-1 in `fsn1` (`pool=clickhouse`, `stateful-worker`); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); runners-linux: 1× OVH RISE-S in `gra` (`pool=runners-linux`) |
 | `tuist-canary` | 3× cpx22 | md-0: 3× cpx32; md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); kura: 3× ccx13 (`pool=kura`); runners-linux: 1× OVH RISE-S in `gra` (`pool=runners-linux`) |
-| `tuist` (production) | 3× cpx22 | md-0: 3× ccx23 (`pool=general`); md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); kura-us-east: 3× ccx13 in `ash` (`pool=kura-us-east`, autoscaled 3→32); kura-us-west: 3× ccx13 in `hil` (`pool=kura-us-west`, autoscaled 3→12); runners-linux: 4× OVH RISE-L in `gra` (`pool=runners-linux`) |
+| `tuist` (production) | 3× cpx22 | md-0: 3× ccx23 (`pool=general`); md-egress: 2× cpx22 (`pool=egress`, HA stable-egress gateway); md-processor: 2× cpx62 (`pool=processor`, autoscaled 2→6); kura: 3× ccx13 (`pool=kura`, autoscaled 3→12); kura-us-east: 3× ccx13 in `ash` (`pool=kura-us-east`, autoscaled 3→32); kura-us-west: 3× ccx13 in `hil` (`pool=kura-us-west`, autoscaled 3→12); runners-linux: 6× OVH RISE-L in `gra` (`pool=runners-linux`) |
 | `tuist-preview` | 1× cpx22 | md-0: 1× cpx42 |
 | `tuist-pentest` | 3× cpx22 | md-0: 2× cpx32 (`pool=general`) |
 


### PR DESCRIPTION
Production Linux runner jobs have exceeded the queue-age threshold while the four-host RISE-L fleet is under placement pressure. Each host has 31 allocatable CPUs, and a 16-vCPU runner requests 16.25 CPUs including Kata overhead, so only one such runner fits per host even when smaller runners can use the remaining capacity.

Increase `ovhFleets.runners-linux.replicas` from four to six and update the fleet capacity comments and cluster inventory. The two additional Ryzen 9 9950X hosts add 64 hardware threads and 256 GB RAM, preserving the existing single-thread performance and provisioning configuration. The fleet can seat up to six 16-vCPU runners when other workloads leave room. Existing runner shapes stay unchanged. This is a capacity increase; the reservation behaviour investigated during the incident still needs a separate correction.

The two purchased hosts are `ns3049365.ip-51-255-75.eu` and `ns3049246.ip-51-255-75.eu`, both RISE-L in GRA1. OVH has accepted the standard Ubuntu 24.04 installation using the existing production fleet SSH public key and the repository's mirrored root plus XFS `/data` layout. Keep this PR in draft until installation is complete and both hosts have the verified production adoption marker. The controller adopts pre-prepared servers; deploying a higher replica count before they are available would stall fleet readiness and can trigger Helm rollback.

Validation:
- Confirmed all four existing production runner Machines are Ready and neither new service was claimed before installation.
- Confirmed both new services report the RISE-L commercial range, GRA1 location, and no existing OS before initiating preparation.
- Rendered the managed production Helm chart in the live `tuist` namespace, supplying placeholder values for image tags normally injected by CI; verified the runner MachineDeployment renders six replicas.
- `git diff --check origin/main...HEAD` passed.

Post-provisioning validation pending: completed OVH install tasks, SSH/storage checks, verified adoption names, and six Ready cluster hosts after deployment.
