### PR TITLE
feat(server,infra): add the eu-east and us-central Kura regions

### DIFF
--- a/infra/helm/platform/Chart.yaml
+++ b/infra/helm/platform/Chart.yaml
@@ -48,6 +48,16 @@ dependencies:
     version: 4.11.3
     repository: https://kubernetes.github.io/ingress-nginx
     condition: kura-sa-west-ingress-nginx.enabled
+  - name: ingress-nginx
+    alias: kura-eu-east-ingress-nginx
+    version: 4.11.3
+    repository: https://kubernetes.github.io/ingress-nginx
+    condition: kura-eu-east-ingress-nginx.enabled
+  - name: ingress-nginx
+    alias: kura-us-central-ingress-nginx
+    version: 4.11.3
+    repository: https://kubernetes.github.io/ingress-nginx
+    condition: kura-us-central-ingress-nginx.enabled
   - name: external-dns
     version: 1.15.0
     repository: https://kubernetes-sigs.github.io/external-dns

--- a/infra/helm/platform/values-tuist.yaml
+++ b/infra/helm/platform/values-tuist.yaml
@@ -191,6 +191,61 @@ kura-sa-west-ingress-nginx:
       externalTrafficPolicy: ""
       annotations: {}
 
+# EU East (Warsaw, OVHcloud). Same host-network shape as the other bare-metal
+# regions: the region's gateway binds the box's public IP, and OVH has no cloud
+# LoadBalancer to put in front of it.
+#
+# Disabled until the box is prepped and adopted. Enabling a region whose pool has
+# no node leaves its Ingresses unclaimed.
+kura-eu-east-ingress-nginx:
+  enabled: false
+  controller:
+    kind: DaemonSet
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
+    reportNodeInternalIp: true
+    config:
+      use-proxy-protocol: "false"
+    nodeSelector:
+      node.cluster.x-k8s.io/pool: kura-eu-east
+    tolerations:
+      - key: tuist.dev/kura-cache
+        operator: Exists
+        effect: NoSchedule
+    publishService:
+      enabled: false
+    service:
+      type: ClusterIP
+      externalTrafficPolicy: ""
+      annotations: {}
+
+# US Central (Chicago, Vultr). Same host-network shape as sa-west, which runs on
+# the same provider and plan.
+#
+# Disabled until the box is prepped and adopted. Enabling a region whose pool has
+# no node leaves its Ingresses unclaimed.
+kura-us-central-ingress-nginx:
+  enabled: false
+  controller:
+    kind: DaemonSet
+    hostNetwork: true
+    dnsPolicy: ClusterFirstWithHostNet
+    reportNodeInternalIp: true
+    config:
+      use-proxy-protocol: "false"
+    nodeSelector:
+      node.cluster.x-k8s.io/pool: kura-us-central
+    tolerations:
+      - key: tuist.dev/kura-cache
+        operator: Exists
+        effect: NoSchedule
+    publishService:
+      enabled: false
+    service:
+      type: ClusterIP
+      externalTrafficPolicy: ""
+      annotations: {}
+
 # The gateways above are host-network, so a region with more than one box needs
 # this to let a gateway reach Kura pods on the other boxes. Without it those
 # requests are dropped by the per-instance NetworkPolicy and answer 504.

--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -278,6 +278,46 @@ kura-sa-west-ingress-nginx:
     metrics:
       enabled: true
 
+kura-eu-east-ingress-nginx:
+  enabled: false
+  controller:
+    replicaCount: 2
+    electionID: kura-eu-east-ingress-nginx-leader
+    ingressClass: kura-eu-east
+    ingressClassResource:
+      name: kura-eu-east
+      controllerValue: k8s.io/kura-eu-east-ingress-nginx
+    publishService:
+      enabled: true
+    service:
+      type: LoadBalancer
+      externalTrafficPolicy: Local
+      annotations: {}
+    admissionWebhooks: *kuraGatewayAdmissionWebhooks
+    config: *kuraGatewayNginxConfig
+    metrics:
+      enabled: true
+
+kura-us-central-ingress-nginx:
+  enabled: false
+  controller:
+    replicaCount: 2
+    electionID: kura-us-central-ingress-nginx-leader
+    ingressClass: kura-us-central
+    ingressClassResource:
+      name: kura-us-central
+      controllerValue: k8s.io/kura-us-central-ingress-nginx
+    publishService:
+      enabled: true
+    service:
+      type: LoadBalancer
+      externalTrafficPolicy: Local
+      annotations: {}
+    admissionWebhooks: *kuraGatewayAdmissionWebhooks
+    config: *kuraGatewayNginxConfig
+    metrics:
+      enabled: true
+
 # Lets the regional Kura gateways above reach Kura pods on the other boxes of a
 # multi-box region. Enable it wherever a `kura-*-ingress-nginx` gateway runs
 # host-network; see templates/kura-gateway-network-policy.yaml for why the

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -358,7 +358,7 @@ kuraController:
 # on that path by the Cilium bandwidth manager (egress_burst_mbps).
 egressTreeAgent:
   enabled: true
