### PR TITLE
feat(server): redesigned newsletter issue page and email in the new marketing language

### DIFF
--- a/server/lib/tuist/marketing/newsletter/issue_parser.ex
+++ b/server/lib/tuist/marketing/newsletter/issue_parser.ex
@@ -3,6 +3,11 @@ defmodule Tuist.Marketing.Newsletter.IssueParser do
   This module is responsible for parsing changelog entries from markdown files.
   """
 
+  # Links inside the issue fragments carry their colour inline (Gmail drops
+  # <style> blocks): the primary label colour of the marketing palette,
+  # underlined, so they read the same in the inbox and on the web page.
+  @link_style "color: #191a1b; text-decoration: underline;"
+
   @plain_html_template Solid.parse!(~s"""
                        <h1>{{ full_title }}</h1>
                        <h2>Welcome to issue {{ number }}</h2>
@@ -102,46 +107,43 @@ defmodule Tuist.Marketing.Newsletter.IssueParser do
     end)
   end
 
-  defp md_to_html(md, opts \\ []) do
-    a_color = Keyword.get(opts, :a_color, "#622ed4")
-
+  defp md_to_html(md) do
     # Gmail doesn't support styling through <style></style>, so when converting markdown to HTML, we have to apply the right
     # styling at the element level by using "style" attributes.
     md
     |> MDEx.to_html!(parse: [smart: false], render: [unsafe: true])
     |> Floki.parse_fragment!()
-    |> style_email_nodes(a_color)
+    |> style_email_nodes()
     |> Floki.raw_html()
   end
 
-  defp style_email_nodes(nodes, a_color) do
-    Enum.map(nodes, &style_email_node(&1, a_color, false))
+  defp style_email_nodes(nodes) do
+    Enum.map(nodes, &style_email_node(&1, false))
   end
 
-  defp style_email_node({"pre", attrs, children}, a_color, _inside_pre) do
-    {"pre", attrs, Enum.map(children, &style_email_node(&1, a_color, true))}
+  defp style_email_node({"pre", attrs, children}, _inside_pre) do
+    {"pre", attrs, Enum.map(children, &style_email_node(&1, true))}
   end
 
-  defp style_email_node({"a", attrs, children}, a_color, inside_pre) do
-    {"a", put_attribute(attrs, "style", "color: #{a_color};"),
-     Enum.map(children, &style_email_node(&1, a_color, inside_pre))}
+  defp style_email_node({"a", attrs, children}, inside_pre) do
+    {"a", put_attribute(attrs, "style", @link_style), Enum.map(children, &style_email_node(&1, inside_pre))}
   end
 
-  defp style_email_node({"blockquote", attrs, children}, a_color, inside_pre) do
+  defp style_email_node({"blockquote", attrs, children}, inside_pre) do
     {"blockquote", put_attribute(attrs, "style", "font-style: italic;"),
-     Enum.map(children, &style_email_node(&1, a_color, inside_pre))}
+     Enum.map(children, &style_email_node(&1, inside_pre))}
   end
 
-  defp style_email_node({"code", attrs, children}, a_color, false) do
-    {"code", put_attribute(attrs, "class", "inline"), Enum.map(children, &style_email_node(&1, a_color, false))}
+  defp style_email_node({"code", attrs, children}, false) do
+    {"code", put_attribute(attrs, "class", "inline"), Enum.map(children, &style_email_node(&1, false))}
   end
 
-  defp style_email_node({tag, attrs, children}, a_color, inside_pre) do
-    {tag, attrs, Enum.map(children, &style_email_node(&1, a_color, inside_pre))}
+  defp style_email_node({tag, attrs, children}, inside_pre) do
+    {tag, attrs, Enum.map(children, &style_email_node(&1, inside_pre))}
   end
 
-  defp style_email_node(text, _a_color, false) when is_binary(text), do: String.replace(text, "\n", " ")
-  defp style_email_node(node, _a_color, _inside_pre), do: node
+  defp style_email_node(text, false) when is_binary(text), do: String.replace(text, "\n", " ")
+  defp style_email_node(node, _inside_pre), do: node
 
   defp put_attribute(attrs, name, value) do
     case List.keytake(attrs, name, 0) do
@@ -154,9 +156,7 @@ defmodule Tuist.Marketing.Newsletter.IssueParser do
   end
 
   defp map_hero(hero) do
-    Map.replace_lazy(hero, "subtitle", fn subtitle_md ->
-      md_to_html(subtitle_md, a_color: "#622ed4")
-    end)
+    Map.replace_lazy(hero, "subtitle", &md_to_html/1)
   end
 
   # The .heex format is designed for the Phoenix.LiveView.Engine to track changes

--- a/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
@@ -728,10 +728,10 @@ defmodule TuistWeb.Marketing.MarketingController do
     conn =
       if email_version? do
         conn
-        |> put_resp_header("Content-Type", "text/plain; charset=utf-8")
+        |> put_resp_header("content-type", "text/plain; charset=utf-8")
         |> PlugMinifyHtml.call(PlugMinifyHtml.init([]))
       else
-        put_resp_header(conn, "Content-Type", "text/html")
+        put_resp_header(conn, "content-type", "text/html")
       end
 
     open_graph_image_url =
@@ -740,8 +740,12 @@ defmodule TuistWeb.Marketing.MarketingController do
         marketing: true
       )
 
+    issues = Newsletter.issues()
+
     render(conn, String.to_atom("newsletter_issue"),
       issue: issue,
+      previous_issue: Enum.find(issues, &(&1.number == issue.number - 1)),
+      next_issue: Enum.find(issues, &(&1.number == issue.number + 1)),
       email_version?: email_version?,
       open_graph_image_url: open_graph_image_url
     )

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex
@@ -1,375 +1,594 @@
-<!DOCTYPE html>
+<%!-- Newsletter issue (/newsletter/issues/:n). One template serves the web
+page and the email export (?email), so the two look the same. Email
+clients set the rules — tables, inline styles, no stylesheet, web-safe
+font fallbacks — and the design follows the marketing site's language
+within them: the neutral palette, bordered boxes on the tertiary ground
+separated by 2px seams, hairline rows, Inter and Geist Mono where they are
+available. The web version adds the head meta, the site's fonts and the
+share script; the email adds the "view in browser" and unsubscribe links. --%>
+<% font =
+  "'Inter Variable', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" %>
+<% mono = "'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" %>
+<% page_url = Tuist.Environment.app_url(path: @current_path, route_type: :marketing) %>
+<% asset_url = fn path ->
+  if String.starts_with?(path, "/"),
+    do: Tuist.Environment.app_url(path: path, route_type: :marketing),
+    else: path
+end %>
+<% link_style = "color: #191a1b; text-decoration: underline;" %>
+<%!-- The hero's alt text is authored as Markdown; keep only the link text. --%>
+<% plain_alt = fn
+  nil -> ""
+  alt -> Regex.replace(~r/\[([^\]]+)\]\([^)]+\)/, alt, "\\1")
+end %>
+<% eyebrow_style =
+  "margin: 0; font-family: #{mono}; font-size: 12px; line-height: 16px; letter-spacing: 0.02em; text-transform: uppercase; color: #535659;" %>
+<% section_title_style =
+  "margin: 0; font-family: #{font}; font-size: 20px; line-height: 26px; font-weight: 400; color: #191a1b;" %>
+<% item_title_style =
+  "margin: 0; font-family: #{font}; font-size: 18px; line-height: 24px; font-weight: 400; color: #191a1b;" %>
+<% muted_style =
+  "margin: 0; font-family: #{font}; font-size: 14px; line-height: 20px; color: #535659;" %>
+<% body_style =
+  "margin: 0; font-family: #{font}; font-size: 14px; line-height: 20px; color: #191a1b;" %>
+<% box_style =
+  "width: 100%; border: 1px solid #eff0f1; background: #fdfdfd; border-collapse: separate;" %>
+<% primary_button_style =
+  "display: inline-block; font-family: #{font}; font-size: 14px; line-height: 20px; font-weight: 500; color: #fdfdfd; background: rgb(111, 44, 255); border: 1px solid rgb(111, 44, 255); border-radius: 6px; padding: 8px 16px; text-decoration: none;" %>
+<% secondary_button_style =
+  "display: inline-block; font-family: #{font}; font-size: 14px; line-height: 20px; font-weight: 500; color: #191a1b; background: #fdfdfd; border: 1px solid #d9dbdd; border-radius: 6px; padding: 8px 16px; text-decoration: none;" %> <!DOCTYPE html>
 <html lang="en">
   <head>
     <title>{@issue.full_title}</title>
     <meta charset="UTF-8" />
+    <%!-- Dark mode: mail clients recolour backgrounds on their own, which
+    washes the purple button out. These rules pin its colours — the media
+    query covers Apple Mail and browsers, the [data-ogsc]/[data-ogsb]
+    selectors are what the Gmail apps honour. Everything else stays inline. --%>
+    <style nonce={get_csp_nonce()}>
+      @media (prefers-color-scheme: dark) {
+        .button-primary {
+          background-color: rgb(111, 44, 255) !important;
+          border-color: rgb(111, 44, 255) !important;
+          color: #fdfdfd !important;
+        }
+      }
+      [data-ogsc] .button-primary,
+      [data-ogsb] .button-primary {
+        background-color: rgb(111, 44, 255) !important;
+        border-color: rgb(111, 44, 255) !important;
+        color: #fdfdfd !important;
+      }
+    </style>
     <%= if not @email_version? do %>
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <meta name="color-scheme" content="light" />
       <meta name="description" content={Tuist.Marketing.Newsletter.description()} />
       <meta
         name="keywords"
         content="swift, developer tooling, open source, tuist, app development, newsletter"
       />
 
-      <meta
-        property="og:url"
-        content={Tuist.Environment.app_url(path: @current_path, route_type: :marketing)}
-      />
+      <meta property="og:url" content={page_url} />
       <meta property="og:type" content="website" />
       <meta property="og:title" content={@issue.full_title} />
       <meta property="og:description" content={Tuist.Marketing.Newsletter.description()} />
-      <meta
-        property="og:image"
-        content={@open_graph_image_url}
-      />
+      <meta property="og:image" content={@open_graph_image_url} />
       <meta property="og:image:width" content="1920" />
       <meta property="og:image:height" content="1080" />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@tuistdev" />
-      <meta
-        name="twitter:image"
-        content={@open_graph_image_url}
-      />
+      <meta name="twitter:image" content={@open_graph_image_url} />
       <meta name="twitter:title" content={@issue.full_title} />
       <meta
         property="twitter:domain"
         content={Tuist.Environment.app_url(path: "/") |> URI.parse() |> Map.get(:host)}
       />
+      <%!-- The site's fonts, for browsers only: the inline stacks fall back
+      to the system sans/mono in mail clients. --%>
+      <style nonce={get_csp_nonce()}>
+        @font-face {
+          font-family: "Inter Variable";
+          font-style: normal;
+          font-weight: 100 900;
+          font-display: swap;
+          src: url("/fonts/InterVariable.woff2") format("woff2");
+        }
+        @font-face {
+          font-family: "Geist Mono";
+          font-style: normal;
+          font-weight: 100 900;
+          font-display: swap;
+          src: url("/fonts/GeistMono-latin.woff2") format("woff2");
+        }
+        a:hover { opacity: 0.8; }
+      </style>
     <% end %>
   </head>
