### PR TITLE
fix(server): defer registry release job on transient GitHub 5xx

### DIFF
--- a/server/lib/tuist/registry/swift/release_worker.ex
+++ b/server/lib/tuist/registry/swift/release_worker.ex
@@ -34,6 +34,12 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   @max_snooze_seconds 3_600
   @default_snooze_seconds 600
 
+  # Statuses that GitHub's REST API returns for transient upstream failures
+  # (edge/proxy 5xx, secondary rate limits). Retrying immediately turns each
+  # blip into an Oban.PerformError report, so treat them the same way we treat
+  # a throttled submodule clone and defer the job instead.
+  @transient_upstream_statuses [429, 502, 503, 504]
+
   @release_deferred_event [:tuist, :registry, :swift, :release, :deferred]
 
   @doc false
@@ -1123,20 +1129,39 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   # and tag, and lets it run once the budget is back.
   defp maybe_skip_release(scope, name, _full_handle, version, reason) do
     case rate_limit_deferral(reason) do
-      nil ->
-        :not_skipped
-
       {status, retry_after} ->
-        seconds = snooze_seconds(retry_after)
+        snooze_after_rate_limit(scope, name, version, status, retry_after)
 
-        Logger.warning(
-          "Deferring registry release #{scope}/#{name}@#{version} for #{seconds}s after GitHub rate limit (HTTP #{status})"
-        )
-
-        :telemetry.execute(@release_deferred_event, %{releases: 1}, %{reason: :rate_limited})
-
-        {:snooze, seconds}
+      nil ->
+        case transient_upstream_deferral(reason) do
+          nil -> :not_skipped
+          status -> snooze_after_transient_upstream(scope, name, version, status)
+        end
     end
+  end
+
+  defp snooze_after_rate_limit(scope, name, version, status, retry_after) do
+    seconds = snooze_seconds(retry_after)
+
+    Logger.warning(
+      "Deferring registry release #{scope}/#{name}@#{version} for #{seconds}s after GitHub rate limit (HTTP #{status})"
+    )
+
+    :telemetry.execute(@release_deferred_event, %{releases: 1}, %{reason: :rate_limited})
+
+    {:snooze, seconds}
+  end
+
+  defp snooze_after_transient_upstream(scope, name, version, status) do
+    seconds = snooze_seconds(nil)
+
+    Logger.warning(
+      "Deferring registry release #{scope}/#{name}@#{version} for #{seconds}s after transient upstream HTTP #{status}"
+    )
+
+    :telemetry.execute(@release_deferred_event, %{releases: 1}, %{reason: :transient_upstream})
+
+    {:snooze, seconds}
   end
 
   defp rate_limit_deferral({:rate_limited, status, retry_after}), do: {status, retry_after}
@@ -1152,6 +1177,24 @@ defmodule Tuist.Registry.Swift.ReleaseWorker do
   defp rate_limit_deferral(map) when is_map(map), do: map |> Map.values() |> Enum.find_value(&rate_limit_deferral/1)
 
   defp rate_limit_deferral(_reason), do: nil
+
+  # Walks the same shapes as rate_limit_deferral/1 so a bare `{:http_error,
+  # 502}` from a REST helper and a wrapped `{:manifest_fetch_failed, [%{reason:
+  # {:http_error, 502}}, ...]}` are both recognised.
+  defp transient_upstream_deferral({:http_error, status}) when status in @transient_upstream_statuses, do: status
+
+  defp transient_upstream_deferral(tuple) when is_tuple(tuple) do
+    tuple
+    |> Tuple.to_list()
+    |> Enum.find_value(&transient_upstream_deferral/1)
+  end
+
+  defp transient_upstream_deferral(list) when is_list(list), do: Enum.find_value(list, &transient_upstream_deferral/1)
+
+  defp transient_upstream_deferral(map) when is_map(map),
+    do: map |> Map.values() |> Enum.find_value(&transient_upstream_deferral/1)
+
+  defp transient_upstream_deferral(_reason), do: nil
 
   defp snooze_seconds(nil), do: @default_snooze_seconds
 

--- a/server/test/tuist/registry/swift/release_worker_test.exs
+++ b/server/test/tuist/registry/swift/release_worker_test.exs
@@ -232,6 +232,75 @@ defmodule Tuist.Registry.Swift.ReleaseWorkerTest do
              })
   end
 
