### PR TITLE
fix(infra): retain legacy CAPI CRDs for Helm recovery

### DIFF
--- a/infra/helm/AGENTS.md
+++ b/infra/helm/AGENTS.md
@@ -26,7 +26,18 @@ This node covers Helm assets under `infra/helm/`.
   pod IP changes do not multiply series. Preserve the cluster label and the
   unready scrape's `ready="false"` label when changing either scrape path.
 
+## Staging CAPI rename recovery
+
+The legacy `StaticAppleSiliconMachine` and template CRDs are retained alongside
+`RackAppleSiliconMachine` for Helm release compatibility. Staging's failed
+September 9, 2026 rollback still references the legacy kinds; Helm cannot build
+the current release manifest to upgrade it when those CRDs are absent. These
+definitions are copied unchanged from `4fbea028` and create no machines. Keep
+them installed until no retained Helm revision needs the old kinds. The active
+controller and fleet templates use the Rack kinds.
+
 ## Related Context
+
 - Parent infra context: `infra/AGENTS.md`
 - Noora Storybook chart: `infra/helm/noora-storybook/AGENTS.md`
 - Slack chart: `infra/helm/slack/AGENTS.md`

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_staticapplesiliconmachines.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_staticapplesiliconmachines.yaml
@@ -1,0 +1,341 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: staticapplesiliconmachines.infrastructure.cluster.x-k8s.io
+  labels:
+    cluster.x-k8s.io/v1beta1: v1alpha1
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+      - cluster-api
+    kind: StaticAppleSiliconMachine
+    listKind: StaticAppleSiliconMachineList
+    plural: staticapplesiliconmachines
+    shortNames:
+      - sasm
+    singular: staticapplesiliconmachine
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .status.rackHost
+          name: RackHost
+          type: string
+        - jsonPath: .spec.providerID
+          name: ProviderID
+          type: string
+        - jsonPath: .status.ready
+          name: Ready
+          type: boolean
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: StaticAppleSiliconMachine is one Mac mini we own, joined as a cluster Node.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                StaticAppleSiliconMachineSpec is the desired state of one Mac mini we own.
+
+                It is the adopt-only sibling of ScalewayAppleSiliconMachine: same host
+                bootstrap, same host-config drift loop, same tailnet egress Service, but the
+                host comes from a RackHost in the cluster's own inventory rather than from a
+                provider's server list, and there is no order, no reinstall and no release
+                path, because nobody bills us per host and no API can wipe one.
+
+                Everything about the HOST lives on the RackHost (address, serial, outlet,
+                position). Everything about the WORKLOAD lives here (sizing, fleet
+                membership, kubelet version). That split is the point of having two kinds: a
+                MachineDeployment clones this spec N times, and a spec carrying an address
+                could not be cloned more than once.
+              properties:
+                adoptPool:
+                  description: |-
+                    AdoptPool is the RackHost pool this Machine claims from: the analog of
+                    the Scaleway kind's adoptPoolPrefix. The controller claims the first free
+                    RackHost whose `spec.pool` matches.
+
+                    Optional on purpose, even though every chart-rendered MachineTemplate
+                    sets it. A required field here is a schema constraint on a resource CAPI
+                    CLONES, so a MachineTemplate that lacks it fails
+                    `InfrastructureTemplateCloningFailed` on every MachineSet scale-up: and
+                    that drift stays invisible until the next scale-up, which is typically
+                    an operator recovering a host by deleting its Machine. The controller
+                    surfaces an empty value as a `NoAdoptPool` condition instead of scanning
+                    every RackHost in the namespace.
+                  type: string
+                fleetName:
+                  description: |-
+                    FleetName groups Machines that share an SSH key and a sudo password. Set
+                    by the MachineTemplate to the parent MachineDeployment's name. Unlike the
+                    Scaleway fleets, the keypair is NOT minted in-cluster: rack hosts are
+                    provisioned out of band by MDM, which authorizes a key the operator never
+                    generated, so the fleet Secret is synced from 1Password by ESO and the
+                    controller only ever reads it.
+                  type: string
+                guestCapacity:
+                  description: |-
+                    GuestCapacity is how many Tart guests this host is expected to run
+                    concurrently. It sizes the per-guest host resources (the VNC relay port
+                    range, the disk-pressure goldens floor); it does not create capacity,
+                    which HostCPU/HostMemoryMB and Tart's own two-guest SLA ceiling bind
+                    first. Falls back to the operator's global default when unset.
+                  type: integer
+                hostCPU:
+                  description: |-
+                    HostCPU is the CPU-core count the host advertises on the Node it
+                    registers (Node.Status.Capacity), via tart-kubelet's `--host-cpu`. Falls
+                    back to the operator's global default when unset.
+
+                    Per-Machine for the same reason it is on the Scaleway kind, and more so
+                    here: a rack fills up over time and the boxes bought in month 12 are not
+                    the boxes bought in month 1.
+                  type: integer
+                hostMemoryMB:
+                  description: |-
+                    HostMemoryMB is the memory advertised on the Node: the box's RAM minus
+                    the ~2 GB Apple's Virtualization.framework reserves for the host, below
+                    which `tart run` fails with `memorySize > maximumAllowedMemorySize`.
+                    Falls back to the operator's global default when unset.
+                  type: integer
+                kubeletVersion:
+                  description: |-
+                    KubeletVersion override; defaults to the operator's chart-level value
+                    when empty.
+                  type: string
+                maxPods:
+                  description: |-
+                    MaxPods is the Pod ceiling tart-kubelet advertises (`--max-pods`). Sized
+                    as guests x 2 + 1: a Pod stays bound to its Node after it finishes, so
+                    each guest slot can transiently hold its running Pod plus a predecessor
+                    GC has not collected, and the +1 is margin. Falls back to the operator's
+                    global default when unset.
+                  type: integer
+                providerID:
+                  description: |-
+                    ProviderID, set by the controller once a RackHost is claimed, takes the
+                    shape `static-applesilicon://<site>/<serial>`; composed from the two
+                    durable physical facts, so re-cabling a host to a new address does not
+                    change its identity to CAPI. CAPI core expects this to populate; without
+                    it the parent Machine never goes Ready. The scheme is deliberately
+                    foreign to the Hetzner CCM so it never reaps the node, the same guard
+                    every other kind here uses.
+                  type: string
+                runnerCacheVolumeGiB:
+                  description: |-
+                    RunnerCacheVolumeGiB is the quota (GiB) of the dedicated APFS volume
+                    bootstrap provisions to hold per-account cache-volume images. Unset
+                    (nil) falls back to the operator's global default; an explicit 0
+                    disables cache volumes on this host entirely.
+
+                    A pointer, unlike its sizing siblings, because 0 is a meaningful value
+                    here and nonsense for them. Staging a new host cold and enabling the
+                    cache once it is validated is how this feature gets rolled out, and with
+                    a scalar that intent would collapse into "unset" and silently inherit
+                    the fleet default, which matters more on a rack than on rented
+                    capacity, since the prototype box has a 256 GB disk that cannot hold the
+                    fleet's normal quota at all.
+                  type: integer
+              type: object
+            status:
+              description: StaticAppleSiliconMachineStatus is the observed state of the Machine.
+              properties:
+                addresses:
+                  description: |-
+                    Addresses surfaces the host's address so kubectl describe and event
+                    correlation can map back to a physical box.
+                  items:
+                    description: MachineAddress contains information for the node's address.
+                    properties:
+                      address:
+                        description: The machine address.
+                        type: string
+                      type:
+                        description: Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.
+                        type: string
+                    required:
+                      - address
+                      - type
+                    type: object
+                  type: array
+                bootstrapAttempts:
+                  description: |-
+                    BootstrapAttempts counts consecutive bootstrap failures on the currently
+                    held host. Reset to zero on a successful bootstrap, and whenever the
+                    underlying host changes (a mini swapped out), since the count describes
+                    a host rather than a Machine. It drives each kind's tiered recovery
+                    escalation: at the reboot threshold the controller clears volatile host
+                    state (PAM lockouts, sshd throttling, half-open connections), and at the
+                    give-up threshold it stops retrying the same box: the Scaleway kind by
+                    releasing it so a different mini gets claimed, the static kind by
+                    quarantining it, since releasing hardware we own would hand back the
+                    same broken host.
+                  format: int32
+                  type: integer
+                bootstrapRebootIssued:
+                  description: |-
+                    BootstrapRebootIssued records that a recovery reboot has already been
+                    triggered for the current host, so a long retry tail doesn't re-reboot
+                    it on every attempt past the threshold. Cleared when the host changes or
+                    on a successful bootstrap. What "reboot" means is kind-specific: the
+                    Scaleway kind calls the provider API, the static kind cycles the host's
+                    PDU outlet, which is a reboot because Apple silicon powers on when mains
+                    is applied.
+                  type: boolean
+                conditions:
+                  description: Conditions are CAPI-style condition entries (Provisioned, Bootstrapped).
+                  items:
+                    description: Condition defines an observation of a Cluster API resource operational state.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          Last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed. If that is not known, then using the time when
+                          the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          A human readable message indicating details about the transition.
+                          This field may be empty.
+                        type: string
+                      reason:
+                        description: |-
+                          The reason for the condition's last transition in CamelCase.
+                          The specific API may choose whether or not this field is considered a guaranteed API.
+                          This field may be empty.
+                        type: string
+                      severity:
+                        description: |-
+                          severity provides an explicit classification of Reason code, so the users or machines can immediately
+                          understand the current situation and act accordingly.
+                          The Severity field MUST be set only when Status=False.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                          can be useful (see .node.status.conditions), the ability to deconflict is important.
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                    type: object
+                  type: array
+                failedHostConfigHash:
+                  description: |-
+                    FailedHostConfigHash records the desired hash that exhausted its
+                    update-retry budget and drove the CR terminal. A broken config can never
+                    be applied, so HostConfigHash never advances to it and a
+                    desired-vs-last-applied comparison would see drift forever, resetting
+                    the retry cap on every reconcile. Comparing desired-vs-failed keeps the
+                    cap for an unchanged broken config while still retrying a new one.
+                  type: string
+                failureMessage:
+                  type: string
+                failureReason:
+                  description: |-
+                    FailureReason / FailureMessage are set on terminal failures. CAPI core
+                    surfaces them on the Machine object and stops auto-driving it.
+                  type: string
+                hostConfigHash:
+                  description: |-
+                    HostConfigHash is the fleet-wide canonical hash of every host config the
+                    operator pushes: the rendered install scripts plus the embedded
+                    binaries (bootstrap.HostConfigHash). Drift between this and the
+                    operator's own computed hash re-pushes on the next reconcile, so a
+                    change to ANY pushed config (a script tweak, a fleet CIDR, a re-baked
+                    binary) rolls to existing hosts rather than only a binary change.
+                  type: string
+                lastUpdateFailureTime:
+                  description: |-
+                    LastUpdateFailureTime is when the drift loop last recorded a failure for
+                    this host. It exists so the terminal state can expire on a timer:
+                    FailedHostConfigHash alone only lifts it when a NEW config ships, which
+                    is right for a config the host rejected and wrong for the far more
+                    common verdict: the host was simply unreachable (`dial tcp ...:22: i/o
+                    timeout`). Those hosts otherwise stay terminal indefinitely while
+                    remaining Ready, schedulable, and running jobs against a host config
+                    frozen at whatever the operator last managed to push, so a fleet-wide
+                    fix rolls out and silently misses them. Re-arming after a cooldown lets
+                    a host that has since come back take the current config on its own,
+                    while a genuinely broken config still backs off to one attempt budget
+                    per cooldown rather than per reconcile.
+                  format: date-time
+                  type: string
+                phase:
+                  description: |-
+                    Phase tracks lifecycle for operators: Pending | Adopting |
+                    Bootstrapping | Ready | Deleting | Failed. CAPI core drives off Ready +
+                    Conditions instead; this is the human-readable summary and the series
+                    the stuck-Failed alert keys on.
+                  type: string
+                rackHost:
+                  description: |-
+                    RackHost is the name of the claimed RackHost, empty before the claim.
+                    It is the Machine's half of the binding whose other half is that host's
+                    `status.claimedBy`; the delete path releases exactly this host.
+                  type: string
+                ready:
+                  description: |-
+                    Ready is set to true once bootstrap has completed and tart-kubelet is
+                    registering the Node. CAPI core reads this to mark the parent Machine
+                    Ready.
+                  type: boolean
+                tartKubeletBinarySHA:
+                  description: |-
+                    TartKubeletBinarySHA is the SHA-256 of the tart-kubelet binary currently
+                    installed on the host, stamped after each successful push. It is a
+                    record, not the drift trigger: HostConfigHash is, and it covers this
+                    binary among everything else.
+                  type: string
+                tartKubeletUpdateAttempts:
+                  description: |-
+                    TartKubeletUpdateAttempts counts consecutive failures of the drift
+                    loop's host-config push. Reset to zero on success. Once it crosses the
+                    operator's max-attempts threshold the CR transitions to a terminal
+                    Failed state with FailureReason "TartKubeletUpdateExceededRetries";
+                    CAPI core surfaces that on the parent Machine and stops auto-driving
+                    it. Recovery is automatic on a new config or an elapsed cooldown (see
+                    FailedHostConfigHash and LastUpdateFailureTime), and operator-driven
+                    before then: clear failureReason and zero this counter. Without the cap
+                    a persistently-broken host (binary corruption, a full disk, a network
+                    partition) gets SSH-hammered every 60s forever with no terminal signal
+                    for ops to alert on.
+                  format: int32
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_staticapplesiliconmachinetemplates.yaml
+++ b/infra/helm/tuist/crds/infrastructure.cluster.x-k8s.io_staticapplesiliconmachinetemplates.yaml
@@ -1,0 +1,171 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: staticapplesiliconmachinetemplates.infrastructure.cluster.x-k8s.io
+  labels:
+    cluster.x-k8s.io/v1beta1: v1alpha1
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+      - cluster-api
+    kind: StaticAppleSiliconMachineTemplate
+    listKind: StaticAppleSiliconMachineTemplateList
+    plural: staticapplesiliconmachinetemplates
+    shortNames:
+      - sasmt
+    singular: staticapplesiliconmachinetemplate
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            StaticAppleSiliconMachineTemplate is the template MachineDeployment +
+            MachineSet objects clone Machines from. Scaling the fleet is a replica count
+            against this one template because nothing host-specific lives in it: the
+            per-box facts are on the RackHost objects the clones then claim.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                StaticAppleSiliconMachineTemplateSpec wraps the per-Machine spec into the
+                template shape CAPI expects.
+              properties:
+                template:
+                  description: |-
+                    StaticAppleSiliconMachineTemplateResource is the embedded "spec" CAPI's
+                    MachineSet controller clones from when scaling up a MachineDeployment.
+                  properties:
+                    spec:
+                      description: |-
+                        StaticAppleSiliconMachineSpec is the desired state of one Mac mini we own.
+
+                        It is the adopt-only sibling of ScalewayAppleSiliconMachine: same host
+                        bootstrap, same host-config drift loop, same tailnet egress Service, but the
+                        host comes from a RackHost in the cluster's own inventory rather than from a
+                        provider's server list, and there is no order, no reinstall and no release
+                        path, because nobody bills us per host and no API can wipe one.
+
+                        Everything about the HOST lives on the RackHost (address, serial, outlet,
+                        position). Everything about the WORKLOAD lives here (sizing, fleet
+                        membership, kubelet version). That split is the point of having two kinds: a
+                        MachineDeployment clones this spec N times, and a spec carrying an address
+                        could not be cloned more than once.
+                      properties:
+                        adoptPool:
+                          description: |-
+                            AdoptPool is the RackHost pool this Machine claims from: the analog of
+                            the Scaleway kind's adoptPoolPrefix. The controller claims the first free
+                            RackHost whose `spec.pool` matches.
+
+                            Optional on purpose, even though every chart-rendered MachineTemplate
+                            sets it. A required field here is a schema constraint on a resource CAPI
+                            CLONES, so a MachineTemplate that lacks it fails
+                            `InfrastructureTemplateCloningFailed` on every MachineSet scale-up: and
+                            that drift stays invisible until the next scale-up, which is typically
+                            an operator recovering a host by deleting its Machine. The controller
+                            surfaces an empty value as a `NoAdoptPool` condition instead of scanning
+                            every RackHost in the namespace.
+                          type: string
+                        fleetName:
+                          description: |-
+                            FleetName groups Machines that share an SSH key and a sudo password. Set
+                            by the MachineTemplate to the parent MachineDeployment's name. Unlike the
+                            Scaleway fleets, the keypair is NOT minted in-cluster: rack hosts are
+                            provisioned out of band by MDM, which authorizes a key the operator never
+                            generated, so the fleet Secret is synced from 1Password by ESO and the
+                            controller only ever reads it.
+                          type: string
+                        guestCapacity:
+                          description: |-
+                            GuestCapacity is how many Tart guests this host is expected to run
+                            concurrently. It sizes the per-guest host resources (the VNC relay port
+                            range, the disk-pressure goldens floor); it does not create capacity,
+                            which HostCPU/HostMemoryMB and Tart's own two-guest SLA ceiling bind
+                            first. Falls back to the operator's global default when unset.
+                          type: integer
+                        hostCPU:
+                          description: |-
+                            HostCPU is the CPU-core count the host advertises on the Node it
+                            registers (Node.Status.Capacity), via tart-kubelet's `--host-cpu`. Falls
+                            back to the operator's global default when unset.
+
+                            Per-Machine for the same reason it is on the Scaleway kind, and more so
+                            here: a rack fills up over time and the boxes bought in month 12 are not
+                            the boxes bought in month 1.
+                          type: integer
+                        hostMemoryMB:
+                          description: |-
+                            HostMemoryMB is the memory advertised on the Node: the box's RAM minus
+                            the ~2 GB Apple's Virtualization.framework reserves for the host, below
+                            which `tart run` fails with `memorySize > maximumAllowedMemorySize`.
+                            Falls back to the operator's global default when unset.
+                          type: integer
+                        kubeletVersion:
+                          description: |-
+                            KubeletVersion override; defaults to the operator's chart-level value
+                            when empty.
+                          type: string
+                        maxPods:
+                          description: |-
+                            MaxPods is the Pod ceiling tart-kubelet advertises (`--max-pods`). Sized
+                            as guests x 2 + 1: a Pod stays bound to its Node after it finishes, so
+                            each guest slot can transiently hold its running Pod plus a predecessor
+                            GC has not collected, and the +1 is margin. Falls back to the operator's
+                            global default when unset.
+                          type: integer
+                        providerID:
+                          description: |-
+                            ProviderID, set by the controller once a RackHost is claimed, takes the
+                            shape `static-applesilicon://<site>/<serial>`; composed from the two
+                            durable physical facts, so re-cabling a host to a new address does not
+                            change its identity to CAPI. CAPI core expects this to populate; without
+                            it the parent Machine never goes Ready. The scheme is deliberately
+                            foreign to the Hetzner CCM so it never reaps the node, the same guard
+                            every other kind here uses.
+                          type: string
+                        runnerCacheVolumeGiB:
+                          description: |-
+                            RunnerCacheVolumeGiB is the quota (GiB) of the dedicated APFS volume
+                            bootstrap provisions to hold per-account cache-volume images. Unset
+                            (nil) falls back to the operator's global default; an explicit 0
+                            disables cache volumes on this host entirely.
+
+                            A pointer, unlike its sizing siblings, because 0 is a meaningful value
+                            here and nonsense for them. Staging a new host cold and enabling the
+                            cache once it is validated is how this feature gets rolled out, and with
+                            a scalar that intent would collapse into "unset" and silently inherit
+                            the fleet default, which matters more on a rack than on rented
+                            capacity, since the prototype box has a 256 GB disk that cannot hold the
+                            fleet's normal quota at all.
+                          type: integer
+                      type: object
+                  required:
+                    - spec
+                  type: object
+              required:
+                - template
+              type: object
+          type: object
+      served: true
+      storage: true


