### PR TITLE
fix(server): hold the backfill's advisory lock for the run, not 15 seconds

### DIFF
--- a/server/lib/tuist/clickhouse/backfill.ex
+++ b/server/lib/tuist/clickhouse/backfill.ex
@@ -120,21 +120,31 @@ defmodule Tuist.ClickHouse.Backfill do
   # Held on one pinned connection for the length of the run rather than inside
   # a transaction: the copy takes hours, and an open transaction for hours is
   # its own problem.
+  #
+  # `timeout: :infinity` because that is how long the connection is held, not
+  # how long any query on it runs. The default is 15 seconds, so DBConnection
+  # killed the pinned connection fifteen seconds into a copy and took the run
+  # down with it, mid-enumeration, no matter how healthy the copy was. Staging
+  # passed only because its dataset finished inside the window; canary's did
+  # not. The run's real bound is the Job's `activeDeadlineSeconds`.
   defp with_single_flight(fun) do
-    Repo.checkout(fn ->
-      case Repo.query!("SELECT pg_try_advisory_lock($1)", [@lock_key]) do
-        %{rows: [[true]]} ->
-          try do
-            fun.()
-          after
-            Repo.query!("SELECT pg_advisory_unlock($1)", [@lock_key])
-          end
+    Repo.checkout(
+      fn ->
+        case Repo.query!("SELECT pg_try_advisory_lock($1)", [@lock_key]) do
+          %{rows: [[true]]} ->
+            try do
+              fun.()
+            after
+              Repo.query!("SELECT pg_advisory_unlock($1)", [@lock_key])
+            end
 
-        _ ->
-          Logger.warning("Another ClickHouse backfill holds the lock; leaving it to finish")
-          {:error, :already_running}
-      end
-    end)
+          _ ->
+            Logger.warning("Another ClickHouse backfill holds the lock; leaving it to finish")
+            {:error, :already_running}
+        end
+      end,
+      timeout: :infinity
+    )
   end
 
   defp backfill(source, target, opts) do


### PR DESCRIPTION
## What changed

`Tuist.ClickHouse.Backfill.with_single_flight/1` now checks its Postgres connection out with `timeout: :infinity`.

## The bug

The function pins one connection for the whole copy so it can hold `pg_try_advisory_lock`, and the comment directly above it says the copy takes hours. `Repo.checkout/2` bounds how long a connection may be held, and its default is 15 seconds. Nothing in the repo config raises it. So DBConnection killed the pinned connection fifteen seconds into the run:

```
Postgrex.Protocol disconnected: (DBConnection.ConnectionError) client timed out
because it queued and checked out the connection for longer than 15000ms
    Mint.HTTP1.recv/3 ... Ch.Connection.receive_full_response/2
    lib/tuist/clickhouse/backfill.ex:130: Tuist.ClickHouse.Backfill.with_single_flight/1
```

The timeout bounds the hold, not any individual query, so a copy that spends more than fifteen seconds talking to ClickHouse dies however healthy it is. Canary's died three tables into enumerating chunks:

```
14:30:31.345  test_suite_runs: 11 chunk(s)
14:30:32.864  test_run_stress_candidates: 1 chunk(s)
14:30:32.922  ... longer than 15000ms
```

## Why nobody saw it

Staging's backfill "succeeded" across 77 tables and was treated as proof the copy engine worked. It was not: staging's dataset simply finished inside the fifteen second window. **The backfill has never once run for longer than fifteen seconds anywhere without failing.** The cap was invisible precisely because the only environment that had exercised it was small enough to duck under it.

That matters beyond this fix. Production's copy is terabyte-scale, so it would have hit this in the first seconds of the real cutover.

## Why `:infinity`

The run's real bound belongs to the Job: `activeDeadlineSeconds` is six hours, and the pod dies with the connection. A second, shorter bound here would only be another cliff to discover on a larger dataset, which is the mistake this is fixing.

## On testing

Deliberately none. The behaviour is "the connection survives past a timeout", and testing it honestly needs either a real database plus a run longer than fifteen seconds, or a mock asserting an option was passed. The latter pins the call shape without proving the behaviour, and would pass just as happily against a subtly wrong value.

The check that means something is canary getting past fifteen seconds, which is exactly where it has failed every time so far.

## This does not on its own re-enable the migration step

Two things remain before the backfill is armed again on canary:

- A cutoff later than the mirror's last error. `2026-09-09T11:20:00Z` is stale, because the deploy churn produced shadow-write errors well after it that neither the backfill nor the mirror would cover. Canary's parity check is already reporting the consequence: 13 of 59 tables diverging, schema drift 0.
- Deploying this, since the step runs from the server image.

The Helm 4 wait problem is **not** a blocker here. Canary's migration block inherits `background: false`, so its step is a `post-upgrade` hook, which is the mode staging used. That problem is specific to production's background copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