-  nodePools: [kura-dedibox, kura-us-east, kura-us-west, kura-ap-southeast, kura-sa-west]
+  nodePools: [kura-dedibox, kura-us-east, kura-us-west, kura-ap-southeast, kura-sa-west, kura-eu-east, kura-us-central]
 
 # CloudNativePG cluster — production shape. 3 instances (primary + 2
 # sync replicas), 100Gi per instance. Each instance is a streaming
@@ -830,6 +830,27 @@ vultrFleet:
     item: VULTR_API
 
 vultrFleets:
+  # US Central (Chicago). Vultr because no provider in the fleet sells bare metal
+  # in the US interior; the plan and shape match sa-west exactly, so the machine
+  # kind, the disk conversion and the fleet wiring are the ones already proven
+  # there.
+  #
+  # Disabled until the box is ordered and converted. The self-join refuses a box
+  # whose /data cannot enforce project quotas, and an enabled fleet with no
+  # adoptable box wedges `helm --wait` for every production deploy.
+  us-central:
+    enabled: false
+    replicas: 1
+    nodePool: kura-us-central
+    machine:
+      adoptTag: tuist-kura-vultr-production
+      region: ord
+      plan: vbm-6c-32gb-amd
+      osID: 2284
+      egressBudgetMbps: 1000
+    sshExternalSecret:
+      enabled: true
+      item: VULTR_FLEET_SSH
   # South America West (Santiago), on Vultr because no other provider in the
   # fleet sells bare metal in South America.
   #
@@ -892,6 +913,26 @@ ovhFleet:
 # and serving before retiring the Hetzner us-east/us-west pools (already dropped
 # from cluster-production.yaml).
 ovhFleets:
+  # EU East (Warsaw). OVH sells bare metal here, so the region reuses the
+  # OVHDedicatedMachine kind and its unmetered bandwidth rather than adding a
+  # metered provider where an unmetered one is available.
+  #
+  # Disabled until a box is ordered, prepped and marked. An enabled fleet with no
+  # adoptable box sits at MD 0/1 and wedges `helm --wait` for every production
+  # deploy, not just this region.
+  eu-east:
+    enabled: false
+    replicas: 1
+    nodePool: kura-eu-east
+    machine:
+      adoptDisplayNamePrefix: tuist-kura-ovh-production-eu-east
+      offer: advance-1
+      datacenter: waw
+      os: ubuntu_24.04
+      egressBudgetMbps: 3000
+    sshExternalSecret:
+      enabled: true
+      item: OVH_FLEET_SSH
   us-east:
     enabled: true
     replicas: 2

--- a/server/lib/tuist/kura/account_region_policy.ex
+++ b/server/lib/tuist/kura/account_region_policy.ex
@@ -24,7 +24,7 @@ defmodule Tuist.Kura.AccountRegionPolicy do
   #
   # Being assignable and being served are separate: this list decides what an
   # assignment may name, `Regions.available?/1` decides whether it resolves.
-  @service_regions ["us-east", "eu-central", "us-west", "ap-southeast", "sa-west"]
+  @service_regions ["us-east", "eu-central", "us-west", "ap-southeast", "sa-west", "eu-east", "us-central"]
 
   @primary_key {:id, UUIDv7, autogenerate: true}
   schema "kura_account_region_policies" do

