### PR TITLE
docs(infra): record why Elastic Metal advertises no egress budget

### DIFF
--- a/infra/cluster-api-provider-tuist/AGENTS.md
+++ b/infra/cluster-api-provider-tuist/AGENTS.md
@@ -395,10 +395,20 @@ see the quantity in question:
 
 - `tuist.dev/egress-mbps` — the box's public egress budget, which Kubernetes has
   no concept of. On OVH it is derived from what the box reports, seeded by the
-  machine's `EgressBudgetMbps` (see below); Dedibox takes the spec value
-  directly and leaves the node alone when it is zero; Elastic Metal has no egress
-  budget and is outside the extended-resource path. The helper itself treats a
-  zero as "withdraw the capacity" — only the OVH kind passes one through.
+  machine's `EgressBudgetMbps` (see below); Vultr takes the spec value directly;
+  Dedibox does too but leaves the node alone when it is zero. The helper itself
+  treats a zero as "withdraw the capacity", so the OVH and Vultr kinds can retire
+  a budget and Dedibox cannot.
+
+  Elastic Metal has no `EgressBudgetMbps` and is deliberately outside this path.
+  It backs only the private runner-cache pool, whose tenants reach it over the
+  Scaleway Private Network (10 Gbit/s on the B-series, 25 Gbit/s on the I-series)
+  rather than over the 1 Gbit/s public bandwidth every offer includes. That
+  public figure is the one the other kinds advertise, and on this pool it
+  describes no path in use: it is the mirror of the vRack over-commit the OVH
+  fleet values warn about. Arbitration on the private path is the per-tenant
+  Cilium ceiling instead, so the pool also stays out of
+  `egressTreeAgent.nodePools`.
 - `tuist.dev/memory-ceiling-mib` — a bounded multiple
   (`MemoryCeilingOversubscription`) of the node's own allocatable memory.
   Kura cache pods run a memory *ceiling* above their *floor*, so their ceilings

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -436,8 +436,11 @@ kuraController:
       item: kura-sentry-hive
 
 # Only the shared mesh cache pools are listed. The runner-cache pool
-# (kura-scw-fr-par) is intentionally excluded: it advertises no egress budget,
-# and its traffic is node-local runner reads that must not be shaped.
+# (kura-scw-fr-par) is excluded: its tenants share the Elastic Metal box's
+# Private Network, not the 1 Gbit/s public bandwidth every budget here is
+# denominated in, so the box advertises no tuist.dev/egress-mbps and there is
+# nothing for a tree to rate its root against. Each tenant is still ceilinged
+# on that path by the Cilium bandwidth manager (egress_burst_mbps).
 egressTreeAgent:
   enabled: true
   nodePools: [kura-dedibox, kura-ca-east]

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -351,8 +351,11 @@ kuraController:
       item: kura-sentry-hive
 
 # Only the shared mesh cache pools are listed. The runner-cache pool
-# (kura-scw-fr-par) is intentionally excluded: it advertises no egress budget,
-# and its traffic is node-local runner reads that must not be shaped.
+# (kura-scw-fr-par) is excluded: its tenants share the Elastic Metal box's
+# Private Network, not the 1 Gbit/s public bandwidth every budget here is
+# denominated in, so the box advertises no tuist.dev/egress-mbps and there is
+# nothing for a tree to rate its root against. Each tenant is still ceilinged
+# on that path by the Cilium bandwidth manager (egress_burst_mbps).
 egressTreeAgent:
   enabled: true
   nodePools: [kura-dedibox, kura-us-east, kura-us-west, kura-ap-southeast, kura-sa-west]


### PR DESCRIPTION
No issue: this started as a report that the Scaleway Elastic Metal Kura node is
missing its `tuist.dev/egress-mbps` capacity and is therefore running outside the
egress HTB tree's arbitration.

The report is accurate about the symptom and about the code path. It is wrong
about the conclusion, and this PR records why so the next reader does not retrace
it. There is no behaviour change.

### What was reported

