### PR TITLE
feat(server): reset an account's free tier from ops

### DIFF
--- a/server/assets/app/css/pages/ops/account.css
+++ b/server/assets/app/css/pages/ops/account.css
@@ -98,6 +98,7 @@
   & [data-part="runner-trial-description"],
   & [data-part="prepaid-description"],
   & [data-part="prepaid-empty"],
+  & [data-part="free-tier-description"],
   & [data-part="kura-egress-limits-description"] {
     margin: var(--noora-spacing-0);
     color: var(--noora-surface-label-secondary);
@@ -137,7 +138,8 @@
     max-width: 480px;
   }
 
-  & [data-part="prepaid-quote"] {
+  & [data-part="prepaid-quote"],
+  & [data-part="free-tier-usage"] {
     display: flex;
     flex-direction: column;
     gap: var(--noora-spacing-2);

--- a/server/lib/tuist/accounts/account.ex
+++ b/server/lib/tuist/accounts/account.ex
@@ -137,6 +137,10 @@ defmodule Tuist.Accounts.Account do
     cast(account, attrs, [:runner_trial_started_at, :runner_trial_ended_at])
   end
 
+  def free_tier_reset_changeset(account, attrs) do
+    cast(account, attrs, [:free_tier_reset_at, :current_month_remote_cache_hits_count])
+  end
+
   def update_changeset(account, attrs) do
     account
     |> cast(attrs, [:name, :region, :billing_email, :cache_write_policy, :custom_cache_endpoints_enabled])

--- a/server/lib/tuist/billing.ex
+++ b/server/lib/tuist/billing.ex
@@ -935,6 +935,30 @@ defmodule Tuist.Billing do
   end
 
   @doc """
+  Starts `account`'s free tier over from now.
+
+  Both fields move together, and the second is the one that is easy to
+  miss. The counter is what `cache_access_blocked?/1` reads, so zeroing
+  it is what unblocks the account. `free_tier_reset_at` is what makes
+  that survive: `CommandEvents.account_month_usage/2` counts events from
+  `max(beginning_of_month, free_tier_reset_at)`, so a reset that left
+  the timestamp behind would be recomputed straight back over the
+  threshold at the next nightly sweep.
+
+  This grants a fresh allowance for the rest of the month, not an
+  exemption. The reset goes inert on the first of the next month, when
+  the counting window returns to the month boundary on its own.
+  """
+  def reset_free_tier(%Account{} = account) do
+    account
+    |> Account.free_tier_reset_changeset(%{
+      free_tier_reset_at: DateTime.utc_now(),
+      current_month_remote_cache_hits_count: 0
+    })
+    |> Repo.update()
+  end
+
+  @doc """
   The ids of the given accounts whose free tier is exhausted.
 
   Only accounts already past the threshold need their plan resolved, and those

--- a/server/lib/tuist_web/live/ops_account_live.ex
+++ b/server/lib/tuist_web/live/ops_account_live.ex
@@ -39,6 +39,7 @@ defmodule TuistWeb.OpsAccountLive do
          |> assign(:on_runner_trial, Trials.on_trial?(account))
          |> assign(:prepaid_quote, nil)
          |> assign(:has_subscription, not is_nil(Billing.get_current_active_subscription(account)))
+         |> assign_free_tier(account)
          |> assign_kura(account)
          |> assign(:upgrade_target_account, nil)
          |> assign(:upgrade_target_customer, nil)}
@@ -49,6 +50,14 @@ defmodule TuistWeb.OpsAccountLive do
          |> put_flash(:error, dgettext("dashboard", "Account not found."))
          |> push_navigate(to: ~p"/ops/accounts")}
     end
+  end
+
+  defp assign_free_tier(socket, account) do
+    socket
+    |> assign(:free_tier_hits, account.current_month_remote_cache_hits_count || 0)
+    |> assign(:free_tier_limit, Billing.get_payment_thresholds()[:remote_cache_hits])
+    |> assign(:free_tier_reset_at, account.free_tier_reset_at)
+    |> assign(:cache_access_blocked, Billing.cache_access_blocked?(account))
   end
 
   defp preload_billing(account) do
@@ -113,6 +122,35 @@ defmodule TuistWeb.OpsAccountLive do
       {:error, reason} ->
         {:noreply,
          put_flash(socket, :error, dgettext("dashboard", "Could not start the trial: %{reason}", reason: inspect(reason)))}
+    end
+  end
+
+  @impl true
+  def handle_event("reset_free_tier", _params, socket) do
+    case Billing.reset_free_tier(socket.assigns.account) do
+      {:ok, account} ->
+        account = preload_billing(account)
+
+        {:noreply,
+         socket
+         |> assign(:account, account)
+         |> assign_free_tier(account)
+         |> put_flash(
+           :info,
+           dgettext(
+             "dashboard",
+             "%{account}'s free tier starts over from now. It has the full allowance again until the end of the month.",
+             account: account.name
+           )
+         )}
+
+      {:error, reason} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           dgettext("dashboard", "Could not reset the free tier: %{reason}", reason: inspect(reason))
+         )}
     end
   end
 
@@ -481,6 +519,9 @@ defmodule TuistWeb.OpsAccountLive do
 
   def prepaid_expiry_label(nil), do: dgettext("dashboard", "No expiry")
   def prepaid_expiry_label(%DateTime{} = expires_at), do: Timex.format!(expires_at, "{Mfull} {D}, {YYYY}")
+
+  def free_tier_reset_label(nil), do: dgettext("dashboard", "Never")
+  def free_tier_reset_label(%DateTime{} = reset_at), do: Timex.format!(reset_at, "{Mfull} {D}, {YYYY} {h24}:{m} UTC")
 
   defp runner_concurrency_form(account) do
     account

--- a/server/lib/tuist_web/live/ops_account_live.html.heex
+++ b/server/lib/tuist_web/live/ops_account_live.html.heex
@@ -455,6 +455,59 @@
     </.card_section>
   </.card>
 
+  <.card title={dgettext("dashboard", "Free tier")} icon="reload">
+    <.card_section>
+      <p data-part="free-tier-description">
+        {dgettext(
+          "dashboard",
+          "An Air account can reach the cache for %{limit} runs a month. Resetting starts the count over from now, so the account is unblocked and has the full allowance again for the rest of the month. It is not an exemption: the reset goes inert on the first of next month, when counting returns to the month boundary.",
+          limit: @free_tier_limit
+        )}
+      </p>
+      <dl data-part="free-tier-usage">
+        <div>
+          <dt>{dgettext("dashboard", "Runs this period")}</dt>
+          <dd data-part="free-tier-hits">
+            {dgettext("dashboard", "%{hits} of %{limit}",
+              hits: @free_tier_hits,
+              limit: @free_tier_limit
+            )}
+          </dd>
+        </div>
+        <div>
+          <dt>{dgettext("dashboard", "Last reset")}</dt>
+          <dd data-part="free-tier-reset-at">{free_tier_reset_label(@free_tier_reset_at)}</dd>
+        </div>
+      </dl>
+      <.alert
+        :if={@cache_access_blocked}
+        id="free-tier-blocked-alert"
+        size="large"
+        status="warning"
+        title={dgettext("dashboard", "Cache access blocked")}
+        description={
+          dgettext(
+            "dashboard",
+            "This account is over its free tier and cannot reach the cache until it upgrades or the free tier is reset. Enforcement runs once a day, so an account can read as over the limit for up to a day before it is actually cut off."
+          )
+        }
+      />
+      <div data-part="actions">
+        <.button
+          phx-click="reset_free_tier"
+          variant="primary"
+          data-confirm={
+            dgettext(
+              "dashboard",
+              "Reset this account's free tier? It gets the full allowance again for the rest of the month, and the runs it has already made stop counting."
+            )
+          }
+          label={dgettext("dashboard", "Reset free tier")}
+        />
+      </div>
+    </.card_section>
+  </.card>
+
   <.card title={dgettext("dashboard", "Runner trial")} icon="hourglass">
     <.card_section>
       <p data-part="runner-trial-description">

--- a/server/priv/gettext/dashboard.pot
+++ b/server/priv/gettext/dashboard.pot
@@ -409,8 +409,8 @@ msgstr ""
 #: lib/tuist_web/components/runs/ran_by_badge.ex:104
 #: lib/tuist_web/live/ops_account_helpers.ex:15
 #: lib/tuist_web/live/ops_account_helpers.ex:24
-#: lib/tuist_web/live/ops_account_live.ex:875
-#: lib/tuist_web/live/ops_account_live.ex:904
+#: lib/tuist_web/live/ops_account_live.ex:916
+#: lib/tuist_web/live/ops_account_live.ex:945
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
@@ -652,13 +652,13 @@ msgstr ""
 msgid "This GitHub app installation is already connected."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:364
+#: lib/tuist_web/live/ops_account_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "%{account} plan set to cancel at the end of the current period."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:313
-#: lib/tuist_web/live/ops_account_live.ex:341
+#: lib/tuist_web/live/ops_account_live.ex:351
+#: lib/tuist_web/live/ops_account_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "%{account} upgraded to Enterprise. Stripe will send an invoice for the first period."
 msgstr ""
@@ -672,7 +672,7 @@ msgstr ""
 #: lib/tuist_web/live/ops_account_kura_deployment_live.ex:23
 #: lib/tuist_web/live/ops_account_kura_placement_live.ex:19
 #: lib/tuist_web/live/ops_account_kura_sizing_live.ex:19
-#: lib/tuist_web/live/ops_account_live.ex:49
+#: lib/tuist_web/live/ops_account_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "Account not found."
 msgstr ""
@@ -682,12 +682,12 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:716
+#: lib/tuist_web/live/ops_account_live.html.heex:769
 #, elixir-autogen, elixir-format
 msgid "Address line 1"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:724
+#: lib/tuist_web/live/ops_account_live.html.heex:777
 #, elixir-autogen, elixir-format
 msgid "Address line 2 (optional)"
 msgstr ""
@@ -697,64 +697,64 @@ msgstr ""
 msgid "Air"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1021
+#: lib/tuist_web/live/ops_account_live.ex:1062
 #, elixir-autogen, elixir-format
 msgid "Argentina"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1022
+#: lib/tuist_web/live/ops_account_live.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Australia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1023
+#: lib/tuist_web/live/ops_account_live.ex:1064
 #, elixir-autogen, elixir-format
 msgid "Austria"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1024
+#: lib/tuist_web/live/ops_account_live.ex:1065
 #, elixir-autogen, elixir-format
 msgid "Belgium"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:625
-#: lib/tuist_web/live/ops_account_live.html.heex:708
+#: lib/tuist_web/live/ops_account_live.html.heex:678
+#: lib/tuist_web/live/ops_account_live.html.heex:761
 #: lib/tuist_web/live/ops_accounts_live.html.heex:30
 #, elixir-autogen, elixir-format
 msgid "Billing email"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1025
+#: lib/tuist_web/live/ops_account_live.ex:1066
 #, elixir-autogen, elixir-format
 msgid "Brazil"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1026
+#: lib/tuist_web/live/ops_account_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Bulgaria"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1027
+#: lib/tuist_web/live/ops_account_live.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Canada"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:766
+#: lib/tuist_web/live/ops_account_live.html.heex:819
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:658
+#: lib/tuist_web/live/ops_account_live.html.heex:711
 #, elixir-autogen, elixir-format
 msgid "Cancel %{account}'s subscription at the end of the current billing period? Access is kept until then."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:371
+#: lib/tuist_web/live/ops_account_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "Cancel failed: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:655
+#: lib/tuist_web/live/ops_account_live.html.heex:708
 #, elixir-autogen, elixir-format
 msgid "Cancel plan"
 msgstr ""
@@ -765,37 +765,37 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1028
+#: lib/tuist_web/live/ops_account_live.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Chile"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1029
+#: lib/tuist_web/live/ops_account_live.ex:1070
 #, elixir-autogen, elixir-format
 msgid "China"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:730
+#: lib/tuist_web/live/ops_account_live.html.heex:783
 #, elixir-autogen, elixir-format
 msgid "City"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1030
+#: lib/tuist_web/live/ops_account_live.ex:1071
 #, elixir-autogen, elixir-format
 msgid "Colombia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:750
+#: lib/tuist_web/live/ops_account_live.html.heex:803
 #, elixir-autogen, elixir-format
 msgid "Country"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:678
+#: lib/tuist_web/live/ops_account_live.html.heex:731
 #, elixir-autogen, elixir-format
 msgid "Creates a Stripe customer (if missing), sets the billing address, and starts an invoice-billed Enterprise subscription. The customer receives an invoice by email; no card is collected here."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1031
+#: lib/tuist_web/live/ops_account_live.ex:1072
 #, elixir-autogen, elixir-format
 msgid "Croatia"
 msgstr ""
@@ -805,17 +805,17 @@ msgstr ""
 msgid "Current version"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1032
+#: lib/tuist_web/live/ops_account_live.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Cyprus"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1033
+#: lib/tuist_web/live/ops_account_live.ex:1074
 #, elixir-autogen, elixir-format
 msgid "Czechia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1034
+#: lib/tuist_web/live/ops_account_live.ex:1075
 #, elixir-autogen, elixir-format
 msgid "Denmark"
 msgstr ""
@@ -835,7 +835,7 @@ msgstr ""
 msgid "Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1035
+#: lib/tuist_web/live/ops_account_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "Estonia"
 msgstr ""
@@ -852,67 +852,67 @@ msgstr ""
 msgid "Finished"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1036
+#: lib/tuist_web/live/ops_account_live.ex:1077
 #, elixir-autogen, elixir-format
 msgid "Finland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1037
+#: lib/tuist_web/live/ops_account_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "France"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1038
+#: lib/tuist_web/live/ops_account_live.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Germany"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1039
+#: lib/tuist_web/live/ops_account_live.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Greece"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1040
+#: lib/tuist_web/live/ops_account_live.ex:1081
 #, elixir-autogen, elixir-format
 msgid "Hong Kong"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1041
+#: lib/tuist_web/live/ops_account_live.ex:1082
 #, elixir-autogen, elixir-format
 msgid "Hungary"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1042
+#: lib/tuist_web/live/ops_account_live.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Iceland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1043
+#: lib/tuist_web/live/ops_account_live.ex:1084
 #, elixir-autogen, elixir-format
 msgid "India"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1044
+#: lib/tuist_web/live/ops_account_live.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Indonesia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1045
+#: lib/tuist_web/live/ops_account_live.ex:1086
 #, elixir-autogen, elixir-format
 msgid "Ireland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1046
+#: lib/tuist_web/live/ops_account_live.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Israel"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1047
+#: lib/tuist_web/live/ops_account_live.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Italy"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1048
+#: lib/tuist_web/live/ops_account_live.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Japan"
 msgstr ""
@@ -933,37 +933,37 @@ msgstr ""
 msgid "Latest deployment"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1049
+#: lib/tuist_web/live/ops_account_live.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Latvia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1050
+#: lib/tuist_web/live/ops_account_live.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Lithuania"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1051
+#: lib/tuist_web/live/ops_account_live.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Luxembourg"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1052
+#: lib/tuist_web/live/ops_account_live.ex:1093
 #, elixir-autogen, elixir-format
 msgid "Malaysia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1053
+#: lib/tuist_web/live/ops_account_live.ex:1094
 #, elixir-autogen, elixir-format
 msgid "Malta"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:638
+#: lib/tuist_web/live/ops_account_live.html.heex:691
 #, elixir-autogen, elixir-format
 msgid "Manage on Stripe"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1054
+#: lib/tuist_web/live/ops_account_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "Mexico"
 msgstr ""
@@ -975,17 +975,17 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:700
+#: lib/tuist_web/live/ops_account_live.html.heex:753
 #, elixir-autogen, elixir-format
 msgid "Name on invoice"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1055
+#: lib/tuist_web/live/ops_account_live.ex:1096
 #, elixir-autogen, elixir-format
 msgid "Netherlands"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1056
+#: lib/tuist_web/live/ops_account_live.ex:1097
 #, elixir-autogen, elixir-format
 msgid "New Zealand"
 msgstr ""
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "No accounts match the current filter."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:354
+#: lib/tuist_web/live/ops_account_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "No active subscription to cancel."
 msgstr ""
@@ -1008,23 +1008,23 @@ msgstr ""
 #: lib/tuist/utilities/date_formatter.ex:5
 #: lib/tuist/utilities/date_formatter.ex:76
 #: lib/tuist_web/live/ops_account_kura_deployment_live.ex:87
-#: lib/tuist_web/live/ops_account_live.ex:716
+#: lib/tuist_web/live/ops_account_live.ex:757
 #: lib/tuist_web/live/ops_account_live.html.heex:41
 #: lib/tuist_web/live/ops_account_live.html.heex:53
 #: lib/tuist_web/live/ops_account_live.html.heex:57
 #: lib/tuist_web/live/ops_account_live.html.heex:63
-#: lib/tuist_web/live/ops_account_live.html.heex:626
+#: lib/tuist_web/live/ops_account_live.html.heex:679
 #: lib/tuist_web/live/ops_accounts_live.html.heex:31
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1057
+#: lib/tuist_web/live/ops_account_live.ex:1098
 #, elixir-autogen, elixir-format
 msgid "Norway"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:629
+#: lib/tuist_web/live/ops_account_live.html.heex:682
 #: lib/tuist_web/live/ops_accounts_live.html.heex:48
 #, elixir-autogen, elixir-format
 msgid "Not created"
@@ -1046,33 +1046,33 @@ msgstr ""
 msgid "Pending"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1058
+#: lib/tuist_web/live/ops_account_live.ex:1099
 #, elixir-autogen, elixir-format
 msgid "Philippines"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:611
+#: lib/tuist_web/live/ops_account_live.html.heex:664
 #: lib/tuist_web/live/ops_accounts_live.html.heex:33
 #, elixir-autogen, elixir-format
 msgid "Plan"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:608
+#: lib/tuist_web/live/ops_account_live.html.heex:661
 #, elixir-autogen, elixir-format
 msgid "Plan & billing"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1059
+#: lib/tuist_web/live/ops_account_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Poland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1060
+#: lib/tuist_web/live/ops_account_live.ex:1101
 #, elixir-autogen, elixir-format
 msgid "Portugal"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:744
+#: lib/tuist_web/live/ops_account_live.html.heex:797
 #, elixir-autogen, elixir-format
 msgid "Postal code"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Region"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1061
+#: lib/tuist_web/live/ops_account_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Romania"
 msgstr ""
@@ -1107,37 +1107,37 @@ msgstr ""
 msgid "Search by name"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:753
+#: lib/tuist_web/live/ops_account_live.html.heex:806
 #, elixir-autogen, elixir-format
 msgid "Select a country"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1062
+#: lib/tuist_web/live/ops_account_live.ex:1103
 #, elixir-autogen, elixir-format
 msgid "Singapore"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1063
+#: lib/tuist_web/live/ops_account_live.ex:1104
 #, elixir-autogen, elixir-format
 msgid "Slovakia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1064
+#: lib/tuist_web/live/ops_account_live.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Slovenia"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1065
+#: lib/tuist_web/live/ops_account_live.ex:1106
 #, elixir-autogen, elixir-format
 msgid "South Africa"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1066
+#: lib/tuist_web/live/ops_account_live.ex:1107
 #, elixir-autogen, elixir-format
 msgid "South Korea"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1067
+#: lib/tuist_web/live/ops_account_live.ex:1108
 #, elixir-autogen, elixir-format
 msgid "Spain"
 msgstr ""
@@ -1147,7 +1147,7 @@ msgstr ""
 msgid "Started"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:738
+#: lib/tuist_web/live/ops_account_live.html.heex:791
 #, elixir-autogen, elixir-format
 msgid "State / region (optional)"
 msgstr ""
@@ -1156,13 +1156,13 @@ msgstr ""
 #: lib/tuist_web/live/ops_account_kura_deployment_live.html.heex:18
 #: lib/tuist_web/live/ops_account_live.html.heex:31
 #: lib/tuist_web/live/ops_account_live.html.heex:99
-#: lib/tuist_web/live/ops_account_live.html.heex:618
+#: lib/tuist_web/live/ops_account_live.html.heex:671
 #: lib/tuist_web/live/ops_accounts_live.html.heex:40
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:628
+#: lib/tuist_web/live/ops_account_live.html.heex:681
 #: lib/tuist_web/live/ops_accounts_live.html.heex:47
 #, elixir-autogen, elixir-format
 msgid "Stripe customer"
@@ -1173,22 +1173,22 @@ msgstr ""
 msgid "Succeeded"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1068
+#: lib/tuist_web/live/ops_account_live.ex:1109
 #, elixir-autogen, elixir-format
 msgid "Sweden"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1069
+#: lib/tuist_web/live/ops_account_live.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Switzerland"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1070
+#: lib/tuist_web/live/ops_account_live.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Taiwan"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1071
+#: lib/tuist_web/live/ops_account_live.ex:1112
 #, elixir-autogen, elixir-format
 msgid "Thailand"
 msgstr ""
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Trialing"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1072
+#: lib/tuist_web/live/ops_account_live.ex:1113
 #, elixir-autogen, elixir-format
 msgid "Turkey"
 msgstr ""
@@ -1214,38 +1214,38 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1073
+#: lib/tuist_web/live/ops_account_live.ex:1114
 #, elixir-autogen, elixir-format
 msgid "Ukraine"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1074
+#: lib/tuist_web/live/ops_account_live.ex:1115
 #, elixir-autogen, elixir-format
 msgid "United Arab Emirates"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1075
+#: lib/tuist_web/live/ops_account_live.ex:1116
 #, elixir-autogen, elixir-format
 msgid "United Kingdom"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1076
+#: lib/tuist_web/live/ops_account_live.ex:1117
 #, elixir-autogen, elixir-format
 msgid "United States"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:673
+#: lib/tuist_web/live/ops_account_live.html.heex:726
 #, elixir-autogen, elixir-format
 msgid "Upgrade %{account} to Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:646
-#: lib/tuist_web/live/ops_account_live.html.heex:774
+#: lib/tuist_web/live/ops_account_live.html.heex:699
+#: lib/tuist_web/live/ops_account_live.html.heex:827
 #, elixir-autogen, elixir-format
 msgid "Upgrade to Enterprise"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1077
+#: lib/tuist_web/live/ops_account_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Uruguay"
 msgstr ""
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "User"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1078
+#: lib/tuist_web/live/ops_account_live.ex:1119
 #, elixir-autogen, elixir-format
 msgid "Vietnam"
 msgstr ""
@@ -1854,12 +1854,12 @@ msgstr ""
 msgid "Runner concurrency"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:92
+#: lib/tuist_web/live/ops_account_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "Runner concurrency limits could not be updated."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:86
+#: lib/tuist_web/live/ops_account_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "Runner concurrency limits updated."
 msgstr ""
@@ -1895,62 +1895,62 @@ msgstr ""
 msgid "Your organization must verify a login email domain that matches your email before new users can sign in. Ask an organization admin to review the single sign-on domain settings."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:287
+#: lib/tuist_web/live/ops_account_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "%{account} is now %{visibility}."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:294
+#: lib/tuist_web/live/ops_account_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "Account visibility could not be updated."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:591
+#: lib/tuist_web/live/ops_account_live.html.heex:644
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:573
+#: lib/tuist_web/live/ops_account_live.html.heex:626
 #, elixir-autogen, elixir-format
 msgid "Dashboards"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:597
+#: lib/tuist_web/live/ops_account_live.html.heex:650
 #, elixir-autogen, elixir-format
 msgid "Make private"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:598
+#: lib/tuist_web/live/ops_account_live.html.heex:651
 #, elixir-autogen, elixir-format
 msgid "Make public"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:588
+#: lib/tuist_web/live/ops_account_live.html.heex:641
 #, elixir-autogen, elixir-format
 msgid "Nothing."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:577
+#: lib/tuist_web/live/ops_account_live.html.heex:630
 #, elixir-autogen, elixir-format
 msgid "Private"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:576
+#: lib/tuist_web/live/ops_account_live.html.heex:629
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:584
+#: lib/tuist_web/live/ops_account_live.html.heex:637
 #, elixir-autogen, elixir-format
 msgid "Public projects, runners, and usage. Members, webhooks, cache, billing, and settings stay private."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:580
+#: lib/tuist_web/live/ops_account_live.html.heex:633
 #, elixir-autogen, elixir-format
 msgid "Signed-out visitors see"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:570
+#: lib/tuist_web/live/ops_account_live.html.heex:623
 #, elixir-autogen, elixir-format
 msgid "Visibility"
 msgstr ""
@@ -1960,176 +1960,176 @@ msgstr ""
 msgid "Claim"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:983
+#: lib/tuist_web/live/ops_account_live.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Kura disk claim set to %{claim}. No running instance changed; it applies the next time volumes are built."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:991
+#: lib/tuist_web/live/ops_account_live.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Kura disk claim lowered to %{claim}. %{count} running instance keeps its cache and evicts down to the new budget."
 msgid_plural "Kura disk claim lowered to %{claim}. %{count} running instances keep their caches and evict down to the new budget."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.ex:1006
+#: lib/tuist_web/live/ops_account_live.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Kura disk claim raised to %{claim}. Up to %{count} running instance rebuilds its volumes, one replica at a time behind the standby that keeps serving."
 msgid_plural "Kura disk claim raised to %{claim}. Up to %{count} running instances rebuild their volumes, one replica at a time behind the standby that keeps serving."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.ex:106
+#: lib/tuist_web/live/ops_account_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "%{account} is on a runner trial and will not be billed for runner usage until it is cancelled."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:129
+#: lib/tuist_web/live/ops_account_live.ex:167
 #, elixir-autogen, elixir-format
 msgid "%{account}'s runner trial is over. Runner usage is billable from now on."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:551
+#: lib/tuist_web/live/ops_account_live.html.heex:604
 #, elixir-autogen, elixir-format
 msgid "Added to next invoice"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:461
+#: lib/tuist_web/live/ops_account_live.html.heex:514
 #, elixir-autogen, elixir-format
 msgid "An account on a runner trial is not billed for runner usage. Usage is still metered and still reported, but the subscription carries no runner item for Stripe to invoice it against. The trial runs until it is cancelled here."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:490
+#: lib/tuist_web/live/ops_account_live.html.heex:543
 #, elixir-autogen, elixir-format
 msgid "Cancel runner trial"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:139
+#: lib/tuist_web/live/ops_account_live.ex:177
 #, elixir-autogen, elixir-format
 msgid "Could not cancel the trial: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:115
+#: lib/tuist_web/live/ops_account_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Could not start the trial: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:528
+#: lib/tuist_web/live/ops_account_live.html.heex:581
 #, elixir-autogen, elixir-format
 msgid "Expires"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:509
+#: lib/tuist_web/live/ops_account_live.html.heex:562
 #, elixir-autogen, elixir-format
 msgid "No active subscription"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:482
+#: lib/tuist_web/live/ops_account_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "No expiry"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:471
+#: lib/tuist_web/live/ops_account_live.html.heex:524
 #, elixir-autogen, elixir-format
 msgid "On a runner trial"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:547
+#: lib/tuist_web/live/ops_account_live.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "Prepaid minutes (macOS 6 vCPU / 14 GB)"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:458
+#: lib/tuist_web/live/ops_account_live.html.heex:511
 #, elixir-autogen, elixir-format
 msgid "Runner trial"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:484
+#: lib/tuist_web/live/ops_account_live.html.heex:537
 #, elixir-autogen, elixir-format
 msgid "Start runner trial"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:511
+#: lib/tuist_web/live/ops_account_live.html.heex:564
 #, elixir-autogen, elixir-format
 msgid "This account has no subscription, so Stripe never generates an invoice for it. A prepaid charge added now would sit unbilled until one exists."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:525
+#: lib/tuist_web/live/ops_account_live.html.heex:578
 #, elixir-autogen, elixir-format
 msgid "Minutes remaining"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:480
+#: lib/tuist_web/live/ops_account_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "Prepaid"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:496
+#: lib/tuist_web/live/ops_account_live.html.heex:549
 #, elixir-autogen, elixir-format
 msgid "Prepaid runner minutes"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:522
+#: lib/tuist_web/live/ops_account_live.html.heex:575
 #, elixir-autogen, elixir-format
 msgid "Source"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:533
+#: lib/tuist_web/live/ops_account_live.html.heex:586
 #, elixir-autogen, elixir-format
 msgid "This account has no prepaid runner minutes."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:479
+#: lib/tuist_web/live/ops_account_live.ex:517
 #, elixir-autogen, elixir-format
 msgid "Trial"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:473
+#: lib/tuist_web/live/ops_account_live.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "Cancelling adds the runner items to this account's subscription, which makes its runner usage billable from that moment. Minutes it ran during the trial stay free, including those already recorded in the current billing period."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:555
+#: lib/tuist_web/live/ops_account_live.html.heex:608
 #, elixir-autogen, elixir-format
 msgid "Granted now"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:453
+#: lib/tuist_web/live/ops_account_live.ex:491
 #, elixir-autogen, elixir-format
 msgid "%{account} now holds %{minutes} prepaid runner minutes. %{amount} was added to its next invoice."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:175
+#: lib/tuist_web/live/ops_account_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Could not set prepaid minutes: %{reason}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:180
+#: lib/tuist_web/live/ops_account_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "Enter a whole number of minutes, or zero to clear."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:563
+#: lib/tuist_web/live/ops_account_live.html.heex:616
 #, elixir-autogen, elixir-format
 msgid "Set minutes"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.html.heex:499
+#: lib/tuist_web/live/ops_account_live.html.heex:552
 #, elixir-autogen, elixir-format
 msgid "Setting this replaces what the account holds rather than adding to it, and the minutes are granted straight away so it can run on them. The charge rides its next invoice alongside the rest of the bill. Minutes expire at the end of the billing period they were bought for and do not roll over. The figures are minutes on the macOS 6 vCPU / 14 GB baseline; a larger machine draws them down faster than one minute per minute it runs."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:447
+#: lib/tuist_web/live/ops_account_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "%{account} no longer holds any prepaid runner minutes."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:719
+#: lib/tuist_web/live/ops_account_live.ex:760
 #, elixir-autogen, elixir-format
 msgid "%{floor} / %{burst} Mbps"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:734
+#: lib/tuist_web/live/ops_account_live.ex:775
 #, elixir-autogen, elixir-format
 msgid "%{mbps} Mbps"
 msgstr ""
@@ -2174,8 +2174,8 @@ msgstr ""
 msgid "Unshaped"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:733
-#: lib/tuist_web/live/ops_account_live.ex:852
+#: lib/tuist_web/live/ops_account_live.ex:774
+#: lib/tuist_web/live/ops_account_live.ex:893
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -2185,24 +2185,24 @@ msgstr ""
 msgid "The floor this account's pods reserve and the ceiling they may burst to, set per region because the boxes differ. Empty a field to hand that number back to the region, which is a default rather than a limit: where the two disagree the region's half gives way to the one you set. The only limit is each region's node budget, since the floor is what the scheduler bin-packs against it. Saving recreates the account's instances in that region so the new pair takes effect. They keep their volumes and restart one at a time behind the standby, so no cache is lost."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:765
+#: lib/tuist_web/live/ops_account_live.ex:806
 #, elixir-autogen, elixir-format
 msgid "up to %{mbps}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:675
+#: lib/tuist_web/live/ops_account_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "Egress limits updated in %{regions}. %{count} instance is recreated to pick them up."
 msgid_plural "Egress limits updated in %{regions}. %{count} instances are recreated to pick them up."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.ex:650
+#: lib/tuist_web/live/ops_account_live.ex:691
 #, elixir-autogen, elixir-format
 msgid "No egress limits changed."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:689
+#: lib/tuist_web/live/ops_account_live.ex:730
 #, elixir-autogen, elixir-format
 msgid "Nothing was saved: %{regions} was rejected."
 msgid_plural "Nothing was saved: %{regions} were rejected."
@@ -2214,14 +2214,14 @@ msgstr[1] ""
 msgid "Saving recreates this account's Kura instances in the regions you changed. They keep their volumes and restart one at a time behind the standby, so no cache is lost. Continue?"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:699
+#: lib/tuist_web/live/ops_account_live.ex:740
 #, elixir-autogen, elixir-format
 msgid "%{regions} was rejected and not saved."
 msgid_plural "%{regions} were rejected and not saved."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.ex:756
+#: lib/tuist_web/live/ops_account_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "up to %{mbps}, across %{count} box"
 msgid_plural "up to %{mbps}, across %{count} boxes"
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Kura Rollouts"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:856
+#: lib/tuist_web/live/ops_account_live.ex:897
 #, elixir-autogen, elixir-format
 msgid "%{count} days"
 msgstr ""
@@ -2251,17 +2251,17 @@ msgid_plural "%{count} decisions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.ex:857
+#: lib/tuist_web/live/ops_account_live.ex:898
 #, elixir-autogen, elixir-format
 msgid "%{count} hours"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:858
+#: lib/tuist_web/live/ops_account_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "%{count} minutes"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:972
+#: lib/tuist_web/live/ops_account_live.ex:1013
 #, elixir-autogen, elixir-format
 msgid "%{used} of %{budget}"
 msgstr ""
@@ -2330,8 +2330,8 @@ msgstr ""
 msgid "No sizing decisions"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:869
-#: lib/tuist_web/live/ops_account_live.ex:898
+#: lib/tuist_web/live/ops_account_live.ex:910
+#: lib/tuist_web/live/ops_account_live.ex:939
 #, elixir-autogen, elixir-format
 msgid "Not resolved yet"
 msgstr ""
@@ -2354,14 +2354,14 @@ msgstr ""
 msgid "Reported"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:821
+#: lib/tuist_web/live/ops_account_live.ex:862
 #, elixir-autogen, elixir-format
 msgid "Seen on %{count} day of measurements (%{bytes} discarded, %{turnover}x the whole cache)."
 msgid_plural "Seen on %{count} consecutive days of measurements (%{bytes} discarded, %{turnover}x the whole cache)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.ex:844
+#: lib/tuist_web/live/ops_account_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "Seen on %{count} day of measurements."
 msgid_plural "Seen on %{count} consecutive days of measurements."
@@ -2374,7 +2374,7 @@ msgid "Segments"
 msgstr ""
 
 #: lib/tuist_web/live/ops_account_kura_sizing_live.ex:24
-#: lib/tuist_web/live/ops_account_live.ex:872
+#: lib/tuist_web/live/ops_account_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Sizing"
 msgstr ""
@@ -2390,7 +2390,7 @@ msgstr ""
 msgid "Sizing has not decided anything for this account yet."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:220
+#: lib/tuist_web/live/ops_account_live.ex:258
 #, elixir-autogen, elixir-format
 msgid "Sizing proposal dismissed."
 msgstr ""
@@ -2405,17 +2405,17 @@ msgstr ""
 msgid "Sizing proposes shrinking the disk claim from %{current} to %{recommended}."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:808
+#: lib/tuist_web/live/ops_account_live.ex:849
 #, elixir-autogen, elixir-format
 msgid "The cache in %{region} has not filled past %{peak}% of the disk it reserves, and has discarded nothing."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:798
+#: lib/tuist_web/live/ops_account_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "The cache in %{region} is discarding work a median of %{shed_age} after it was written, when it should keep everything for at least %{floor}."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:202
+#: lib/tuist_web/live/ops_account_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "The proposal no longer applies; the next sizing sweep re-evaluates the account."
 msgstr ""
@@ -2442,43 +2442,43 @@ msgstr ""
 msgid "Why"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:864
+#: lib/tuist_web/live/ops_account_live.ex:905
 #, elixir-autogen, elixir-format
 msgid "applied"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:880
+#: lib/tuist_web/live/ops_account_live.ex:921
 #, elixir-autogen, elixir-format
 msgid "discarding work after %{shed_age}, target %{floor}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:865
+#: lib/tuist_web/live/ops_account_live.ex:906
 #, elixir-autogen, elixir-format
 msgid "dismissed"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:887
+#: lib/tuist_web/live/ops_account_live.ex:928
 #, elixir-autogen, elixir-format
 msgid "peaked at %{peak}% of its disk"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:866
+#: lib/tuist_web/live/ops_account_live.ex:907
 #, elixir-autogen, elixir-format
 msgid "superseded"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:867
+#: lib/tuist_web/live/ops_account_live.ex:908
 #, elixir-autogen, elixir-format
 msgid "waiting"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:916
-#: lib/tuist_web/live/ops_account_live.ex:923
+#: lib/tuist_web/live/ops_account_live.ex:957
+#: lib/tuist_web/live/ops_account_live.ex:964
 #, elixir-autogen, elixir-format
 msgid "%{rate} runs a day over %{days} days"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:909
+#: lib/tuist_web/live/ops_account_live.ex:950
 #, elixir-autogen, elixir-format
 msgid "%{share}%% of runs over %{days} days"
 msgstr ""
@@ -2494,12 +2494,12 @@ msgid "No placement decisions"
 msgstr ""
 
 #: lib/tuist_web/live/ops_account_kura_placement_live.ex:24
-#: lib/tuist_web/live/ops_account_live.ex:901
+#: lib/tuist_web/live/ops_account_live.ex:942
 #, elixir-autogen, elixir-format
 msgid "Placement"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:964
+#: lib/tuist_web/live/ops_account_live.ex:1005
 #, elixir-autogen, elixir-format
 msgid "Placement added %{region}. It is provisioned on the account's next cache demand."
 msgstr ""
@@ -2520,32 +2520,32 @@ msgstr ""
 msgid "Placement has recorded nothing for this account; it is served from wherever its instances already are."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:968
+#: lib/tuist_web/live/ops_account_live.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Placement is leaving %{region}. It drains once nothing else is waiting on it."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:955
+#: lib/tuist_web/live/ops_account_live.ex:996
 #, elixir-autogen, elixir-format
 msgid "Placement moved to %{to}. %{from} keeps serving until %{to} is up, then drains."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:263
+#: lib/tuist_web/live/ops_account_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Placement proposal dismissed."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:944
+#: lib/tuist_web/live/ops_account_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "Placement proposes also serving this account from %{to}."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:948
+#: lib/tuist_web/live/ops_account_live.ex:989
 #, elixir-autogen, elixir-format
 msgid "Placement proposes giving up %{from} for this account."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:930
+#: lib/tuist_web/live/ops_account_live.ex:971
 #, elixir-autogen, elixir-format
 msgid "Placement proposes moving this account from %{from} to %{to}."
 msgstr ""
@@ -2560,17 +2560,17 @@ msgstr ""
 msgid "Since"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:245
+#: lib/tuist_web/live/ops_account_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "The proposal no longer applies; the next placement sweep re-evaluates the account."
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:893
+#: lib/tuist_web/live/ops_account_live.ex:934
 #, elixir-autogen, elixir-format
 msgid "add %{region}"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:896
+#: lib/tuist_web/live/ops_account_live.ex:937
 #, elixir-autogen, elixir-format
 msgid "leave %{region}"
 msgstr ""
@@ -2685,14 +2685,14 @@ msgstr ""
 msgid "No change"
 msgstr ""
 
-#: lib/tuist_web/live/ops_account_live.ex:834
+#: lib/tuist_web/live/ops_account_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Seen on %{count} day of measurements (%{bytes} discarded)."
 msgid_plural "Seen on %{count} consecutive days of measurements (%{bytes} discarded)."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/ops_account_live.ex:937
+#: lib/tuist_web/live/ops_account_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "Placement proposes moving this account off its first region, %{from}, to %{to}."
 msgstr ""
@@ -2700,4 +2700,64 @@ msgstr ""
 #: lib/tuist_web/components/app_layout_components.ex:146
 #, elixir-autogen, elixir-format
 msgid "Bazel Cache"
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.ex:140
+#, elixir-autogen, elixir-format
+msgid "%{account}'s free tier starts over from now. It has the full allowance again until the end of the month."
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.html.heex:471
+#, elixir-autogen, elixir-format
+msgid "%{hits} of %{limit}"
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.html.heex:461
+#, elixir-autogen, elixir-format
+msgid "An Air account can reach the cache for %{limit} runs a month. Resetting starts the count over from now, so the account is unblocked and has the full allowance again for the rest of the month. It is not an exemption: the reset goes inert on the first of next month, when counting returns to the month boundary."
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.html.heex:487
+#, elixir-autogen, elixir-format
+msgid "Cache access blocked"
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.ex:152
+#, elixir-autogen, elixir-format
+msgid "Could not reset the free tier: %{reason}"
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.html.heex:458
+#, elixir-autogen, elixir-format
+msgid "Free tier"
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.html.heex:478
+#, elixir-autogen, elixir-format
+msgid "Last reset"
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.ex:523
+#, elixir-autogen, elixir-format
+msgid "Never"
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.html.heex:505
+#, elixir-autogen, elixir-format
+msgid "Reset free tier"
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.html.heex:469
+#, elixir-autogen, elixir-format
+msgid "Runs this period"
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.html.heex:489
+#, elixir-autogen, elixir-format
+msgid "This account is over its free tier and cannot reach the cache until it upgrades or the free tier is reset. Enforcement runs once a day, so an account can read as over the limit for up to a day before it is actually cut off."
+msgstr ""
+
+#: lib/tuist_web/live/ops_account_live.html.heex:500
+#, elixir-autogen, elixir-format
+msgid "Reset this account's free tier? It gets the full allowance again for the rest of the month, and the runs it has already made stop counting."
 msgstr ""

--- a/server/test/tuist/billing_test.exs
+++ b/server/test/tuist/billing_test.exs
@@ -1714,6 +1714,45 @@ defmodule Tuist.BillingTest do
     end
   end
 
+  describe "reset_free_tier/1" do
+    test "zeroes the counter so the account is no longer blocked" do
+      # Given
+      threshold = Billing.get_payment_thresholds()[:remote_cache_hits]
+
+      %{account: account} =
+        AccountsFixtures.user_fixture(
+          current_month_remote_cache_hits_count: threshold * 2,
+          preload: [:account]
+        )
+
+      assert Billing.cache_access_blocked?(account)
+
+      # When
+      {:ok, account} = Billing.reset_free_tier(account)
+
+      # Then
+      assert account.current_month_remote_cache_hits_count == 0
+      refute Billing.cache_access_blocked?(Repo.preload(account, :subscriptions))
+    end
+
+    test "moves the counting window forward so the nightly recount does not undo it" do
+      # Given
+      %{account: account} =
+        AccountsFixtures.user_fixture(
+          current_month_remote_cache_hits_count: 500,
+          preload: [:account]
+        )
+
+      before = DateTime.utc_now() |> DateTime.add(-1, :second) |> DateTime.truncate(:second)
+
+      # When
+      {:ok, account} = Billing.reset_free_tier(account)
+
+      # Then
+      assert DateTime.after?(account.free_tier_reset_at, before)
+    end
+  end
+
   describe "upgrade_to_enterprise/2" do
     test "creates an invoice-billed subscription and updates the customer when no sub exists" do
       # Given

--- a/server/test/tuist_web/live/ops_account_live_test.exs
+++ b/server/test/tuist_web/live/ops_account_live_test.exs
@@ -1028,6 +1028,65 @@ defmodule TuistWeb.OpsAccountLiveTest do
     end
   end
 
+  describe "free tier" do
+    test "shows the usage against the limit and when it was last reset", %{conn: conn, user: user} do
+      user.account
+      |> Ecto.Changeset.change(current_month_remote_cache_hits_count: 42)
+      |> Repo.update!()
+
+      {:ok, _lv, html} = live(conn, ~p"/ops/accounts/#{user.account.id}")
+
+      assert html =~ "Free tier"
+      assert html =~ "42 of 200"
+      assert html =~ "Never"
+    end
+
+    test "warns only when the account is actually cut off", %{conn: conn, user: user} do
+      {:ok, lv, _html} = live(conn, ~p"/ops/accounts/#{user.account.id}")
+      refute has_element?(lv, "#free-tier-blocked-alert")
+
+      threshold = Billing.get_payment_thresholds()[:remote_cache_hits]
+
+      user.account
+      |> Ecto.Changeset.change(current_month_remote_cache_hits_count: threshold)
+      |> Repo.update!()
+
+      {:ok, lv, _html} = live(conn, ~p"/ops/accounts/#{user.account.id}")
+      assert has_element?(lv, "#free-tier-blocked-alert")
+    end
+
+    test "resetting unblocks the account and clears the warning", %{conn: conn, user: user} do
+      threshold = Billing.get_payment_thresholds()[:remote_cache_hits]
+
+      user.account
+      |> Ecto.Changeset.change(current_month_remote_cache_hits_count: threshold * 2)
+      |> Repo.update!()
+
+      {:ok, lv, _html} = live(conn, ~p"/ops/accounts/#{user.account.id}")
+      assert has_element?(lv, "#free-tier-blocked-alert")
+
+      html = lv |> element("button", "Reset free tier") |> render_click()
+
+      refute has_element?(lv, "#free-tier-blocked-alert")
+      assert html =~ "starts over from now"
+
+      account = Repo.reload!(user.account)
+      assert account.current_month_remote_cache_hits_count == 0
+      assert account.free_tier_reset_at
+    end
+
+    test "the reset survives the nightly recount by moving the counting window", %{conn: conn, user: user} do
+      # Zeroing the counter alone would be recomputed straight back over
+      # the threshold, so the timestamp is the half that matters.
+      {:ok, lv, _html} = live(conn, ~p"/ops/accounts/#{user.account.id}")
+
+      lv |> element("button", "Reset free tier") |> render_click()
+
+      account = Repo.reload!(user.account)
+      assert DateTime.after?(account.free_tier_reset_at, DateTime.add(DateTime.utc_now(), -60, :second))
+    end
+  end
+
   describe "claim sizing proposals" do
     setup %{user: user} do
       stub(Tuist.Environment, :tuist_hosted?, fn -> true end)


### PR DESCRIPTION
> Describe here the purpose of your PR.

Resetting an account's Air free tier was a production database write. It took JIT elevation, a second approver, and a `bin/tuist eval` Job cloned from the migrate Job, because `kubectl exec` does not survive the Pomerium gateway. That is a lot of machinery for something support wants to do while a customer is on the phone, and it is easy to get wrong in a way that looks like it worked.

### The trap this closes

The reset is two fields, not one, and only one of them is obvious.

`current_month_remote_cache_hits_count` is what `Billing.cache_access_blocked?/1` reads, so zeroing it is what actually unblocks the account. But `CommandEvents.account_month_usage/2` counts events from `max(beginning_of_month, free_tier_reset_at)`, and `UpdateAllAccountsUsageWorker` recomputes that counter nightly. Zero the counter alone and the account looks fine all day, then is blocked again by morning. `free_tier_reset_at` is what moves the counting window so the reset survives the recount.

The August migration that seeded `free_tier_reset_at` for every Air account already sets both together for exactly this reason. `Billing.reset_free_tier/1` now encodes that pairing in one place so the next caller cannot split them.

### What changed

- `Billing.reset_free_tier/1` sets both fields together, with the reasoning in the docstring.
- `Account.free_tier_reset_changeset/2`, alongside the runner-trial one. `free_tier_reset_at` was in no cast list before, only raw SQL in the migration and `Ecto.Changeset.change/2` in a test, so this keeps it out of any broader changeset.
- A Free tier card on the ops account page, above Runner trial.

The card shows usage against the limit, when the tier was last reset, and a warning that appears only when the account is genuinely cut off. It also states what the reset is not: a fresh allowance for the rest of the month rather than an exemption, going inert on the first of next month when the window returns to the month boundary on its own. The button is behind a confirmation.

### Impact

Support can unblock an account from the dashboard instead of pulling two people into an elevation. The eval-Job path still works and is still the fallback if ops is unavailable. No behaviour changes for customers, and no change to how the free tier is enforced or counted.

### How to test locally

1. `mise run dev` in `server/`, then sign in and open `/ops/accounts/<id>` for an account with no active subscription.
2. Put it over the limit:

```sql
UPDATE accounts SET current_month_remote_cache_hits_count = 247, free_tier_reset_at = NULL WHERE id = <id>;
```

3. Reload. The Free tier card shows `247 of 200`, `Last reset: Never`, and the Cache access blocked warning.
4. Press Reset free tier and confirm. The warning clears, the counter reads `0 of 200`, and `free_tier_reset_at` is stamped with now.

Automated coverage:

```bash
mix test test/tuist/billing_test.exs test/tuist_web/live/ops_account_live_test.exs
```

Two tests on `reset_free_tier/1` cover the unblock and the window move. Four LiveView tests cover the usage display, the warning appearing only when the account is actually blocked, the reset clearing it, and the timestamp being written.

### Validation

Before writing this, the same reset was applied to two blocked production accounts through the old eval-Job path, verifying both fields and the resulting unblock against an independent read. This change reproduces that behaviour behind a button and covers it with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