-  <body style="font-family: 'Arial', sans-serif; margin: 0; padding: 0;">
+  <body style={"margin: 0; padding: 0; background: #f7f7f7; font-family: #{font}; -webkit-font-smoothing: antialiased;"}>
     <span class="random" style="opacity: 0">{UUIDv7.generate()}</span>
     <table
-      width="768"
+      id="newsletter-issue"
+      role="presentation"
+      width="720"
       align="center"
-      style="width: 100% !important; max-width: 768px; padding: 1rem 2rem; box-sizing: border-box; vertical-align: middle;"
+      cellpadding="0"
+      cellspacing="0"
+      style="width: 100% !important; max-width: 720px; padding: 24px 8px 40px; box-sizing: border-box;"
     >
+      <%!-- Masthead box: the mark and the newsletter's name, with the email's
+      "view in browser" link (the web page links to the archive instead). Its
+      own bordered box on the surface colour, which also matches the logo
+      PNG's opaque background. --%>
       <tr>
-        <td style="width: 55px;">
-          <img
-            src={Tuist.Environment.email_icon_url()}
-            alt="Tuist Logo"
-            style="width: 55px; height: 55px; vertical-align: middle;"
-          />
-        </td>
-        <td style="width: 100%;">
-          <h1 style="margin: 0; font-size: 24px; vertical-align: middle; color: #2c2250; text-align: left;">
-            Swift Stories
-          </h1>
-        </td>
-        <td style="white-space: nowrap;">
-          <a
-            style="vertical-align: middle; color: #622ed4; text-decoration: underline; font-size: 16px; padding-left: 1rem;"
-            href={Tuist.Environment.app_url(path: @current_path, route_type: :marketing)}
-          >
-            {dgettext("marketing", "View in web browser")}
-          </a>
+        <td>
+          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+            <tr>
+              <td style="padding: 20px 32px; vertical-align: middle;">
+                <%!-- Logo and name in their own cells, both centred on the
+                same axis: inline image + text line boxes drift by a pixel
+                or two between mail clients. --%>
+                <table role="presentation" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td style="vertical-align: middle; padding-right: 12px;">
+                      <a
+                        href={
+                          Tuist.Environment.app_url(path: ~p"/newsletter", route_type: :marketing)
+                        }
+                        style="display: block; text-decoration: none;"
+                      >
+                        <img
+                          src={Tuist.Environment.email_icon_url()}
+                          alt="Tuist"
+                          width="64"
+                          height="28"
+                          style="display: block; width: 64px; height: 28px; border: 0;"
+                        />
+                      </a>
+                    </td>
+                    <td style="vertical-align: middle;">
+                      <a
+                        href={
+                          Tuist.Environment.app_url(path: ~p"/newsletter", route_type: :marketing)
+                        }
+                        style={"display: block; font-family: #{font}; font-size: 16px; line-height: 28px; color: #191a1b; text-decoration: none;"}
+                      >
+                        Swift Stories
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+              <td style="padding: 20px 32px; vertical-align: middle; text-align: right; white-space: nowrap;">
+                <%= if @email_version? do %>
+                  <a
+                    href={page_url}
+                    style={"font-family: #{font}; font-size: 14px; line-height: 20px; color: #535659; text-decoration: underline;"}
+                  >
+                    {dgettext("marketing", "View in web browser")}
+                  </a>
+                <% else %>
+                  <a
+                    href={
+                      Tuist.Environment.app_url(path: ~p"/newsletter", route_type: :marketing)
+                    }
+                    style={"font-family: #{font}; font-size: 14px; line-height: 20px; color: #535659; text-decoration: underline;"}
+                  >
+                    {dgettext("marketing", "All issues")}
+                  </a>
+                <% end %>
+              </td>
+            </tr>
+          </table>
         </td>
       </tr>
-    </table>
-    <div style="background-color: #F3F2FD; padding-top: 2rem; padding-bottom: 2rem; max-width: 100%; box-sizing: border-box; text-align: center;">
-      <%= if not is_nil(@issue.hero["image"]) do %>
-        <% img_src =
-          if(String.starts_with?(@issue.hero["image"], "/"),
-            do: Tuist.Environment.app_url(path: @issue.hero["image"], route_type: :marketing),
-            else: @issue.hero["image"]
-          ) %>
-        <img
-          src={img_src}
-          alt={@issue.hero["alt"]}
-          style={"object-fit: cover; max-width: #{Map.get(@issue.hero, "image_max_width", "150px")}; height: auto; border-radius: 2rem; display: block; margin-left: auto; margin-right: auto;"}
-        />
-      <% end %>
-      <%= if not is_nil(@issue.hero["video"]) do %>
-        <% video_src =
-          if(String.starts_with?(@issue.hero["video"], "/"),
-            do: Tuist.Environment.app_url(path: @issue.hero["video"], route_type: :marketing),
-            else: @issue.hero["video"]
-          ) %>
-        <video
-          src={video_src}
-          alt={@issue.hero["alt"]}
-          autoplay
-          loop
-          playsinline
-          muted
-          style="object-fit: cover; max-width: 150px; height: 300px; display: block; margin-left: auto; margin-right: auto;"
-        />
-      <% end %>
-      <div style="font-size: 16px; line-height: 22px; color: #622ed4;">
-        {raw(@issue.hero["subtitle"])}
-      </div>
-    </div>
 
-    <div style="padding-top: 4rem; padding-bottom: 4rem; max-width: 100%; box-sizing: border-box;">
-      <table
-        width="768"
-        align="center"
-        cellpadding="0"
-        cellspacing="0"
-        style="width: 100% !important; max-width: 768px; padding: 0 32px;"
-      >
-        <tr>
-          <td>
-            <p style="color: #3c315b; font-weight: bold; line-height: 16px; font-size: 16px; text-transform: uppercase; margin: 0;">
-              #{@issue.number} - {@issue.date |> Timex.format!("{Mshort} {D}, {YYYY}")}
-            </p>
-            <h2 style="color: #622ed4; font-weight: bold; line-height: 40px; font-size: 30px; margin: 1rem 0;">
-              {@issue.title}
-            </h2>
-            <%= if not is_nil(@issue.welcome_message) do %>
-              <div style="background: rgb(232, 231, 249); padding: 2rem; border-radius: 2rem; display: table; width: 100%; max-width: 100%; box-sizing: border-box;">
-                <h3 style="font-size: 26px; line-height: 26px; font-weight: bold; color: #622ed4; margin: 0;">
-                  Welcome to issue {@issue.number}!
-                </h3>
-                <div style="font-size: 18px; line-height: 22px; font-weight: bold; color: #2c2250; margin-top: 1rem;">
-                  {raw(@issue.welcome_message)}
-                </div>
-              </div>
-            <% else %>
-              <h3 style="font-weight: bold; color: #622ed4; margin: 0;">
-                Welcome to issue {@issue.number}!
-              </h3>
-            <% end %>
+      <tr>
+        <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
+      </tr>
 
-            <div style="color: #2c2250; font-weight: normal; margin: 3rem 0; font-size: 16px; line-height: 22px;">
-              {raw(@issue.body)}
-            </div>
-
-            <hr style="border: 1px solid rgb(232, 231, 249); width: 100%;" />
-
-            <div>
-              <div>
-                <h3 style="font-size: 26px; line-height: 26px; font-weight: bold; color: #622ed4; margin: 3rem 0 2rem 0;">
-                  Tools & sites
-                </h3>
-              </div>
-              <table style="width: 100%; margin: 0 0 3rem 0;">
-                <tr :for={tool <- @issue.tools}>
-                  <td style="vertical-align: top; width: 50%; padding-right: 1rem; padding-bottom: 2rem;">
-                    <a
-                      href={tool["link"]}
-                      target="_blank"
-                      style="text-decoration: none; color: #2c2250;"
-                    >
-                      <h2 style="margin: 1rem 0 0 0; font-size: 18px; font-weight: bold; background: #d7f775; padding: 0.4rem; display: inline-block;">
-                        <span>{tool["title"]}</span>
+      <%!-- Article box: issue eyebrow, title, the featured work on the
+      tertiary ground, the welcome note and the editorial. --%>
+      <tr>
+        <td>
+          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+            <tr>
+              <td style="padding: 48px 32px 8px;">
+                <p style={eyebrow_style}>
+                  {dgettext("marketing", "Issue %{number}", number: @issue.number)} &middot; {Timex.format!(
+                    @issue.date,
+                    "{Mshort} {D}, {YYYY}"
+                  )}
+                </p>
+                <h1 style={"margin: 16px 0 0; font-family: #{font}; font-size: 32px; line-height: 40px; font-weight: 400; letter-spacing: -0.02em; color: #191a1b;"}>
+                  {@issue.title}
+                </h1>
+              </td>
+            </tr>
+            <tr :if={@issue.hero["image"] || @issue.hero["video"]}>
+              <td style="padding: 32px 32px 0;">
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="width: 100%; border: 1px solid #eff0f1; border-radius: 8px; background: #f7f7f7; border-collapse: separate;"
+                >
+                  <tr>
+                    <td style="padding: 32px 24px; text-align: center;">
+                      <%= if @issue.hero["image"] do %>
+                        <img
+                          src={asset_url.(@issue.hero["image"])}
+                          alt={plain_alt.(@issue.hero["alt"])}
+                          style={"display: block; margin: 0 auto; max-width: #{String.trim_trailing(Map.get(@issue.hero, "image_max_width", "250px"), ";")}; width: 100%; height: auto; border-radius: 8px; border: 0;"}
+                        />
+                      <% else %>
+                        <video
+                          src={asset_url.(@issue.hero["video"])}
+                          aria-label={plain_alt.(@issue.hero["alt"])}
+                          autoplay
+                          loop
+                          playsinline
+                          muted
+                          style="display: block; margin: 0 auto; max-width: 250px; width: 100%; height: auto; border-radius: 8px;"
+                        ></video>
+                      <% end %>
+                      <div
+                        :if={@issue.hero["subtitle"]}
+                        style={"margin-top: 20px; font-family: #{font}; font-size: 14px; line-height: 20px; color: #535659;"}
+                      >
+                        {raw(@issue.hero["subtitle"])}
+                      </div>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr :if={@issue.welcome_message}>
+              <td style="padding: 32px 32px 0;">
+                <table
+                  role="presentation"
+                  width="100%"
+                  cellpadding="0"
+                  cellspacing="0"
+                  style="width: 100%; border: 1px solid #eff0f1; border-radius: 8px; background: #f7f7f7; border-collapse: separate;"
+                >
+                  <tr>
+                    <td style="padding: 24px;">
+                      <h2 style={item_title_style}>
+                        {dgettext("marketing", "Welcome to issue %{number}",
+                          number: @issue.number
+                        )}
                       </h2>
