### PR TITLE
docs(infra): document the build ingestion alert rules that were dead for three months

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -2336,6 +2336,122 @@ The limit is a gauge rather than a constant in the expression because it
 is per environment: production runs `queueConcurrency: 6`, and the
 in-code default is 4.
 
+### Ingestion jobs being discarded
+
+Rule uids `dfkmt5dtpx43kb` (`process_build`) and `cfl2e4b9eg8aoc`
+(`process_xcresult`), folder `Alerts`, group `Server`.
+
+A discarded job has exhausted every retry attempt. Oban prunes discarded
+rows, so each one is permanently lost customer data once pruning catches
+up with it. On 2026-09-09 build ingestion failed for 3.4 hours, 1,629
+jobs were discarded, and roughly 30 were pruned before recovery.
+
+```promql
+max by (queue) (
+  tuist_oban_queue_length_count{env="production", queue="process_build", state="discarded"}
+) > 25
+```
+
+- Pending period: 10 minutes
+- Severity: critical
+- No Data: **Alerting**, which is the opposite of most rules in this
+  document. See below.
+
+Threshold, measured over the 14 days to 2026-09-09 on production:
+
+| queue | p50 | p95 | p99 | outage peak |
+| --- | --- | --- | --- | --- |
+| `process_build` | 0 | 3 | 7 | 1,650 |
+| `process_xcresult` | 0 | 0 | 0 | 0 |
+
+25 sits about 3.5x above the `process_build` p99 and was crossed by
+roughly 11:10 UTC during the outage, about 15 minutes after the first
+error. `process_xcresult` never discards in normal operation, so its
+threshold matches its sibling rather than sitting near any noise floor.
+
+**Both rules were dead for nearly three months and this is the lesson of
+the section.** They previously read `tuist_oban_jobs_recent_terminal_count`,
+a metric emitted nowhere in the codebase and never present in Prometheus.
+They sat in `Normal (NoData)` from 2026-06-19, and because No Data mapped
+to OK that silence was indistinguishable from health. They were therefore
+dead through the whole 2026-09-09 outage. The rule looked specified,
+carried a good description, was unpaused, and could not fire. Run a new
+expression and confirm it returns a series before saving it.
+
+That is why No Data is Alerting here. The gauge is polled from the shared
+`oban_jobs` table by every node running `Tuist.Oban.PromExPlugin`, so it
+is present whenever any server pod is up, and the plugin emits an explicit
+zero for a queue that drains. Its absence means the telemetry broke rather
+than that the queue is clean. The 10 minute pending period is what keeps a
+deploy roll from paging.
+
+**Do not rewrite either rule onto `rate()` or `increase()`.** The Oban job
+counters (`tuist_oban_job_exception_attempts_count` and its siblings) are
+subject to Grafana Cloud adaptive metrics, which aggregates away `instance`
+and `pod`. Measured on 2026-09-09 at 5m, 15m, 1h and 6h windows, and again
+evaluated at a timestamp inside the outage, `rate()` and `increase()` over
+those aggregated counters return an **empty result rather than an error**,
+while an instant `sum by` over the same selector returns correct values.
+A rule built on them is silently dead in exactly the way these two were.
+The polled gauges are not counters and do not have this problem.
+
+### Build ingestion queue not draining
+
+Rule uid `ffxqtj0ye58g0b`, folder `Alerts`, group `Server`.
+
+The leading indicator for the same failure. It turns positive as soon as
+work stops draining, roughly an hour before retries are exhausted and the
+discarded-jobs rule above can see anything.
+
+```promql
+max by (queue) (
+  tuist_oban_queue_oldest_available_age_seconds{env="production", queue="process_build"}
+) > 300
+```
+
+- Pending period: 10 minutes
+- Severity: critical
+- No Data: OK, because the paired discarded-jobs rule above already runs
+  with No Data set to Alerting over the same plugin. A telemetry failure
+  should be loud once, not twice.
+
+For `process_build` this gauge had p50 0, p95 0 and p99 60 seconds over
+the same 14 days, so 300 is 5x p99. During the outage it crossed 300 at
+roughly 12:20 UTC and reached 690 seconds by the time the incident was
+mitigated by hand.
+
+**Scope this per queue and never fleet-wide.** Over that window the
+`default` queue sat at an oldest-available age of about 61 days as a
+matter of course, and `process_xcresult` had a p95 of roughly 5 hours
+because it legitimately runs long backlogs. One shared threshold across
+queues is either permanently firing or useless. A sibling rule for
+another queue needs its own baseline.
+
+`available` age rather than queue depth: this measures how long the
+oldest job that is ready to run has been waiting, so a backlog being
+worked through steadily does not fire, while a queue whose consumer has
+stopped completing does.
+
+Expect this to read high for a while after any recovery. Draining a
+backlog leaves the oldest job waiting behind newer higher-priority work,
+so the age climbs at wall-clock rate until the front of the queue is
+reached.
+
+### Why request-level alerting cannot see any of this
+
+The 2026-09-09 outage is the reference case. The CLI uploaded builds and
+received 2xx responses throughout; production HTTP counts for 200, 201,
+202 and 204 climbed normally for the entire window with no growth in any
+error status. The data was destroyed afterwards, inside an Oban job. HTTP
+error rate, latency and availability SLOs therefore all stayed green while
+100 percent of build ingestion was failing.
+
+No request-level rule can cover this class of outage. Any pipeline whose
+work is acknowledged synchronously and performed asynchronously needs a
+rule on the asynchronous half, and the three rules above are that cover
+for build and test ingestion.
+
+
 ### Swift registry catalog coverage deferred
 
 Same shape as the queue rule above, for the writer rather than a