--- a/server/lib/tuist/kura/origin_map.ex
+++ b/server/lib/tuist/kura/origin_map.ex
@@ -17,19 +17,21 @@ defmodule Tuist.Kura.OriginMap do
 
   # Bumped when an entry moves. Recorded on decisions rather than compared
   # against anything: it dates a verdict, it does not gate one.
-  @version 1
+  @version 2
 
   # Nearest first, and every list names every candidate region. An origin
   # always has an answer, so a region being unserved or unfunded narrows the
   # choice instead of leaving the account unplaced.
   @zone_preferences %{
-    us_east: ["us-east", "ca-east", "us-west", "eu-central", "sa-west", "ap-southeast"],
-    us_west: ["us-west", "us-east", "ca-east", "sa-west", "ap-southeast", "eu-central"],
-    canada_east: ["ca-east", "us-east", "us-west", "eu-central", "sa-west", "ap-southeast"],
-    europe: ["eu-central", "us-east", "ca-east", "us-west", "ap-southeast", "sa-west"],
-    apac: ["ap-southeast", "us-west", "us-east", "eu-central", "ca-east", "sa-west"],
-    south_america: ["sa-west", "us-east", "ca-east", "us-west", "eu-central", "ap-southeast"],
-    africa_middle_east: ["eu-central", "us-east", "ca-east", "us-west", "ap-southeast", "sa-west"]
+    us_east: ["us-east", "ca-east", "us-central", "us-west", "eu-central", "eu-east", "sa-west", "ap-southeast"],
+    us_central: ["us-central", "us-east", "ca-east", "us-west", "eu-central", "eu-east", "sa-west", "ap-southeast"],
+    us_west: ["us-west", "us-central", "us-east", "ca-east", "sa-west", "ap-southeast", "eu-central", "eu-east"],
+    canada_east: ["ca-east", "us-east", "us-central", "us-west", "eu-central", "eu-east", "sa-west", "ap-southeast"],
+    europe: ["eu-central", "eu-east", "us-east", "ca-east", "us-central", "us-west", "ap-southeast", "sa-west"],
+    europe_east: ["eu-east", "eu-central", "us-east", "ca-east", "us-central", "us-west", "ap-southeast", "sa-west"],
+    apac: ["ap-southeast", "us-west", "us-central", "us-east", "eu-central", "eu-east", "ca-east", "sa-west"],
+    south_america: ["sa-west", "us-east", "us-central", "ca-east", "us-west", "eu-central", "eu-east", "ap-southeast"],
+    africa_middle_east: ["eu-central", "eu-east", "us-east", "ca-east", "us-central", "us-west", "ap-southeast", "sa-west"]
   }
 
   # Where an origin no entry covers is served from. The same region an account
