### PR TITLE
docs(server): document Bazel across cache, build insights, and test insights

### DIFF
--- a/server/lib/tuist/docs_sidebar.ex
+++ b/server/lib/tuist/docs_sidebar.ex
@@ -208,7 +208,7 @@ defmodule Tuist.Docs.Sidebar do
               %Item{label: "Xcode cache", slug: "/en/guides/features/cache/xcode-cache"},
               %Item{label: "Module cache", slug: "/en/guides/features/cache/module-cache"},
               %Item{label: "Gradle cache", slug: "/en/guides/features/cache/gradle-cache"},
-              %Item{label: "Bazel cache and invocations", slug: "/en/guides/features/cache/bazel-cache"}
+              %Item{label: "Bazel cache", slug: "/en/guides/features/cache/bazel-cache"}
             ]
           },
           %Item{
@@ -217,7 +217,8 @@ defmodule Tuist.Docs.Sidebar do
             items: [
               %Item{label: "Xcode", slug: "/en/guides/features/build-insights/xcode"},
               %Item{label: "Generated projects", slug: "/en/guides/features/build-insights/generated-projects"},
-              %Item{label: "Gradle", slug: "/en/guides/features/build-insights/gradle"}
+              %Item{label: "Gradle", slug: "/en/guides/features/build-insights/gradle"},
+              %Item{label: "Bazel", slug: "/en/guides/features/build-insights/bazel"}
             ]
           }
         ]
