### PR TITLE
fix(infra): stop migration steps restarting ClickHouse, and stop the backfill racing it

### DIFF
--- a/infra/helm/tuist/templates/clickhouse-managed.yaml
+++ b/infra/helm/tuist/templates/clickhouse-managed.yaml
@@ -573,7 +573,22 @@ spec:
         # ConfigMap edit sits on disk unread until something else restarts
         # the pod. ClickHouse reloads some of these itself, but not the
         # profile settings that gate the replicated-engine guard.
-        checksum/config: {{ printf "%s|%s" ($m | toYaml) $password | sha256sum | trunc 32 }}
+        #
+        # `migration` and `shadowWrites` are omitted because neither reaches
+        # this server's configuration. `migration` selects a step and its
+        # cutoff, and `shadowWrites` is read by the application's env. Hashing
+        # them restarted the database on every step of the very migration they
+        # describe, which is not a theoretical cost: enabling dual writes
+        # rolled the pod out from under the mirror and lost four writes to a
+        # terminal error, and arming the backfill rolled it again five seconds
+        # after the backfill Job started, so the copy died on `connection
+        # refused` before reading a single row.
+        #
+        # Everything else stays hashed, including `backup`, which does reach
+        # the ConfigMap through the disk declaration. The rule is that a value
+        # is omitted only when it configures the client or the rollout rather
+        # than the server.
+        checksum/config: {{ printf "%s|%s" (omit $m "migration" "shadowWrites" | toYaml) $password | sha256sum | trunc 32 }}
     spec:
       nodeSelector:
         node.cluster.x-k8s.io/pool: {{ $m.nodePool }}

--- a/infra/helm/tuist/templates/clickhouse-migration-job.yaml
+++ b/infra/helm/tuist/templates/clickhouse-migration-job.yaml
@@ -4,6 +4,9 @@
 {{- $objectStorageSecretKey := include "tuist.objectStorageSecretKey" . -}}
 {{- $task := .Values.clickhouse.managed.migration.task | quote }}
 {{- $background := .Values.clickhouse.managed.migration.background }}
