### PR TITLE
feat(infra): backfill canary's in-cluster ClickHouse up to the dual-write cutoff

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -334,9 +334,33 @@ clickhouse:
     # backfill covers everything before it, the mirror covers everything after,
     # and naming the boundary is what stops the two from leaving a gap.
     migration:
-      enabled: false
+      enabled: true
       name: backfill
       task: Tuist.Release.backfill_clickhouse
+      # The minute the deploy that turned dual writes on finished rolling out
+      # was 10:40:52Z, and this is deliberately later than that. Four mirrored
+      # writes ended in a terminal `error` during that window, because the
+      # ClickHouse pod was itself restarting alongside the writers, so those
+      # rows reached Cloud and not the destination. A cutoff after them is what
+      # makes the backfill pick them up.
+      #
+      # Later is the safe direction. The backfill covers everything up to the
+      # cutoff and the mirror covers everything from the moment it started, so
+      # a cutoff after the mirror began overlaps rather than leaves a gap, and
+      # the overlap costs nothing: each chunk fills gaps by row identity rather
+      # than appending, so re-copying a range it already holds is a no-op.
+      cutoff: "2026-09-09T11:20:00Z"
+      # An ordinary Job rather than a deploy hook, so the release does not wait
+      # for the copy. Canary's dataset is small enough that waiting would work
+      # here, which is exactly why this is the place to exercise the path
+      # production needs: helm waits for hook Jobs, and a terabyte-scale copy
+      # would hold the release for hours and then fail it on the deadline,
+      # rolling the release back with it.
+      #
+      # Consequence for reading the result: the deploy going green says the
+      # copy started, not that it finished. The gate is every chunk recorded
+      # done in the ledger with no failures, read from the Job afterwards.
+      background: true
 
   poolSize: "30"
   bufferPoolSize: "30"


### PR DESCRIPTION
## What changed

Arms the backfill on canary, which is the initial replication: everything written before the dual-write cutoff gets copied to the in-cluster server.

```yaml
migration:
  enabled: true
  name: backfill
  task: Tuist.Release.backfill_clickhouse
  cutoff: "2026-09-09T11:20:00Z"
  background: true
```

## Where the cutoff comes from

Dual writes went live with [#13029](https://github.com/tuist/tuist/pull/13029). The canary server Deployment reports `Progressing True ... NewReplicaSetAvailable` at **2026-09-09T10:40:52Z**, and its only pod started at 10:40:41Z, so that is when the mirror began covering new rows. Everything before it is on Cloud alone.

The cutoff is set later than that, at 11:20:00Z, for a specific reason. Four mirrored writes ended in a terminal `error` during the deploy window: `tuist-tuist-clickhouse-0` started at 10:40:46Z, so the destination was itself restarting while the writers came up. Those rows reached Cloud and not the in-cluster server, and they are after the mirror started, so only a cutoff placed after them causes the backfill to collect them.

Later is the safe direction generally. The backfill covers everything up to the cutoff, the mirror covers everything from when it started, so any cutoff after the mirror began produces an overlap rather than a gap. The overlap costs nothing: each chunk fills gaps by row identity rather than appending, so re-copying a range the destination already holds is a no-op.

## The dual-write gate, checked before arming this

Per-minute samples across 23 minutes on canary:

| result | behaviour |
|---|---|
| `ok` | climbing, 22 to 30 |
| `error` | flat at 4 |
| `retried` | flat at 8 |
| `dropped` | series does not exist |

`dropped` is the one that would matter most, since it means the in-flight bound was hit and writes were shed. It has never fired here.

The errors and retries are bounded to the deploy window and stopped. Reading the emitter to be sure of the semantics rather than guessing: `retried` is a transient failure that is retried, `error` is terminal after retries are exhausted, and `dropped` is `max_children`. So the four are genuinely missing from the destination, which is what the cutoff choice above accounts for.

## Why an ordinary Job rather than a hook

Canary's dataset is small enough that a blocking hook would work here, which is exactly why this is the place to exercise the path production needs. Helm waits for hook Jobs, so a terabyte-scale copy would hold the release for hours and then fail it on `activeDeadlineSeconds`, rolling the release back with it. As an ordinary Job the release completes while the copy runs.

Renders as expected: `tuist-tuist-clickhouse-backfill-r<revision>`, no `helm.sh/hook` annotation, `helm.sh/resource-policy: keep`, `ttlSecondsAfterFinished: 86400`, running `eval "Tuist.Release.backfill_clickhouse"` with `TUIST_CLICKHOUSE_BACKFILL_CUTOFF=2026-09-09T11:20:00Z`.

**Consequence for reading the result:** the deploy going green says the copy started, not that it finished. The Job has to be checked afterwards.

## Gate and recovery

Gate: every chunk recorded done in the ledger with no failures.

There is nothing to roll back, because nothing reads from that server. A copy that turns out short is repaired by re-running with a later cutoff, not undone: the ledger key is `(table, chunk_start, chunk_end)`, so earlier months are skipped and only the chunk whose end moved is redone.

The task also takes an advisory lock, so a second deploy while a copy is running starts a Job that exits immediately rather than a second copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