### PR DESCRIPTION
## What changed

Three Grafana alert rules in the `Alerts` folder, group `Server`, plus the `alerts.md` sections documenting them. The rule changes are already deployed; this PR is the documentation half that the folder convention asks for in the same pass.

| Rule | uid | Change |
| --- | --- | --- |
| ProcessBuildWorker - jobs being discarded | `dfkmt5dtpx43kb` | Repointed at a metric that exists |
| ProcessXcresultWorker - jobs being discarded | `cfl2e4b9eg8aoc` | Same defect, same fix |
| Build ingestion queue not draining | `ffxqtj0ye58g0b` | New, leading indicator on queue age |

## Why

On 2026-09-09 build ingestion failed on production for 3.4 hours. Every job raised `Postgrex.Error 42501 insufficient_privilege` for table `feature_flags` inside `Tuist.Builds.create_build/1`. 1,629 jobs exhausted five attempts and were discarded, roughly 30 were pruned before recovery and are permanently lost customer build data, and the queue backed up to about 2,400 jobs. Nobody was paged, no incident was declared, and it was found by a human opening the Hive issue by hand over three hours in.

Hive issue: https://hive.tuist.dev/errors/24c4d50e-53fb-5c76-980a-8ff116ca45d5

## Root cause of the alerting gap

Two independent failures, and only the second is what most people would guess.

**The rules named for this exact failure were dead.** Both discarded-jobs rules queried `tuist_oban_jobs_recent_terminal_count`. That metric is emitted nowhere in the codebase and has never existed in Prometheus. Both sat in `Normal (NoData)` from 2026-06-19 until 2026-09-09, and because `no_data_state` mapped to OK, that silence was indistinguishable from health. They were unpaused, carried good descriptions, had a receiver configured, and could not fire. This is the same class of defect as a rule written up in `alerts.md` and never created: it looks specified and is not live.

**Request-level alerting is structurally blind to this.** The CLI uploaded builds and received 2xx responses throughout. Production HTTP counts for 200, 201, 202 and 204 climbed normally for the entire window with no growth in any error status. The data was destroyed afterwards, inside an Oban job, so HTTP error rate, latency and availability SLOs all stayed green while 100 percent of build ingestion was failing.