@@ -38,9 +40,21 @@ defmodule Tuist.Kura.OriginMap do
   @default_zone :us_east
 
   @europe ~w[
-    AD AL AT AX BA BE BG BY CH CY CZ DE DK EE ES FI FO FR GB GG GI GR HR HU IE
-    IM IS IT JE LI LT LU LV MC MD ME MK MT NL NO PL PT RO RS RU SE SI SJ SK SM
-    UA VA XK
+    AD AL AT AX BA BE CH CY DE ES FO FR GB GG GI GR HR IE IM IS IT JE LI LU MC
+    ME MK MT NL PT RS SI SJ SM VA XK
+  ]
+
+  # Nearer Warsaw than Paris, by enough that the routes follow the geography.
+  # Helsinki is 930km from Warsaw against 1910 from Paris, Copenhagen 670
+  # against 1030, Vilnius 400 against 1600, so the Nordics sit here with the
+  # Baltics rather than with western Europe.
+  #
+  # The boundary stops short of the Balkans, Greece and Cyprus. They are also
+  # nearer Warsaw on a straight line, but their transit is provisioned westward
+  # and the traffic behind them is small, so they stay on the Paris routes until
+  # eu-east has a record. Widening this list is one edit and re-reads history.
+  @europe_east ~w[
+    BG BY CZ DK EE FI HU LT LV MD NO PL RO RU SE SK UA
   ]
 
   @africa_middle_east ~w[
@@ -66,8 +80,16 @@ defmodule Tuist.Kura.OriginMap do
   @us_west_subdivisions ~w[AK AZ CA CO HI ID MT NM NV OR UT WA WY]
   @canada_west_subdivisions ~w[AB BC NT YT]
 
+  # The interior, which Chicago serves and neither Vint Hill nor Hillsboro does
+  # well: Dallas is 1300km from Chicago against 1900 from Vint Hill, Minneapolis
+  # 570 against 1600. Ohio, Kentucky and Tennessee are close to even between the
+  # two and stay on us-east; Colorado, Wyoming and Montana are already us-west
+  # and are no nearer Chicago than Hillsboro.
+  @us_central_subdivisions ~w[AR IA IL IN KS LA MI MN MO ND NE OK SD TX WI]
+
   @country_zones Map.new(
                    Enum.map(@europe, &{&1, :europe}) ++
+                     Enum.map(@europe_east, &{&1, :europe_east}) ++
                      Enum.map(@africa_middle_east, &{&1, :africa_middle_east}) ++
                      Enum.map(@apac, &{&1, :apac}) ++
                      Enum.map(@south_america, &{&1, :south_america}) ++
@@ -76,6 +98,7 @@ defmodule Tuist.Kura.OriginMap do
 
   @subdivision_zones Map.new(
                        Enum.map(@us_west_subdivisions, &{"US-" <> &1, :us_west}) ++
+                         Enum.map(@us_central_subdivisions, &{"US-" <> &1, :us_central}) ++
                          Enum.map(@canada_west_subdivisions, &{"CA-" <> &1, :us_west})
                      )
 

--- a/server/lib/tuist/kura/origin_map.ex
+++ b/server/lib/tuist/kura/origin_map.ex
@@ -31,7 +31,16 @@ defmodule Tuist.Kura.OriginMap do
     europe_east: ["eu-east", "eu-central", "us-east", "ca-east", "us-central", "us-west", "ap-southeast", "sa-west"],
     apac: ["ap-southeast", "us-west", "us-central", "us-east", "eu-central", "eu-east", "ca-east", "sa-west"],
     south_america: ["sa-west", "us-east", "us-central", "ca-east", "us-west", "eu-central", "eu-east", "ap-southeast"],
-    africa_middle_east: ["eu-central", "eu-east", "us-east", "ca-east", "us-central", "us-west", "ap-southeast", "sa-west"]
+    africa_middle_east: [
+      "eu-central",
+      "eu-east",
+      "us-east",
+      "ca-east",
+      "us-central",
+      "us-west",
+      "ap-southeast",
+      "sa-west"
+    ]
   }
 
   # Where an origin no entry covers is served from. The same region an account

--- a/server/lib/tuist/kura/regions.ex
+++ b/server/lib/tuist/kura/regions.ex
@@ -388,6 +388,69 @@ defmodule Tuist.Kura.Regions do
       # datacenter sits.
       country: "CL",
       subdivision: "CL-RM"
+    },
+    # EU East (Warsaw / OVHcloud WAW) on OVH bare metal: the `kura-eu-east` node
+    # pool (an `ovhFleets` entry), local-NVMe storage, and a hostNetwork regional
+    # gateway bound to the box's public IP, the same bare-metal shape as us-east
+    # and us-west.
+    #
+    # Serves the east of the OriginMap's europe split: the Baltics, the Nordics,
+    # and everything east of Germany. eu-central is in Paris, so those origins
+    # read across the continent today, Vilnius being 400km from Warsaw and 1600
+    # from Paris.
+    #
+    # OVH rather than Vultr, unlike sa-west: OVH sells in Warsaw, so the region
+    # reuses the OVHDedicatedMachine kind, its prep tooling and its unmetered
+    # bandwidth instead of adding a metered provider where an unmetered one is
+    # available.
+    %{
+      id: "eu-east",
+      display_name: "EU East",
+      cluster_id: "eu-east-1",
+      ingress_class_name: "kura-eu-east",
+      node_pool: "kura-eu-east",
+      storage_class: "scw-local-nvme",
+      gateway: :host_network,
+      replicas: 2,
+      # Egress governance on the shared box (Advance-1 ~3 Gbit/s public NIC), the
+      # same shape us-east and us-west carry on the same range.
+      egress_guaranteed_mbps: @enterprise_egress_floor_mbps,
+      egress_burst_mbps: 1500,
+      # OVHcloud WAW, Warsaw, Masovian Voivodeship.
+      country: "PL",
+      subdivision: "PL-MZ"
+    },
+    # US Central (Chicago / Vultr ORD) on Vultr bare metal: the `kura-us-central`
+    # node pool (a `vultrFleets` entry), local-NVMe storage, and a hostNetwork
+    # regional gateway bound to the box's public IP. The id matches the legacy
+    # cache fleet's `cache-us-central.tuist.dev` endpoint, which was also in
+    # Chicago, so an account moved off the legacy lane keeps the region name it
+    # already knows.
+    #
+    # Vultr rather than OVH because no provider in the fleet sells bare metal in
+    # the US interior: OVH's datacenter availability API lists vin and hil in the
+    # United States, Hetzner sells Ashburn and Hillsboro, and Dedibox is EU-only.
+    # Chicago is where the interior's CI runs, and neither Vint Hill nor
+    # Hillsboro reaches it well.
+    %{
+      id: "us-central",
+      display_name: "US Central",
+      cluster_id: "us-central-1",
+      ingress_class_name: "kura-us-central",
+      node_pool: "kura-us-central",
+      storage_class: "scw-local-nvme",
+      gateway: :host_network,
+      replicas: 2,
+      # Same metered plan as sa-west: a 10 TB/month egress quota rather than the
+      # unmetered bandwidth the OVH and Dedibox regions buy, so the quota rather
+      # than the link binds. Vultr pools the quota account-wide, so sa-west's
+      # unused allowance covers a burst here. 500 Mbps matches sa-west and is
+      # provisional until the region serves enough to measure.
+      egress_guaranteed_mbps: @enterprise_egress_floor_mbps,
+      egress_burst_mbps: 500,
+      # Vultr ORD, Chicago, Illinois.
+      country: "US",
+      subdivision: "US-IL"
     }
   ]
   # Private runner-cache regions. Both share the same model: a single-

