### PR TITLE
fix(server,infra): wait for the in-cluster ClickHouse before backfilling

### DIFF
--- a/infra/helm/tuist/templates/clickhouse-migration-job.yaml
+++ b/infra/helm/tuist/templates/clickhouse-migration-job.yaml
@@ -42,12 +42,13 @@ metadata:
     app.kubernetes.io/component: clickhouse-migration
   annotations:
 {{- if $background }}
-    # Not a hook, so helm does not wait for it: the deploy passes `--wait` but
-    # not `--wait-for-jobs`, and a copy of the production dataset would
-    # otherwise hold the release for hours and then fail it on the deadline.
-    #
     # Kept, so that the deploy which rolls the *next* revision does not delete
     # a copy that is still running. Finished ones remove themselves.
+    #
+    # Being an ordinary resource rather than a hook does not take it off the
+    # release's critical path. That held under helm 3, where `--wait` skipped
+    # Jobs unless `--wait-for-jobs` was passed; helm 4's `--wait` watches them
+    # either way, so a failure here fails the upgrade and rolls it back.
     "helm.sh/resource-policy": keep
 {{- else }}
     helm.sh/hook: post-upgrade,post-install

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -350,16 +350,18 @@ clickhouse:
       # the overlap costs nothing: each chunk fills gaps by row identity rather
       # than appending, so re-copying a range it already holds is a no-op.
       cutoff: "2026-09-09T11:20:00Z"
-      # An ordinary Job rather than a deploy hook, so the release does not wait
-      # for the copy. Canary's dataset is small enough that waiting would work
-      # here, which is exactly why this is the place to exercise the path
-      # production needs: helm waits for hook Jobs, and a terabyte-scale copy
-      # would hold the release for hours and then fail it on the deadline,
-      # rolling the release back with it.
+      # An ordinary Job rather than a deploy hook, so a copy that is still
+      # running when the next revision rolls is not deleted with the hook.
       #
-      # Consequence for reading the result: the deploy going green says the
-      # copy started, not that it finished. The gate is every chunk recorded
-      # done in the ledger with no failures, read from the Job afterwards.
+      # It does not follow that the release stops waiting for it. Helm 4's
+      # `--wait` watches ordinary Jobs as well as hook ones, so this stays on
+      # the release's critical path and a failure rolls the release back.
+      # Canary's dataset is small enough for that to be workable; the
+      # terabyte-scale copy production needs is not, and needs a launch path
+      # helm does not watch before it can be armed there.
+      #
+      # The gate on the result is every chunk recorded done in the ledger with
+      # no failures, read from the Job afterwards.
       background: true
 
   poolSize: "30"

--- a/server/lib/tuist/clickhouse/backfill.ex
+++ b/server/lib/tuist/clickhouse/backfill.ex
@@ -113,7 +113,9 @@ defmodule Tuist.ClickHouse.Backfill do
   """
   def run(opts \\ []) do
     Endpoints.with_repos(opts, fn source, target ->
-      with_single_flight(fn -> backfill(source, target, opts) end)
+      with :ok <- Endpoints.await_ready(target, opts) do
+        with_single_flight(fn -> backfill(source, target, opts) end)
+      end
     end)
   end
 

--- a/server/lib/tuist/clickhouse/endpoints.ex
+++ b/server/lib/tuist/clickhouse/endpoints.ex
@@ -25,6 +25,11 @@ defmodule Tuist.ClickHouse.Endpoints do
 
   alias Tuist.Environment
 
+  require Logger
+
+  @ready_timeout to_timeout(minute: 5)
+  @ready_interval to_timeout(second: 5)
+
   @doc """
   Starts the ledger, source and destination repositories and calls `fun` with a
   descriptor for the two ClickHouse ones, then shuts them all down again.
@@ -44,6 +49,42 @@ defmodule Tuist.ClickHouse.Endpoints do
       # first query rather than at lookup, so the omission surfaced only once
       # the first chunk had already been copied.
       with_started_repo(Tuist.Repo, fn _ledger -> with_clickhouse_repos(source_repo, target_repo, fun) end)