@@ -232,7 +233,8 @@ defmodule Tuist.Docs.Sidebar do
             slug: "/en/guides/features/test-insights",
             items: [
               %Item{label: "Xcode", slug: "/en/guides/features/test-insights/xcode"},
-              %Item{label: "Gradle", slug: "/en/guides/features/test-insights/gradle"}
+              %Item{label: "Gradle", slug: "/en/guides/features/test-insights/gradle"},
+              %Item{label: "Bazel", slug: "/en/guides/features/test-insights/bazel"}
             ]
           },
           %Item{

--- a/server/priv/docs/en/guides/features/build-insights.md
+++ b/server/priv/docs/en/guides/features/build-insights.md
@@ -2,12 +2,12 @@
 {
   "title": "Build Insights",
   "titleTemplate": ":title · Features · Guides · Tuist",
-  "description": "Track build performance for Xcode and Gradle projects with Tuist Build Insights."
+  "description": "Track build performance for Xcode, Gradle, and Bazel projects with Tuist Build Insights."
 }
 ---
 # Build Insights {#build-insights}
 
-Use Build Insights to track local and CI build performance. It currently supports both Xcode and Gradle build systems.
+Use Build Insights to track local and CI build performance. It currently supports Xcode, Gradle, and Bazel build systems.
 
 <.home_cards>
   <.home_card
@@ -24,5 +24,10 @@ Use Build Insights to track local and CI build performance. It currently support
     title="Gradle"
     details="Track Gradle task timing and cache effectiveness with the Tuist Gradle plugin."
     link="/guides/features/build-insights/gradle"
+/>
+  <.home_card
+    title="Bazel"
+    details="Track Bazel command duration, cache totals, and critical-path diagnostics through the Build Event Protocol."
+    link="/guides/features/build-insights/bazel"
 />
 </.home_cards>

--- a/server/priv/docs/en/guides/features/build-insights/bazel.md
+++ b/server/priv/docs/en/guides/features/build-insights/bazel.md
@@ -1,0 +1,67 @@
+---
+{
+  "title": "Bazel Build Insights",
+  "titleTemplate": ":title · Build Insights · Features · Guides · Tuist",
+  "description": "Track Bazel command duration, cache totals, and critical-path diagnostics in the Tuist dashboard."
+}
+---
+# Bazel build insights {#bazel-build-insights}
+
+> [!WARNING]
+> **Requirements**
+>
+> - A <.localized_link href="/guides/server/accounts-and-projects">Tuist account and project</.localized_link> with Bazel selected as the build system
+> - `tuist bazel setup` has been run in the workspace (see <.localized_link href="/guides/features/cache/bazel-cache">Bazel cache</.localized_link>)
+
+Every completed `build`, `test`, and other Bazel command shows up on the project's **Invocations** dashboard: command kind, exit status, start and finish time, duration, and the cache hits, misses, downloads, and uploads that Bazel attributed to that same invocation.
+
+Invocation data is delivered through Bazel's [Build Event Protocol](https://bazel.build/remote/bep). Setup wires it in for you when you run `tuist bazel setup`; no extra flags are required to start seeing invocations.
+
+## What the dashboard shows {#what-the-dashboard-shows}
+
+Each invocation records:
+
+- The command Bazel ran, its exit code, start and finish time, and total duration.
+- Action, target, and package counts.
+- A bounded build timeline and critical-path summary.
+- Cache hits, misses, downloads, and uploads attributed to the invocation.
+- Progress-log lines captured during the run, in execution order.
+- The Bazel version, the git branch and commit when Bazel reports them, and whether the run happened on CI.
+
+Cache activity that Bazel cannot attribute to a completed invocation, for example when a command is interrupted mid-run, still appears on the project **Overview** as a raw remote-cache observation. It is not treated as evidence of command success, duration, or test results.
+
+## Custom metadata {#custom-metadata}
+
+Attach key-value data to invocations to compare runs from different teams, hardware, or workflows. Values appear on each invocation's detail page and through the application programming interface and Model Context Protocol tools.
+
+Set metadata with Bazel's built-in `--build_metadata` flag:
+
+```bash
+bazel build --build_metadata=TICKET=TUIST-123 --build_metadata=RUNNER=macos-14 //...
+```
+
+Or set them once per lane in your `.bazelrc`:
+
+```text
+build:ci --build_metadata=RUNNER=macos-14
+```
+
+Each invocation can carry up to 20 custom entries. Keys can contain up to 50 characters and values up to 500 characters. Entries that exceed those bounds are dropped before the invocation is stored, so an invalid entry does not prevent the rest of the report from being recorded.
+
+Context keys that Tuist derives from the build environment, such as `CI`, `GIT_BRANCH`, and `GIT_COMMIT`, are not stored as custom values because they already populate first-class fields on the invocation.
+
+Custom metadata is visible to project members in the dashboard and through the application programming interface and Model Context Protocol tools. Do not use it for credentials, access tokens, or other sensitive data.
+
+## Opting out {#opting-out}
+
+The Build Event Protocol stream carries command-line arguments, environment values, and command output. Tuist only keeps the completed-command fields listed above and discards the rest, but if you would rather not send the event stream at all, re-run setup with:
+
+```bash
+tuist bazel setup --no-build-insights
+```
+
+The generated `.bazelrc.tuist` then configures only the remote cache. Invocations stop showing up in the dashboard, and cache observations remain on the **Overview** page.
+
+## Data retention {#data-retention}
+
+Tuist retains Bazel invocations and their logs for 90 days. See <.localized_link href="/guides/server/data-retention">data retention</.localized_link> for the full policy.

--- a/server/priv/docs/en/guides/features/cache.md
+++ b/server/priv/docs/en/guides/features/cache.md
@@ -11,38 +11,33 @@ Build artifacts are not shared across environments, forcing you to rebuild the s
 
 Learn the cache workflow that matches your project or deployment model:
 
-<HomeCards>
-    <HomeCard
-        icon="<img src='/images/guides/features/xcode-icon.png' alt='Xcode' width='32' height='32' />"
-        title="Module cache"
-        details="Cache individual modules as binaries for projects using Tuist's generated projects. Requires Tuist project generation."
-        linkText="Set up module cache"
-        link="/guides/features/cache/module-cache"/>
-    <HomeCard
-        icon="<img src='/images/guides/features/xcode-icon.png' alt='Xcode' width='32' height='32' />"
-        title="Xcode cache"
-        details="Share Xcode compilation artifacts across environments. Works with any Xcode project, no project generation required."
-        linkText="Set up Xcode cache"
-        link="/guides/features/cache/xcode-cache"/>
-    <HomeCard
-        icon="<img src='/images/guides/features/gradle-icon.svg' alt='Gradle' width='32' height='32' />"
-        title="Gradle cache"
-        details="Share Gradle build cache artifacts remotely. Includes build insights for performance visibility."
-        linkText="Set up Gradle cache"
-        link="/guides/features/cache/gradle-cache"/>
-    <HomeCard
-        icon="<img src='/images/logo.webp' alt='Bazel' width='32' height='32' />"
-        title="Bazel cache and invocations"
-        details="Share Bazel remote-cache entries and inspect completed command duration, outcome, and attributable cache totals."
-        linkText="Set up Bazel cache"
-        link="/guides/features/cache/bazel-cache"/>
-    <HomeCard
-        icon="<img src='/images/logo.webp' alt='Tuist' width='32' height='32' />"
-        title="Self-hosting"
-        details="Run cache nodes close to CI, offices, or regional compute and connect them to hosted or self-hosted Tuist."
-        linkText="Deploy self-hosted cache"
-        link="/guides/features/cache/self-hosting"/>
-</HomeCards>
+<.home_cards>
+  <.home_card
+    title="Module cache"
+    details="Cache individual modules as binaries for projects using Tuist's generated projects. Requires Tuist project generation."
+    link="/guides/features/cache/module-cache"
+/>
+  <.home_card
+    title="Xcode cache"
+    details="Share Xcode compilation artifacts across environments. Works with any Xcode project, no project generation required."
+    link="/guides/features/cache/xcode-cache"
+/>
+  <.home_card
+    title="Gradle cache"
+    details="Share Gradle build cache artifacts remotely. Includes build insights for performance visibility."
+    link="/guides/features/cache/gradle-cache"
+/>
+  <.home_card
+    title="Bazel cache"
+    details="Point Bazel at Tuist's Remote Execution API cache to share action outputs across your team and CI."
+    link="/guides/features/cache/bazel-cache"
+/>
+  <.home_card
+    title="Self-hosting"
+    details="Run cache nodes close to CI, offices, or regional compute and connect them to hosted or self-hosted Tuist."
+    link="/guides/features/cache/self-hosting"
+/>
+</.home_cards>
 
 > [!TIP]
 > **Fastest on Tuist Runners**

--- a/server/priv/docs/en/guides/features/cache/bazel-cache.md
+++ b/server/priv/docs/en/guides/features/cache/bazel-cache.md
@@ -1,33 +1,37 @@
 ---
 {
-  "title": "Bazel cache and invocations",
+  "title": "Bazel cache",
   "titleTemplate": ":title · Cache · Features · Guides · Tuist",
-  "description": "Share Bazel cache entries and inspect completed Bazel invocations with Tuist."
+  "description": "Share Bazel remote cache entries across your team and CI with Tuist."
 }
 ---
-# Bazel cache and invocations {#bazel-cache-and-invocations}
+# Bazel cache {#bazel-cache}
 
-Tuist connects a Bazel project to the remote cache and reports completed commands through Bazel's [Build Event Protocol](https://bazel.build/remote/bep). The dashboard keeps the two kinds of data distinct: **Overview** shows remote-cache observations from Kura, while **Invocations** shows command outcome and duration with cache totals when Bazel supplied the same invocation identifier.
+Tuist exposes a [Remote Execution API](https://github.com/bazelbuild/remote-apis) cache that Bazel connects to as a remote cache. When an action's outputs are already in the cache, Bazel skips the action and pulls the result from Tuist's cache, saving compilation time across your team and CI environments.
+
+> [!WARNING]
+> **Requirements**
+>
+> - A <.localized_link href="/guides/server/accounts-and-projects">Tuist account and project</.localized_link> with Bazel selected as the build system
+> - The Tuist command-line interface, authenticated with `tuist auth login`
 
 ## Setup {#setup}
 
-Create a project with Bazel as its build system, authenticate the Tuist command-line interface, and run this from the root of the Bazel repository:
+From the root of the Bazel workspace, run:
 
 ```bash
 tuist bazel setup
 ```
 
-By default, setup adds the generated file to your repository's `.bazelrc`:
+This writes a `.bazelrc.tuist` file next to your `.bazelrc`, wired to the closest Tuist cache region and authenticated through a per-workspace credential helper. It also adds a `try-import` line to your repository's `.bazelrc`:
 
 ```text
 try-import %workspace%/.bazelrc.tuist
 ```
 
-Pass `--no-add-bazelrc-import` if you want to manage the import yourself. Setup also leaves `.bazelrc` unchanged when it cannot find a Bazel workspace marker, when the file is a symbolic link, or when the file already configures a remote cache or Build Event Service.
+Pass `--no-add-bazelrc-import` if you want to manage the import yourself. The generated file is safe to check in.
 
-The generated configuration points both Bazel's [Remote Execution API](https://github.com/bazelbuild/remote-apis) cache and Build Event Service at Kura. It uses the existing Tuist credential helper for both connections.
-
-Build Event Service uploads the complete event stream from the machine running Bazel. That stream can include command-line arguments, environment values, and command output. Kura retains only the completed-command fields documented below and discards the other events, but teams that do not want to transmit this telemetry can run `tuist bazel setup --no-build-insights` to configure only the remote cache.
+Setup leaves an existing `.bazelrc` alone when it cannot find a Bazel workspace marker, when the file is a symbolic link, or when it already configures a remote cache or Build Event Service. That way, running it again is idempotent.
 
 Run a normal Bazel command to verify the integration:
 
@@ -35,10 +39,22 @@ Run a normal Bazel command to verify the integration:
 bazel build //...
 ```
 
-## Dashboard data {#dashboard-data}
+Cache activity then appears on the project's **Overview** page in the Tuist dashboard, broken down by action-cache and content-addressable-storage operations.
 
-The **Invocations** page records completed `build`, `test`, and other Bazel commands. It includes the command kind, success or failure status, exit code, start and finish time, and duration. The page also shows cache hits, misses, downloads, and uploads only for cache requests that Bazel attributed to that same invocation.
+## Build insights {#build-insights}
 
-Cache activity can occur without a completed invocation, for example if Kura restarts while a command is running. Those observations remain visible on **Overview**, but they are not treated as evidence of command success, duration, or test results.
+By default, `tuist bazel setup` also configures Bazel's Build Event Service so completed commands appear on the **Invocations** dashboard. See <.localized_link href="/guides/features/build-insights/bazel">Bazel build insights</.localized_link> for what the dashboard shows and how to attach custom metadata.
 
-Tuist retains Bazel invocation and remote action-cache analytics for 90 days. See <.localized_link href="/guides/server/data-retention">data retention</.localized_link> for the full policy.
+If you only want the remote cache and would rather not send the build-event stream, opt out with:
+
+```bash
+tuist bazel setup --no-build-insights
+```
+
+## Continuous integration {#continuous-integration}
+
+Authenticate CI with one of the methods in the <.localized_link href="/guides/server/authentication#continuous-integration">Authentication guide</.localized_link>, then run `tuist bazel setup` once as part of the checkout step so `.bazelrc.tuist` reflects the right region for the runner. See the <.localized_link href="/guides/integrations/continuous-integration">Continuous Integration guide</.localized_link> for provider-specific examples.
+
+## Data retention {#data-retention}
+
+Tuist keeps remote cache observations for 90 days. See <.localized_link href="/guides/server/data-retention">data retention</.localized_link> for the full policy.

--- a/server/priv/docs/en/guides/features/test-insights.md
+++ b/server/priv/docs/en/guides/features/test-insights.md
@@ -2,12 +2,12 @@
 {
   "title": "Test Insights",
   "titleTemplate": ":title · Features · Guides · Tuist",
-  "description": "Identify flaky and slow tests in Xcode and Gradle with Tuist Test Insights."
+  "description": "Identify flaky and slow tests in Xcode, Gradle, and Bazel with Tuist Test Insights."
 }
 ---
 # Test Insights {#test-insights}
 
-Use Test Insights to monitor your test suite's health by identifying slow tests, tracking flaky tests, and quickly understanding failed CI runs. It currently supports both Xcode and Gradle build systems.
+Use Test Insights to monitor your test suite's health by identifying slow tests, tracking flaky tests, and quickly understanding failed CI runs. It currently supports Xcode, Gradle, and Bazel build systems.
 
 > [!WARNING]
 > **Requirements**
@@ -15,17 +15,20 @@ Use Test Insights to monitor your test suite's health by identifying slow tests,
 > - A <.localized_link href="/guides/server/accounts-and-projects">Tuist account and project</.localized_link>
 
 
-<HomeCards>
-    <HomeCard
-        icon="<img src='/images/guides/features/xcode-icon.png' alt='Xcode' width='32' height='32' />"
-        title="Xcode"
-        details="Track Xcode test analytics using scheme post-actions and the Tuist CLI."
-        linkText="Set up Xcode test insights"
-        link="/guides/features/test-insights/xcode"/>
-    <HomeCard
-        icon="<img src='/images/guides/features/gradle-icon.svg' alt='Gradle' width='32' height='32' />"
-        title="Gradle"
-        details="Track Gradle test analytics with the Tuist Gradle plugin."
-        linkText="Set up Gradle test insights"
-        link="/guides/features/test-insights/gradle"/>
-</HomeCards>
+<.home_cards>
+  <.home_card
+    title="Xcode"
+    details="Track Xcode test analytics using scheme post-actions and the Tuist CLI."
+    link="/guides/features/test-insights/xcode"
+/>
+  <.home_card
+    title="Gradle"
+    details="Track Gradle test analytics with the Tuist Gradle plugin."
+    link="/guides/features/test-insights/gradle"
+/>
+  <.home_card
+    title="Bazel"
+    details="Track Bazel test analytics by running tests through tuist bazel test."
+    link="/guides/features/test-insights/bazel"
+/>
+</.home_cards>

--- a/server/priv/docs/en/guides/features/test-insights/bazel.md
+++ b/server/priv/docs/en/guides/features/test-insights/bazel.md
@@ -1,0 +1,58 @@
+---
+{
+  "title": "Bazel Test Insights",
+  "titleTemplate": ":title · Test Insights · Features · Guides · Tuist",
+  "description": "Track Bazel test analytics in the Tuist dashboard to monitor test performance and reliability."
+}
+---
+# Bazel test insights {#bazel-test-insights}
+
+> [!WARNING]
+> **Requirements**
+>
+> - A <.localized_link href="/guides/server/accounts-and-projects">Tuist account and project</.localized_link> with Bazel selected as the build system
+> - `tuist bazel setup` has been run in the workspace (see <.localized_link href="/guides/features/cache/bazel-cache">Bazel cache</.localized_link>)
+
+Run Bazel tests through Tuist to feed the same test dashboards used by every other build system:
+
+```bash
+tuist bazel test -- //app:tests
+```
+
+Arguments after `--` are forwarded to `bazel test`. Use `--path` to select the project and working directory, and `--bazel` to select a different executable such as `bazelisk`. Ordinary `bazel test` still runs your tests, but does not report individual cases to Tuist and does not enforce quarantine policies.
+
+## What is tracked {#what-is-tracked}
+
+Tuist parses the `test.xml` reports and captures the `test.log` output that Bazel produces for each test target, then rolls them up into the shared test-runs model. Each run records:
+
+- Individual test case pass, fail, and skipped status, along with duration.
+- Test target, class, and suite structure.
+- Retry attempts, when Bazel is configured to retry flaky tests.
+- Failure output, captured from the target's `test.log`.
+
+The **Test Runs**, **Test Cases**, and individual test pages all work the same way for Bazel as they do for other build systems.
+
+## Test identity {#test-identity}
+
+Cases are identified by target label, class name (falling back to the suite name), and test name. This keeps identically named methods in different classes separate. Older reports that used a different enclosing suite name retain their history under the old identity; state changes applied to the old identity need to be reapplied to the new one, and the command warns you when a failure matches an old identity so you know which policy to move.
+
+## Providing CI context {#providing-ci-context}
+
+Tuist reads git commit and branch information from Bazel's build metadata so runs on the same commit can be compared across environments. Most continuous integration systems set these already; when yours does not, pass them explicitly:
+
+```bash
+tuist bazel test -- \
+  --build_metadata=CI=true \
+  --build_metadata=GIT_COMMIT="$GIT_COMMIT" \
+  --build_metadata=GIT_BRANCH="$GIT_BRANCH" //app:tests
+```
+
+The same `--build_metadata` flag is what the <.localized_link href="/guides/features/build-insights/bazel#custom-metadata">Bazel build insights</.localized_link> page describes for tagging invocations, so a single set of flags covers both surfaces.
+
+## Flaky tests and quarantine {#flaky-tests-and-quarantine}
+
+Retries, cross-run flakiness detection, and per-case quarantine (Mute and Skip) all work through `tuist bazel test`. See <.localized_link href="/guides/features/test-insights/flaky-tests/bazel">Bazel flaky tests</.localized_link> for the full workflow.
+
+## Data retention {#data-retention}
+
+Tuist retains Bazel test data for 90 days. See <.localized_link href="/guides/server/data-retention">data retention</.localized_link> for the full policy.

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests.md
@@ -15,25 +15,25 @@
 
 Flaky tests are tests that produce different results (pass or fail) when run multiple times with the same code. They erode trust in your test suite and waste developer time investigating false failures. Tuist automatically detects flaky tests and helps you track them over time.
 
-<HomeCards>
-    <HomeCard
-        icon="<img src='/images/guides/features/xcode-icon.png' alt='Xcode' width='32' height='32' />"
-        title="Xcode"
-        details="Detect, manage, and quarantine flaky tests in Xcode projects via tuist xcodebuild test."
-        linkText="Xcode flaky tests"
-        link="/guides/features/test-insights/flaky-tests/xcode"/>
-    <HomeCard
-        icon="<img src='/images/guides/features/xcode-icon.png' alt='Xcode' width='32' height='32' />"
-        title="Generated projects"
-        details="Detect, manage, and quarantine flaky tests in Tuist generated projects via tuist test."
-        linkText="Generated projects flaky tests"
-        link="/guides/features/test-insights/flaky-tests/generated-projects"/>
-    <HomeCard
-        icon="<img src='/images/guides/features/gradle-icon.svg' alt='Gradle' width='32' height='32' />"
-        title="Gradle"
-        details="Detect and manage flaky tests in Gradle projects."
-        linkText="Gradle flaky tests"
-        link="/guides/features/test-insights/flaky-tests/gradle"/>
-</HomeCards>
-
-For Bazel projects, see <.localized_link href="/guides/features/test-insights/flaky-tests/bazel">Bazel flaky tests and quarantine</.localized_link>.
+<.home_cards>
+  <.home_card
+    title="Xcode"
+    details="Detect, manage, and quarantine flaky tests in Xcode projects via tuist xcodebuild test."
+    link="/guides/features/test-insights/flaky-tests/xcode"
+/>
+  <.home_card
+    title="Generated projects"
+    details="Detect, manage, and quarantine flaky tests in Tuist generated projects via tuist test."
+    link="/guides/features/test-insights/flaky-tests/generated-projects"
+/>
+  <.home_card
+    title="Gradle"
+    details="Detect and manage flaky tests in Gradle projects."
+    link="/guides/features/test-insights/flaky-tests/gradle"
+/>
+  <.home_card
+    title="Bazel"
+    details="Detect, mute, and skip flaky Bazel test cases through tuist bazel test."
+    link="/guides/features/test-insights/flaky-tests/bazel"
+/>
+</.home_cards>

--- a/server/priv/docs/en/guides/features/test-insights/flaky-tests/bazel.md
+++ b/server/priv/docs/en/guides/features/test-insights/flaky-tests/bazel.md
@@ -1,14 +1,21 @@
 ---
 {
-  "title": "Bazel",
-  "titleTemplate": ":title · Flaky Tests · Test Insights · Tuist",
+  "title": "Bazel Flaky Tests",
+  "titleTemplate": ":title · Flaky Tests · Test Insights · Features · Guides · Tuist",
   "description": "Detect flaky Bazel tests, mute their failures, and skip quarantined targets."
 }
 ---
 
-# Bazel {#bazel}
+# Bazel flaky tests {#bazel-flaky-tests}
 
-Configure build and test reporting with `tuist bazel setup`, then use `tuist bazel test` to fetch and apply Tuist's quarantine policy before each invocation.
+> [!WARNING]
+> **Requirements**
+>
+> - A <.localized_link href="/guides/server/accounts-and-projects">Tuist account and project</.localized_link> with Bazel selected as the build system
+> - `tuist bazel setup` has been run in the workspace (see <.localized_link href="/guides/features/cache/bazel-cache">Bazel cache</.localized_link>)
+> - Tests are executed with `tuist bazel test` (see <.localized_link href="/guides/features/test-insights/bazel">Bazel test insights</.localized_link>)
+
+`tuist bazel test` fetches Tuist's quarantine policy before each invocation and applies it to the underlying `bazel test` run.
 
 ## Applying quarantine {#applying-quarantine}
 

--- a/server/priv/docs/en/guides/get-started/observability.md
+++ b/server/priv/docs/en/guides/get-started/observability.md
@@ -2,7 +2,7 @@
 {
   "title": "Observe",
   "titleTemplate": ":title · Get started · Guides · Tuist",
-  "description": "Understand build and test performance, failures, flaky behavior, and regressions across Xcode and Gradle projects."
+  "description": "Understand build and test performance, failures, flaky behavior, and regressions across Xcode, Gradle, and Bazel projects."
 }
 ---
 # Observe {#observe}
@@ -26,6 +26,7 @@ Connect the guide that matches the build system already used by the project:
 - For an existing Xcode project or workspace, follow the <.localized_link href="/guides/features/build-insights/xcode">Xcode build insights guide</.localized_link>.
 - For a generated Xcode project, follow the <.localized_link href="/guides/features/build-insights/generated-projects">generated project build insights guide</.localized_link>.
 - For a Gradle project, follow the <.localized_link href="/guides/features/build-insights/gradle">Gradle build insights guide</.localized_link>.
+- For a Bazel project, follow the <.localized_link href="/guides/features/build-insights/bazel">Bazel build insights guide</.localized_link>.
 
 Once builds appear in the dashboard, compare runs that perform similar work. A clean build and an incremental build answer different questions, just as a small source change and a dependency update create different workloads. Keeping those comparisons focused makes a regression easier to identify and explain.
 
@@ -37,6 +38,7 @@ Connect test insights through the guide for your project:
 
 - For Xcode projects, follow the <.localized_link href="/guides/features/test-insights/xcode">Xcode test insights guide</.localized_link>.
 - For Gradle projects, follow the <.localized_link href="/guides/features/test-insights/gradle">Gradle test insights guide</.localized_link>.
+- For Bazel projects, follow the <.localized_link href="/guides/features/test-insights/bazel">Bazel test insights guide</.localized_link>.
 - Use <.localized_link href="/guides/features/test-insights/flaky-tests">flaky test detection</.localized_link> to identify tests whose results change without a corresponding code change.
 
 Not every test failure has the same cause. A test that fails consistently after a source change can point to a regression, while a test whose result changes without a corresponding code change can interrupt the workflow without providing useful feedback. Looking at results over time helps the team separate these cases and decide whether to fix product behavior, improve the test, or investigate the environment.

--- a/server/priv/docs/en/guides/get-started/optimization.md
+++ b/server/priv/docs/en/guides/get-started/optimization.md
@@ -2,7 +2,7 @@
 {
   "title": "Optimize",
   "titleTemplate": ":title · Get started · Guides · Tuist",
-  "description": "Reduce build and test times with caching, selective testing, and test sharding for Xcode and Gradle projects."
+  "description": "Reduce build and test times with caching, selective testing, and test sharding for Xcode, Gradle, and Bazel projects."
 }
 ---
 # Optimize {#optimize}
@@ -20,6 +20,7 @@ Start with the cache that matches your project:
 - For an existing Xcode project or workspace, follow the <.localized_link href="/guides/get-started/existing-xcode-project">existing Xcode project guide</.localized_link> to enable compilation caching without adopting project generation.
 - For a generated Xcode project, follow the <.localized_link href="/guides/get-started/generated-xcode-project">generated Xcode project guide</.localized_link> to use module caching or Xcode compilation caching.
 - For a Gradle project, follow the <.localized_link href="/guides/get-started/gradle-project">Gradle project guide</.localized_link> to connect Gradle's build cache to Tuist.
+- For a Bazel project, follow the <.localized_link href="/guides/features/cache/bazel-cache">Bazel cache guide</.localized_link> to point Bazel at Tuist's Remote Execution API cache.
 
 Xcode compilation caching is useful when a team wants to keep an existing Xcode project or workspace, but it is generally less effective than Tuist's module cache. It reuses individual compilation outputs during the build, so Xcode still plans and executes the build around those cache hits.
 


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/YYY>

## What changed

- Added two new pages: **Bazel build insights** (`/guides/features/build-insights/bazel`) and **Bazel test insights** (`/guides/features/test-insights/bazel`), so Bazel is a first-class sibling of Xcode and Gradle in both sections.
- Refocused the existing **Bazel cache** page (previously "Bazel cache and invocations") on the cache workflow, and moved the invocation dashboard story to the new build-insights page it belongs to.
- Polished **Bazel flaky tests**: renamed the H1 (`Bazel` → `Bazel flaky tests`), added the standard Requirements callout, and tightened the intro.
- Registered the two new pages in `Tuist.Docs.Sidebar` under **Build Insights** and **Test Insights**, and renamed the sidebar entry for the cache page to `Bazel cache`.
- Added Bazel cards to the **Cache**, **Build Insights**, **Test Insights**, and **Flaky Tests** landing pages, and mentioned Bazel in **Get started → Observe** and **Get started → Optimize** so the discovery path from those pages reaches the new content.
- Converted the **Cache**, **Test Insights**, and **Flaky Tests** landing pages from the old `<HomeCards>` markup to the same `<.home_cards>` component that **Build Insights** already uses. All four landing grids now render as the same plain-card layout.

## Why

Bazel support has grown a lot in the product (`tuist bazel setup`, `tuist bazel test`, remote cache via the Remote Execution API, invocation and cache dashboards, flaky-test quarantine, and MCP tools), but the docs still framed it as a corner case: Bazel was only mentioned on one combined "cache and invocations" page and, as an afterthought, on the flaky-tests page. Landing pages and the Get started paths said "Xcode and Gradle" and did not surface Bazel at all.

The result is that a Bazel user landing on the docs could not tell that Tuist supports the workflows they care about, and the sidebar's Build Insights / Test Insights groups had no Bazel entry.

## Approach

Mirrored the Gradle layout, which is the closest analogue — a single upstream setup command that unlocks cache, build insights, and test insights:

- **Cache** owns `tuist bazel setup` and the `.bazelrc.tuist` story.
- **Build insights** owns the Invocations dashboard, custom metadata via `--build_metadata`, and the `--no-build-insights` opt-out.
- **Test insights** owns `tuist bazel test` and what it reports.
- **Flaky tests** owns the Mute/Skip quarantine flow.

Kept the setup instructions in one place (the cache page) and cross-linked to it from the other three, so nothing is duplicated. Added a Requirements callout at the top of each new page pointing back to the setup guide.

The landing pages were using two different card components (`<HomeCards>` vs `<.home_cards>`). Standardised on the newer `<.home_cards>` / `<.home_card>` component so Cache, Build Insights, Test Insights, and Flaky Tests all render as the same grid style.

## Impact

- Bazel now appears as a first-class option in every relevant docs surface (landing pages, sidebar groups, Get started paths).
- No content was removed — the Bazel cache page was reorganized, not deleted, and its existing URL is preserved.
- No non-English translation files were touched. Weblate will pick up the English changes.

## Validation

Ran the server locally against the changed files:

```
mise run install    # from server/
mise run dev
```

Fetched each affected URL against the local dev server (`http://localhost:8430`) and verified:

- All ten pages return `200` with the expected H1 (`Bazel cache`, `Bazel build insights`, `Bazel test insights`, `Bazel flaky tests`, and the four landing pages).
- The sidebar shows Bazel as a sibling of Xcode / Gradle under both **Build Insights** and **Test Insights**, and as the fourth entry under **Flaky tests**.
- All four landing pages emit the same `<div data-part="feature-cards">` markup with `<a data-part="feature-card">` cards (5 on Cache, 4 on Build Insights, 3 on Test Insights, 4 on Flaky Tests).

## How to test locally

From the `server/` directory:

```sh
mise run dev
```

Then open:

- http://localhost:8080/en/docs/guides/features/cache/bazel-cache
- http://localhost:8080/en/docs/guides/features/build-insights/bazel
- http://localhost:8080/en/docs/guides/features/test-insights/bazel
- http://localhost:8080/en/docs/guides/features/test-insights/flaky-tests/bazel
- http://localhost:8080/en/docs/guides/features/cache
- http://localhost:8080/en/docs/guides/features/build-insights
- http://localhost:8080/en/docs/guides/features/test-insights
- http://localhost:8080/en/docs/guides/features/test-insights/flaky-tests
- http://localhost:8080/en/docs/guides/get-started/observability
- http://localhost:8080/en/docs/guides/get-started/optimization

Check that the sidebar under **Builds → Build insights** and **Tests → Test insights** lists Bazel, that the four landing pages render as identical card grids, and that the "Get started → Observe" and "Get started → Optimize" pages mention Bazel alongside Xcode and Gradle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
