### PR TITLE
fix(infra): route Bazel BEP through the kura-controller gRPC ingress

### DIFF
--- a/infra/kura-controller/controllers/kurainstance_controller.go
+++ b/infra/kura-controller/controllers/kurainstance_controller.go
@@ -1654,10 +1654,11 @@ func (r *KuraInstanceReconciler) reconcilePublicIngress(ctx context.Context, ins
 	return err
 }
 
-// grpcREAPIPathPrefixes are the disjoint, stable URL prefixes of the gRPC
-// services Kura serves: the Bazel Remote Execution API and ByteStream.
-// Paired with the use-regex annotation (see grpcIngressAnnotations) they are
-// rendered by ingress-nginx as anchored regex locations
+// grpcPublicPathPrefixes are the disjoint, stable URL prefixes of the gRPC
+// services Kura serves on the public host: the Bazel Remote Execution API,
+// ByteStream, and the Build Event Protocol (PublishBuildEvent). Paired with
+// the use-regex annotation (see grpcIngressAnnotations) they are rendered by
+// ingress-nginx as anchored regex locations
 // (`location ~* "^/build\.bazel\.remote\.execution\.v2\."`), so a real method
 // path such as /build.bazel.remote.execution.v2.Capabilities/GetCapabilities
 // routes to the gRPC backend. A plain Prefix/ImplementationSpecific path