+  test "defers the job when GitHub returns a transient upstream error on a REST call" do
+    # Repeats the shape of the Hive report: attempt 1 saw HTTP 502 from GitHub's
+    # edge and Oban.PerformError re-raised the bare {:http_error, 502} tuple.
+    # The retry budget already covers this; deferring turns each blip into a
+    # snooze instead of a Sentry-reported failure.
+    for status <- [429, 502, 503, 504] do
+      expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
+        {:ok, :acquired}
+      end)
+
+      expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+        {:error, :not_found}
+      end)
+
+      expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+        {:error, {:http_error, status}}
+      end)
+
+      stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ -> flunk("unexpected zipball download") end)
+      stub(TuistCommon.GitHub, :get_file_content, fn _, _, _, _, _ -> flunk("unexpected file request") end)
+      stub(Metadata, :put_package, fn _, _, _ -> flunk("unexpected skipped-release write") end)
+
+      assert {:snooze, 600} =
+               ReleaseWorker.perform(%Oban.Job{
+                 args: %{
+                   "scope" => "apple",
+                   "name" => "swift-argument-parser",
+                   "repository_full_handle" => "apple/swift-argument-parser",
+                   "tag" => "v1.0.0"
+                 }
+               })
+    end
+  end
+
+  test "defers the job when a transient upstream error is wrapped in a manifest fetch failure" do
+    # A per-manifest `{:http_error, 503}` bubbles up as
+    # `{:manifest_fetch_failed, [%{path: ..., reason: {:http_error, 503}}]}`,
+    # so the deferral walk has to look inside the wrapping tuple/list/map.
+    expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
+      {:ok, :acquired}
+    end)
+
+    expect(Metadata, :get_package, fn "apple", "swift-argument-parser", [fresh: true] ->
+      {:error, :not_found}
+    end)
+
+    expect(TuistCommon.GitHub, :list_repository_contents, fn "apple/swift-argument-parser", "token", "v1.0.0", _ ->
+      {:ok, [%{"path" => "Package.swift", "type" => "file"}]}
+    end)
+
+    expect(TuistCommon.GitHub, :get_file_content, fn
+      "apple/swift-argument-parser", "token", "Package.swift", "v1.0.0", _ ->
+        {:error, {:http_error, 503}}
+    end)
+
+    stub(TuistCommon.GitHub, :download_zipball, fn _, _, _, _, _ -> flunk("unexpected zipball download") end)
+    stub(Metadata, :put_package, fn _, _, _ -> flunk("unexpected skipped-release write") end)
+
+    assert {:snooze, 600} =
+             ReleaseWorker.perform(%Oban.Job{
+               args: %{
+                 "scope" => "apple",
+                 "name" => "swift-argument-parser",
+                 "repository_full_handle" => "apple/swift-argument-parser",
+                 "tag" => "v1.0.0"
+               }
+             })
+  end
+
   test "snoozes immediately without retrying when the skip-write lock is contended" do
     expect(Lock, :try_acquire, fn {:release, "apple", "swift-argument-parser", "1.0.0"}, _ ->
       {:ok, :acquired}


### PR DESCRIPTION
Resolves the Hive issue at <https://hive.tuist.dev/errors/63304c45-28e0-5ab9-98fb-a587dcae3a2e>.

## What changed

- `Tuist.Registry.Swift.ReleaseWorker` now recognises transient upstream HTTP responses (429, 502, 503, 504) coming out of the GitHub REST helpers as deferrable, alongside the existing `{:rate_limited, ...}` shape.
- A new `transient_upstream_deferral/1` walker mirrors `rate_limit_deferral/1` and recurses into tuples, lists, and maps, so a bare `{:http_error, 502}` from `list_repository_contents` or `download_zipball` and a wrapped one inside `{:manifest_fetch_failed, [%{reason: {:http_error, 503}}, ...]}` or `{:gitmodules_fetch_failed, {:http_error, 502}}` are both caught.
- When one matches, the job snoozes for the default 600 second window instead of raising `Oban.PerformError`.
- Two new tests: one loops over 429/502/503/504 as the bare REST error, one asserts a wrapped `{:http_error, 503}` inside a manifest fetch failure also defers.

## Why

The Hive issue was firing on every GitHub edge blip during a `swift_registry_release` sync burst. Each `mparticle-integrations/mp-apple-integration-*` release job saw one 502/503 on attempt 1 and re-raised the bare `{:error, {:http_error, 502}}` tuple as an `Oban.PerformError`. The job's `max_attempts: 20` retry budget always recovered, so the reports were pure noise, but they still paged and drowned out real regressions in that worker.

## Root cause

`TuistCommon.GitHub.http_error/1` only tags 429 (and rate-limited 403) as `{:rate_limited, status, retry_after}`. Every other status is returned as `{:error, {:http_error, status}}`. The `ReleaseWorker.maybe_skip_release/5` deferral path only inspected the rate-limit shape, so a plain `{:http_error, 502}` fell through to `:not_skipped`, the job returned `{:error, reason}`, and Oban re-raised it.

## Approach

Two reasonable places to fix this:

1. Widen `TuistCommon.GitHub.http_error/1` so 502/503/504 return the transient shape. Cleaner as a single source of truth, but changes the return shape seen by every caller in `cache/` and `server/` and needs a sweep.
2. Add a transient-HTTP deferral clause in `ReleaseWorker` mirroring the throttled-submodule handler already there.

Went with option 2. It is localised to the noisy path, has no downstream impact, and matches the pattern that already exists in the same file (`@transient_http_statuses ~w(429 502 503 504)` for git submodule failures). Oban's 20-attempt retry stays as the ultimate backstop, so nothing loses coverage; the loud attempt-1 failure just becomes a snooze.

## Impact

- No more Hive reports for transient GitHub 5xx on `Tuist.Registry.Swift.ReleaseWorker`.
- Same eventual success rate on release syncs (Oban still retries the deferred job).
- Slightly longer wall-clock on affected releases during a GitHub incident (a 600 second snooze instead of an immediate retry), which is a feature rather than a regression: retrying immediately against a struggling upstream is what created the burst in the first place.

## Validation

- `mix compile` in `server/` — clean.
- `mix format` — no diff.
- `mix credo lib/tuist/registry/swift/release_worker.ex` — no issues.
- `mix test test/tuist/registry/swift/release_worker_test.exs` — could not run locally because the machine's Postgres was saturated by other Tuist dev services holding idle connections. CI will run the suite.

### How to test locally

```
cd server
mix test test/tuist/registry/swift/release_worker_test.exs
```

The two new tests (`defers the job when GitHub returns a transient upstream error on a REST call` and `defers the job when a transient upstream error is wrapped in a manifest fetch failure`) cover both shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