--- a/server/priv/repo/migrations/20260909150000_allow_eu_east_and_us_central_kura_service_regions.exs
+++ b/server/priv/repo/migrations/20260909150000_allow_eu_east_and_us_central_kura_service_regions.exs
@@ -1,0 +1,48 @@
+defmodule Tuist.Repo.Migrations.AllowEuEastAndUsCentralKuraServiceRegions do
+  use Ecto.Migration
+
+  # `eu-east` (Warsaw) and `us-central` (Chicago), on the same terms as
+  # `sa-west` before them. `accounts.region` is `all | europe | usa`, so neither
+  # derives from it: an account reaches either by explicit assignment, by
+  # picking it in account settings, or through a placement proposal. Widening
+  # ahead of the hardware joining the cluster is deliberate, because an
+  # assignment has to be recordable before the box it names can be placed into
+  # service, and TUIST_KURA_AVAILABLE_REGIONS is what keeps both unserved until
+  # then.
+  def up do
+    drop(
+      constraint(
+        :kura_account_region_policies,
+        :kura_account_region_policies_service_region_valid
+      )
+    )
+
+    # excellent_migrations:safety-assured-for-next-line check_constraint_added
+    create(
+      constraint(
+        :kura_account_region_policies,
+        :kura_account_region_policies_service_region_valid,
+        check:
+          "service_region IN ('us-east', 'eu-central', 'us-west', 'ap-southeast', 'sa-west', 'eu-east', 'us-central')"
+      )
+    )
+  end
+
+  def down do
+    drop(
+      constraint(
+        :kura_account_region_policies,
+        :kura_account_region_policies_service_region_valid
+      )
+    )
+
+    # excellent_migrations:safety-assured-for-next-line check_constraint_added
+    create(
+      constraint(
+        :kura_account_region_policies,
+        :kura_account_region_policies_service_region_valid,
+        check: "service_region IN ('us-east', 'eu-central', 'us-west', 'ap-southeast', 'sa-west')"
+      )
+    )
+  end
+end

--- a/server/test/tuist/kura/regions_test.exs
+++ b/server/test/tuist/kura/regions_test.exs
@@ -64,7 +64,7 @@ defmodule Tuist.Kura.RegionsTest do
     end
 
     test "sets a uniform enterprise egress floor across the bare-metal regions" do