@@ -1671,12 +1672,21 @@ func (r *KuraInstanceReconciler) reconcilePublicIngress(ctx context.Context, ins
 // anchor itself when use-regex is set, so it is not — and must not be —
 // included here.
 //
-// Note: only the REAPI and ByteStream packages are routed. Kura registers no
-// gRPC health or reflection service, so those paths intentionally fall to the
-// HTTP backend; add `/grpc\.` here if Kura ever serves them.
-var grpcREAPIPathPrefixes = []string{
+// The Build Event Protocol prefix `/google\.devtools\.build\.v1\.` covers
+// both PublishLifecycleEvent (unary) and PublishBuildToolEventStream (bidi
+// streaming). Without it BEP falls through to the HTTP `/` location and
+// ingress-nginx forwards h2 gRPC frames as HTTP/1 to Kura, which returns a
+// 200 response with no gRPC trailers — Bazel then aborts with
+// "unexpected EOS on empty DATA frame from server" and no build/test/cache
+// insight events land in the analytics pipeline.
+//
+// Note: no gRPC health or reflection service is registered by Kura, so
+// `/grpc\.` intentionally falls to the HTTP backend; add it here if Kura
+// ever serves them.
+var grpcPublicPathPrefixes = []string{
 	`/build\.bazel\.remote\.execution\.v2\.`,
 	`/google\.bytestream\.`,
+	`/google\.devtools\.build\.v1\.`,
 }
 
 // reconcileGRPCIngress co-hosts the gRPC (Bazel REAPI) backend on the public
@@ -1713,8 +1723,8 @@ func (r *KuraInstanceReconciler) reconcileGRPCIngress(ctx context.Context, insta
 		// The backend is the same co-hosted cache port that serves HTTP;
 		// this Ingress only exists so ingress-nginx renders these paths
 		// with grpc_pass (backend-protocol: GRPC) instead of proxy_pass.
-		paths := make([]networkingv1.HTTPIngressPath, 0, len(grpcREAPIPathPrefixes))
-		for _, prefix := range grpcREAPIPathPrefixes {
+		paths := make([]networkingv1.HTTPIngressPath, 0, len(grpcPublicPathPrefixes))
+		for _, prefix := range grpcPublicPathPrefixes {
 			paths = append(paths, networkingv1.HTTPIngressPath{
 				Path:     prefix,
 				PathType: ptr(networkingv1.PathTypeImplementationSpecific),
@@ -3669,9 +3679,9 @@ func publicIngressAnnotations() map[string]string {
 
 func grpcIngressAnnotations() map[string]string {
 	annotations := streamingIngressAnnotations("GRPC")
-	// The gRPC service paths are anchored regexes (see grpcREAPIPathPrefixes);
+	// The gRPC service paths are anchored regexes (see grpcPublicPathPrefixes);
 	// use-regex makes ingress-nginx render them as `location ~* ...` so real
-	// REAPI/ByteStream method paths match.
+	// REAPI/ByteStream/BEP method paths match.
 	//
 	// The whole path-split scheme (use-regex + per-location backend-protocol on
 	// a host shared with the public Ingress) is ingress-nginx specific. A

--- a/infra/kura-controller/controllers/kurainstance_controller_test.go
+++ b/infra/kura-controller/controllers/kurainstance_controller_test.go
@@ -1419,7 +1419,7 @@ func TestKuraInstanceReconcileExposesGRPCWhenHostSet(t *testing.T) {
 			t.Fatalf("expected gRPC ingress path to route to the co-hosted cache port %s:http, got %#v", instance.Name, backend)
 		}
 	}
-	wantPaths := []string{`/build\.bazel\.remote\.execution\.v2\.`, `/google\.bytestream\.`}
+	wantPaths := []string{`/build\.bazel\.remote\.execution\.v2\.`, `/google\.bytestream\.`, `/google\.devtools\.build\.v1\.`}
 	if len(gotPaths) != len(wantPaths) {
 		t.Fatalf("expected gRPC ingress to expose the REAPI/ByteStream prefixes, got %v", gotPaths)
 	}
@@ -1850,7 +1850,7 @@ func TestKuraInstanceReconcileConvertsLegacyGRPCIngressToSingleHost(t *testing.T
 			t.Fatalf("expected converted gRPC ingress paths to be ImplementationSpecific, got %v", p.PathType)
 		}
 	}
-	wantPaths := []string{`/build\.bazel\.remote\.execution\.v2\.`, `/google\.bytestream\.`}
+	wantPaths := []string{`/build\.bazel\.remote\.execution\.v2\.`, `/google\.bytestream\.`, `/google\.devtools\.build\.v1\.`}
 	if len(gotPaths) != len(wantPaths) {
 		t.Fatalf("expected converted gRPC ingress to expose the REAPI/ByteStream prefixes, got %v", gotPaths)
 	}


### PR DESCRIPTION
## Summary

Bazel build, test, and cache insights have never landed for any project in prod. Root cause: the kura-controller renders two nginx Ingresses for the same public host — one HTTP on `/`, one gRPC on a regex allowlist — and the allowlist only covers `/build\.bazel\.remote\.execution\.v2\.` and `/google\.bytestream\.`. Every request to `/google.devtools.build.v1.PublishBuildEvent/*` fell through to the HTTP-backend Ingress and ingress-nginx proxied it with `proxy_pass` instead of `grpc_pass`, downgrading h2 gRPC frames to HTTP/1 into Kura's cache port. Bazel saw a bare `200 content-type: application/grpc` response with no DATA frames and no gRPC trailers, retried four times, and aborted with:

```
ERROR: The Build Event Protocol upload failed: All 4 retry attempts failed.
INTERNAL: Received unexpected EOS on empty DATA frame from server
```

The four ClickHouse tables that back the Bazel insight views — `bazel_invocations`, `bazel_invocation_logs`, `reapi_cache_events`, `build_steps` — are all `0 rows, 0 bytes`, which matched what the empty views on `tuist.dev/tuist/kura` were showing.

## What changed

- Add `/google\.devtools\.build\.v1\.` to the gRPC ingress path regex allowlist in `infra/kura-controller/controllers/kurainstance_controller.go`. This prefix covers both `PublishLifecycleEvent` (unary) and `PublishBuildToolEventStream` (bidi streaming); Kura's tonic server registers both via `PublishBuildEventServer` in `kura/src/reapi/service.rs:132,171`.
- Rename `grpcREAPIPathPrefixes` → `grpcPublicPathPrefixes` since the list now covers three packages (REAPI + ByteStream + BEP), and update the doc comment plus the internal reference in `grpcIngressAnnotations`.
- Update the two ingress reconcile tests (`kurainstance_controller_test.go`) that pin the exact rendered path list.

## Why not other approaches

- **Serve BEP from a separate host** (e.g. `bes.<host>`): rejected. The `AGENTS.md` note in `infra/kura-controller` calls out that the single-host layout was the deliberate choice, and BEP is architecturally paired with the REAPI cache (Kura runs both on the same co-hosted port `KURA_PORT`). A second host would need its own DNS, its own external-dns entry, and its own certificate coverage from the wildcard.
- **Add `/grpc\.` or a catch-all regex**: rejected. The current comment already argues for the disjoint-prefix design ("Kura registers no gRPC health or reflection service, so those paths intentionally fall to the HTTP backend"). Adding the BEP prefix explicitly preserves that property while unblocking the one service Kura actually serves under `google.devtools.build.v1`.
- **Fix on the CLI side** (`tuist bazel setup`): rejected. The CLI already writes the correct `.bazelrc.tuist` and points BES at the exact host that the REAPI cache uses — this is the intended contract. The mismatch is on the ingress side.

## Verification

Reproduced locally against production before the change:

```
$ tuist bazel setup   # generates .bazelrc.tuist with --bes_backend=grpcs://tuist-eu-central-1.kura.tuist.dev
$ bazel build //... --bes_upload_mode=wait_for_upload_complete
INFO: Elapsed time: 508.803s, Critical Path: 378.77s
INFO: 1189 processes: 243 remote cache hit, 456 internal, 490 darwin-sandbox.
INFO: Build completed successfully, 1189 total actions
ERROR: The Build Event Protocol upload failed: All 4 retry attempts failed.
INTERNAL: Received unexpected EOS on empty DATA frame from server
```

Same empty-EOS reproduced with `grpcurl` against `PublishLifecycleEvent` (a unary call), confirming the failure is not a bidi-streaming quirk.

Kura pod logs on `kura-tuist-eu-central-1-{0,1}` showed zero BEP-related activity during the reproduction, which lined up with nginx never routing to the gRPC backend. The kube ingress for that host lists exactly the two prefixes above, with `nginx.ingress.kubernetes.io/backend-protocol: GRPC` set only on that Ingress.

After merge and controller rollout, the same `bazel build` should produce a `bazel_invocations` row (visible via `list_bazel_invocations` MCP and on `tuist.dev/tuist/kura` once the project's Bazel views are wired). A follow-up may be needed to also swap CI's default `bes_upload_mode` if `fully_async` still loses events on GitHub-Actions step teardown, but the ingress fix is a prerequisite either way.

## Test plan

- [ ] Rebuild and roll out the kura-controller image; confirm the reconciled `kura-tuist-eu-central-1-grpc` Ingress now lists three regex paths.
- [ ] Rerun `bazel build //...` locally in `kura/` with `--bes_upload_mode=wait_for_upload_complete`; confirm no BEP upload error, and an invocation lands via `list_bazel_invocations account_handle=tuist project_handle=kura`.
- [ ] Rerun the `Kura` CI workflow on `main`; confirm invocations, cache events, and (if a `bazel test` job runs) test insights land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)