### PR TITLE
fix(cli): support headless cache setup [4.203.x backport]

### DIFF
--- a/cli/Sources/TuistKit/AGENTS.md
+++ b/cli/Sources/TuistKit/AGENTS.md
@@ -16,6 +16,7 @@ This module houses CLI command definitions, command wiring, and high-level orche
 - `TuistCommand.main` initializes cache directories, loads config, resolves server URL, and runs `TrackableCommand`.
 - Noora logging is reinitialized after command execution to ensure logs are captured in verbose logs.
 - Cache warm selection is scoped from explicit non-test roots; focused test roots may remain in the graph but do not expand binary cache candidates.
+- Cache readiness probes keep their read side open until the daemon responds or closes the connection. Closing immediately after connecting can crash SwiftNIO on Darwin before it accepts the socket.
 
 ## Related Context
 - CLI entry point: `cli/Sources/tuist/AGENTS.md`

--- a/cli/Sources/TuistKit/Services/Setup/CacheSocketService.swift
+++ b/cli/Sources/TuistKit/Services/Setup/CacheSocketService.swift
@@ -18,7 +18,7 @@ struct CacheSocketService: CacheSocketServicing {
         let deadline = clock.now.advanced(by: timeout)
 
         repeat {
-            if canConnect(to: path.pathString) {
+            if await canConnect(to: path.pathString, deadline: deadline) {
                 return true
             }
             if clock.now >= deadline || Task.isCancelled {
@@ -28,7 +28,7 @@ struct CacheSocketService: CacheSocketServicing {
         } while true
     }
 
-    private func canConnect(to path: String) -> Bool {
+    private func canConnect(to path: String, deadline: ContinuousClock.Instant) async -> Bool {
         #if canImport(Darwin)
             let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
         #else
@@ -70,6 +70,18 @@ struct CacheSocketService: CacheSocketServicing {
                 #endif
             }
         }
-        return result == 0
+        guard result == 0, shutdown(descriptor, SHUT_WR) == 0 else { return false }
+
+        // Closing before the server accepts can make Darwin reject SwiftNIO's
+        // fcntl calls and kill the daemon. Keep the read side open until the
+        // server responds or closes its side, proving it handled the connection.
+        var byte: UInt8 = 0
+        repeat {
+            let received = recv(descriptor, &byte, 1, MSG_PEEK | MSG_DONTWAIT)
+            if received >= 0 { return true }
+            guard errno == EAGAIN || errno == EWOULDBLOCK else { return false }
+            if ContinuousClock.now >= deadline || Task.isCancelled { return false }
+            try? await Task.sleep(for: .milliseconds(10))
+        } while true
     }
 }

--- a/cli/Sources/TuistLaunchctl/AGENTS.md
+++ b/cli/Sources/TuistLaunchctl/AGENTS.md
@@ -14,3 +14,6 @@ This module provides launchctl integration helpers for macOS automation.
 
 ## Invariants
 - Uses `/bin/launchctl` and waits for command completion.
+- Select the GUI domain when it exists, otherwise the background user domain, based on launchd availability rather than CI environment variables.
+- The plist's `LimitLoadToSessionType` must match the selected domain (`Aqua` for GUI, `Background` for user). Background agents must not also autoload into a later GUI login.
+- Look up existing agents in both domains for status, restart, and teardown; a desktop login may have appeared since setup. Preserve unexpected launchctl failures rather than treating them as missing jobs or domains.

--- a/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
+++ b/cli/Sources/TuistLaunchctl/LaunchAgentService.swift
@@ -56,6 +56,7 @@ public struct LaunchAgentService: LaunchAgentServicing {
         environmentVariables: [String: String] = [:]
     ) async throws {
         let tuistBinaryPath = try await determineTuistBinaryPath()
+        let domain = try await launchctlController.preferredDomain()
 
         let launchAgentsDir = Environment.current.homeDirectory.appending(
             components: "Library", "LaunchAgents"
@@ -88,6 +89,7 @@ public struct LaunchAgentService: LaunchAgentServicing {
             programPath: tuistBinaryPath.pathString,
             programArguments: fullArguments,
             label: label,
+            domain: domain,
             environmentVariables: environmentVariables,
             standardOutPath: stdoutLogPath.pathString,
             standardErrorPath: stderrLogPath.pathString
@@ -98,7 +100,7 @@ public struct LaunchAgentService: LaunchAgentServicing {
         Logger.current.debug("Created LaunchAgent plist at: \(plistPath.pathString)")
 
         do {
-            try await launchctlController.bootstrap(plistPath: plistPath)
+            try await launchctlController.bootstrap(plistPath: plistPath, domain: domain)
             Logger.current.debug("Bootstrapped LaunchAgent")
         } catch let commandError as CommandError {
             var message = String(describing: commandError)
@@ -157,14 +159,12 @@ public struct LaunchAgentService: LaunchAgentServicing {
         programPath: String,
         programArguments: [String],
         label: String,
+        domain: LaunchAgentDomain,
         environmentVariables: [String: String] = [:],
         standardOutPath: String,
         standardErrorPath: String
     ) -> String {
-        let programArgumentsXML =
-            programArguments
-                .map { "<string>\($0)</string>" }
-                .joined(separator: "\n\t\t")
+        let programArgumentsXML = programArguments.map { "<string>\($0)</string>" }.joined(separator: "\n\t\t")
 
         let environmentVariablesXML: String
         if environmentVariables.isEmpty {
@@ -191,6 +191,8 @@ public struct LaunchAgentService: LaunchAgentServicing {
         <dict>
             <key>Label</key>
             <string>\(label)</string>
+            <key>LimitLoadToSessionType</key>
+            <string>\(domain.sessionType)</string>
             <key>Program</key>
             <string>\(programPath)</string>
             <key>ProgramArguments</key>

--- a/cli/Sources/TuistLaunchctl/LaunchctlController.swift
+++ b/cli/Sources/TuistLaunchctl/LaunchctlController.swift
@@ -3,20 +3,38 @@ import Foundation
 import Mockable
 import Path
 
+public enum LaunchAgentDomain: String, CaseIterable, Sendable {
+    case gui
+    case user
+
+    var target: String { "\(rawValue)/\(getuid())" }
+
+    /// launchd requires Background for the user domain. Restricting the plist to
+    /// that session also prevents a later GUI login from starting a second copy.
+    var sessionType: String {
+        switch self {
+        case .gui: "Aqua"
+        case .user: "Background"
+        }
+    }
+}
+
 /// Utility to interact with the `launchctl` CLI.
 @Mockable
 public protocol LaunchctlControlling {
-    /// Bootstraps a LaunchAgent from the given plist path into the current user's GUI domain.
-    func bootstrap(plistPath: AbsolutePath) async throws
+    /// Prefers the GUI domain when available, otherwise the background user domain.
+    func preferredDomain() async throws -> LaunchAgentDomain
 
-    /// Boots out a LaunchAgent by label from the current user's GUI domain.
+    /// Bootstraps a LaunchAgent whose session type matches the selected domain.
+    func bootstrap(plistPath: AbsolutePath, domain: LaunchAgentDomain) async throws
+
+    /// Boots out the label from both domains, including agents installed before a GUI login.
     func bootout(label: String) async throws
 
-    /// Restarts a LaunchAgent by label in the current user's GUI domain.
+    /// Restarts a LaunchAgent in the domain where it is loaded.
     func kickstart(label: String) async throws
 
-    /// Returns whether a LaunchAgent with the given label is currently loaded in the
-    /// current user's GUI domain.
+    /// Returns whether the label is loaded in the GUI or background user domain.
     func isLoaded(label: String) async throws -> Bool
 }
 
@@ -27,13 +45,28 @@ public struct LaunchctlController: LaunchctlControlling {
         self.commandRunner = commandRunner
     }
 
-    public func bootstrap(plistPath: AbsolutePath) async throws {
-        let uid = getuid()
+    public func preferredDomain() async throws -> LaunchAgentDomain {
+        do {
+            _ = try await commandRunner.run(arguments: ["/bin/launchctl", "print", LaunchAgentDomain.gui.target])
+                .awaitCompletion()
+            return .gui
+        } catch let error as CommandError {
+            guard case let .terminated(code, stderr, _) = error,
+                  Self.describesAMissingDomain(code: code, stderr: stderr)
+            else { throw error }
+        }
+
+        _ = try await commandRunner.run(arguments: ["/bin/launchctl", "print", LaunchAgentDomain.user.target])
+            .awaitCompletion()
+        return .user
+    }
+
+    public func bootstrap(plistPath: AbsolutePath, domain: LaunchAgentDomain) async throws {
         _ = try await commandRunner.run(
             arguments: [
                 "/bin/launchctl",
                 "bootstrap",
-                "gui/\(uid)",
+                domain.target,
                 plistPath.pathString,
             ]
         )
@@ -41,47 +74,81 @@ public struct LaunchctlController: LaunchctlControlling {
     }
 
     public func bootout(label: String) async throws {
-        let uid = getuid()
-        _ = try await commandRunner.run(
-            arguments: [
-                "/bin/launchctl",
-                "bootout",
-                "gui/\(uid)/\(label)",
-            ]
-        )
-        .awaitCompletion()
+        for domain in LaunchAgentDomain.allCases where try await isLoaded(label: label, domain: domain) {
+            _ = try await commandRunner.run(
+                arguments: ["/bin/launchctl", "bootout", "\(domain.target)/\(label)"]
+            )
+            .awaitCompletion()
+        }
     }
 
     public func kickstart(label: String) async throws {
-        let uid = getuid()
+        let domain: LaunchAgentDomain
+        if let loadedDomain = try await loadedDomain(label: label) {
+            domain = loadedDomain
+        } else {
+            domain = try await preferredDomain()
+        }
         _ = try await commandRunner.run(
             arguments: [
                 "/bin/launchctl",
                 "kickstart",
                 "-k",
-                "gui/\(uid)/\(label)",
+                "\(domain.target)/\(label)",
             ]
         )
         .awaitCompletion()
     }
 
     public func isLoaded(label: String) async throws -> Bool {
-        let uid = getuid()
+        try await loadedDomain(label: label) != nil
+    }
+
+    private func loadedDomain(label: String) async throws -> LaunchAgentDomain? {
+        for domain in LaunchAgentDomain.allCases where try await isLoaded(label: label, domain: domain) {
+            return domain
+        }
+        return nil
+    }
+
+    private func isLoaded(label: String, domain: LaunchAgentDomain) async throws -> Bool {
         do {
             _ = try await commandRunner.run(
                 arguments: [
                     "/bin/launchctl",
                     "print",
-                    "gui/\(uid)/\(label)",
+                    "\(domain.target)/\(label)",
                 ]
             )
             .awaitCompletion()
             return true
         } catch let error as CommandError {
-            if case .terminated = error {
-                return false
-            }
-            throw error
+            guard case let .terminated(code, stderr, _) = error else { throw error }
+            guard Self.describesAMissingService(code: code, stderr: stderr)
+                || Self.describesAMissingDomain(code: code, stderr: stderr)
+            else { throw error }
+            return false
         }
+    }
+
+    private static func describesAMissingDomain(code: Int32, stderr: String) -> Bool {
+        let message = stderr.lowercased()
+        return (code == 125 && message.contains("domain does not support specified action"))
+            || (code == 112 && message.contains("could not find domain"))
+    }
+
+    /// `launchctl print` exits non-zero both for a service that is not there and
+    /// for every other failure, so only the missing-service termination may be
+    /// read as "not loaded". Reading the rest that way reports a loaded agent as
+    /// absent, which skips the bootout and leaves the bootstrap after it landing
+    /// on a live label.
+    ///
+    /// Matched on the code and the wording together because neither is a
+    /// contract: launchctl's status for a missing service is not stable across
+    /// macOS versions, and a reworded message under a known code still has to
+    /// resolve.
+    private static func describesAMissingService(code: Int32, stderr: String) -> Bool {
+        code == 113 || code == ESRCH
+            || stderr.lowercased().contains("could not find service")
     }
 }

--- a/cli/Tests/TuistKitTests/Services/Setup/CacheSocketServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Setup/CacheSocketServiceTests.swift
@@ -2,6 +2,8 @@ import Darwin
 import FileSystem
 import FileSystemTesting
 import Foundation
+import GRPCCore
+import GRPCNIOTransportHTTP2
 import Path
 import Testing
 
@@ -12,7 +14,32 @@ struct CacheSocketServiceTests {
     private let subject = CacheSocketService()
 
     @Test(.inTemporaryDirectory)
-    func waitUntilListening_returnsTrueForAListeningSocket() async throws {
+    func waitUntilListening_doesNotCrashGRPCServer() async throws {
+        let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+        let shortDirectoryPath = try AbsolutePath(validating: "/tmp/\(UUID().uuidString)")
+        try await fileSystem.createSymbolicLink(from: shortDirectoryPath, to: temporaryDirectory)
+        let socketPath = shortDirectoryPath.appending(component: "cache.sock")
+        defer { unlink(shortDirectoryPath.pathString) }
+        let server = GRPCServer(
+            transport: .http2NIOPosix(
+                address: .unixDomainSocket(path: socketPath.pathString),
+                transportSecurity: .plaintext
+            ),
+            services: []
+        )
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await server.serve() }
+            defer { server.beginGracefulShutdown() }
+
+            for _ in 0 ..< 10 {
+                #expect(await subject.waitUntilListening(at: socketPath, timeout: .seconds(5)))
+            }
+        }
+    }
+
+    @Test(.inTemporaryDirectory)
+    func waitUntilListening_returnsFalseWhenServerDoesNotAccept() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let shortDirectoryPath = try AbsolutePath(validating: "/tmp/\(UUID().uuidString)")
         try await fileSystem.createSymbolicLink(from: shortDirectoryPath, to: temporaryDirectory)
@@ -47,7 +74,7 @@ struct CacheSocketServiceTests {
         try #require(Darwin.listen(descriptor, 1) == 0)
 
         #expect(
-            await subject.waitUntilListening(
+            await !subject.waitUntilListening(
                 at: socketPath,
                 timeout: .milliseconds(100)
             )

--- a/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
+++ b/cli/Tests/TuistLaunchctlTests/LaunchAgentServiceTests.swift
@@ -22,18 +22,22 @@ struct LaunchAgentServiceTests {
             fileSystem: fileSystem,
             launchctlController: launchctlController
         )
+        given(launchctlController).preferredDomain().willReturn(.gui)
         given(launchctlController)
             .isLoaded(label: .any)
             .willReturn(false)
     }
 
-    @Test(.inTemporaryDirectory, .withMockedEnvironment())
-    func setupLaunchAgent_createsDirectoryAndPlist() async throws {
+    @Test(.inTemporaryDirectory, .withMockedEnvironment(), arguments: [LaunchAgentDomain.gui, .user])
+    func setupLaunchAgent_createsDirectoryAndPlist(domain: LaunchAgentDomain) async throws {
+        launchctlController.reset()
+        given(launchctlController).preferredDomain().willReturn(domain)
+        given(launchctlController).isLoaded(label: .any).willReturn(false)
         let environment = try #require(Environment.mocked)
         environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
 
         given(launchctlController)
-            .bootstrap(plistPath: .any)
+            .bootstrap(plistPath: .any, domain: .any)
             .willReturn()
 
         try await subject.setupLaunchAgent(
@@ -48,6 +52,10 @@ struct LaunchAgentServiceTests {
         )
 
         let plistContent = try await fileSystem.readTextFile(at: expectedPlistPath)
+        let plist = try #require(PropertyListSerialization.propertyList(
+            from: Data(plistContent.utf8), format: nil
+        ) as? [String: Any])
+        #expect(plist["LimitLoadToSessionType"] as? String == (domain == .gui ? "Aqua" : "Background"))
         #expect(plistContent.contains("<string>tuist.test</string>"))
         #expect(plistContent.contains("<string>/usr/local/bin/tuist</string>"))
         #expect(plistContent.contains("<string>test-start</string>"))
@@ -64,7 +72,7 @@ struct LaunchAgentServiceTests {
         #expect(!plistContent.contains("<key>KeepAlive</key>\n            <true/>"))
 
         verify(launchctlController)
-            .bootstrap(plistPath: .value(expectedPlistPath))
+            .bootstrap(plistPath: .value(expectedPlistPath), domain: .value(domain))
             .called(1)
     }
 
@@ -74,7 +82,7 @@ struct LaunchAgentServiceTests {
         environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
 
         given(launchctlController)
-            .bootstrap(plistPath: .any)
+            .bootstrap(plistPath: .any, domain: .any)
             .willReturn()
 
         try await subject.setupLaunchAgent(
@@ -101,7 +109,7 @@ struct LaunchAgentServiceTests {
         environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
 
         given(launchctlController)
-            .bootstrap(plistPath: .any)
+            .bootstrap(plistPath: .any, domain: .any)
             .willReturn()
 
         try await subject.setupLaunchAgent(
@@ -133,6 +141,7 @@ struct LaunchAgentServiceTests {
         try await fileSystem.writeText("existing plist", at: expectedPlistPath)
 
         launchctlController.reset()
+        given(launchctlController).preferredDomain().willReturn(.gui)
         given(launchctlController)
             .isLoaded(label: .value("tuist.test"))
             .willReturn(true)
@@ -142,7 +151,7 @@ struct LaunchAgentServiceTests {
             .willReturn()
 
         given(launchctlController)
-            .bootstrap(plistPath: .any)
+            .bootstrap(plistPath: .any, domain: .any)
             .willReturn()
 
         try await subject.setupLaunchAgent(
@@ -156,7 +165,7 @@ struct LaunchAgentServiceTests {
             .called(1)
 
         verify(launchctlController)
-            .bootstrap(plistPath: .value(expectedPlistPath))
+            .bootstrap(plistPath: .value(expectedPlistPath), domain: .value(.gui))
             .called(1)
     }
 
@@ -174,6 +183,7 @@ struct LaunchAgentServiceTests {
         try await fileSystem.writeText("existing plist", at: expectedPlistPath)
 
         launchctlController.reset()
+        given(launchctlController).preferredDomain().willReturn(.gui)
         given(launchctlController)
             .isLoaded(label: .value("tuist.test"))
             .willReturn(true)
@@ -191,7 +201,7 @@ struct LaunchAgentServiceTests {
         }
 
         verify(launchctlController)
-            .bootstrap(plistPath: .any)
+            .bootstrap(plistPath: .any, domain: .any)
             .called(0)
         #expect(try await fileSystem.readTextFile(at: expectedPlistPath) == "existing plist")
     }
@@ -202,6 +212,7 @@ struct LaunchAgentServiceTests {
         environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
 
         launchctlController.reset()
+        given(launchctlController).preferredDomain().willReturn(.gui)
         given(launchctlController)
             .isLoaded(label: .value("tuist.test"))
             .willReturn(true)
@@ -209,7 +220,7 @@ struct LaunchAgentServiceTests {
             .bootout(label: .value("tuist.test"))
             .willReturn()
         given(launchctlController)
-            .bootstrap(plistPath: .any)
+            .bootstrap(plistPath: .any, domain: .any)
             .willReturn()
 
         try await subject.setupLaunchAgent(
@@ -222,7 +233,7 @@ struct LaunchAgentServiceTests {
             .bootout(label: .value("tuist.test"))
             .called(1)
         verify(launchctlController)
-            .bootstrap(plistPath: .any)
+            .bootstrap(plistPath: .any, domain: .any)
             .called(1)
     }
 
@@ -238,7 +249,7 @@ struct LaunchAgentServiceTests {
         )
 
         given(launchctlController)
-            .bootstrap(plistPath: .any)
+            .bootstrap(plistPath: .any, domain: .any)
             .willThrow(bootstrapError)
 
         await #expect(
@@ -278,7 +289,7 @@ struct LaunchAgentServiceTests {
         environment.currentExecutablePathStub = currentMisePath
 
         given(launchctlController)
-            .bootstrap(plistPath: .any)
+            .bootstrap(plistPath: .any, domain: .any)
             .willReturn()
 
         try await subject.setupLaunchAgent(
@@ -306,6 +317,7 @@ struct LaunchAgentServiceTests {
         try await fileSystem.writeText("existing plist", at: plistPath)
 
         launchctlController.reset()
+        given(launchctlController).preferredDomain().willReturn(.gui)
         given(launchctlController)
             .isLoaded(label: .value("tuist.test"))
             .willReturn(true)
@@ -335,6 +347,7 @@ struct LaunchAgentServiceTests {
         try await fileSystem.writeText("existing plist", at: plistPath)
 
         launchctlController.reset()
+        given(launchctlController).preferredDomain().willReturn(.gui)
         given(launchctlController)
             .isLoaded(label: .value("tuist.test"))
             .willReturn(false)
@@ -366,6 +379,7 @@ struct LaunchAgentServiceTests {
         )
 
         launchctlController.reset()
+        given(launchctlController).preferredDomain().willReturn(.gui)
         given(launchctlController)
             .isLoaded(label: .value("tuist.test"))
             .willReturn(true)
@@ -388,6 +402,7 @@ struct LaunchAgentServiceTests {
     @Test(.inTemporaryDirectory, .withMockedEnvironment())
     func teardownLaunchAgent_succeedsWhenPlistIsMissing() async throws {
         launchctlController.reset()
+        given(launchctlController).preferredDomain().willReturn(.gui)
         given(launchctlController)
             .isLoaded(label: .value("tuist.test"))
             .willReturn(false)
@@ -413,7 +428,7 @@ struct LaunchAgentServiceTests {
         environment.currentExecutablePathStub = currentMisePath
 
         given(launchctlController)
-            .bootstrap(plistPath: .any)
+            .bootstrap(plistPath: .any, domain: .any)
             .willReturn()
 
         try await subject.setupLaunchAgent(
@@ -440,5 +455,30 @@ struct LaunchAgentServiceTests {
         verify(launchctlController)
             .kickstart(label: .value("tuist.test"))
             .called(1)
+    }
+
+    @Test(.inTemporaryDirectory, .withMockedEnvironment())
+    func setupLaunchAgent_preservesExistingPlistWhenDomainDetectionFails() async throws {
+        let environment = try #require(Environment.mocked)
+        environment.currentExecutablePathStub = AbsolutePath("/usr/local/bin/tuist")
+        let plistPath = Environment.current.homeDirectory.appending(
+            components: "Library", "LaunchAgents", "tuist.test.plist"
+        )
+        try await fileSystem.makeDirectory(at: plistPath.parentDirectory)
+        try await fileSystem.writeText("existing plist", at: plistPath)
+        launchctlController.reset()
+        given(launchctlController).preferredDomain().willThrow(NSError(domain: "test", code: 1))
+
+        await #expect(throws: NSError.self) {
+            try await subject.setupLaunchAgent(
+                label: "tuist.test",
+                plistFileName: "tuist.test.plist",
+                programArguments: ["test-start"]
+            )
+        }
+
+        #expect(try await fileSystem.readTextFile(at: plistPath) == "existing plist")
+        verify(launchctlController).bootout(label: .any).called(0)
+        verify(launchctlController).bootstrap(plistPath: .any, domain: .any).called(0)
     }
 }

--- a/cli/Tests/TuistLaunchctlTests/LaunchctlControllerTests.swift
+++ b/cli/Tests/TuistLaunchctlTests/LaunchctlControllerTests.swift
@@ -16,7 +16,8 @@ struct LaunchctlControllerTests {
         )
     }
 
-    @Test func bootstrap_plist() async throws {
+    @Test(arguments: [LaunchAgentDomain.gui, .user])
+    func bootstrap_plist(domain: LaunchAgentDomain) async throws {
         // Given
         let plistPath = try AbsolutePath(validating: "/Users/test/Library/LaunchAgents/com.example.service.plist")
         let uid = getuid()
@@ -31,7 +32,7 @@ struct LaunchctlControllerTests {
             })
 
         // When
-        try await subject.bootstrap(plistPath: plistPath)
+        try await subject.bootstrap(plistPath: plistPath, domain: domain)
 
         // Then
         verify(commandRunner)
@@ -40,7 +41,7 @@ struct LaunchctlControllerTests {
                     [
                         "/bin/launchctl",
                         "bootstrap",
-                        "gui/\(uid)",
+                        "\(domain.rawValue)/\(uid)",
                         plistPath.pathString,
                     ]
                 ),
@@ -125,6 +126,7 @@ struct LaunchctlControllerTests {
                 workingDirectory: .any
             )
             .willReturn(AsyncThrowingStream { continuation in
+                continuation.yield(.standardOutput(Array(Self.printOutput(processIdentifier: 4242).utf8)))
                 continuation.finish()
             })
 
@@ -157,19 +159,70 @@ struct LaunchctlControllerTests {
                 environment: .any,
                 workingDirectory: .any
             )
-            .willReturn(AsyncThrowingStream { continuation in
-                continuation.finish(throwing: CommandError.terminated(
-                    113,
-                    stderr: "Could not find service \"tuist.cache.org_project\" in domain for port",
-                    command: ["/bin/launchctl", "print", "gui/501/tuist.cache.org_project"]
-                ))
-            })
+            .willProduce { _, _, _ in
+                AsyncThrowingStream { continuation in
+                    continuation.finish(throwing: CommandError.terminated(
+                        113,
+                        stderr: "Could not find service \"tuist.cache.org_project\" in domain for port",
+                        command: ["/bin/launchctl", "print", "gui/501/tuist.cache.org_project"]
+                    ))
+                }
+            }
 
         // When
         let isLoaded = try await subject.isLoaded(label: label)
 
         // Then
         #expect(isLoaded == false)
+    }
+
+    @Test func isLoaded_returnsFalseWhenLaunchctlPrintCannotFindTheServiceUnderAnotherCode() async throws {
+        // Given
+        let label = "tuist.cache.org_project"
+        given(commandRunner)
+            .run(
+                arguments: .any,
+                environment: .any,
+                workingDirectory: .any
+            )
+            .willProduce { _, _, _ in
+                AsyncThrowingStream { continuation in
+                    continuation.finish(throwing: CommandError.terminated(
+                        3,
+                        stderr: "Could not find service \"tuist.cache.org_project\" in domain for port",
+                        command: ["/bin/launchctl", "print", "gui/501/tuist.cache.org_project"]
+                    ))
+                }
+            }
+
+        // When
+        let isLoaded = try await subject.isLoaded(label: label)
+
+        // Then
+        #expect(isLoaded == false)
+    }
+
+    @Test func isLoaded_propagatesTerminationsThatAreNotAMissingService() async throws {
+        // Given
+        let label = "tuist.cache.org_project"
+        given(commandRunner)
+            .run(
+                arguments: .any,
+                environment: .any,
+                workingDirectory: .any
+            )
+            .willReturn(AsyncThrowingStream { continuation in
+                continuation.finish(throwing: CommandError.terminated(
+                    1,
+                    stderr: "Bootstrap failed: 5: Input/output error",
+                    command: ["/bin/launchctl", "print", "gui/501/tuist.cache.org_project"]
+                ))
+            })
+
+        // When / Then
+        await #expect(throws: CommandError.self) {
+            _ = try await subject.isLoaded(label: label)
+        }
     }
 
     @Test func isLoaded_propagatesNonTerminatedErrors() async throws {
@@ -190,5 +243,144 @@ struct LaunchctlControllerTests {
         await #expect(throws: BoomError.self) {
             _ = try await subject.isLoaded(label: label)
         }
+    }
+
+    @Test func preferredDomain_usesGUIWhenAvailable() async throws {
+        stubCommand(["/bin/launchctl", "print", "gui/\(getuid())"])
+
+        #expect(try await subject.preferredDomain() == .gui)
+
+        verify(commandRunner)
+            .run(arguments: .value(["/bin/launchctl", "print", "user/\(getuid())"]), environment: .any, workingDirectory: .any)
+            .called(0)
+    }
+
+    @Test(arguments: [
+        (Int32(125), "Could not print domain: 125: Domain does not support specified action"),
+        (Int32(112), "Could not find domain for user gui: 501"),
+    ])
+    func preferredDomain_usesBackgroundWhenGUIIsUnavailable(code: Int32, stderr: String) async throws {
+        let arguments = ["/bin/launchctl", "print", "gui/\(getuid())"]
+        stubCommand(arguments, error: .terminated(code, stderr: stderr, command: arguments))
+        stubCommand(["/bin/launchctl", "print", "user/\(getuid())"])
+
+        #expect(try await subject.preferredDomain() == .user)
+    }
+
+    @Test(arguments: [
+        (Int32(1), "Operation not permitted"),
+        (Int32(5), "Input/output error"),
+        (Int32(125), "Unexpected failure"),
+    ])
+    func preferredDomain_preservesUnexpectedErrors(code: Int32, stderr: String) async throws {
+        let arguments = ["/bin/launchctl", "print", "gui/\(getuid())"]
+        let error = CommandError.terminated(code, stderr: stderr, command: arguments)
+        stubCommand(arguments, error: error)
+
+        await #expect {
+            try await subject.preferredDomain()
+        } throws: {
+            ($0 as? CommandError)?.description == error.description
+        }
+
+        verify(commandRunner)
+            .run(arguments: .value(["/bin/launchctl", "print", "user/\(getuid())"]), environment: .any, workingDirectory: .any)
+            .called(0)
+    }
+
+    @Test func preferredDomain_preservesBackgroundDomainFailure() async throws {
+        let gui = ["/bin/launchctl", "print", "gui/\(getuid())"]
+        let user = ["/bin/launchctl", "print", "user/\(getuid())"]
+        stubCommand(gui, error: .terminated(125, stderr: "Domain does not support specified action", command: gui))
+        let error = CommandError.terminated(1, stderr: "Operation not permitted", command: user)
+        stubCommand(user, error: error)
+
+        await #expect {
+            try await subject.preferredDomain()
+        } throws: {
+            ($0 as? CommandError)?.description == error.description
+        }
+    }
+
+    @Test(arguments: [
+        (Int32(125), "Could not print domain: 125: Domain does not support specified action"),
+        (Int32(113), "Could not find service"),
+    ])
+    func backgroundAgent_remainsManageableWithOrWithoutGUILogin(code: Int32, stderr: String) async throws {
+        let label = "tuist.cache.org_project"
+        let guiTarget = "gui/\(getuid())/\(label)"
+        let userTarget = "user/\(getuid())/\(label)"
+        let guiPrint = ["/bin/launchctl", "print", guiTarget]
+        stubCommand(guiPrint, error: .terminated(code, stderr: stderr, command: guiPrint))
+        stubCommand(["/bin/launchctl", "print", userTarget], output: Self.printOutput(processIdentifier: 4242))
+        stubCommand(["/bin/launchctl", "kickstart", "-k", userTarget])
+        stubCommand(["/bin/launchctl", "bootout", userTarget])
+
+        #expect(try await subject.isLoaded(label: label) == true)
+        try await subject.kickstart(label: label)
+        try await subject.bootout(label: label)
+
+        for arguments in [
+            ["/bin/launchctl", "kickstart", "-k", userTarget],
+            ["/bin/launchctl", "bootout", userTarget],
+        ] {
+            verify(commandRunner)
+                .run(arguments: .value(arguments), environment: .any, workingDirectory: .any)
+                .called(1)
+        }
+    }
+
+    @Test func bootout_removesAgentsFromBothDomains() async throws {
+        let label = "tuist.cache.org_project"
+        for domain in ["gui", "user"] {
+            let target = "\(domain)/\(getuid())/\(label)"
+            stubCommand(["/bin/launchctl", "print", target], output: Self.printOutput(processIdentifier: 4242))
+            stubCommand(["/bin/launchctl", "bootout", target])
+        }
+
+        try await subject.bootout(label: label)
+
+        for domain in ["gui", "user"] {
+            verify(commandRunner)
+                .run(
+                    arguments: .value(["/bin/launchctl", "bootout", "\(domain)/\(getuid())/\(label)"]),
+                    environment: .any, workingDirectory: .any
+                )
+                .called(1)
+        }
+    }
+
+    @Test func bootstrap_preservesErrorsInSelectedDomain() async throws {
+        let path = try AbsolutePath(validating: "/Users/test/Library/LaunchAgents/tuist.test.plist")
+        let arguments = ["/bin/launchctl", "bootstrap", "user/\(getuid())", path.pathString]
+        let error = CommandError.terminated(5, stderr: "Input/output error", command: arguments)
+        stubCommand(arguments, error: error)
+
+        await #expect {
+            try await subject.bootstrap(plistPath: path, domain: .user)
+        } throws: {
+            ($0 as? CommandError)?.description == error.description
+        }
+    }
+
+    private func stubCommand(_ arguments: [String], output: String = "", error: CommandError? = nil) {
+        given(commandRunner)
+            .run(arguments: .value(arguments), environment: .any, workingDirectory: .any)
+            .willProduce { _, _, _ in
+                AsyncThrowingStream { continuation in
+                    continuation.yield(.standardOutput(Array(output.utf8)))
+                    continuation.finish(throwing: error)
+                }
+            }
+    }
+
+    private static func printOutput(processIdentifier: Int32) -> String {
+        """
+        gui/501/tuist.cache.org_project = {
+        \tactive count = 1
+        \tstate = running
+        \tpid = \(processIdentifier)
+        }
+        """
     }
 }


### PR DESCRIPTION
## Problem

Backport #13042 (`5e79b2fa4999ed49b4c2a3c41f0717215cc26c95`) to `releases/4.203.x`, based on the release branch containing 4.203.4.

Cache setup on a macOS runner without a graphical login attempted to bootstrap into the unavailable `gui/<uid>` domain and failed with launchctl code 125. The existing readiness probe could also crash the legacy cache daemon by closing its Unix socket before SwiftNIO accepted and configured it.

## Approach

- Probe launchd domain availability before modifying the plist or bootstrapping. Prefer the GUI domain when present; otherwise select the background user domain and set the matching plist session type.
- Discover, restart, and remove agents across both domains, including when a GUI login appears after setup. Preserve unexpected launchctl errors.
- Keep the readiness probe's read side open until the daemon responds or closes the connection, bounded by the startup deadline.

The release line still uses `LaunchctlControlling.isLoaded` rather than main's process-aware `job` API. This backport retains that API and adapts the domain lookup and tests to it, without bringing in unrelated process-tracking changes. The readiness fix applies unchanged. No smoke pipeline or low-level documentation paragraph is added.

## Validation

- Resolved dependencies using the release branch's pinned versions and generated the focused Xcode workspace.
- `mise run cli:lint --fix` passed; `git diff --check` passed.
- 34 focused tests passed via `xcodebuild test`: 31 LaunchctlController/LaunchAgentService tests and three CacheSocketService tests, including repeated probes against a real SwiftNIO gRPC server. The generated workspace and tests used the 4.203 source and pinned dependencies.
- The upstream fix passed [headless end-to-end smoke run 34351598205](https://github.com/tuist/tuist/actions/runs/34351598205), covering the missing GUI domain, setup, daemon replacement, a clean build with remote cache hits, and teardown. That run tested the main-branch implementation; this backport is validated separately with the release-line tests above.
