### PR TITLE
fix(server): grant processors read access to feature flags

### DIFF
--- a/infra/cnpg/tuist-processor-grants.sql
+++ b/infra/cnpg/tuist-processor-grants.sql
@@ -48,8 +48,9 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE :"tuist_schema".oban_jobs, :"tuist
 GRANT USAGE, SELECT ON SEQUENCE :"tuist_schema".oban_jobs_id_seq TO tuist_processor;
 
 -- Read-only lookups the workers perform. These rows are not written by the
--- processors, hence no INSERT/UPDATE.
-GRANT SELECT ON TABLE :"tuist_schema".accounts, :"tuist_schema".projects, :"tuist_schema".automation_alerts, :"tuist_schema".webhook_endpoints TO tuist_processor;
+-- processors, hence no INSERT/UPDATE. Build ingestion reads feature_flags to
+-- decide whether to collect Xcode build steps, even when the flag is disabled.
+GRANT SELECT ON TABLE :"tuist_schema".accounts, :"tuist_schema".projects, :"tuist_schema".automation_alerts, :"tuist_schema".webhook_endpoints, :"tuist_schema".feature_flags TO tuist_processor;
 
 COMMIT;
 

--- a/server/lib/tuist/AGENTS.md
+++ b/server/lib/tuist/AGENTS.md
@@ -13,6 +13,11 @@ This directory contains the core business logic and domain modules for the serve
 
 ## Boundaries
 
+- Build ingestion reads `feature_flags` through the restricted processor role,
+  even when Xcode build step collection is disabled. Keep its read grant in
+  `Release` and `infra/cnpg/tuist-processor-grants.sql` in sync; every migration
+  revokes processor table privileges before restoring the allowlist.
+
 - `ClickHouseDictionarySource` builds escaped local dictionary sources for migrations.
   Its query options suppress application SQL logging without overriding managed
   ClickHouse logging policy; server password masking requires valid dictionary DDL.

--- a/server/lib/tuist/release.ex
+++ b/server/lib/tuist/release.ex
@@ -21,7 +21,7 @@ defmodule Tuist.Release do
     bazel_test_results
     bazel_test_summaries
   )
-  @processor_read_tables ~w(accounts projects automation_alerts webhook_endpoints)
+  @processor_read_tables ~w(accounts projects automation_alerts webhook_endpoints feature_flags)
   @swift_registry_sync_write_tables ~w(oban_jobs oban_peers)
 
   # Exact column allowlist for the Grafana "Tuist Product Usage" dashboard role.

--- a/server/test/tuist/release_test.exs
+++ b/server/test/tuist/release_test.exs
@@ -146,7 +146,7 @@ defmodule Tuist.ReleaseTest do
                ~s(GRANT USAGE ON SCHEMA "public" TO "tuist_processor"),
                ~s(GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "public".oban_jobs, "public".oban_peers, "public".test_case_run_flaky_corrections, "public".bazel_test_invocations, "public".bazel_test_results, "public".bazel_test_summaries TO "tuist_processor"),
                ~s(GRANT USAGE, SELECT ON SEQUENCE "public".oban_jobs_id_seq TO "tuist_processor"),
-               ~s(GRANT SELECT ON TABLE "public".accounts, "public".projects, "public".automation_alerts, "public".webhook_endpoints TO "tuist_processor")
+               ~s(GRANT SELECT ON TABLE "public".accounts, "public".projects, "public".automation_alerts, "public".webhook_endpoints, "public".feature_flags TO "tuist_processor")
              ]
     end
 
@@ -158,7 +158,7 @@ defmodule Tuist.ReleaseTest do
         |> File.read!()
 
       expected_read_grant =
-        ~s(GRANT SELECT ON TABLE :"tuist_schema".accounts, :"tuist_schema".projects, :"tuist_schema".automation_alerts, :"tuist_schema".webhook_endpoints TO tuist_processor;)
+        ~s(GRANT SELECT ON TABLE :"tuist_schema".accounts, :"tuist_schema".projects, :"tuist_schema".automation_alerts, :"tuist_schema".webhook_endpoints, :"tuist_schema".feature_flags TO tuist_processor;)
 
       assert occurrences(sql, expected_read_grant) == 1
 


### PR DESCRIPTION
## Problem

The September 9 production rollout of `sha-38b4e7c130f8` caused both Linux build processors to fail every `process_build` job with `Postgrex.Error: permission denied for table feature_flags`. The first recorded error was at 11:03:24 UTC. The Xcode timeline change in #12963 added `FeatureFlags.build_steps_enabled?/1` to `Builds.create_build/1`, but the restricted `tuist_processor` role's table allowlist did not include the FunWithFlags backing table. The lookup runs even when build-step collection is disabled.

The consumers stayed Running and continued claiming work while exhausting retries. An emergency `GRANT SELECT ON TABLE public.feature_flags TO tuist_processor` restored successful completions on both pods. All 366 jobs discarded with that permission error were requeued through `Oban.retry_all_jobs/1`; recovery is draining through the existing queue limits.

## Durable change

Add `feature_flags` to the processor's read-only table allowlist in `Tuist.Release` and the matching CloudNativePG bootstrap SQL, update the grant expectations, and document the dependency in the business-logic intent node. No write access or flag activation is added.

This belongs in the existing grant reconciliation rather than a one-time migration: each managed deployment revokes all processor table privileges and restores the allowlist. Without this change, the next migration removes the emergency grant and reintroduces the incident. Restarting pods or disabling the flag cannot repair the missing read privilege.

## Validation

- Production `has_table_privilege` changed from false to true after the emergency grant; both original processor pods resumed completing jobs without restarting.
- Selectively retried 366 discarded jobs whose errors contain the exact `feature_flags` permission failure using Oban's retry API. No unrelated failed jobs were retried.
- Ran all 10 tests in `server/test/tuist/release_test.exs` with standalone ExUnit against the updated `Tuist.Release`: all passed. This checkout has no Mix dependencies, so the full application/database suite was not run; standalone compilation reports expected warnings for unavailable remote dependencies.
- Elixir formatting checked with the repository's 120-column layout; `git diff --check` passed.

Alert: https://tuist.grafana.net/alerting/grafana/cfwbxvlcr6p6oa/view?orgId=1