+{{- $m := .Values.clickhouse.managed }}
+{{- $chName := include "tuist.componentName" (dict "root" . "component" "clickhouse") }}
+{{- $chSecretName := printf "%s-credentials" $chName }}
 {{- /*
 Runs one step of the ClickHouse migration (spec #73) against the in-cluster
 server: cloning the schema from the system of record, backfilling the rows
@@ -73,6 +76,68 @@ spec:
         {{- end }}
     spec:
       restartPolicy: Never
+      # Wait for the destination before doing anything, because this Job can be
+      # applied at the same moment the server it needs is being replaced.
+      #
+      # A background step is an ordinary release resource, so Kubernetes starts
+      # its pod as soon as Helm applies the release, concurrently with any
+      # rolling update of the ClickHouse StatefulSet. The backfill lost that
+      # race twice: it began five seconds before the pod was recreated, got
+      # `connection refused`, and `backoffLimit: 0` made that final. A hook
+      # step does not race in the same way, and waiting costs it nothing.
+      #
+      # This is a wait, not a retry. Startup stops being a failure; a step that
+      # fails once the server is answering still fails, and is re-run
+      # deliberately rather than repeated automatically against a database.
+      initContainers:
+        - name: wait-for-clickhouse
+          image: "{{ $m.image.repository }}:{{ $m.image.tag }}"
+          imagePullPolicy: {{ $m.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            # The `clickhouse` user in the server image, which is what
+            # `clickhouse-client` expects to find a home directory for. Stated
+            # here rather than inherited, because this pod sets no
+            # pod-level security context: the step container is the server
+            # image and runs as its own user.
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
+          env:
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $chSecretName }}
+                  key: password
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              i=0
+              until clickhouse-client \
+                      --host {{ $chName }} \
+                      --port 9000 \
+                      --user default \
+                      --password "$CLICKHOUSE_PASSWORD" \
+                      --query "SELECT 1" >/dev/null 2>&1; do
+                i=$((i + 1))
+                if [ "$i" -ge {{ $m.migration.waitAttempts }} ]; then
+                  echo "ClickHouse did not answer after {{ $m.migration.waitAttempts }} attempts; giving up." >&2
+                  exit 1
+                fi
+                echo "Waiting for ClickHouse at {{ $chName }} (attempt $i)"
+                sleep 5
+              done
+              echo "ClickHouse is answering."
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
       {{- with .Values.server.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -3049,6 +3049,11 @@ clickhouse:
       # Only used by a background Job, which is not deleted by the deploy that
       # follows it. Long enough to read the logs of one that failed overnight.
       ttlSecondsAfterFinished: 86400
+      # How many five-second attempts the init container makes at reaching the
+      # server before giving up. Five minutes covers a StatefulSet rolling a
+      # replica, which is what this exists for, and still fails inside the
+      # step's own deadline if the server is genuinely down.
+      waitAttempts: 60
       # No retries. These steps are resumable, so a failure should be read
       # and re-run deliberately rather than repeated automatically against a
       # database.


### PR DESCRIPTION
## The failure

Canary's backfill failed twice, `backfill-r890` and `backfill-r892`, without copying a row. It died on the first query it makes:

```
Ch.Connection failed to connect: ** (Mint.TransportError) connection refused
** (DBConnection.ConnectionError) [Tuist.ShadowIngestRepo] connection not available
    lib/tuist/clickhouse/tables.ex:113: Tuist.ClickHouse.Tables.view_targets/1
    lib/tuist/clickhouse/backfill.ex:146: Tuist.ClickHouse.Backfill.backfill/3
```

The events say why:

```
8m6s  Started container clickhouse-migration
8m1s  SuccessfulCreate  create Pod tuist-tuist-clickhouse-0
7m58s Started container clickhouse
7m56s BackoffLimitExceeded  job/...backfill-r892
```

The copy started five seconds before the server it needed was recreated, and `backoffLimit: 0` made that final.

## Cause one: every migration step restarted the database

`checksum/config` hashed the entire `clickhouse.managed` block:

```
checksum/config: {{ printf "%s|%s" ($m | toYaml) $password | sha256sum | trunc 32 }}
```

That includes `migration` and `shadowWrites`, neither of which reaches the server's configuration. `migration` selects a step and its cutoff; `shadowWrites` is read by the application's env. So the database restarted on every step of the migration it was running.

This also explains something previously attributed to coincidence. When dual writes went on in [#13029](https://github.com/tuist/tuist/pull/13029), four mirrored writes ended in a terminal `error`, and the ClickHouse pod happened to be starting at that moment. It was not a coincidence: that deploy changed `shadowWrites.enabled`, which changed the checksum, which rolled the pod out from under the mirror.

For production this is the part that matters most. Once ClickHouse is in-cluster, any deploy touching those values takes analytics writes down briefly, and after the read cutover it takes reads down too.

Both keys are now omitted. Everything else stays hashed, including `backup`, because the backup disk is declared in the ConfigMap. The rule is that a value is omitted only when it configures the client or the rollout rather than the server.

## Cause two: the Job raced the server

A background step is an ordinary release resource, so Kubernetes starts its pod as soon as Helm applies the release, concurrently with any rolling update of the StatefulSet. The schema clone never hit this because it is a `post-upgrade` hook, which Helm runs after the release settles.

The step now waits behind an init container that polls `SELECT 1` using `clickhouse-client` on the ClickHouse image, which is already present on the node. Attempts are bounded by `migration.waitAttempts`, defaulting to 60 five-second tries.

**This is a wait, not a retry.** Startup stops being a failure, while a step that fails once the server is answering still fails and is re-run deliberately, which is what `backoffLimit: 0` is for. Fixing only the checksum would leave the race live for any legitimate config change that rolls the pod on the same deploy as a step.

The init container pins `runAsUser: 101` rather than inheriting, because this pod sets no pod-level security context and its step container is the server image running as its own user. That mirrors the backup CronJobs, which already run this image in this namespace with the same UID.

## Validation

Rendered all three environments with `values-managed-common.yaml` plus the per-env overlay; all render, and the init container appears only where a step is armed.

The checksum was A/B tested with the password pinned. That pinning is load-bearing: without a cluster `lookup` the password is `randAlphaNum 40`, so every render differs for that reason alone and an unpinned comparison shows "changed" no matter what. My first attempt at this measured exactly that and looked like the fix had not worked.

| Change | Checksum |
|---|---|
| `migration.cutoff` | same, no restart |
| `migration.name` | same, no restart |
| `shadowWrites.enabled` | same, no restart |
| `logLevel` | different, restarts |
| `backup.prefix` | different, restarts |
| `systemLogTtlDays` | different, restarts |

The wait loop was run against a stub for both outcomes: exits 0 once the server answers, exits 1 when it never does.

## After this

The backfill has copied nothing, so there is no partial state to clean up and the ledger is empty. Once this is deployed, the next deploy with the step armed will run it against a server that is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