Worth recording for the record: one rule did work. "Remote processing queue consumer takes work but completes none" went Alerting at 11:27 UTC, 33 minutes after the first error, and stayed Alerting until 14:22. It reached a Slack channel and nothing else, alongside 26 other Alerting transitions from ten rules in the same six-hour window. That part of the problem is routing, not instrumentation, and is not addressed here.

## Why this solution

No new instrumentation was needed. `Tuist.Oban.PromExPlugin` already emits queue length by state including `discarded`, oldest available age, in-flight jobs against queue limit, and per-node last attempt and completion timestamps. The rules were repointed at gauges that already existed rather than adding metrics.

The obvious alternative, counting discard events with `increase()` over `tuist_oban_job_exception_attempts_count`, was tested and rejected. Those counters are subject to Grafana Cloud adaptive metrics, which aggregates away `instance` and `pod`. Measured at 5m, 15m, 1h and 6h windows, and again evaluated at a timestamp inside the outage, `rate()` and `increase()` over them return an empty result rather than an error, while an instant `sum by` over the same selector returns correct values. A rule built that way is silently dead in precisely the way the old ones were. Both the rule descriptions and `alerts.md` now say so explicitly.

`no_data_state` is set to Alerting on the discarded-jobs rules, against the usual convention in this folder. The gauge is polled from the shared `oban_jobs` table by every node running the plugin, so it is present whenever any server pod is up and emits an explicit zero for a queue that drains. Its absence means telemetry broke, which is the exact state these rules spent three months in. The 10 minute pending period keeps a deploy roll from paging.

The queue-age rule is scoped to one queue on purpose. Over the same 14 days the `default` queue sat at an oldest-available age of about 61 days as a matter of course, and `process_xcresult` had a p95 of roughly 5 hours because it legitimately runs long backlogs. A shared fleet-wide threshold would be either permanently firing or useless.

## Thresholds

Every threshold is measured against 14 days of production baseline rather than picked.

| Signal | p50 | p95 | p99 | Outage peak | Threshold |
| --- | --- | --- | --- | --- | --- |
| `process_build` discarded | 0 | 3 | 7 | 1,650 | 25 |
| `process_xcresult` discarded | 0 | 0 | 0 | 0 | 25 |
| `process_build` queue age (s) | 0 | 0 | 60 | 690 | 300 |

Against the outage timeline, the discarded threshold was crossed by roughly 11:10 UTC and the age threshold by roughly 12:20 UTC, versus a first error at 10:54 and hand mitigation at 14:16.

## Impact

Build and test ingestion now have live alerting on the asynchronous half of the pipeline, which is the half that can destroy customer data while every synchronous signal reads healthy. The two rules that were silently dead are live and verified returning series.

## Validation

- Replayed the deployed expression of every rule discussed here against the real outage window rather than reasoning about it.
- Confirmed `tuist_oban_jobs_recent_terminal_count` returns nothing in Prometheus and appears nowhere in the codebase or its history.
- Read Grafana alert state history for the outage window to establish what actually fired and when.
- Confirmed both new expressions return series after the change: discarded reads 0 for both queues, queue age reads a live value.
- Derived all baselines from 14 days of production data at 30 minute resolution.

## Not addressed here

- Notification routing. The policy tree is a bare default with no routes, so `severity: critical` is inert, and every rule pins its own receiver and bypasses the tree regardless. The three rules here are pinned to the `Incidents` receiver, but the OnCall schedule behind it currently has no shifts, so it reaches nobody until someone is rostered. Changing the tree needs a token with `alert.notifications.provisioning:write`, which the one available does not have.
- Hive has no escalation path at all. Notification preferences hold only spec-update subscriptions and no error topic, and every project has an empty webhook list, so 14,092 events on a brand new issue produced zero notifications.
- The underlying grant drift in `Tuist.Release.do_grant_processor_role` has now recurred three times, with `webhook_endpoints`, then `automation_alerts`, then `feature_flags`. The hardcoded table lists want a structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)