-      for id <- ["us-east", "us-west", "eu-central", "ca-east", "ap-southeast", "sa-west"] do
+      for id <- ["us-east", "us-west", "eu-central", "ca-east", "ap-southeast", "sa-west", "eu-east", "us-central"] do
         assert Regions.get(id).provisioner_config.egress_guaranteed_mbps == 25
       end
 
@@ -104,7 +104,7 @@ defmodule Tuist.Kura.RegionsTest do
       # Safe here and not before: a tiered floor sits far below its ceiling, so
       # it is only a scheduling promise until the kubelet's MemoryQoS gate makes
       # it the pod's cgroup memory.min. That gate ships in this same change.
-      for id <- ["us-east", "us-west", "eu-central", "ca-east", "ap-southeast", "sa-west"] do
+      for id <- ["us-east", "us-west", "eu-central", "ca-east", "ap-southeast", "sa-west", "eu-east", "us-central"] do
         assert Regions.memory_governed?(Regions.get(id))
       end
 
@@ -114,7 +114,7 @@ defmodule Tuist.Kura.RegionsTest do
     test "bin-packs memory ceilings only where a node budget is advertised" do
       # Every managed region runs on a bare-metal pool the CAPI provider patches
       # with a tuist.dev/memory-ceiling-mib budget.
-      for id <- ["us-east", "us-west", "eu-central", "ca-east", "ap-southeast", "sa-west"] do
+      for id <- ["us-east", "us-west", "eu-central", "ca-east", "ap-southeast", "sa-west", "eu-east", "us-central"] do
         assert Regions.memory_ceiling_bin_packed?(Regions.get(id))
       end
 
@@ -125,7 +125,7 @@ defmodule Tuist.Kura.RegionsTest do
     end
 
     test "sizes the managed regions' storage per tier" do
-      for id <- ["us-east", "us-west", "eu-central", "ca-east", "ap-southeast", "sa-west"] do
+      for id <- ["us-east", "us-west", "eu-central", "ca-east", "ap-southeast", "sa-west", "eu-east", "us-central"] do
         assert Regions.storage_governed?(Regions.get(id))
       end
 
@@ -354,7 +354,9 @@ defmodule Tuist.Kura.RegionsTest do
         # go unclaimed the moment it was switched on, and nothing else in the
         # tree ties the two files together.
         "ap-southeast" => "kura-ap-southeast-ingress-nginx",
-        "sa-west" => "kura-sa-west-ingress-nginx"
+        "sa-west" => "kura-sa-west-ingress-nginx",
+        "eu-east" => "kura-eu-east-ingress-nginx",
+        "us-central" => "kura-us-central-ingress-nginx"
       }
 
       for {id, platform_ingress_key} <- platform_ingress_keys do
@@ -396,7 +398,11 @@ defmodule Tuist.Kura.RegionsTest do
         # unstated instead of guessed.
         "ap-southeast" => %{country: "SG", subdivision: nil},
         # Vultr Santiago, in the Región Metropolitana.
-        "sa-west" => %{country: "CL", subdivision: "CL-RM"}
+        "sa-west" => %{country: "CL", subdivision: "CL-RM"},
+        # OVHcloud Warsaw, in the Masovian Voivodeship.
+        "eu-east" => %{country: "PL", subdivision: "PL-MZ"},
+        # Vultr Chicago, in Illinois.
+        "us-central" => %{country: "US", subdivision: "US-IL"}
       }
 
       for {id, location} <- locations do


### PR DESCRIPTION
## What changed

Two new Kura regions, defined and wired but **disabled**:

- **eu-east**, Warsaw, on OVH bare metal (`ovhFleets.eu-east`, ADVANCE-1)
- **us-central**, Chicago, on Vultr bare metal (`vultrFleets.us-central`, `vbm-6c-32gb-amd`)

Each gets a region spec, a fleet entry, a regional ingress-nginx gateway in the platform chart, an entry in the egress-tree-agent node pools, and a widened service-region constraint. Enabling either is a separate change, once its box is prepped and adoptable.

## Why these two, and why here

Region siting reads `run_count`, not `demand_count`. `AccountPolicies.majority_origin_of/1` is `leader(by_origin, &run_count) || leader(by_origin, &demand_count)`, with the comment "Runs decide. Resolutions decide only when there are no runs at all." The two disagree sharply, and answering on demand gives the wrong call: by demand the US interior looks like 2.5% of US traffic and not worth a region, by runs it is 19.7% across 91 accounts.

