### PR TITLE
fix(infra): preserve metrics for macOS PN VLAN alerts

### DIFF
--- a/infra/helm/AGENTS.md
+++ b/infra/helm/AGENTS.md
@@ -19,6 +19,9 @@ This node covers Helm assets under `infra/helm/`.
 - Grafana-managed alert queries and their operational rationale live in
   `k8s-monitoring/alerts.md`. Keep that runbook aligned with live rule changes;
   browser LCP p99 also requires distinct affected sessions, not just total samples.
+- When filtering metrics, preserve every side of absence-based alerts. The
+  macOS PN VLAN check needs both `node_load1` and VLAN transmit series in
+  non-production; keeping only liveness falsely reports a missing interface.
 - Kura metrics use `instance=<namespace>/<pod>` at the metrics destination so
   pod IP changes do not multiply series. Preserve the cluster label and the
   unready scrape's `ready="false"` label when changing either scrape path.

--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1642,7 +1642,7 @@ says so, which matters once a region has boxes with different budgets.
 
 ```promql
 count by (instance) (
-  node_load1{job="tuist-macos-node-exporter"}
+  node_load1{job="tuist-macos-node-exporter", instance!~".*-rack-fleet-.*"}
 )
 unless
 count by (instance) (
@@ -1675,6 +1675,23 @@ drift loop keys on desired config, not live host state.
 the same job works. The `unless` yields one series per host that is scraping but
 has no VLAN, and nothing at all in the healthy case, which is why **No Data**
 must be **Normal** here.
+
+Rack-owned Macs have no Scaleway Private Network, so the instance exclusion
+must remain. Their cache path needs a separate check when it is introduced.
+
+Both sides of this query must survive metric filtering. On 2026-09-09 the
+non-production remote-write allow-list retained `node_load1` but dropped
+`node_network_transmit_bytes_total`, falsely firing for both canary Macs.
+The destination rules retain VLAN transmit series from
+`job="tuist-macos-node-exporter"` specifically to preserve this check without
+restoring every network interface's metrics.
+
+Before re-running bootstrap, compare Grafana's result with the host's raw
+`http://<Node InternalIP>:9100/metrics` over the tailnet. If it exports
+`node_network_transmit_bytes_total{device="vlan0"}` and
+`node_scrape_collector_success{collector="netdev"} 1` but Grafana has no VLAN
+series, investigate Alloy's scrape and remote-write filters. A missing series
+in Grafana alone does not prove the device is absent on the host.
 
 Residual gap, deliberately not covered: a VLAN that exists but has lost its DHCP
 address also has no PN route and is invisible to both rules. node_exporter runs

--- a/infra/helm/k8s-monitoring/values.yaml
+++ b/infra/helm/k8s-monitoring/values.yaml
@@ -177,6 +177,17 @@ k8s-monitoring:
           replacement = "keep"
           action = "replace"
         }
+        // The PN VLAN alert compares node_load1 against VLAN transmit metrics.
+        // Keeping only its liveness anchor makes healthy non-production Macs
+        // appear to have no VLAN. Retain one series per VLAN, not every NIC.
+        write_relabel_config {
+          source_labels = ["job", "__name__", "device"]
+          separator = ";"
+          regex = "tuist-macos-node-exporter;node_network_transmit_bytes_total;vlan.*"
+          target_label = "__tmp_nonprod_keep"
+          replacement = "keep"
+          action = "replace"
+        }
         // `hubble_*` is in the dropped set because its `source` label is a bare
         // remote address for external traffic, so its cardinality is unbounded.
         // The mis-sourced-host runbook in alerts.md that justifies keeping it


### PR DESCRIPTION
## Summary

- Preserve `node_network_transmit_bytes_total` series for VLAN devices on non-production macOS node exporters.
- Exclude rack-owned Macs from the Scaleway Private Network VLAN alert, since they do not have a Private Network.
- Document the failure mode and troubleshooting procedure for comparing Grafana data with raw node-exporter metrics.

The alert compares `node_load1` with VLAN transmit metrics using `unless`. The remote-write allow-list retained the `node_load1` liveness side but dropped `node_network_transmit_bytes_total`, causing both canary Macs to appear to be missing their VLAN interfaces. The new relabel rule keeps only VLAN transmit series, preserving the alert while avoiding the cardinality cost of retaining every network interface metric.

Validation confirmed the observed mismatch: node-exporter exposed VLAN metrics and a healthy `netdev` collector, while Grafana lacked the VLAN series. The documentation now records how to validate this distinction against the host's raw metrics endpoint before re-running bootstrap.

## Testing

Not run (not requested).