### PR DESCRIPTION
The `StaticAppleSiliconMachine` → `RackAppleSiliconMachine` rename left staging's retained Helm revisions referring to API kinds that were no longer installed. This PR retains the two legacy CRD definitions alongside the Rack definitions so Helm can read those revisions and upgrade the release.

### Why this is needed

On September 9, the staging deployment at `cc991515` installed the Rack CRDs and matching controller, then timed out waiting for Kura's wildcard certificate. Its atomic rollback restored controller image `4fbea028` and the old RBAC rules, but failed while recreating a `StaticAppleSiliconMachineTemplate` because that CRD was absent. The restored controller then repeatedly exited after its two-minute cache-sync timeout because it could not discover `StaticAppleSiliconMachine`.

Retrying the deployment after the certificate became Ready was insufficient: Helm could not even build the current release manifest while its legacy kinds were missing. Restoring only the controller image also left the rolled-back RBAC rules incompatible with the Rack resource names.

### Approach

- Restore `StaticAppleSiliconMachine` and `StaticAppleSiliconMachineTemplate` CRDs byte-for-byte from `4fbea028`. These are frozen compatibility definitions; the active controller, machine resources, and fleet templates continue to use the Rack kinds.
- Document why the definitions must remain installed until no retained Helm revision references them.

The existing deployment workflow applies chart CRDs before invoking Helm, so these definitions unblock manifest decoding through the normal deployment path. Installing them creates no machines or machine templates. Retaining them avoids rewriting Helm's stored release records or attempting to recreate fleet hosts. This does not make an old controller understand Rack resources; compatible controller images and RBAC are still required.

### Validation

- Rendered the chart from current main plus this change with the managed staging overlays and explicit image pins; `helm template --include-crds` passed.
- Parsed the rendered YAML: each of the four Static/Rack CRDs appears exactly once, and no legacy machine instances or templates are rendered.
- Verified both restored files are byte-identical to their definitions in `4fbea028`; `git diff --check` passed.
- Deployed the same compatibility definitions through an isolated recovery branch based on the original staging chart. [Final staging recovery run](https://github.com/tuist/tuist/actions/runs/34375711774) succeeded, recording Helm revision 683 as `deployed` with matching CAPI and Kura controller image pins. Server and registry smoke tests passed, both controllers were 2/2 healthy, all 15 nodes were Ready, and CAPI had no further restarts for over 17 minutes at final verification.

The recovery image pins are operational state and are intentionally not added as permanent chart defaults in this PR.