Over 30 days:

- **US interior**: 31,835 runs, 19.7% of US runs, 91 accounts. Illinois and Wisconsin are 79% of it. Chicago is roughly 20-25ms from those origins against Vint Hill; the upper-midwest catchment is 28,100 runs against 3,334 for a south-central one, so Chicago rather than Dallas.
- **Nordics and Baltics**: 28,903 runs, 26.9% of EU runs, sitting 30-35ms from eu-central in Paris. Warsaw is roughly 400km from Vilnius against 1600 from Paris.

## The origin map split is the substantive part

Neither region would ever be chosen without it. All of Europe was one `:europe` zone and every non-western US state was `:us_east`, so the new regions would have been reachable only by explicit assignment.

- `:europe_east` takes the Baltics, the Nordics and everything east of Germany. The Nordics belong here on distance: Helsinki is 930km from Warsaw against 1910 from Paris, Copenhagen 670 against 1030.
- `:us_central` takes the interior. Ohio, Kentucky and Tennessee are close to even between Chicago and Vint Hill and stay on us-east; Colorado, Wyoming and Montana were already us-west and are no nearer Chicago than Hillsboro.

The boundary deliberately stops short of the Balkans, Greece and Cyprus. They are nearer Warsaw on a straight line, but their transit is provisioned westward and the traffic behind them is small, so they stay on the Paris routes until eu-east has a record.

`@version` goes to 2, which is what that field is for: entries moved between zones, and decisions carry the version they were taken under so history re-reads correctly.

## Why OVH for one and Vultr for the other

OVH sells bare metal in Warsaw, so eu-east reuses the `OVHDedicatedMachine` kind, its prep tooling and its unmetered bandwidth. No new machine kind.

No provider in the fleet sells in the US interior. OVH's datacenter availability API lists `vin` and `hil` in the United States, Hetzner sells Ashburn and Hillsboro, Dedibox is EU-only. So us-central is Vultr, on exactly sa-west's plan and shape, which makes the machine kind, the disk conversion and the fleet wiring the ones already proven there. Vultr meters egress at a 10 TB monthly quota against unmetered on OVH, but pools it account-wide, and the expected load is far inside it.

## Naming

`us-central` matches the legacy cache fleet's `cache-us-central.tuist.dev`, which was also in Chicago, so an account moving off the legacy lane keeps the region name it knows. That is the same continuity argument that kept `sa-west` for Santiago. The convention elsewhere is inconsistent, so it is worth being explicit that we are not following it: GCP's `us-central1` is Iowa and Azure calls Iowa "Central US" with Chicago as "North Central".

A future Dallas region would be `us-south` rather than renaming this pair. The id lands in the customer-facing host template, `{account_handle}-{cluster_id}{env_suffix}.kura.tuist.dev`, so renaming a live region costs every tenant a hostname change plus an endpoint drain.

## Enumerations

Adding a region has repeatedly meant finding every hardcoded list that names one. Three were fixed recently and now read the fleet maps generically, so they need no edit here: the CAPI CRD contract labels, the hcloud-csi `instance-type` exclusion, and the volume-quota exporter's node pools. Confirmed by rendering with both fleets enabled, where the exporter picks up `kura-eu-east` and `kura-us-central` on its own.

The ones that did need edits are the region catalog, the origin map, the service-region constraint, the platform chart's gateway aliases, and the egress-tree-agent pools.

## Validation

- `regions_test.exs`, `origin_map_test.exs`, `account_policies_test.exs`: 133 passed.
- The cross-file drift guards in `regions_test.exs` now cover both regions, so a region whose ingress class no controller declares fails the suite rather than going unclaimed at switch-on.
- `origin_map_test.exs` asserts every zone names every region; both new ones are in all nine zones, 8 unique entries each.
- The production chart renders with both fleets present and disabled, and with both enabled.
- The delivered Warsaw box reports `commercialRange: ADVANCE-1 | AMD EPYC 4245P` and `datacenter: waw1`, which match `offer: advance-1` (lowercase substring) and `datacenter: waw` (region prefix).