### PR TITLE
fix(infra): disarm the canary backfill, which is failing every canary release

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -333,34 +333,29 @@ clickhouse:
     # the deploy that turns dual writes on above has finished rolling out: the
     # backfill covers everything before it, the mirror covers everything after,
     # and naming the boundary is what stops the two from leaving a gap.
+    # Off. Arming this failed three canary releases in a row and rolled each
+    # one back, because helm 4 waits on ordinary Jobs:
+    #
+    #   Error: UPGRADE FAILED: release tuist failed, and has been rolled back
+    #   due to rollback-on-failure being set: resource
+    #   Job/tuist-canary/tuist-tuist-clickhouse-backfill-r894 not ready.
+    #   status: Failed, message: Job Failed. failed: 1/1
+    #
+    # `background: true` was written for helm 3, where `--wait` covered pods
+    # and workloads but not Jobs, so an ordinary Job really did run beside the
+    # release. Under helm 4 it does not: the release waits for the Job, and a
+    # Job that fails fails the release. That inverts the whole reason the
+    # setting exists, and on a production-sized copy it would hold the release
+    # for hours and then roll it back on the deadline, which is exactly the
+    # outcome it was meant to prevent.
+    #
+    # So the backfill needs a way to run that helm does not wait on before it
+    # can be armed again, here or anywhere. Until then this stays off, and
+    # `name` and `task` keep naming the step it would run.
     migration:
-      enabled: true
+      enabled: false
       name: backfill
       task: Tuist.Release.backfill_clickhouse
-      # The minute the deploy that turned dual writes on finished rolling out
-      # was 10:40:52Z, and this is deliberately later than that. Four mirrored
-      # writes ended in a terminal `error` during that window, because the
-      # ClickHouse pod was itself restarting alongside the writers, so those
-      # rows reached Cloud and not the destination. A cutoff after them is what
-      # makes the backfill pick them up.
-      #
-      # Later is the safe direction. The backfill covers everything up to the
-      # cutoff and the mirror covers everything from the moment it started, so
-      # a cutoff after the mirror began overlaps rather than leaves a gap, and
-      # the overlap costs nothing: each chunk fills gaps by row identity rather
-      # than appending, so re-copying a range it already holds is a no-op.
-      cutoff: "2026-09-09T11:20:00Z"
-      # An ordinary Job rather than a deploy hook, so the release does not wait
-      # for the copy. Canary's dataset is small enough that waiting would work
-      # here, which is exactly why this is the place to exercise the path
-      # production needs: helm waits for hook Jobs, and a terabyte-scale copy
-      # would hold the release for hours and then fail it on the deadline,
-      # rolling the release back with it.
-      #
-      # Consequence for reading the result: the deploy going green says the
-      # copy started, not that it finished. The gate is every chunk recorded
-      # done in the ledger with no failures, read from the Job afterwards.
-      background: true
 
   poolSize: "30"
   bufferPoolSize: "30"

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -3035,13 +3035,20 @@ clickhouse:
       # leaving a gap between them. RFC 3339, for example
       # "2026-09-04T07:30:00Z". The backfill refuses to run without it.
       cutoff: ""
-      # Run the step as an ordinary Job rather than a deploy hook, so the
-      # release does not wait for it. For the schema clone and the parity
-      # checks, which take seconds to minutes, waiting is what makes the
-      # deploy's result meaningful. For the backfill it is the opposite: helm
-      # waits for hook Jobs, so a copy of a production-sized dataset would hold
-      # the release for hours and then fail it on the deadline below, rolling
-      # the release back with it.
+      # BROKEN under helm 4, and left here only so the values keep their shape
+      # while a replacement is chosen. Do not set it to true.
+      #
+      # The intent was to run the step as an ordinary Job rather than a deploy
+      # hook, so the release would not wait for it: waiting is what makes the
+      # deploy's result meaningful for the schema clone and the parity checks,
+      # which take seconds to minutes, and is the opposite of what a
+      # production-sized copy wants.
+      #
+      # That relied on helm 3, whose `--wait` covered pods and workloads but
+      # not Jobs. Helm 4 waits on Jobs too, so an ordinary Job is not
+      # background at all: the release blocks on it, and a Job that fails
+      # fails the release. Arming it on canary rolled back three releases in a
+      # row on `resource Job/... not ready. status: Failed`.
       #
       # The task takes an advisory lock, so a second deploy while a copy is
       # running starts a Job that exits immediately rather than a second copy.


### PR DESCRIPTION
## Canary has not taken a release since 12:02

Three consecutive canary releases failed and were rolled back:

```
Error: UPGRADE FAILED: release tuist failed, and has been rolled back due to
rollback-on-failure being set: resource
Job/tuist-canary/tuist-tuist-clickhouse-backfill-r894 not ready.
status: Failed, message: Job Failed. failed: 1/1
```

`helm history` shows the same shape three times:

| revision | time | failure |
|---|---|---|
| 890 | 12:02:35 | `Job/...backfill-r890 not ready` |
| 892 | 13:22:21 | `Job/...backfill-r892 not ready` |
| 894 | 14:01:57 | `Job/...backfill-r894 not ready` |

Because the server release runs with `--atomic`, each failure rolled canary back, which is why its image went *backwards* from `sha-a7df7e765b88` to `sha-a0b6a6beedf5`. The cascade to production is blocked behind canary, so this is not confined to one environment.

## Cause

`background: true` rests on an assumption that was true for Helm 3 and is false here.

The chart says, in as many words, that the step is "not a hook, so helm does not wait for it: the deploy passes `--wait` but not `--wait-for-jobs`". Under Helm 3 that held, because `--wait` covered pods and workloads but not Jobs. **Helm 4 waits on Jobs.** So an ordinary Job is not background at all: the release blocks on it, and a Job that fails fails the release.

That inverts the setting's entire purpose. The reason it exists is that a production-sized copy would hold a hook-based release for hours and then fail it on the deadline. As things stand it would do exactly that, and roll production back with it.

It is also why the three backfill failures were not merely a failed side task. Each one took a whole release down.

## What this changes

Only the bleeding. The backfill is off on canary, `name` and `task` still name the step so the sequence is not lost, and `background` is documented as broken rather than left as a knob that looks usable.

Deliberately **not** included: a new execution mechanism. Choosing how a long copy should run under Helm 4, whether that is a suspended CronJob triggered on demand, an Oban job, or something else, is a design decision that should not be made while deploys are red.

## Prerequisite for resuming the migration

Step 5 cannot be armed again, in any environment, until that mechanism exists. This blocks canary's backfill and the production one behind it.

Two things are unaffected. The schema clone works, because it is a `post-upgrade` hook, which Helm is supposed to wait for. Dual writes are unaffected, since they are server env rather than a Job, so canary keeps mirroring and the cutoff at `2026-09-09T11:20:00Z` stays valid as long as the mirror is not interrupted.

## Validation

Rendered all three environments with `values-managed-common.yaml` plus the per-env overlay: all render, and none produces a migration Job.

The failure signature came from the deploy job's own log rather than inference, and `helm history` in the same log confirms the pattern across the three revisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