-                    </a>
-                    <p style="margin: 1rem 0 0 0; font-size: 14px; font-weight: normal; line-height: 22px; color: #622ed4;">
-                      {tool["subtitle"]}
-                    </p>
-                  </td>
-                  <td style="vertical-align: top; width: 50%; padding-bottom: 2rem; font-size: 16px; line-height: 22px; color: #2c2250;">
-                    {raw(tool["description"])}
-                  </td>
-                </tr>
-              </table>
-            </div>
+                      <p style={"#{muted_style} margin-top: 8px;"}>{@issue.welcome_message}</p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td style={"padding: 32px 32px 48px; font-family: #{font}; font-size: 16px; line-height: 26px; color: #191a1b;"}>
+                {raw(@issue.body)}
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
 
-            <hr style="border: 1px solid rgb(232, 231, 249); width: 100%;" />
+      <tr>
+        <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
+      </tr>
 
-            <div style="background: #f3f2fd; padding: 2rem; border-radius: 2rem; display: table; width: 100%; max-width: 100%; box-sizing: border-box; margin: 3rem 0;">
-              <div style="display: table-row;">
-                <h3 style="font-size: 26px; line-height: 26px; font-weight: bold; color: #622ed4; margin: 0; padding: 1rem 0;">
-                  Worthy Five: {@issue.interview["interviewee"]}
+      <%!-- Tools & sites: a title row, then one hairline row per link with
+      the name as the link, its tagline and the write-up. --%>
+      <tr>
+        <td>
+          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+            <tr>
+              <td style="padding: 24px 32px; border-bottom: 1px solid #eff0f1;">
+                <h2 style={section_title_style}>{dgettext("marketing", "Tools & sites")}</h2>
+              </td>
+            </tr>
+            <tr :for={{tool, index} <- Enum.with_index(@issue.tools)}>
+              <td style={"padding: 24px 32px; #{if index > 0, do: "border-top: 1px solid #eff0f1;"}"}>
+                <h3 style={item_title_style}>
+                  <a
+                    href={tool["link"]}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style="color: #191a1b; text-decoration: none;"
+                  >
+                    {tool["title"]}
+                  </a>
                 </h3>
-                <div style="margin: 1rem 0; color: #2c2250; font-weight: bold; font-size: 16px; line-height: 22px;">
+                <p :if={tool["subtitle"]} style={"#{muted_style} margin-top: 4px;"}>
+                  {tool["subtitle"]}
+                </p>
+                <div style={"#{body_style} margin-top: 12px;"}>{raw(tool["description"])}</div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+
+      <tr>
+        <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
+      </tr>
+
+      <%!-- Worthy Five: a compact profile row (avatar beside the name and
+      role, the intro under it), then the five answers at full width. One
+      column on purpose: mail clients can't reflow a two-column table on
+      phones, and the export carries no media queries. --%>
+      <tr>
+        <td>
+          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+            <tr>
+              <td style="padding: 24px 32px; border-bottom: 1px solid #eff0f1;">
+                <h2 style={section_title_style}>
+                  {dgettext("marketing", "Worthy Five: %{name}",
+                    name: @issue.interview["interviewee"]
+                  )}
+                </h2>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 32px 32px 0;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td
+                      :if={@issue.interview["interviewee_avatar_url"]}
+                      width="96"
+                      style="width: 96px; vertical-align: middle; padding-right: 20px;"
+                    >
+                      <img
+                        src={asset_url.(@issue.interview["interviewee_avatar_url"])}
+                        alt=""
+                        width="96"
+                        height="96"
+                        style="display: block; width: 96px; height: 96px; border-radius: 8px; border: 1px solid #eff0f1; background: #f7f7f7; object-fit: cover;"
+                      />
+                    </td>
+                    <td style="vertical-align: middle;">
+                      <p style={item_title_style}>{@issue.interview["interviewee"]}</p>
+                      <p
+                        :if={@issue.interview["interviewee_role"]}
+                        style={"#{muted_style} margin-top: 4px;"}
+                      >
+                        {@issue.interview["interviewee_role"]}
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+                <div style={"#{body_style} margin-top: 16px;"}>
                   {raw(@issue.interview["interviewee_intro"])}
                 </div>
-              </div>
-
-              <table style="width: 100%;">
-                <tr>
-                  <td style="vertical-align: top; width: 30%; padding-right: 1rem;">
-                    <% interviewee_avatar_src =
-                      if(String.starts_with?(@issue.interview["interviewee_avatar_url"], "/"),
-                        do:
-                          Tuist.Environment.app_url(
-                            path: @issue.interview["interviewee_avatar_url"],
-                            route_type: :marketing
-                          ),
-                        else: @issue.interview["interviewee_avatar_url"]
-                      ) %>
-                    <img
-                      src={interviewee_avatar_src}
-                      alt={@issue.interview["interviewee"]}
-                      style="width: 100%; max-width: 100%; object-fit: cover; border-radius: 1rem;"
-                    />
-                    <p style="font-size: 14px; line-height: 20px; color: #3c315b; margin: 0;">
-                      {@issue.interview["interviewee_subtitle"]}
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 24px 32px 32px;">
+                <%= for question <- @issue.interview["questions"] do %>
+                  <div style="border-top: 1px solid #eff0f1; padding-top: 20px; margin-top: 20px;">
+                    <p style={"margin: 0; font-family: #{font}; font-size: 16px; line-height: 22px; font-weight: 400; color: #191a1b;"}>
+                      {question["question"]}
                     </p>
-                  </td>
-                  <td style="vertical-align: top; width: 70%;">
-                    <%= for {question, index} <- Enum.with_index(@issue.interview["questions"]) do %>
-                      <div style="display: table-row;">
-                        <p style="margin: 0; font-size: 16px; line-height: 20px; font-weight: bold; color: #2c2250;">
-                          {question["question"]}:
-                        </p>
-                        <div style="margin: 1rem 0; font-size: 16px; line-height: 20px; font-weight: normal; color: #2c2250;">
-                          {raw(question["answer"])}
-                        </div>
-                      </div>
+                    <div style={"#{body_style} margin-top: 8px;"}>{raw(question["answer"])}</div>
+                  </div>
+                <% end %>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
 
-                      <hr
-                        :if={index < Enum.count(@issue.interview["questions"]) - 1}
-                        style="border: 2px solid white; width: 100%; margin-bottom: 1rem;"
-                      />
-                    <% end %>
-                  </td>
-                </tr>
-              </table>
-            </div>
+      <tr>
+        <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
+      </tr>
 
-            <hr style="border: 1px solid rgb(232, 231, 249); width: 100%;" />
+      <%!-- Food for thought: the same rows as tools & sites, without the
+      "Read"/"Watch" taglines — the titles are the links. --%>
+      <tr>
+        <td>
+          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+            <tr>
+              <td style="padding: 24px 32px; border-bottom: 1px solid #eff0f1;">
+                <h2 style={section_title_style}>{dgettext("marketing", "Food for thought")}</h2>
+              </td>
+            </tr>
+            <tr :for={{item, index} <- Enum.with_index(@issue.food_for_thought)}>
+              <td style={"padding: 24px 32px; #{if index > 0, do: "border-top: 1px solid #eff0f1;"}"}>
+                <h3 style={item_title_style}>
+                  <a
+                    href={item["link"]}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style="color: #191a1b; text-decoration: none;"
+                  >
+                    {item["title"]}
+                  </a>
+                </h3>
+                <div style={"#{body_style} margin-top: 12px;"}>{raw(item["description"])}</div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
 
-            <div style="margin: 3rem 0;">
-              <h3 style="font-size: 26px; line-height: 26px; font-weight: bold; color: #622ed4; margin: 0;">
-                Food for thought
-              </h3>
-              <table style="width: 100%; margin-top: 2rem;">
-                <tr :for={item <- @issue.food_for_thought}>
-                  <td style="vertical-align: top; width: 50%; padding-right: 1rem; padding-bottom: 2rem;">
-                    <a
-                      href={item["link"]}
-                      target="_blank"
-                      style="text-decoration: none; color: #2c2250;"
-                    >
-                      <h2 style="margin: 1rem 0 0 0; font-size: 18px; font-weight: bold; background: #ffa8f6; padding: 0.4rem; display: inline-block;">
-                        <span>{item["title"]}</span>
-                      </h2>
-                    </a>
-                    <p style="margin: 1rem 0 0 0; font-size: 14px; font-weight: normal; line-height: 22px; color: #622ed4;">
-                      {item["subtitle"]}
-                    </p>
-                  </td>
-                  <td style="vertical-align: top; width: 50%; padding-bottom: 2rem; font-size: 16px; line-height: 22px; color: #2c2250;">
-                    {raw(item["description"])}
-                  </td>
-                </tr>
-              </table>
-            </div>
-          </td>
-        </tr>
-      </table>
-    </div>
+      <tr>
+        <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
+      </tr>
 
-    <footer style="background: rgb(232, 231, 249); padding-top: 4rem; padding-bottom: 4rem;">
-      <table
-        width="768"
-        align="center"
-        cellpadding="0"
-        cellspacing="0"
-        style="width: 100% !important; max-width: 768px; padding: 0 32px;"
-      >
-        <tr>
-          <td>
-            <div style="width: 100%;">
-              <h3 style="vertical-align: middle; margin: 0; color: #622ed4;">
-                <span style="font-size: 26px; line-height: 26px; font-weight: bold; margin-right: 1rem;">
-                  Enjoyed it?
-                </span>
-                <a
-                  class="share-link"
-                  href={Tuist.Environment.app_url(path: @current_path, route_type: :marketing)}
-                  style="font-size: 14px; line-height: 22px; font-weight: bold; color: #2c2250; border-style: solid; border-width: 2px; border-color: #2c2250; border-radius: 0.25rem; padding: 0.5rem; text-decoration: none;"
-                  rel="noopener noreferrer"
-                  data-title={@issue.full_title}
-                  data-description={Tuist.Marketing.Newsletter.description()}
-                >
-                  Share it
-                </a>
-              </h3>
-              <div>
-                <p style="margin: 1rem 0; font-size: 16px; line-height: 22px; color: #2c2250;">
+      <%!-- Previous / next issue: two cells with a hairline between; a
+      missing neighbour keeps its cell as muted text. --%>
+      <tr>
+        <td>
+          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+            <tr>
+              <td width="50%" style="width: 50%; vertical-align: top; padding: 24px 32px;">
+                <p style={eyebrow_style}>{dgettext("marketing", "Previous issue")}</p>
+                <%= if @previous_issue do %>
+                  <a
+                    href={
+                      Tuist.Environment.app_url(
+                        path: ~p"/newsletter/issues/#{@previous_issue.number}",
+                        route_type: :marketing
+                      )
+                    }
+                    style={"display: block; margin-top: 8px; font-family: #{font}; font-size: 16px; line-height: 22px; color: #191a1b; text-decoration: none;"}
+                  >
+                    #{@previous_issue.number} {@previous_issue.title}
+                  </a>
+                <% else %>
+                  <p style={"margin: 8px 0 0; font-family: #{font}; font-size: 16px; line-height: 22px; color: #a2a5a8;"}>
+                    {dgettext("marketing", "This is the first issue")}
+                  </p>
+                <% end %>
+              </td>
+              <td
+                width="50%"
+                style="width: 50%; vertical-align: top; padding: 24px 32px; border-left: 1px solid #eff0f1; text-align: right;"
+              >
+                <p style={eyebrow_style}>{dgettext("marketing", "Next issue")}</p>
+                <%= if @next_issue do %>
+                  <a
+                    href={
+                      Tuist.Environment.app_url(
+                        path: ~p"/newsletter/issues/#{@next_issue.number}",
+                        route_type: :marketing
+                      )
+                    }
+                    style={"display: block; margin-top: 8px; font-family: #{font}; font-size: 16px; line-height: 22px; color: #191a1b; text-decoration: none;"}
+                  >
+                    #{@next_issue.number} {@next_issue.title}
+                  </a>
+                <% else %>
+                  <p style={"margin: 8px 0 0; font-family: #{font}; font-size: 16px; line-height: 22px; color: #a2a5a8;"}>
+                    {dgettext("marketing", "This is the latest issue")}
+                  </p>
+                <% end %>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+
+      <tr>
+        <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
+      </tr>
+
+      <%!-- Closing box: subscribe and share, the newsletter's blurb, the
+      social links and the legal line (unsubscribe in the email only). --%>
+      <tr>
+        <td>
+          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+            <tr>
+              <td style="padding: 56px 32px 48px; text-align: center;">
+                <p style={"#{eyebrow_style} font-size: 14px; line-height: 20px;"}>
+                  Swift Stories
+                </p>
+                <h2 style={"margin: 20px 0 0; font-family: #{font}; font-size: 28px; line-height: 34px; font-weight: 400; letter-spacing: -0.01em; color: #191a1b;"}>
+                  {dgettext("marketing", "Get the next issue in your inbox")}
+                </h2>
+                <p style="margin: 32px 0 0;">
+                  <a
+                    class="button-primary"
+                    href={
+                      Tuist.Environment.app_url(path: ~p"/newsletter", route_type: :marketing)
+                    }
+                    style={primary_button_style}
+                  >
+                    {dgettext("marketing", "Subscribe")}
+                  </a>
+                  <a
+                    class="share-link"
+                    href={page_url}
+                    style={"#{secondary_button_style} margin-left: 8px;"}
+                    rel="noopener noreferrer"
+                    data-title={@issue.full_title}
+                    data-description={Tuist.Marketing.Newsletter.description()}
+                  >
+                    {dgettext("marketing", "Share it")}
+                  </a>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: 32px; border-top: 1px solid #eff0f1;">
+                <p style={muted_style}>
                   Swift Stories is a newsletter brought to you by the people behind <a
-                    style="color: #2c2250;"
+                    style={link_style}
                     href="https://tuist.dev"
-                  >Tuist</a>. We love cross-polinating ideas from and to the Swift ecosystem and building tools that make developers' lives easier. If you want to share ideas for future issues, you can do so in our <a
-                    style="color: #2c2250;"
+                  >Tuist</a>. We love cross-pollinating ideas from and to the Swift ecosystem and building tools that make developers' lives easier. If you want to share ideas for future issues, you can do so in our <a
+                    style={link_style}
                     href="https://community.tuist.dev/c/swift-stories/22"
                   >community forum</a>. If you like this newsletter, you can support us by sharing it with your friends and colleagues.
                 </p>
-                <p style="white-space: nowrap; font-size: 14px; line-height: 20px; font-weight: bold; margin: 2rem 0 1rem 0;">
-                  Stay in touch
-                </p>
-                <div style="display: table; width: 100%;">
+                <p style={"#{body_style} margin-top: 24px;"}>
                   <a
                     href={Tuist.Environment.get_url(:forum)}
                     target="_blank"
                     rel="noopener noreferrer"
-                    style="margin-right: 1rem; font-size: 16px; line-height: 22px; color: #2c2250;"
+                    style={link_style}
                   >
                     Community
                   </a>
-                  &#9;
+                  <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
                   <a
                     href={Tuist.Environment.get_url(:mastodon)}
                     target="_blank"
                     rel="noopener noreferrer"
-                    style="margin-right: 1rem; font-size: 16px; line-height: 22px; color: #2c2250;"
+                    style={link_style}
                   >
                     Mastodon
                   </a>
-                  &#9;
+                  <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
                   <a
                     href={Tuist.Environment.get_url(:github)}
                     target="_blank"
                     rel="noopener noreferrer"
-                    style="margin-right: 1rem; font-size: 16px; line-height: 22px; color: #2c2250;"
+                    style={link_style}
                   >
                     GitHub
                   </a>
-                  &#9;
+                  <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
                   <a
                     href={Tuist.Environment.get_url(:slack)}
                     target="_blank"
                     rel="noopener noreferrer"
-                    style="font-size: 16px; line-height: 22px; color: #2c2250;"
+                    style={link_style}
                   >
                     Slack
                   </a>
-                </div>
-                <a
-                  href={Tuist.Environment.app_url(path: ~p"/newsletter", route_type: :marketing)}
-                  style="font-size: 14px; line-height: 22px; font-weight: bold; color: #2c2250; border-style: solid; border-width: 2px; border-color: #2c2250; border-radius: 0.25rem; padding: 0.5rem; text-decoration: none; margin: 1rem 0; display: inline-block; box-sizing: content-box;"
-                  rel="noopener noreferrer"
-                >
-                  Subscribe
-                </a>
-              </div>
-
-              <div style="margin-top: 2rem;">
-                <a
-                  style="display: table-cell; vertical-align: middle; padding-right: 1rem; font-size: 16px; line-height: 22px; color: #622ed4;"
-                  href={~p"/terms"}
-                >
-                  Terms of service
-                </a>
-                <div style="display: table-cell; vertical-align: middle; background: #622ed4; width: 2px; max-width: 2px;" />
-                <a
-                  style="display: table-cell; vertical-align: middle; padding: 0 1rem; font-size: 16px; line-height: 22px; color: #622ed4;"
-                  href={~p"/privacy"}
-                >
-                  Privacy policy
-                </a>
-                <div
-                  :if={@email_version?}
-                  style="display: table-cell; vertical-align: middle; background: #622ed4; width: 2px; max-width: 2px;"
-                />
-                <a
-                  :if={@email_version?}
-                  style="display: table-cell; vertical-align: middle; padding-left: 2rem; font-size: 16px; line-height: 22px; color: #622ed4;"
-                  href="{unsubscribe_url}"
-                >
-                  Unsubscribe
-                </a>
-              </div>
-            </div>
-          </td>
-        </tr>
-      </table>
-    </footer>
+                </p>
+                <p style={"#{muted_style} margin-top: 24px;"}>
+                  <a
+                    href={Tuist.Environment.app_url(path: ~p"/terms", route_type: :marketing)}
+                    style="color: #535659; text-decoration: underline;"
+                  >
+                    Terms of service
+                  </a>
+                  <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
+                  <a
+                    href={Tuist.Environment.app_url(path: ~p"/privacy", route_type: :marketing)}
+                    style="color: #535659; text-decoration: underline;"
+                  >
+                    Privacy policy
+                  </a>
+                  <%= if @email_version? do %>
+                    <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
+                    <a
+                      href="{unsubscribe_url}"
+                      style="color: #535659; text-decoration: underline;"
+                    >
+                      Unsubscribe
+                    </a>
+                  <% end %>
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
   </body>
 
   <%= if not @email_version? do %>

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex
@@ -36,8 +36,9 @@ end %>
 <% primary_button_style =
   "display: inline-block; font-family: #{font}; font-size: 14px; line-height: 20px; font-weight: 500; color: #fdfdfd; background: rgb(111, 44, 255); border: 1px solid rgb(111, 44, 255); border-radius: 6px; padding: 8px 16px; text-decoration: none;" %>
 <% secondary_button_style =
-  "display: inline-block; font-family: #{font}; font-size: 14px; line-height: 20px; font-weight: 500; color: #191a1b; background: #fdfdfd; border: 1px solid #d9dbdd; border-radius: 6px; padding: 8px 16px; text-decoration: none;" %> <!DOCTYPE html>
-<html lang="en">
+  "display: inline-block; font-family: #{font}; font-size: 14px; line-height: 20px; font-weight: 500; color: #191a1b; background: #fdfdfd; border: 1px solid #d9dbdd; border-radius: 6px; padding: 8px 16px; text-decoration: none;" %> <!DOCTYPE html> <% document_locale =
+  TuistWeb.Gettext |> Gettext.get_locale() |> String.replace("_", "-") %>
+<html lang={document_locale}>
   <head>
     <title>{@issue.full_title}</title>
     <meta charset="UTF-8" />
@@ -62,7 +63,6 @@ end %>
     </style>
     <%= if not @email_version? do %>
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <meta name="color-scheme" content="light" />
       <meta name="description" content={Tuist.Marketing.Newsletter.description()} />
       <meta
         name="keywords"
@@ -70,12 +70,15 @@ end %>
       />
 
       <meta property="og:url" content={page_url} />
-      <meta property="og:type" content="website" />
+      <meta property="og:type" content="article" />
       <meta property="og:title" content={@issue.full_title} />
       <meta property="og:description" content={Tuist.Marketing.Newsletter.description()} />
       <meta property="og:image" content={@open_graph_image_url} />
       <meta property="og:image:width" content="1920" />
       <meta property="og:image:height" content="1080" />
+      <meta property="og:image:alt" content={@issue.full_title} />
+      <meta property="article:published_time" content={Timex.format!(@issue.date, "{ISOdate}")} />
+      <meta property="article:author" content="Tuist" />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@tuistdev" />
       <meta name="twitter:image" content={@open_graph_image_url} />
@@ -102,493 +105,532 @@ end %>
           src: url("/fonts/GeistMono-latin.woff2") format("woff2");
         }
         a:hover { opacity: 0.8; }
+        a:focus-visible { opacity: 0.8; outline: 2px solid rgb(111, 44, 255); outline-offset: 2px; }
       </style>
     <% end %>
   </head>
   <body style={"margin: 0; padding: 0; background: #f7f7f7; font-family: #{font}; -webkit-font-smoothing: antialiased;"}>
-    <span class="random" style="opacity: 0">{UUIDv7.generate()}</span>
-    <table
-      id="newsletter-issue"
-      role="presentation"
-      width="720"
-      align="center"
-      cellpadding="0"
-      cellspacing="0"
-      style="width: 100% !important; max-width: 720px; padding: 24px 8px 40px; box-sizing: border-box;"
+    <%!-- Gmail clipping guard: unique text per render, kept out of the
+    layout and the accessibility tree. --%>
+    <span
+      class="random"
+      aria-hidden="true"
+      style="position: absolute; left: -9999px; font-size: 0; line-height: 0;"
     >
-      <%!-- Masthead box: the mark and the newsletter's name, with the email's
+      {UUIDv7.generate()}
+    </span>
+    <%!-- Landmarks for the web view; the email export wraps the same table
+    in plain divs, which mail clients ignore. --%>
+    <.dynamic_tag tag_name={if @email_version?, do: "div", else: "main"}>
+      <.dynamic_tag tag_name={if @email_version?, do: "div", else: "article"}>
+        <table
+          id="newsletter-issue"
+          role="presentation"
+          width="720"
+          align="center"
+          cellpadding="0"
+          cellspacing="0"
+          style="width: 100% !important; max-width: 720px; padding: 24px 8px 40px; box-sizing: border-box;"
+        >
+          <%!-- Masthead box: the mark and the newsletter's name, with the email's
       "view in browser" link (the web page links to the archive instead). Its
       own bordered box on the surface colour, which also matches the logo
       PNG's opaque background. --%>
-      <tr>
-        <td>
-          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
-            <tr>
-              <td style="padding: 20px 32px; vertical-align: middle;">
-                <%!-- Logo and name in their own cells, both centred on the
+          <tr>
+            <td>
+              <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+                <tr>
+                  <td style="padding: 20px 32px; vertical-align: middle;">
+                    <%!-- Logo and name in their own cells, both centred on the
                 same axis: inline image + text line boxes drift by a pixel
                 or two between mail clients. --%>
-                <table role="presentation" cellpadding="0" cellspacing="0">
-                  <tr>
-                    <td style="vertical-align: middle; padding-right: 12px;">
+                    <table role="presentation" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td style="vertical-align: middle; padding-right: 12px;">
+                          <a
+                            href={
+                              Tuist.Environment.app_url(
+                                path: ~p"/newsletter",
+                                route_type: :marketing
+                              )
+                            }
+                            style="display: block; text-decoration: none;"
+                            aria-hidden="true"
+                            tabindex="-1"
+                          >
+                            <img
+                              src={Tuist.Environment.email_icon_url()}
+                              alt=""
+                              width="64"
+                              height="28"
+                              style="display: block; width: 64px; height: 28px; border: 0;"
+                            />
+                          </a>
+                        </td>
+                        <td style="vertical-align: middle;">
+                          <a
+                            href={
+                              Tuist.Environment.app_url(
+                                path: ~p"/newsletter",
+                                route_type: :marketing
+                              )
+                            }
+                            style={"display: block; font-family: #{font}; font-size: 16px; line-height: 28px; color: #191a1b; text-decoration: none;"}
+                          >
+                            Swift Stories
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                  <td style="padding: 20px 32px; vertical-align: middle; text-align: right; white-space: nowrap;">
+                    <%= if @email_version? do %>
+                      <a
+                        href={page_url}
+                        style={"font-family: #{font}; font-size: 14px; line-height: 20px; color: #535659; text-decoration: underline;"}
+                      >
+                        {dgettext("marketing", "View in web browser")}
+                      </a>
+                    <% else %>
                       <a
                         href={
                           Tuist.Environment.app_url(path: ~p"/newsletter", route_type: :marketing)
                         }
-                        style="display: block; text-decoration: none;"
+                        style={"font-family: #{font}; font-size: 14px; line-height: 20px; color: #535659; text-decoration: underline;"}
                       >
-                        <img
-                          src={Tuist.Environment.email_icon_url()}
-                          alt="Tuist"
-                          width="64"
-                          height="28"
-                          style="display: block; width: 64px; height: 28px; border: 0;"
-                        />
+                        {dgettext("marketing", "All issues")}
                       </a>
-                    </td>
-                    <td style="vertical-align: middle;">
-                      <a
-                        href={
-                          Tuist.Environment.app_url(path: ~p"/newsletter", route_type: :marketing)
-                        }
-                        style={"display: block; font-family: #{font}; font-size: 16px; line-height: 28px; color: #191a1b; text-decoration: none;"}
-                      >
-                        Swift Stories
-                      </a>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-              <td style="padding: 20px 32px; vertical-align: middle; text-align: right; white-space: nowrap;">
-                <%= if @email_version? do %>
-                  <a
-                    href={page_url}
-                    style={"font-family: #{font}; font-size: 14px; line-height: 20px; color: #535659; text-decoration: underline;"}
-                  >
-                    {dgettext("marketing", "View in web browser")}
-                  </a>
-                <% else %>
-                  <a
-                    href={
-                      Tuist.Environment.app_url(path: ~p"/newsletter", route_type: :marketing)
-                    }
-                    style={"font-family: #{font}; font-size: 14px; line-height: 20px; color: #535659; text-decoration: underline;"}
-                  >
-                    {dgettext("marketing", "All issues")}
-                  </a>
-                <% end %>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
+                    <% end %>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
 
-      <tr>
-        <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
-      </tr>
+          <tr>
+            <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
+          </tr>
 
-      <%!-- Article box: issue eyebrow, title, the featured work on the
+          <%!-- Article box: issue eyebrow, title, the featured work on the
       tertiary ground, the welcome note and the editorial. --%>
-      <tr>
-        <td>
-          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
-            <tr>
-              <td style="padding: 48px 32px 8px;">
-                <p style={eyebrow_style}>
-                  {dgettext("marketing", "Issue %{number}", number: @issue.number)} &middot; {Timex.format!(
-                    @issue.date,
-                    "{Mshort} {D}, {YYYY}"
-                  )}
-                </p>
-                <h1 style={"margin: 16px 0 0; font-family: #{font}; font-size: 32px; line-height: 40px; font-weight: 400; letter-spacing: -0.02em; color: #191a1b;"}>
-                  {@issue.title}
-                </h1>
-              </td>
-            </tr>
-            <tr :if={@issue.hero["image"] || @issue.hero["video"]}>
-              <td style="padding: 32px 32px 0;">
-                <table
-                  role="presentation"
-                  width="100%"
-                  cellpadding="0"
-                  cellspacing="0"
-                  style="width: 100%; border: 1px solid #eff0f1; border-radius: 8px; background: #f7f7f7; border-collapse: separate;"
-                >
-                  <tr>
-                    <td style="padding: 32px 24px; text-align: center;">
-                      <%= if @issue.hero["image"] do %>
-                        <img
-                          src={asset_url.(@issue.hero["image"])}
-                          alt={plain_alt.(@issue.hero["alt"])}
-                          style={"display: block; margin: 0 auto; max-width: #{String.trim_trailing(Map.get(@issue.hero, "image_max_width", "250px"), ";")}; width: 100%; height: auto; border-radius: 8px; border: 0;"}
-                        />
-                      <% else %>
-                        <video
-                          src={asset_url.(@issue.hero["video"])}
-                          aria-label={plain_alt.(@issue.hero["alt"])}
-                          autoplay
-                          loop
-                          playsinline
-                          muted
-                          style="display: block; margin: 0 auto; max-width: 250px; width: 100%; height: auto; border-radius: 8px;"
-                        ></video>
-                      <% end %>
-                      <div
-                        :if={@issue.hero["subtitle"]}
-                        style={"margin-top: 20px; font-family: #{font}; font-size: 14px; line-height: 20px; color: #535659;"}
-                      >
-                        {raw(@issue.hero["subtitle"])}
-                      </div>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-            <tr :if={@issue.welcome_message}>
-              <td style="padding: 32px 32px 0;">
-                <table
-                  role="presentation"
-                  width="100%"
-                  cellpadding="0"
-                  cellspacing="0"
-                  style="width: 100%; border: 1px solid #eff0f1; border-radius: 8px; background: #f7f7f7; border-collapse: separate;"
-                >
-                  <tr>
-                    <td style="padding: 24px;">
-                      <h2 style={item_title_style}>
-                        {dgettext("marketing", "Welcome to issue %{number}",
-                          number: @issue.number
-                        )}
-                      </h2>
-                      <p style={"#{muted_style} margin-top: 8px;"}>{@issue.welcome_message}</p>
-                    </td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-            <tr>
-              <td style={"padding: 32px 32px 48px; font-family: #{font}; font-size: 16px; line-height: 26px; color: #191a1b;"}>
-                {raw(@issue.body)}
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
+          <tr>
+            <td>
+              <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+                <tr>
+                  <td style="padding: 48px 32px 8px;">
+                    <p style={eyebrow_style}>
+                      {dgettext("marketing", "Issue %{number}", number: @issue.number)} &middot;
+                      <time datetime={Timex.format!(@issue.date, "{ISOdate}")}>{Timex.format!(
+                        @issue.date,
+                        "{Mshort} {D}, {YYYY}"
+                      )}</time>
+                    </p>
+                    <h1 style={"margin: 16px 0 0; font-family: #{font}; font-size: 32px; line-height: 40px; font-weight: 400; letter-spacing: -0.02em; color: #191a1b;"}>
+                      {@issue.title}
+                    </h1>
+                  </td>
+                </tr>
+                <tr :if={@issue.hero["image"] || @issue.hero["video"]}>
+                  <td style="padding: 32px 32px 0;">
+                    <table
+                      role="presentation"
+                      width="100%"
+                      cellpadding="0"
+                      cellspacing="0"
+                      style="width: 100%; border: 1px solid #eff0f1; border-radius: 8px; background: #f7f7f7; border-collapse: separate;"
+                    >
+                      <tr>
+                        <td style="padding: 32px 24px; text-align: center;">
+                          <%= if @issue.hero["image"] do %>
+                            <img
+                              src={asset_url.(@issue.hero["image"])}
+                              alt={plain_alt.(@issue.hero["alt"])}
+                              style={"display: block; margin: 0 auto; max-width: #{String.trim_trailing(Map.get(@issue.hero, "image_max_width", "250px"), ";")}; width: 100%; height: auto; border-radius: 8px; border: 0;"}
+                            />
+                          <% else %>
+                            <video
+                              class="hero-video"
+                              src={asset_url.(@issue.hero["video"])}
+                              aria-label={plain_alt.(@issue.hero["alt"])}
+                              controls={not @email_version?}
+                              autoplay
+                              loop
+                              playsinline
+                              muted
+                              style="display: block; margin: 0 auto; max-width: 250px; width: 100%; height: auto; border-radius: 8px;"
+                            ></video>
+                          <% end %>
+                          <div
+                            :if={@issue.hero["subtitle"]}
+                            style={"margin-top: 20px; font-family: #{font}; font-size: 14px; line-height: 20px; color: #535659;"}
+                          >
+                            {raw(@issue.hero["subtitle"])}
+                          </div>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <tr :if={@issue.welcome_message}>
+                  <td style="padding: 32px 32px 0;">
+                    <table
+                      role="presentation"
+                      width="100%"
+                      cellpadding="0"
+                      cellspacing="0"
+                      style="width: 100%; border: 1px solid #eff0f1; border-radius: 8px; background: #f7f7f7; border-collapse: separate;"
+                    >
+                      <tr>
+                        <td style="padding: 24px;">
+                          <h2 style={item_title_style}>
+                            {dgettext("marketing", "Welcome to issue %{number}",
+                              number: @issue.number
+                            )}
+                          </h2>
+                          <p style={"#{muted_style} margin-top: 8px;"}>
+                            {@issue.welcome_message}
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td style={"padding: 32px 32px 48px; font-family: #{font}; font-size: 16px; line-height: 26px; color: #191a1b;"}>
+                    {raw(@issue.body)}
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
 
-      <tr>
-        <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
-      </tr>
+          <tr>
+            <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
+          </tr>
 
-      <%!-- Tools & sites: a title row, then one hairline row per link with
+          <%!-- Tools & sites: a title row, then one hairline row per link with
       the name as the link, its tagline and the write-up. --%>
-      <tr>
-        <td>
-          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
-            <tr>
-              <td style="padding: 24px 32px; border-bottom: 1px solid #eff0f1;">
-                <h2 style={section_title_style}>{dgettext("marketing", "Tools & sites")}</h2>
-              </td>
-            </tr>
-            <tr :for={{tool, index} <- Enum.with_index(@issue.tools)}>
-              <td style={"padding: 24px 32px; #{if index > 0, do: "border-top: 1px solid #eff0f1;"}"}>
-                <h3 style={item_title_style}>
-                  <a
-                    href={tool["link"]}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style="color: #191a1b; text-decoration: none;"
-                  >
-                    {tool["title"]}
-                  </a>
-                </h3>
-                <p :if={tool["subtitle"]} style={"#{muted_style} margin-top: 4px;"}>
-                  {tool["subtitle"]}
-                </p>
-                <div style={"#{body_style} margin-top: 12px;"}>{raw(tool["description"])}</div>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
+          <tr>
+            <td>
+              <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+                <tr>
+                  <td style="padding: 24px 32px; border-bottom: 1px solid #eff0f1;">
+                    <h2 style={section_title_style}>{dgettext("marketing", "Tools & sites")}</h2>
+                  </td>
+                </tr>
+                <tr :for={{tool, index} <- Enum.with_index(@issue.tools)}>
+                  <td style={"padding: 24px 32px; #{if index > 0, do: "border-top: 1px solid #eff0f1;"}"}>
+                    <h3 style={item_title_style}>
+                      <a
+                        href={tool["link"]}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style="color: #191a1b; text-decoration: none;"
+                      >
+                        {tool["title"]}
+                      </a>
+                    </h3>
+                    <p :if={tool["subtitle"]} style={"#{muted_style} margin-top: 4px;"}>
+                      {tool["subtitle"]}
+                    </p>
+                    <div style={"#{body_style} margin-top: 12px;"}>
+                      {raw(tool["description"])}
+                    </div>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
 
-      <tr>
-        <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
-      </tr>
+          <tr>
+            <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
+          </tr>
 
-      <%!-- Worthy Five: a compact profile row (avatar beside the name and
+          <%!-- Worthy Five: a compact profile row (avatar beside the name and
       role, the intro under it), then the five answers at full width. One
       column on purpose: mail clients can't reflow a two-column table on
       phones, and the export carries no media queries. --%>
-      <tr>
-        <td>
-          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
-            <tr>
-              <td style="padding: 24px 32px; border-bottom: 1px solid #eff0f1;">
-                <h2 style={section_title_style}>
-                  {dgettext("marketing", "Worthy Five: %{name}",
-                    name: @issue.interview["interviewee"]
-                  )}
-                </h2>
-              </td>
-            </tr>
-            <tr>
-              <td style="padding: 32px 32px 0;">
-                <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-                  <tr>
-                    <td
-                      :if={@issue.interview["interviewee_avatar_url"]}
-                      width="96"
-                      style="width: 96px; vertical-align: middle; padding-right: 20px;"
-                    >
-                      <img
-                        src={asset_url.(@issue.interview["interviewee_avatar_url"])}
-                        alt=""
-                        width="96"
-                        height="96"
-                        style="display: block; width: 96px; height: 96px; border-radius: 8px; border: 1px solid #eff0f1; background: #f7f7f7; object-fit: cover;"
-                      />
-                    </td>
-                    <td style="vertical-align: middle;">
-                      <p style={item_title_style}>{@issue.interview["interviewee"]}</p>
-                      <p
-                        :if={@issue.interview["interviewee_role"]}
-                        style={"#{muted_style} margin-top: 4px;"}
-                      >
-                        {@issue.interview["interviewee_role"]}
-                      </p>
-                    </td>
-                  </tr>
-                </table>
-                <div style={"#{body_style} margin-top: 16px;"}>
-                  {raw(@issue.interview["interviewee_intro"])}
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <td style="padding: 24px 32px 32px;">
-                <%= for question <- @issue.interview["questions"] do %>
-                  <div style="border-top: 1px solid #eff0f1; padding-top: 20px; margin-top: 20px;">
-                    <p style={"margin: 0; font-family: #{font}; font-size: 16px; line-height: 22px; font-weight: 400; color: #191a1b;"}>
-                      {question["question"]}
-                    </p>
-                    <div style={"#{body_style} margin-top: 8px;"}>{raw(question["answer"])}</div>
-                  </div>
-                <% end %>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
+          <tr>
+            <td>
+              <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+                <tr>
+                  <td style="padding: 24px 32px; border-bottom: 1px solid #eff0f1;">
+                    <h2 style={section_title_style}>
+                      {dgettext("marketing", "Worthy Five: %{name}",
+                        name: @issue.interview["interviewee"]
+                      )}
+                    </h2>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 32px 32px 0;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td
+                          :if={@issue.interview["interviewee_avatar_url"]}
+                          width="96"
+                          style="width: 96px; vertical-align: middle; padding-right: 20px;"
+                        >
+                          <img
+                            src={asset_url.(@issue.interview["interviewee_avatar_url"])}
+                            alt={@issue.interview["interviewee"]}
+                            width="96"
+                            height="96"
+                            style="display: block; width: 96px; height: 96px; border-radius: 8px; border: 1px solid #eff0f1; background: #f7f7f7; object-fit: cover;"
+                          />
+                        </td>
+                        <td style="vertical-align: middle;">
+                          <p style={item_title_style}>{@issue.interview["interviewee"]}</p>
+                          <p
+                            :if={@issue.interview["interviewee_role"]}
+                            style={"#{muted_style} margin-top: 4px;"}
+                          >
+                            {@issue.interview["interviewee_role"]}
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+                    <div style={"#{body_style} margin-top: 16px;"}>
+                      {raw(@issue.interview["interviewee_intro"])}
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 24px 32px 32px;">
+                    <%= for question <- @issue.interview["questions"] do %>
+                      <section style="border-top: 1px solid #eff0f1; padding-top: 20px; margin-top: 20px;">
+                        <h3 style={"margin: 0; font-family: #{font}; font-size: 16px; line-height: 22px; font-weight: 400; color: #191a1b;"}>
+                          {question["question"]}
+                        </h3>
+                        <div style={"#{body_style} margin-top: 8px;"}>
+                          {raw(question["answer"])}
+                        </div>
+                      </section>
+                    <% end %>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
 
-      <tr>
-        <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
-      </tr>
+          <tr>
+            <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
+          </tr>
 
-      <%!-- Food for thought: the same rows as tools & sites, without the
+          <%!-- Food for thought: the same rows as tools & sites, without the
       "Read"/"Watch" taglines — the titles are the links. --%>
-      <tr>
-        <td>
-          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
-            <tr>
-              <td style="padding: 24px 32px; border-bottom: 1px solid #eff0f1;">
-                <h2 style={section_title_style}>{dgettext("marketing", "Food for thought")}</h2>
-              </td>
-            </tr>
-            <tr :for={{item, index} <- Enum.with_index(@issue.food_for_thought)}>
-              <td style={"padding: 24px 32px; #{if index > 0, do: "border-top: 1px solid #eff0f1;"}"}>
-                <h3 style={item_title_style}>
-                  <a
-                    href={item["link"]}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style="color: #191a1b; text-decoration: none;"
-                  >
-                    {item["title"]}
-                  </a>
-                </h3>
-                <div style={"#{body_style} margin-top: 12px;"}>{raw(item["description"])}</div>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
+          <tr>
+            <td>
+              <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+                <tr>
+                  <td style="padding: 24px 32px; border-bottom: 1px solid #eff0f1;">
+                    <h2 style={section_title_style}>
+                      {dgettext("marketing", "Food for thought")}
+                    </h2>
+                  </td>
+                </tr>
+                <tr :for={{item, index} <- Enum.with_index(@issue.food_for_thought)}>
+                  <td style={"padding: 24px 32px; #{if index > 0, do: "border-top: 1px solid #eff0f1;"}"}>
+                    <h3 style={item_title_style}>
+                      <a
+                        href={item["link"]}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style="color: #191a1b; text-decoration: none;"
+                      >
+                        {item["title"]}
+                      </a>
+                    </h3>
+                    <div style={"#{body_style} margin-top: 12px;"}>
+                      {raw(item["description"])}
+                    </div>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
 
-      <tr>
-        <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
-      </tr>
+          <tr>
+            <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
+          </tr>
 
-      <%!-- Previous / next issue: two cells with a hairline between; a
+          <%!-- Previous / next issue: two cells with a hairline between; a
       missing neighbour keeps its cell as muted text. --%>
-      <tr>
-        <td>
-          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
-            <tr>
-              <td width="50%" style="width: 50%; vertical-align: top; padding: 24px 32px;">
-                <p style={eyebrow_style}>{dgettext("marketing", "Previous issue")}</p>
-                <%= if @previous_issue do %>
-                  <a
-                    href={
-                      Tuist.Environment.app_url(
-                        path: ~p"/newsletter/issues/#{@previous_issue.number}",
-                        route_type: :marketing
-                      )
-                    }
-                    style={"display: block; margin-top: 8px; font-family: #{font}; font-size: 16px; line-height: 22px; color: #191a1b; text-decoration: none;"}
+          <tr>
+            <td>
+              <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+                <tr>
+                  <td width="50%" style="width: 50%; vertical-align: top; padding: 24px 32px;">
+                    <p style={eyebrow_style}>{dgettext("marketing", "Previous issue")}</p>
+                    <%= if @previous_issue do %>
+                      <a
+                        href={
+                          Tuist.Environment.app_url(
+                            path: ~p"/newsletter/issues/#{@previous_issue.number}",
+                            route_type: :marketing
+                          )
+                        }
+                        style={"display: block; margin-top: 8px; font-family: #{font}; font-size: 16px; line-height: 22px; color: #191a1b; text-decoration: none;"}
+                      >
+                        <span aria-hidden="true">#</span>{@previous_issue.number} {@previous_issue.title}
+                      </a>
+                    <% else %>
+                      <p style={"margin: 8px 0 0; font-family: #{font}; font-size: 16px; line-height: 22px; color: #a2a5a8;"}>
+                        {dgettext("marketing", "This is the first issue")}
+                      </p>
+                    <% end %>
+                  </td>
+                  <td
+                    width="50%"
+                    style="width: 50%; vertical-align: top; padding: 24px 32px; border-left: 1px solid #eff0f1; text-align: right;"
                   >
-                    #{@previous_issue.number} {@previous_issue.title}
-                  </a>
-                <% else %>
-                  <p style={"margin: 8px 0 0; font-family: #{font}; font-size: 16px; line-height: 22px; color: #a2a5a8;"}>
-                    {dgettext("marketing", "This is the first issue")}
-                  </p>
-                <% end %>
-              </td>
-              <td
-                width="50%"
-                style="width: 50%; vertical-align: top; padding: 24px 32px; border-left: 1px solid #eff0f1; text-align: right;"
-              >
-                <p style={eyebrow_style}>{dgettext("marketing", "Next issue")}</p>
-                <%= if @next_issue do %>
-                  <a
-                    href={
-                      Tuist.Environment.app_url(
-                        path: ~p"/newsletter/issues/#{@next_issue.number}",
-                        route_type: :marketing
-                      )
-                    }
-                    style={"display: block; margin-top: 8px; font-family: #{font}; font-size: 16px; line-height: 22px; color: #191a1b; text-decoration: none;"}
-                  >
-                    #{@next_issue.number} {@next_issue.title}
-                  </a>
-                <% else %>
-                  <p style={"margin: 8px 0 0; font-family: #{font}; font-size: 16px; line-height: 22px; color: #a2a5a8;"}>
-                    {dgettext("marketing", "This is the latest issue")}
-                  </p>
-                <% end %>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
+                    <p style={eyebrow_style}>{dgettext("marketing", "Next issue")}</p>
+                    <%= if @next_issue do %>
+                      <a
+                        href={
+                          Tuist.Environment.app_url(
+                            path: ~p"/newsletter/issues/#{@next_issue.number}",
+                            route_type: :marketing
+                          )
+                        }
+                        style={"display: block; margin-top: 8px; font-family: #{font}; font-size: 16px; line-height: 22px; color: #191a1b; text-decoration: none;"}
+                      >
+                        <span aria-hidden="true">#</span>{@next_issue.number} {@next_issue.title}
+                      </a>
+                    <% else %>
+                      <p style={"margin: 8px 0 0; font-family: #{font}; font-size: 16px; line-height: 22px; color: #a2a5a8;"}>
+                        {dgettext("marketing", "This is the latest issue")}
+                      </p>
+                    <% end %>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
 
-      <tr>
-        <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
-      </tr>
+          <tr>
+            <td style="height: 2px; line-height: 2px; font-size: 2px;">&nbsp;</td>
+          </tr>
 
-      <%!-- Closing box: subscribe and share, the newsletter's blurb, the
+          <%!-- Closing box: subscribe and share, the newsletter's blurb, the
       social links and the legal line (unsubscribe in the email only). --%>
-      <tr>
-        <td>
-          <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
-            <tr>
-              <td style="padding: 56px 32px 48px; text-align: center;">
-                <p style={"#{eyebrow_style} font-size: 14px; line-height: 20px;"}>
-                  Swift Stories
-                </p>
-                <h2 style={"margin: 20px 0 0; font-family: #{font}; font-size: 28px; line-height: 34px; font-weight: 400; letter-spacing: -0.01em; color: #191a1b;"}>
-                  {dgettext("marketing", "Get the next issue in your inbox")}
-                </h2>
-                <p style="margin: 32px 0 0;">
-                  <a
-                    class="button-primary"
-                    href={
-                      Tuist.Environment.app_url(path: ~p"/newsletter", route_type: :marketing)
-                    }
-                    style={primary_button_style}
-                  >
-                    {dgettext("marketing", "Subscribe")}
-                  </a>
-                  <a
-                    class="share-link"
-                    href={page_url}
-                    style={"#{secondary_button_style} margin-left: 8px;"}
-                    rel="noopener noreferrer"
-                    data-title={@issue.full_title}
-                    data-description={Tuist.Marketing.Newsletter.description()}
-                  >
-                    {dgettext("marketing", "Share it")}
-                  </a>
-                </p>
-              </td>
-            </tr>
-            <tr>
-              <td style="padding: 32px; border-top: 1px solid #eff0f1;">
-                <p style={muted_style}>
-                  Swift Stories is a newsletter brought to you by the people behind <a
-                    style={link_style}
-                    href="https://tuist.dev"
-                  >Tuist</a>. We love cross-pollinating ideas from and to the Swift ecosystem and building tools that make developers' lives easier. If you want to share ideas for future issues, you can do so in our <a
-                    style={link_style}
-                    href="https://community.tuist.dev/c/swift-stories/22"
-                  >community forum</a>. If you like this newsletter, you can support us by sharing it with your friends and colleagues.
-                </p>
-                <p style={"#{body_style} margin-top: 24px;"}>
-                  <a
-                    href={Tuist.Environment.get_url(:forum)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={link_style}
-                  >
-                    Community
-                  </a>
-                  <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
-                  <a
-                    href={Tuist.Environment.get_url(:mastodon)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={link_style}
-                  >
-                    Mastodon
-                  </a>
-                  <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
-                  <a
-                    href={Tuist.Environment.get_url(:github)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={link_style}
-                  >
-                    GitHub
-                  </a>
-                  <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
-                  <a
-                    href={Tuist.Environment.get_url(:slack)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={link_style}
-                  >
-                    Slack
-                  </a>
-                </p>
-                <p style={"#{muted_style} margin-top: 24px;"}>
-                  <a
-                    href={Tuist.Environment.app_url(path: ~p"/terms", route_type: :marketing)}
-                    style="color: #535659; text-decoration: underline;"
-                  >
-                    Terms of service
-                  </a>
-                  <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
-                  <a
-                    href={Tuist.Environment.app_url(path: ~p"/privacy", route_type: :marketing)}
-                    style="color: #535659; text-decoration: underline;"
-                  >
-                    Privacy policy
-                  </a>
-                  <%= if @email_version? do %>
-                    <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
-                    <a
-                      href="{unsubscribe_url}"
-                      style="color: #535659; text-decoration: underline;"
-                    >
-                      Unsubscribe
-                    </a>
-                  <% end %>
-                </p>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
+          <tr>
+            <td>
+              <table role="presentation" cellpadding="0" cellspacing="0" style={box_style}>
+                <tr>
+                  <td style="padding: 56px 32px 48px; text-align: center;">
+                    <p style={"#{eyebrow_style} font-size: 14px; line-height: 20px;"}>
+                      Swift Stories
+                    </p>
+                    <h2 style={"margin: 20px 0 0; font-family: #{font}; font-size: 28px; line-height: 34px; font-weight: 400; letter-spacing: -0.01em; color: #191a1b;"}>
+                      {dgettext("marketing", "Get the next issue in your inbox")}
+                    </h2>
+                    <p style="margin: 32px 0 0;">
+                      <a
+                        class="button-primary"
+                        href={
+                          Tuist.Environment.app_url(path: ~p"/newsletter", route_type: :marketing)
+                        }
+                        style={primary_button_style}
+                      >
+                        {dgettext("marketing", "Subscribe")}
+                      </a>
+                      <a
+                        class="share-link"
+                        href={"mailto:?subject=#{URI.encode(@issue.full_title, &URI.char_unreserved?/1)}&body=#{URI.encode(page_url, &URI.char_unreserved?/1)}"}
+                        style={"#{secondary_button_style} margin-left: 8px;"}
+                        rel="noopener noreferrer"
+                        data-url={page_url}
+                        data-title={@issue.full_title}
+                        data-description={Tuist.Marketing.Newsletter.description()}
+                      >
+                        {dgettext("marketing", "Share it")}
+                      </a>
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 32px; border-top: 1px solid #eff0f1;">
+                    <p style={muted_style}>
+                      Swift Stories is a newsletter brought to you by the people behind <a
+                        style={link_style}
+                        href="https://tuist.dev"
+                      >Tuist</a>. We love cross-pollinating ideas from and to the Swift ecosystem and building tools that make developers' lives easier. If you want to share ideas for future issues, you can do so in our <a
+                        style={link_style}
+                        href="https://community.tuist.dev/c/swift-stories/22"
+                      >community forum</a>. If you like this newsletter, you can support us by sharing it with your friends and colleagues.
+                    </p>
+                    <p style={"#{body_style} margin-top: 24px;"}>
+                      <a
+                        href={Tuist.Environment.get_url(:forum)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={link_style}
+                      >
+                        Community
+                      </a>
+                      <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
+                      <a
+                        href={Tuist.Environment.get_url(:mastodon)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={link_style}
+                      >
+                        Mastodon
+                      </a>
+                      <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
+                      <a
+                        href={Tuist.Environment.get_url(:github)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={link_style}
+                      >
+                        GitHub
+                      </a>
+                      <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
+                      <a
+                        href={Tuist.Environment.get_url(:slack)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={link_style}
+                      >
+                        Slack
+                      </a>
+                    </p>
+                    <p style={"#{muted_style} margin-top: 24px;"}>
+                      <a
+                        href={Tuist.Environment.app_url(path: ~p"/terms", route_type: :marketing)}
+                        style="color: #535659; text-decoration: underline;"
+                      >
+                        Terms of service
+                      </a>
+                      <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
+                      <a
+                        href={
+                          Tuist.Environment.app_url(path: ~p"/privacy", route_type: :marketing)
+                        }
+                        style="color: #535659; text-decoration: underline;"
+                      >
+                        Privacy policy
+                      </a>
+                      <%= if @email_version? do %>
+                        <span style="color: #a2a5a8; padding: 0 8px;">&middot;</span>
+                        <a
+                          href="{unsubscribe_url}"
+                          style="color: #535659; text-decoration: underline;"
+                        >
+                          Unsubscribe
+                        </a>
+                      <% end %>
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </.dynamic_tag>
+    </.dynamic_tag>
   </body>
 
   <%= if not @email_version? do %>
@@ -601,16 +643,24 @@ end %>
               await navigator.share({
                 title: link.dataset.title,
                 text: link.dataset.description,
-                url: link.href
+                url: link.dataset.url
               });
             } catch (err) {
               if (err.name !== 'AbortError') {
-                window.open(link.href, '_blank');
+                window.open(link.dataset.url, '_blank');
               }
             }
           }
         });
       });
+      // Reduced motion: the hero video keeps its controls but does not run on its own.
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        document.querySelectorAll('.hero-video').forEach(video => {
+          video.removeAttribute('autoplay');
+          video.removeAttribute('loop');
+          video.pause();
+        });
+      }
     </script>
   <% end %>
 </html>

--- a/server/priv/gettext/errors.pot
+++ b/server/priv/gettext/errors.pot
@@ -12,9 +12,9 @@ msgid ""
 msgstr ""
 
 #: lib/tuist_web/live/docs_live.ex:81
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1074
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1106
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1139
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1078
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1110
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1143
 #, elixir-autogen, elixir-format
 msgid "Page not found"
 msgstr ""

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -86,7 +86,7 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:86
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:293
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:598
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:920
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:924
 #: lib/tuist_web/marketing/controllers/marketing_html/blog_post.html.heex:10
 #: lib/tuist_web/marketing/live/marketing_blog_live/blog.html.heex:13
 #: lib/tuist_web/marketing/live/marketing_blog_live/new/blog.html.heex:4
@@ -168,7 +168,7 @@ msgstr ""
 msgid "Cache"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:999
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1003
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:491
 #, elixir-autogen, elixir-format
 msgid "Can I change or cancel my plan at any time?"
@@ -325,24 +325,24 @@ msgstr ""
 msgid "Developers"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1054
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1058
 #, elixir-autogen, elixir-format
 msgid "Discover our flexible pricing plans at Tuist. Enjoy a free tier with no time limits, and pay only for what you use. Plus, it's free forever for open source projects."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1006
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1010
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Do you offer annual billing discounts?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1028
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1032
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:687
 #, elixir-autogen, elixir-format
 msgid "Do you offer discounts for non-profits and open-source?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:992
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:996
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:438
 #, elixir-autogen, elixir-format
 msgid "Do you support a seat-based pricing model?"
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Host Tuist server on your own infrastructure for complete control and data sovereignty."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1018
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1022
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:631
 #, elixir-autogen, elixir-format
 msgid "How can I estimate the cost for my project?"
@@ -576,13 +576,13 @@ msgstr ""
 msgid "Invalid verification link. Please try signing up again."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1023
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1027
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:659
 #, elixir-autogen, elixir-format
 msgid "Is there a free trial for paid plans?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1011
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1015
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:575
 #, elixir-autogen, elixir-format
 msgid "Is there a minimum contract length?"
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Newsletter"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1205
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1209
 #: lib/tuist_web/marketing/controllers/marketing_html/new/newsletter_verify.html.heex:13
 #: lib/tuist_web/marketing/controllers/marketing_html/newsletter_verify.html.heex:14
 #, elixir-autogen, elixir-format
@@ -712,7 +712,7 @@ msgstr ""
 msgid "Newsletter issues are sent every 6 weeks and you can unsubscribe at any time."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1012
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1016
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:586
 #, elixir-autogen, elixir-format
 msgid "No, there's no minimum contract length. You're free to cancel at any time."
@@ -811,7 +811,7 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:43
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:286
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:595
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1049
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Pricing"
 msgstr ""
@@ -1027,6 +1027,7 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/new/newsletter.html.heex:37
 #: lib/tuist_web/marketing/controllers/marketing_html/newsletter.html.heex:77
 #: lib/tuist_web/marketing/controllers/marketing_html/newsletter.html.heex:120
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:499
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr ""
@@ -1149,12 +1150,12 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:461
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:518
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:584
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:919
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:971
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1048
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1093
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1125
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1158
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:923
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:975
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1052
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1097
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1129
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1162
 #: lib/tuist_web/marketing/live/marketing_blog_post_live.ex:87
 #: lib/tuist_web/marketing/live/marketing_changelog_entry_live.ex:52
 #, elixir-autogen, elixir-format
@@ -1192,7 +1193,7 @@ msgstr ""
 msgid "Tuist Icon"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1014
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1018
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:614
 #, elixir-autogen, elixir-format
 msgid "Tuist Pro includes support through our community forum and GitHub issues. Enterprise plans include dedicated support via Slack channels with high priority response times."
@@ -1330,12 +1331,12 @@ msgstr ""
 msgid "View all"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:65
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:168
 #, elixir-autogen, elixir-format
 msgid "View in web browser"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:998
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1002
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:477
 #, elixir-autogen, elixir-format
 msgid "We accept credit card payments and wire transfers."
@@ -1351,7 +1352,7 @@ msgstr ""
 msgid "We embrace standards for long-term success while respecting freedom of choice."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1024
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1028
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:670
 #, elixir-autogen, elixir-format
 msgid "We have a generous free tier on every paid plan so you can try out the features before paying any money."
@@ -1383,19 +1384,19 @@ msgstr ""
 msgid "We’ve sent a confirmation email to your inbox. Please check your spam or promotions folder and confirm your subscription."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1001
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1005
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:519
 #, elixir-autogen, elixir-format
 msgid "What happens if I exceed my plan limits?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:997
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1001
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:466
 #, elixir-autogen, elixir-format
 msgid "What payment methods do you accept?"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1013
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1017
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:603
 #, elixir-autogen, elixir-format
 msgid "What support is included with each plan?"
@@ -1421,37 +1422,37 @@ msgstr ""
 msgid "Years of building OSS Foundation"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:993
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:997
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:449
 #, elixir-autogen, elixir-format
 msgid "Yes, we do. Please contact us at contact@tuist.dev to discuss your team's needs and we'll set up a custom plan that works for you."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1029
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1033
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:698
 #, elixir-autogen, elixir-format
 msgid "Yes, we do. Please reach out to contact@tuist.dev for more information."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1007
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1011
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:558
 #, elixir-autogen, elixir-format
 msgid "Yes, we offer discounts for yearly subscriptions. Please contact us at contact@tuist.dev to learn more."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1000
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1004
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "Yes, you can manage your plan at any time through our management interface."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1019
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1023
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:642
 #, elixir-autogen, elixir-format
 msgid "You can set up the Air plan and use the features for a few days to get a usage estimate. If you need a higher limit, let us know and we can help you set up a custom plan."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1002
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1006
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:530
 #, elixir-autogen, elixir-format
 msgid "You'll be warned before reaching your plan limits. Once reached, the plan will cap interactions to prevent unexpected charges."
@@ -1676,7 +1677,7 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/footer.html.heex:182
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:82
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:124
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:972
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:976
 #: lib/tuist_web/marketing/controllers/marketing_html/case_study.html.heex:10
 #: lib/tuist_web/marketing/controllers/marketing_html/new/case_study.html.heex:6
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:918
@@ -1715,7 +1716,7 @@ msgstr ""
 
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:14
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:24
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1126
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1130
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:271
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:539
 #: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:99
@@ -2188,7 +2189,7 @@ msgstr ""
 
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:10
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:16
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1094
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1098
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:223
 #, elixir-autogen, elixir-format
 msgid "Compute"
@@ -2680,7 +2681,7 @@ msgstr ""
 msgid "Brand guidelines"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1118
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1122
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:542
 #: lib/tuist_web/marketing/controllers/marketing_html/new/tests.html.heex:31
 #, elixir-autogen, elixir-format
@@ -3115,7 +3116,7 @@ msgstr ""
 msgid "Fast macOS and Linux runners that scale with your workloads and plug directly into the rest of the Tuist platform."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1086
+#: lib/tuist_web/marketing/controllers/marketing_controller.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Fast macOS and Linux runners that spin up in seconds and scale with your team and your agents."
 msgstr ""
@@ -3550,4 +3551,64 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:628
 #, elixir-autogen, elixir-format
 msgid "System theme"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:177
+#, elixir-autogen, elixir-format
+msgid "All issues"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:394
+#, elixir-autogen, elixir-format
+msgid "Food for thought"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:489
+#, elixir-autogen, elixir-format
+msgid "Get the next issue in your inbox"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:198
+#, elixir-autogen, elixir-format
+msgid "Issue %{number}"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:450
+#, elixir-autogen, elixir-format
+msgid "Next issue"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:427
+#, elixir-autogen, elixir-format
+msgid "Previous issue"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:509
+#, elixir-autogen, elixir-format
+msgid "Share it"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:442
+#, elixir-autogen, elixir-format
+msgid "This is the first issue"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:465
+#, elixir-autogen, elixir-format
+msgid "This is the latest issue"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:289
+#, elixir-autogen, elixir-format
+msgid "Tools & sites"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:259
+#, elixir-autogen, elixir-format
+msgid "Welcome to issue %{number}"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:328
+#, elixir-autogen, elixir-format
+msgid "Worthy Five: %{name}"
 msgstr ""

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -1027,7 +1027,7 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/new/newsletter.html.heex:37
 #: lib/tuist_web/marketing/controllers/marketing_html/newsletter.html.heex:77
 #: lib/tuist_web/marketing/controllers/marketing_html/newsletter.html.heex:120
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:499
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:536
 #, elixir-autogen, elixir-format
 msgid "Subscribe"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "View all"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:168
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:192
 #, elixir-autogen, elixir-format
 msgid "View in web browser"
 msgstr ""
@@ -3553,62 +3553,62 @@ msgstr ""
 msgid "System theme"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:177
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:201
 #, elixir-autogen, elixir-format
 msgid "All issues"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:394
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:428
 #, elixir-autogen, elixir-format
 msgid "Food for thought"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:489
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "Get the next issue in your inbox"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:198
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "Issue %{number}"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:450
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:487
 #, elixir-autogen, elixir-format
 msgid "Next issue"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:427
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:464
 #, elixir-autogen, elixir-format
 msgid "Previous issue"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:509
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:547
 #, elixir-autogen, elixir-format
 msgid "Share it"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:442
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:479
 #, elixir-autogen, elixir-format
 msgid "This is the first issue"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:465
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:502
 #, elixir-autogen, elixir-format
 msgid "This is the latest issue"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:289
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:318
 #, elixir-autogen, elixir-format
 msgid "Tools & sites"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:259
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:286
 #, elixir-autogen, elixir-format
 msgid "Welcome to issue %{number}"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:328
+#: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Worthy Five: %{name}"
 msgstr ""

--- a/server/test/tuist/marketing/newsletter/issue_parser_test.exs
+++ b/server/test/tuist/marketing/newsletter/issue_parser_test.exs
@@ -26,7 +26,7 @@ defmodule Tuist.Marketing.Newsletter.IssueParserTest do
     parsed_body = Floki.parse_fragment!(attrs["body"])
 
     [link] = Floki.find(parsed_body, "a")
-    assert Floki.attribute(link, "style") == ["color: #622ed4; font-weight: bold;"]
+    assert Floki.attribute(link, "style") == ["color: #191a1b; text-decoration: underline; font-weight: bold;"]
 
     [blockquote] = Floki.find(parsed_body, "blockquote")
     assert Floki.attribute(blockquote, "style") == ["font-style: italic; color: red;"]

--- a/server/test/tuist_web/controllers/marketing_controller_test.exs
+++ b/server/test/tuist_web/controllers/marketing_controller_test.exs
@@ -370,6 +370,40 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
     end
   end
 
+  describe "GET /newsletter/issues/:issue_number" do
+    test "renders the issue page", %{conn: conn} do
+      issue = Enum.max_by(Newsletter.issues(), & &1.number)
+
+      conn = get(conn, ~p"/newsletter/issues/#{issue.number}")
+
+      html = html_response(conn, 200)
+      assert html =~ ~s(id="newsletter-issue")
+      assert html =~ issue.title
+      assert html =~ "Worthy Five: #{issue.interview["interviewee"]}"
+      assert html =~ "/newsletter/issues/#{issue.number - 1}"
+      assert html =~ "This is the latest issue"
+      assert html =~ "All issues"
+      refute html =~ "View in web browser"
+      refute html =~ "{unsubscribe_url}"
+      refute html =~ "#622ed4"
+    end
+
+    test "renders the same page as the email export", %{conn: conn} do
+      issue = Enum.max_by(Newsletter.issues(), & &1.number)
+
+      conn = get(conn, ~p"/newsletter/issues/#{issue.number}?email")
+
+      assert response_content_type(conn, :text) =~ "charset=utf-8"
+      body = response(conn, 200)
+      assert body =~ ~s(id="newsletter-issue")
+      assert body =~ issue.title
+      assert body =~ "View in web browser"
+      assert body =~ "{unsubscribe_url}"
+      refute body =~ "@font-face"
+      assert body =~ "[data-ogsc] .button-primary"
+    end
+  end
+
   describe "POST /newsletter" do
     test "successfully sends confirmation email", %{conn: conn} do
       # Given


### PR DESCRIPTION


https://github.com/user-attachments/assets/6a1320c7-af91-419e-bd06-2103479b5773


## Impact

Readers of the web page and email get the new design. Issue authors change nothing: the YAML structure is untouched, and the export flow (`?email` pasted into the mailing tool) is the same. The `{unsubscribe_url}` merge tag is preserved.

## Validation

- `mix test test/tuist_web/controllers/marketing_controller_test.exs --only describe:"GET /newsletter/issues/:issue_number"` (web render, email export as `text/plain` with the merge tag and dark-mode rules, no old purple).
- `mix test test/tuist/marketing/newsletter/issue_parser_test.exs`.
- The export was sent to a Gmail inbox over SMTP and checked in Gmail web, Gmail iOS and Apple Mail, in light and dark mode. That surfaced and fixed: the squashed Worthy Five columns on phones, the masthead logo/name misalignment, the old purple links (a dev-only content cache had masked the parser change), and the washed-out button in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
