### PR TITLE
fix(server): include failed ClickHouse queries in error reports

### DIFF
--- a/server/data-export.md
+++ b/server/data-export.md
@@ -13,6 +13,10 @@ Sensitive authentication data (passwords, tokens) are excluded from exports.
 
 ## Exportable Data
 
+### Error Diagnostics
+
+- Failed ClickHouse reads attach the query template (up to 16,384 characters), repository name, and execution, decoding, and pool-wait timings to the existing error event under `extra.database_query`. Bound parameter values and query results are not included. Reports use the configured Sentry-compatible destination, including Hive, and its existing retention policy. Where an event is associated with an account or project through its existing context, its diagnostic data can be retrieved with that event for an export.
+
 ### Account & User Data
 - User profiles (email, active/inactive status, account settings, preferred locale)
 - User account lifecycle timestamps (`users` table): `last_sign_in_at`, the moment the user most recently authenticated by any means, recorded on session sign-in, application programming interface token use, and remember-me resumption, and written at most once every twelve hours per user; and `disabled_at`, the moment the account was suspended, which is set only for suspended accounts and is what the inactivity control measures its retirement window from. Both are exportable and are retained for the life of the account.

--- a/server/lib/tuist.ex
+++ b/server/lib/tuist.ex
@@ -188,6 +188,7 @@ defmodule Tuist do
       ClickHouseRepo,
       ClickHouseFlop,
       ClickHouseTimeSeries,
+      Telemetry.QueryErrorContext,
       OpsClickHouseRepo,
       Markdown,
       Cldr,

--- a/server/lib/tuist/application.ex
+++ b/server/lib/tuist/application.ex
@@ -24,6 +24,7 @@ defmodule Tuist.Application do
   alias Tuist.Gradle.Build.Buffer
   alias Tuist.Gradle.ConfigurationOperation
   alias Tuist.Kura
+  alias Tuist.Telemetry.QueryErrorContext
   alias Tuist.Tests.TestCase
   alias Tuist.Tests.TestCaseEvent
   alias Tuist.Tests.TestCaseFailure
@@ -69,6 +70,7 @@ defmodule Tuist.Application do
     Oban.Telemetry.attach_default_logger()
     TuistCommon.ObanTelemetry.attach()
     TransportLogger.attach(:tuist)
+    QueryErrorContext.attach()
 
     if Application.get_env(:opentelemetry, :traces_exporter) != :none do
       OpentelemetryLoggerMetadata.setup()