`tuist-tuist-kura-fleet-6vx2l-plpvc` (pool `kura-scw-fr-par`, 32 CPU, 11 Kura
tenants) advertises no `tuist.dev/egress-mbps`, while every other Kura node does.
`shared.ReconcileNodeEgressCapacity` is called from the OVH, Dedibox and Vultr
controllers and from nowhere in
`controllers/linux/scalewayelasticmetalmachine_controller.go`, so the Elastic
Metal kind has no path that advertises the resource. The concern was governance:
that node has no box cap, so one tenant could take the whole NIC.

### Why it is correct as it stands

Scaleway's Baremetal API answers both questions the OVH discovery path answers.
It reports `shared_bandwidth: true` on all three Elastic Metal offers in the
fleet, so the NIC is shared and the box does want arbitration. But the budget
that governs it is not the one the sibling kinds advertise:

| offer | public | max public | private | shared |
|---|---|---|---|---|
| EM-B220E-NVME (staging, canary) | 1G | 10G | 10G | true |
| EM-B320E-NVME | 1G | 10G | 10G | true |
| EM-I220E-NVME (production) | 1G | 25G | 25G | true |

`scw-fr-par-runners` is a private region. Its data plane is `:node_port`, its
clients are confined to `172.16.0.0/22` by NetworkPolicy, and the cluster carries
zero Ingresses for it. The tenants are Mac minis reaching the node across the
Scaleway Private Network, so they never touch the 1 Gbit/s public bandwidth the
offer includes. Publishing that figure as the node budget would rate an HTB root
at a twenty-fifth of the path actually in use and start shaping runner cache
reads that run at line rate today. It is the vRack over-commit that the OVH
ap-southeast values comment warns about, inverted.

Arbitration on that path already exists and is not the tree. Cilium's bandwidth
manager is enabled cluster-wide (`enable-bandwidth-manager: true`) and all eleven
pods on the node carry `kubernetes.io/egress-bandwidth: 750M`, rendered from the
region's `egress_burst_mbps`. One tenant tops out at 750 Mbps of a 25 Gbit/s
link, and all eleven together at 8.25 Gbit/s. Measured on the node, 7-day peak
transmit is 454 Mbps and 24-hour peak is 41 Mbps.

### What changed

Documentation only.

- `infra/helm/tuist/values-managed-{production,canary}.yaml`: the comment
  excluding `kura-scw-fr-par` from `egressTreeAgent.nodePools` gave the wrong
  reason. It called the pool's traffic "node-local runner reads"; the minis are
  separate hosts reached across the private network. Replaced with the real
  reason.
- `infra/cluster-api-provider-tuist/AGENTS.md`: the Node extended resources
  section already said Elastic Metal is outside this path but never said why,
  which is how the absence read as a hole in the provider. It now carries the
  reason and the derivation to use if an Elastic Metal box ever joins a public
  mesh region: the offer's `bandwidth` plus any enabled `public_bandwidth` server
  option, never `max_bandwidth` or `private_bandwidth`.
- Same bullet: it claimed only the OVH kind passes a zero budget through to the
  helper. Vultr does too, so only Dedibox guards on a positive value.

### Two premises worth correcting

There is a Vultr Go controller. `controllers/linux/vultrmachine_controller.go`
calls the shared helper straight from spec, and the sa-west fleet sets 1000 in
values, which is where that node's budget comes from.

The "10G PN" in `server/lib/tuist/kura/regions.ex` is not drift against the 25G
production box. It is the conservative B-series floor that staging and canary
run, and it is what the 750 Mbps ceiling is sized against.

### How to test locally

Nothing to run. The change touches only comments and a markdown intent node, and
the diff over both values files contains zero non-comment lines:

```bash
git diff main -U0 -- infra/helm/tuist/values-managed-production.yaml infra/helm/tuist/values-managed-canary.yaml | grep -E '^[+-]' | grep -v '^[+-][+-]' | grep -vE '^[+-]#' | wc -l
```

To confirm the values still parse and `egressTreeAgent.nodePools` is untouched:

```bash
ruby -ryaml -e 'puts YAML.load(File.read("infra/helm/tuist/values-managed-production.yaml"))["egressTreeAgent"].inspect'
```

To reproduce the provider readings (read-only, Scaleway credentials from the
production vault):

```bash
curl -s -H "X-Auth-Token: $(op read 'op://tuist-k8s-production/SCALEWAY_API/secret-key')" "https://api.scaleway.com/baremetal/v1/zones/fr-par-1/offers?page_size=100"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