+    end
+  end
+
+  @doc """
+  Waits until `endpoint` answers a query, for up to `:ready_timeout`.
+
+  The in-cluster server is rolled by the same release that runs these tasks, so
+  a `post-upgrade` Job reaches it while its pod may still be coming back. The
+  pool reports that as a queue timeout within seconds, and a task that takes
+  the first refusal at face value fails its Job, which fails the release and
+  rolls it back. Waiting is what keeps a restart window a transient rather than
+  a failed deploy.
+
+  Returns `{:error, {:not_ready, database, reason}}` carrying the last refusal
+  once the deadline passes.
+  """
+  def await_ready(endpoint, opts \\ []) do
+    interval = Keyword.get(opts, :ready_interval, @ready_interval)
+    deadline = System.monotonic_time(:millisecond) + Keyword.get(opts, :ready_timeout, @ready_timeout)
+
+    await_ready(endpoint, interval, deadline)
+  end
+
+  defp await_ready(endpoint, interval, deadline) do
+    case endpoint.repo.query("SELECT 1", [], log: false) do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        if System.monotonic_time(:millisecond) + interval < deadline do
+          Logger.info("#{endpoint.database} is not answering yet; retrying in #{interval}ms")
+          Process.sleep(interval)
+          await_ready(endpoint, interval, deadline)
+        else
+          {:error, {:not_ready, endpoint.database, reason}}
+        end
     end
   end
 