--- a/server/lib/tuist/sentry_event_filter.ex
+++ b/server/lib/tuist/sentry_event_filter.ex
@@ -4,6 +4,8 @@ defmodule Tuist.SentryEventFilter do
   This module is used to exclude expected errors that are not actionable.
   """
 
+  alias Tuist.Telemetry.QueryErrorContext
+
   @additional_ignored_exceptions [
     TuistWeb.Errors.BadRequestError,
     TuistWeb.Errors.NotFoundError,
@@ -24,6 +26,8 @@ defmodule Tuist.SentryEventFilter do
   end
 
   def before_send(event) do
-    TuistCommon.SentryEventFilter.before_send(event, @additional_ignored_exceptions)
+    event
+    |> QueryErrorContext.enrich_event()
+    |> TuistCommon.SentryEventFilter.before_send(@additional_ignored_exceptions)
   end
 end

--- a/server/lib/tuist/telemetry/AGENTS.md
+++ b/server/lib/tuist/telemetry/AGENTS.md
@@ -4,6 +4,7 @@ This context defines telemetry event names used across the server.
 
 ## Responsibilities
 - Provide consistent event name helpers for storage, cache, repo pool, and run events.
+- Attach failed ClickHouse read templates and timings to the matching Sentry-compatible error event. Keep parameters out of reports and clear process-local query context after a successful retry.
 
 ## Boundaries
 - HTTP/API and UI code live in `server/lib/tuist_web`.

--- a/server/lib/tuist/telemetry/query_error_context.ex
+++ b/server/lib/tuist/telemetry/query_error_context.ex
@@ -1,0 +1,53 @@
+defmodule Tuist.Telemetry.QueryErrorContext do
+  @moduledoc """
+  Keeps the most recent failed ClickHouse read in the calling process so the
+  existing error report can include its query and timings without parameters.
+  Successful queries clear the context, including successful retries.
+  """
+
+  @context_key {__MODULE__, :failed_query}
+  @query_events [
+    [:tuist, :click_house_repo, :query],
+    [:tuist, :shadow_click_house_repo, :query],
+    [:tuist, :ops_click_house_repo, :query]
+  ]
+  @statement_limit 16_384
+
+  def attach do
+    :telemetry.attach_many(__MODULE__, @query_events, &__MODULE__.handle_event/4, nil)
+  end
+
+  def handle_event(_event, measurements, %{result: {:error, error}, query: query, repo: repo}, _config)
+      when is_binary(query) do
+    context = %{
+      repository: inspect(repo),
+      statement: String.slice(query, 0, @statement_limit),
+      statement_truncated: String.length(query) > @statement_limit,
+      parameters: "[REDACTED]",
+      timings_ms: Map.new(measurements, fn {key, value} -> {key, milliseconds(value)} end)
+    }
+
+    Process.put(@context_key, {error, context})
+    :ok
+  end
+
+  def handle_event(_event, _measurements, _metadata, _config) do
+    Process.delete(@context_key)
+    :ok
+  end
+
+  def enrich_event(%Sentry.Event{original_exception: exception} = event) when not is_nil(exception) do
+    case Process.get(@context_key) do
+      {^exception, context} ->
+        %{event | extra: Map.put(event.extra || %{}, :database_query, context)}
+
+      _ ->
+        event
+    end
+  end
+
+  def enrich_event(event), do: event
+
+  defp milliseconds(value) when is_integer(value), do: System.convert_time_unit(value, :native, :microsecond) / 1_000
+  defp milliseconds(_value), do: nil
+end

--- a/server/test/tuist/clickhouse_repo_test.exs
+++ b/server/test/tuist/clickhouse_repo_test.exs
@@ -1,7 +1,38 @@
 defmodule Tuist.ClickHouseRepoTest do
   use ExUnit.Case, async: false
 
+  import Ecto.Query
+
   alias Tuist.ClickHouseRepo
+  alias Tuist.SentryEventFilter
+
+  test "a failed raw query enriches the original error event" do
+    with_read_repo(fn ->
+      statement = "SELECT throwIf(1) WHERE {name:String} = {name:String}"
+
+      error = assert_raise Ch.Error, fn -> ClickHouseRepo.query!(statement, %{name: "private value"}) end
+
+      event = error_event(error)
+      assert event.original_exception == error
+      assert event.extra.database_query.statement == statement
+      assert event.extra.database_query.timings_ms.total_time > 0
+      refute inspect(event.extra) =~ "private value"
+    end)
+  end
+
+  test "a failed generated query enriches the original error event" do
+    with_read_repo(fn ->
+      value = "private value"
+      query = from(n in fragment("numbers(1)"), where: ^value == ^value, select: fragment("throwIf(1)"))
+      {statement, _params} = ClickHouseRepo.to_sql(:all, query)
+
+      error = assert_raise Ch.Error, fn -> ClickHouseRepo.all(query) end
+
+      event = error_event(error)
+      assert event.extra.database_query.statement == statement
+      refute inspect(event.extra) =~ "private value"
+    end)
+  end
 
   test "query settings override the connection defaults" do
     with_read_repo(fn ->
@@ -35,6 +66,14 @@ defmodule Tuist.ClickHouseRepoTest do
       )
 
     %{max_threads: max_threads, max_memory_usage: max_memory_usage}
+  end
+
+  defp error_event(error) do
+    original = Sentry.Event.create_event(exception: error)
+    enriched = SentryEventFilter.before_send(original)
+    assert enriched.exception == original.exception
+    assert enriched.fingerprint == original.fingerprint
+    enriched
   end
 
   defp with_read_repo(fun) do

--- a/server/test/tuist/telemetry/query_error_context_test.exs
+++ b/server/test/tuist/telemetry/query_error_context_test.exs
@@ -1,0 +1,121 @@
+defmodule Tuist.Telemetry.QueryErrorContextTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.SentryEventFilter
+  alias Tuist.Telemetry.QueryErrorContext
+
+  @query_event [:tuist, :click_house_repo, :query]
+
+  test "adds the failed query and timings to the matching event without parameter values" do
+    error = %Ch.Error{code: 159, message: "Timeout exceeded"}
+    query = "SELECT name FROM test_cases WHERE project_id = {project_id:Int64} AND name = {name:String}"
+
+    :telemetry.execute(
+      @query_event,
+      %{
+        query_time: System.convert_time_unit(15_000, :millisecond, :native),
+        queue_time: System.convert_time_unit(25, :millisecond, :native),
+        total_time: System.convert_time_unit(15_025, :millisecond, :native)
+      },
+      %{
+        repo: Tuist.ClickHouseRepo,
+        result: {:error, error},
+        query: query,
+        params: %{project_id: 123, name: "private customer value"},
+        cast_params: %{name: "another private value"}
+      }
+    )
+
+    original = event(error, %{existing_context: "preserved"})
+    enriched = SentryEventFilter.before_send(original)
+
+    assert enriched.original_exception == error
+    assert enriched.extra.existing_context == "preserved"
+
+    assert enriched.extra.database_query == %{
+             repository: "Tuist.ClickHouseRepo",
+             statement: query,
+             statement_truncated: false,
+             parameters: "[REDACTED]",
+             timings_ms: %{query_time: 15_000.0, queue_time: 25.0, total_time: 15_025.0}
+           }
+
+    refute inspect(enriched.extra) =~ "private customer value"
+    refute inspect(enriched.extra) =~ "another private value"
+  end
+
+  test "does not attach a recovered query to a later error" do
+    error = %Ch.Error{code: 241, message: "Memory limit exceeded"}
+    emit_failure(error)
+    :telemetry.execute(@query_event, %{}, %{result: {:ok, %Ch.Result{}}})
+
+    original = event(error)
+    assert SentryEventFilter.before_send(original) == original
+  end
+
+  test "does not attach a previous query to an unrelated exception" do
+    emit_failure(%Ch.Error{code: 159, message: "Timeout exceeded"})
+    original = event(%RuntimeError{message: "another failure"})
+
+    assert SentryEventFilter.before_send(original) == original
+  end
+
+  test "retains only the latest failed query" do
+    error = %Ch.Error{code: 159, message: "Timeout exceeded"}
+    emit_failure(error, "SELECT 1")
+    emit_failure(error, "SELECT 2")
+
+    assert SentryEventFilter.before_send(event(error)).extra.database_query.statement == "SELECT 2"
+  end
+
+  test "captures pool failures and does not share context between tasks" do
+    error = DBConnection.ConnectionError.exception("connection not available", :queue_timeout)
+    emit_failure(error)
+    original = event(error)
+
+    assert %{database_query: %{statement: "SELECT 1"}} = SentryEventFilter.before_send(original).extra
+
+    assert fn -> SentryEventFilter.before_send(original) end |> Task.async() |> Task.await() == original
+  end
+
+  test "bounds long statements without splitting Unicode characters" do
+    error = %Ch.Error{code: 159, message: "Timeout exceeded"}
+    emit_failure(error, "SELECT '" <> String.duplicate("é", 20_000) <> "'")
+
+    context = SentryEventFilter.before_send(event(error)).extra.database_query
+    assert context.statement_truncated
+    assert String.length(context.statement) == 16_384
+    assert String.valid?(context.statement)
+  end
+
+  test "supports the operations read repository" do
+    error = %Ch.Error{code: 159, message: "Timeout exceeded"}
+
+    :telemetry.execute([:tuist, :ops_click_house_repo, :query], %{}, %{
+      repo: Tuist.OpsClickHouseRepo,
+      result: {:error, error},
+      query: "SELECT 1"
+    })
+
+    assert SentryEventFilter.before_send(event(error)).extra.database_query.repository == "Tuist.OpsClickHouseRepo"
+  end
+
+  test "ignores events without an original exception" do
+    emit_failure(%Ch.Error{code: 159, message: "Timeout exceeded"})
+    original = event(nil)
+    assert QueryErrorContext.enrich_event(original) == original
+  end
+
+  defp emit_failure(error, query \\ "SELECT 1") do
+    :telemetry.execute(@query_event, %{}, %{repo: Tuist.ClickHouseRepo, result: {:error, error}, query: query})
+  end
+
+  defp event(exception, extra \\ %{}) do
+    %Sentry.Event{
+      event_id: String.duplicate("a", 32),
+      timestamp: "2026-09-09T00:00:00Z",
+      original_exception: exception,
+      extra: extra
+    }
+  end
+end


### PR DESCRIPTION
Attach the failed ClickHouse read's query template and timings to the existing error report. Hive can display this under `extra.database_query` in its existing Additional data panel, without a separate Hive change.

Investigating slow module-cache queries exposed a gap in our diagnostics: the error reports contain the exception and stack trace, but not the statement that caused the timeout or memory failure. The query telemetry already has that statement and its timings; this change carries them into the matching Sentry-compatible event.

The telemetry handler keeps only the latest failed read in the process that issued it. The existing before-send callback attaches that context when the exception matches, preserving the original exception, grouping, and existing event data. Successful queries clear the context, including successful retries, and unrelated errors or other processes do not inherit it.

The context covers the primary, shadow, and operations ClickHouse read repositories. Statements are capped at 16,384 characters and include a truncation flag. Repository names and execution, decoding, and pool-wait timings are included; bound parameter values and query results are not. Values written directly into the statement remain unchanged. The telemetry guidance and data-export documentation describe this diagnostic data.

This improves error reporting only. It does not optimize the slow queries, change query limits or retries, or modify deployment configuration. There are no interface changes.

### How to test locally

From `server/`, with the local PostgreSQL and ClickHouse services running:

```sh
ERL_FLAGS='+S 4:4' mise exec -- mix test \
  test/tuist/telemetry/query_error_context_test.exs \
  test/tuist/sentry_event_filter_test.exs \
  test/tuist/clickhouse_repo_test.exs
```

All 16 focused tests passed. They cover real failures from hand-written and generated queries, omitted bound parameter values, preserved exception grouping, successful-query cleanup, process isolation, pool failures, and Unicode-safe statement truncation. Four schedulers keep the local test connection pools small.

The following checks also passed:

```sh
mise exec -- mix credo --strict \
  lib/tuist/telemetry/query_error_context.ex \
  lib/tuist/sentry_event_filter.ex \
  lib/tuist/application.ex \
  test/tuist/telemetry/query_error_context_test.exs \
  test/tuist/clickhouse_repo_test.exs

mise exec -- mix format --check-formatted \
  lib/tuist/telemetry/query_error_context.ex \
  lib/tuist/sentry_event_filter.ex \
  lib/tuist/application.ex \
  lib/tuist.ex \
  test/tuist/telemetry/query_error_context_test.exs \
  test/tuist/clickhouse_repo_test.exs

git diff --check
```