--- a/server/lib/tuist/clickhouse/parity.ex
+++ b/server/lib/tuist/clickhouse/parity.ex
@@ -77,56 +77,60 @@ defmodule Tuist.ClickHouse.Parity do
   """
   def compare(opts \\ []) do
     Endpoints.with_repos(opts, fn source, target ->
-      copied = Keyword.get_lazy(opts, :tables, fn -> Tables.copied(target) end)
-      derived = Keyword.get_lazy(opts, :derived, fn -> Tables.derived(target) end)
-      as_of = Keyword.get_lazy(opts, :as_of, &default_as_of/0)
-      since = Keyword.get(opts, :since)
-
-      window = if since, do: " written since #{since}", else: ""
-      Logger.info("Comparing #{length(copied)} copied and #{length(derived)} derived table(s)#{window} as of #{as_of}")
-
-      drift = Tables.schema_drift(source, target)
-
-      {matching, differing, skipped} = split(source, target, copied, since, as_of)
-      {derived_matching, derived_differing, _} = split(source, target, derived, since, as_of)
-
-      report = %{
-        compared: length(copied) - length(skipped),
-        skipped: skipped,
-        schema: drift,
-        matching: Enum.map(matching, & &1.table),
-        differing: Enum.map(differing, &Map.delete(&1, :matches)),
-        derived: %{
-          compared: length(derived),
-          matching: Enum.map(derived_matching, & &1.table),
-          differing: Enum.map(derived_differing, &Map.delete(&1, :matches))
-        }
-      }
-
-      if report.differing == [] do
-        Logger.info("ClickHouse parity: all #{report.compared} copied table(s) agree")
-      else
-        Logger.error("ClickHouse parity: #{length(report.differing)} of #{report.compared} copied table(s) differ")
+      with :ok <- Endpoints.await_ready(target, opts) do
+        compare_ready(source, target, opts)
       end
-
-      if drift.missing_on_destination != [] or drift.differing_columns != [] do
-        Logger.error(
-          "ClickHouse schema drift: #{inspect(Map.take(drift, [:missing_on_destination, :differing_columns]))}"
-        )
-      end
-
-      if report.derived.differing != [] do
-        # Reported with both fingerprints rather than by name. These tables are
-        # recomputed rather than copied, so some difference is expected, and
-        # the question is only ever how much: a percent on a rebuilt aggregate
-        # is the design working, and half the rows is not.
-        Logger.warning(
-          "ClickHouse parity: #{length(report.derived.differing)} of #{report.derived.compared} derived table(s) differ, which is reported and not a gate: #{inspect(report.derived.differing)}"
-        )
-      end
-
-      {:ok, report}
     end)
+  end
+
+  defp compare_ready(source, target, opts) do
+    copied = Keyword.get_lazy(opts, :tables, fn -> Tables.copied(target) end)
+    derived = Keyword.get_lazy(opts, :derived, fn -> Tables.derived(target) end)
+    as_of = Keyword.get_lazy(opts, :as_of, &default_as_of/0)
+    since = Keyword.get(opts, :since)
+
+    window = if since, do: " written since #{since}", else: ""
+    Logger.info("Comparing #{length(copied)} copied and #{length(derived)} derived table(s)#{window} as of #{as_of}")
+
+    drift = Tables.schema_drift(source, target)
+
+    {matching, differing, skipped} = split(source, target, copied, since, as_of)
+    {derived_matching, derived_differing, _} = split(source, target, derived, since, as_of)
+
+    report = %{
+      compared: length(copied) - length(skipped),
+      skipped: skipped,
+      schema: drift,
+      matching: Enum.map(matching, & &1.table),
+      differing: Enum.map(differing, &Map.delete(&1, :matches)),
+      derived: %{
+        compared: length(derived),
+        matching: Enum.map(derived_matching, & &1.table),
+        differing: Enum.map(derived_differing, &Map.delete(&1, :matches))
+      }
+    }
+
+    if report.differing == [] do
+      Logger.info("ClickHouse parity: all #{report.compared} copied table(s) agree")
+    else
+      Logger.error("ClickHouse parity: #{length(report.differing)} of #{report.compared} copied table(s) differ")
+    end
+
+    if drift.missing_on_destination != [] or drift.differing_columns != [] do
+      Logger.error("ClickHouse schema drift: #{inspect(Map.take(drift, [:missing_on_destination, :differing_columns]))}")
+    end
+
+    if report.derived.differing != [] do
+      # Reported with both fingerprints rather than by name. These tables are
+      # recomputed rather than copied, so some difference is expected, and
+      # the question is only ever how much: a percent on a rebuilt aggregate
+      # is the design working, and half the rows is not.
+      Logger.warning(
+        "ClickHouse parity: #{length(report.derived.differing)} of #{report.derived.compared} derived table(s) differ, which is reported and not a gate: #{inspect(report.derived.differing)}"
+      )
+    end
+
+    {:ok, report}
   end
 
   defp split(source, target, tables, since, as_of) do

--- a/server/test/tuist/clickhouse/endpoints_test.exs
+++ b/server/test/tuist/clickhouse/endpoints_test.exs
@@ -1,0 +1,42 @@
+defmodule Tuist.ClickHouse.EndpointsTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Tuist.ClickHouse.Endpoints
+
+  @endpoint_descriptor %{repo: Tuist.IngestRepo, database: "in_cluster"}
+
+  describe "await_ready/2" do
+    test "returns once the endpoint answers" do
+      stub(Tuist.IngestRepo, :query, fn _sql, _params, _opts -> {:ok, %{rows: [[1]]}} end)
+
+      assert Endpoints.await_ready(@endpoint_descriptor) == :ok
+    end
+
+    test "keeps asking while the endpoint is still coming back" do
+      # The window this exists for: the destination is rolled by the same
+      # release, so the first queries land while its pod is restarting and the
+      # pool refuses them within seconds.
+      {:ok, attempts} = Agent.start_link(fn -> 0 end)
+
+      stub(Tuist.IngestRepo, :query, fn _sql, _params, _opts ->
+        case Agent.get_and_update(attempts, &{&1 + 1, &1 + 1}) do
+          attempt when attempt < 3 -> {:error, %DBConnection.ConnectionError{message: "connection not available"}}
+          _ -> {:ok, %{rows: [[1]]}}
+        end
+      end)
+
+      assert Endpoints.await_ready(@endpoint_descriptor, ready_interval: 1, ready_timeout: 1_000) == :ok
+      assert Agent.get(attempts, & &1) == 3
+    end
+
+    test "gives up with the refusal it last saw" do
+      stub(Tuist.IngestRepo, :query, fn _sql, _params, _opts ->
+        {:error, %DBConnection.ConnectionError{message: "connection not available"}}
+      end)
+
+      assert {:error, {:not_ready, "in_cluster", %DBConnection.ConnectionError{}}} =
+               Endpoints.await_ready(@endpoint_descriptor, ready_interval: 1, ready_timeout: 0)
+    end
+  end
+end


### PR DESCRIPTION
## What changed

`Tuist.ClickHouse.Backfill.run/1` and `Tuist.ClickHouse.Parity.compare/1` now wait for the in-cluster ClickHouse to answer a query before they touch it, via a new `Tuist.ClickHouse.Endpoints.await_ready/2`. It polls every five seconds for up to five minutes and returns `{:error, {:not_ready, database, reason}}` carrying the last refusal if the destination never comes back.

Two comments that asserted Helm does not wait on these jobs are corrected, because that is what made this a release-failing bug rather than a slow one.

## Why

The backfill and parity tasks run from a `post-upgrade` hook, so they reach a server that the same release is still rolling. The first query lands while the ClickHouse pod is restarting, the connection pool refuses it inside its queue timeout, and `Tables.copied/1` raises on the very first statement.

The job is rendered with `backoffLimit: 0`, so that single refusal is terminal. Helm then fails the upgrade and rolls the release back with it.

## Root cause

Two things had to line up.

The first is the six second failure. The task took the pool's queue timeout as a verdict about the destination rather than as a statement about a pod that was thirty seconds into a restart. Nothing about the copy needs to start at that instant, so waiting is free and correct.

The second is the assumption that a failure here was contained. Both the chart template and the canary values say the backfill is an ordinary Job rather than a hook so that the release does not wait for it. That was true under Helm 3, where `--wait` skipped Jobs unless `--wait-for-jobs` was also passed. The repository pins Helm 4.2.0, whose `--wait` watches ordinary Jobs too, so `background: true` no longer keeps the copy off the release's critical path. The comments now say so.

## Why this fix and not the alternatives

Raising `backoffLimit` would let Kubernetes retry the pod, but each retry re-runs process startup and the advisory lock dance to discover the same thing, and the ceiling is a retry count rather than a duration. Waiting inside the task expresses the actual requirement, which is that the destination is reachable before the copy begins.

Putting the wait inside `Endpoints.with_repos/2` would have covered every caller in one place, but `SchemaClone.reconcile/0` runs from the `pre-upgrade` migration job on the deploy critical path, and is deliberately best effort about an unreachable destination. Making it block for minutes on every deploy would trade one deploy failure for a slower deploy every time. The two post-upgrade tasks ask for the wait explicitly instead.

## Impact

A canary deploy no longer fails because the in-cluster ClickHouse was mid-restart when the backfill started. This matters beyond the copy itself: the deploy that failed this way on 2026-09-09 was carrying an unrelated urgent fix, which never reached production because the cascade halted at canary.

The parity check is the next step of the same migration and runs from the same job with the same `backoffLimit: 0`, so it is fixed here too rather than left to fail the same way on the deploy that arms it.

## Known limitation, not addressed here

Because Helm 4 watches ordinary Jobs, `background: true` does not currently take a copy off the release's critical path. Canary's dataset is small enough for that to be workable. The terabyte-scale copy production needs will require a launch path Helm does not watch, which is a separate change.

## Validation

- `mix test test/tuist/clickhouse/` passes, 45 tests including three new ones covering the immediate answer, the retry while the destination is still coming back, and giving up with the refusal last seen.
- `mix test test/tuist/release_test.exs` passes, 10 tests.
- `mix credo` reports no issues on the three changed modules.
- `helm template` renders `templates/clickhouse-migration-job.yaml` against the canary values, confirming the comment edits leave the job intact and `backoffLimit: 0` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
