### PR TITLE
fix(infra): reconcile Kura peer demuxes left behind by a region change

### DIFF
--- a/infra/kura-controller/controllers/peer_demux_controller.go
+++ b/infra/kura-controller/controllers/peer_demux_controller.go
@@ -342,8 +342,12 @@ func (r *PeerDemuxReconciler) image() string {
 	return defaultPeerDemuxImage
 }
 
-func (r *PeerDemuxReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	mapInstance := func(_ context.Context, obj client.Object) []reconcile.Request {
+// peerDemuxInstanceEventHandler enqueues the region of the KuraInstance an
+// event is about. EnqueueRequestsFromMapFunc maps both the old and the new
+// object of an update, so a region change also enqueues the region the
+// instance left and that region's demux is torn down.
+func peerDemuxInstanceEventHandler() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
 		instance, ok := obj.(*kurav1alpha1.KuraInstance)
 		if !ok || instance.Spec.Region == "" {
 			return nil
@@ -351,12 +355,15 @@ func (r *PeerDemuxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return []reconcile.Request{{
 			NamespacedName: types.NamespacedName{Name: instance.Spec.Region, Namespace: instance.Namespace},
 		}}
-	}
+	})
+}
+
+func (r *PeerDemuxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("peer-demux").
 		Watches(
 			&kurav1alpha1.KuraInstance{},
-			handler.EnqueueRequestsFromMapFunc(mapInstance),
+			peerDemuxInstanceEventHandler(),
 			builder.WithPredicates(kuraInstanceDesiredStateChangedPredicate()),
 		).
 		Complete(r)

--- a/infra/kura-controller/controllers/peer_demux_controller.go
+++ b/infra/kura-controller/controllers/peer_demux_controller.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kurav1alpha1 "github.com/tuist/tuist/infra/kura-controller/api/v1alpha1"
@@ -358,6 +359,24 @@ func peerDemuxInstanceEventHandler() handler.EventHandler {
 	})
 }
 
+// peerDemuxDaemonSetEventHandler enqueues the region a demux DaemonSet
+// belongs to. The informer's initial list emits a Create for every existing
+// demux, so a demux left behind for a region no instance is in any more (the
+// instances moved while the controller was not running) is reconciled and
+// torn down at startup instead of holding the host port forever.
+func peerDemuxDaemonSetEventHandler() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
+		labels := obj.GetLabels()
+		region := labels["tuist.dev/region"]
+		if labels["app.kubernetes.io/name"] != "kura-peer-demux" || region == "" {
+			return nil
+		}
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{Name: region, Namespace: obj.GetNamespace()},
+		}}
+	})
+}
+
 func (r *PeerDemuxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("peer-demux").
@@ -365,6 +384,11 @@ func (r *PeerDemuxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&kurav1alpha1.KuraInstance{},
 			peerDemuxInstanceEventHandler(),
 			builder.WithPredicates(kuraInstanceDesiredStateChangedPredicate()),
+		).
+		Watches(
+			&appsv1.DaemonSet{},
+			peerDemuxDaemonSetEventHandler(),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		Complete(r)
 }

--- a/infra/kura-controller/controllers/peer_demux_controller_test.go
+++ b/infra/kura-controller/controllers/peer_demux_controller_test.go
@@ -331,6 +331,96 @@ func TestPeerDemuxReconcileFollowsRegionChange(t *testing.T) {
 	}
 }
 
+func TestPeerDemuxDaemonSetEventHandlerEnqueuesItsRegion(t *testing.T) {
+	ctx := context.Background()
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[ctrl.Request]())
+	defer queue.ShutDown()
+
+	demux := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+		Name: peerDemuxName("eu-central"), Namespace: "kura", Labels: peerDemuxLabels("eu-central"),
+	}}
+	peerDemuxDaemonSetEventHandler().Create(ctx, event.CreateEvent{Object: demux}, queue)
+	got := drainPeerDemuxRequests(queue)
+	want := ctrl.Request{NamespacedName: types.NamespacedName{Name: "eu-central", Namespace: "kura"}}
+	if len(got) != 1 || !got[want] {
+		t.Fatalf("expected the demux DaemonSet to enqueue its region, got %v", got)
+	}
+
+	unrelated := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+		Name: "node-exporter", Namespace: "kura", Labels: map[string]string{"tuist.dev/region": "eu-central"},
+	}}
+	peerDemuxDaemonSetEventHandler().Create(ctx, event.CreateEvent{Object: unrelated}, queue)
+	if got := drainPeerDemuxRequests(queue); len(got) != 0 {
+		t.Fatalf("expected a DaemonSet that is not a demux to enqueue nothing, got %v", got)
+	}
+}
+
+func TestPeerDemuxReconcileTearsDownDemuxOrphanedWhileControllerWasDown(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := kurav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	instance := hostNetworkPeerInstance("kura-acme", "eu-central", "peer.acme-eu-central.kura.tuist.dev")
+	dns := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"},
+		Spec:       corev1.ServiceSpec{ClusterIP: "10.96.0.10"},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance, dns).Build()
+	reconciler := &PeerDemuxReconciler{Client: client, APIReader: client, Scheme: scheme}
+
+	if _, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "eu-central", Namespace: "kura"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The instance moves region while no controller is running, so no update
+	// event is ever observed for it.
+	moved := &kurav1alpha1.KuraInstance{}
+	if err := client.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: "kura"}, moved); err != nil {
+		t.Fatal(err)
+	}
+	moved.Spec.Region = "eu-west"
+	moved.Spec.MeshPublicPeerHost = "peer.acme-eu-west.kura.tuist.dev"
+	if err := client.Update(ctx, moved); err != nil {
+		t.Fatal(err)
+	}
+
+	// On restart the informers' initial lists emit a Create for every
+	// existing instance and demux DaemonSet.
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[ctrl.Request]())
+	defer queue.ShutDown()
+	peerDemuxInstanceEventHandler().Create(ctx, event.CreateEvent{Object: moved}, queue)
+	orphan := &appsv1.DaemonSet{}
+	if err := client.Get(ctx, types.NamespacedName{Name: peerDemuxName("eu-central"), Namespace: "kura"}, orphan); err != nil {
+		t.Fatal(err)
+	}
+	peerDemuxDaemonSetEventHandler().Create(ctx, event.CreateEvent{Object: orphan}, queue)
+	requests := drainPeerDemuxRequests(queue)
+	if !requests[ctrl.Request{NamespacedName: types.NamespacedName{Name: "eu-central", Namespace: "kura"}}] {
+		t.Fatalf("expected the orphaned demux to enqueue eu-central at startup, got %v", requests)
+	}
+	for request := range requests {
+		if _, err := reconciler.Reconcile(ctx, request); err != nil {
+			t.Fatalf("reconciling %s: %v", request.Name, err)
+		}
+	}
+
+	oldName := peerDemuxName("eu-central")
+	if err := client.Get(ctx, types.NamespacedName{Name: oldName, Namespace: "kura"}, &appsv1.DaemonSet{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected the orphaned eu-central demux DaemonSet to be deleted, got %v", err)
+	}
+	if err := client.Get(ctx, types.NamespacedName{Name: oldName, Namespace: "kura"}, &corev1.ConfigMap{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected the orphaned eu-central demux ConfigMap to be deleted, got %v", err)
+	}
+	if err := client.Get(ctx, types.NamespacedName{Name: peerDemuxName("eu-west"), Namespace: "kura"}, &appsv1.DaemonSet{}); err != nil {
+		t.Fatalf("expected the eu-west demux DaemonSet: %v", err)
+	}
+}
+
 func TestInstancePublicPeerServiceUsesClusterIPOnHostNetwork(t *testing.T) {
 	ctx := context.Background()
 	scheme := runtime.NewScheme()

--- a/infra/kura-controller/controllers/peer_demux_controller_test.go
+++ b/infra/kura-controller/controllers/peer_demux_controller_test.go
@@ -19,8 +19,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	kurav1alpha1 "github.com/tuist/tuist/infra/kura-controller/api/v1alpha1"
 )
@@ -214,6 +216,118 @@ func TestPeerDemuxReconcileCreatesAndTearsDown(t *testing.T) {
 	}
 	if err := client.Get(ctx, types.NamespacedName{Name: name, Namespace: "kura"}, &appsv1.DaemonSet{}); !apierrors.IsNotFound(err) {
 		t.Fatalf("expected demux DaemonSet to be deleted, got %v", err)
+	}
+}
+
+func drainPeerDemuxRequests(queue workqueue.TypedRateLimitingInterface[ctrl.Request]) map[ctrl.Request]bool {
+	requests := map[ctrl.Request]bool{}
+	for queue.Len() > 0 {
+		request, _ := queue.Get()
+		queue.Done(request)
+		requests[request] = true
+	}
+	return requests
+}
+
+func TestPeerDemuxInstanceEventHandlerEnqueuesBothRegionsOnRegionChange(t *testing.T) {
+	ctx := context.Background()
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[ctrl.Request]())
+	defer queue.ShutDown()
+
+	before := hostNetworkPeerInstance("kura-acme", "eu-central", "peer.acme-eu-central.kura.tuist.dev")
+	after := before.DeepCopy()
+	after.Spec.Region = "eu-west"
+	after.Spec.MeshPublicPeerHost = "peer.acme-eu-west.kura.tuist.dev"
+
+	peerDemuxInstanceEventHandler().Update(ctx, event.UpdateEvent{ObjectOld: before, ObjectNew: after}, queue)
+
+	got := drainPeerDemuxRequests(queue)
+	want := map[ctrl.Request]bool{
+		{NamespacedName: types.NamespacedName{Name: "eu-central", Namespace: "kura"}}: true,
+		{NamespacedName: types.NamespacedName{Name: "eu-west", Namespace: "kura"}}:    true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected the old and the new region to be enqueued, got %v", got)
+	}
+	for request := range want {
+		if !got[request] {
+			t.Fatalf("expected %s to be enqueued, got %v", request.Name, got)
+		}
+	}
+}
+
+func TestPeerDemuxReconcileFollowsRegionChange(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := kurav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	instance := hostNetworkPeerInstance("kura-acme", "eu-central", "peer.acme-eu-central.kura.tuist.dev")
+	dns := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"},
+		Spec:       corev1.ServiceSpec{ClusterIP: "10.96.0.10"},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance, dns).Build()
+	reconciler := &PeerDemuxReconciler{Client: client, APIReader: client, Scheme: scheme}
+
+	oldRegion := ctrl.Request{NamespacedName: types.NamespacedName{Name: "eu-central", Namespace: "kura"}}
+	if _, err := reconciler.Reconcile(ctx, oldRegion); err != nil {
+		t.Fatal(err)
+	}
+	oldName := peerDemuxName("eu-central")
+	if err := client.Get(ctx, types.NamespacedName{Name: oldName, Namespace: "kura"}, &appsv1.DaemonSet{}); err != nil {
+		t.Fatalf("expected the eu-central demux DaemonSet before the region change: %v", err)
+	}
+
+	before := &kurav1alpha1.KuraInstance{}
+	if err := client.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: "kura"}, before); err != nil {
+		t.Fatal(err)
+	}
+	after := before.DeepCopy()
+	after.Spec.Region = "eu-west"
+	after.Spec.MeshPublicPeerHost = "peer.acme-eu-west.kura.tuist.dev"
+	if err := client.Update(ctx, after); err != nil {
+		t.Fatal(err)
+	}
+
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[ctrl.Request]())
+	defer queue.ShutDown()
+	peerDemuxInstanceEventHandler().Update(ctx, event.UpdateEvent{ObjectOld: before, ObjectNew: after}, queue)
+	requests := drainPeerDemuxRequests(queue)
+	if len(requests) != 2 {
+		t.Fatalf("expected the region change to enqueue both regions, got %v", requests)
+	}
+	for request := range requests {
+		if _, err := reconciler.Reconcile(ctx, request); err != nil {
+			t.Fatalf("reconciling %s: %v", request.Name, err)
+		}
+	}
+
+	if err := client.Get(ctx, types.NamespacedName{Name: oldName, Namespace: "kura"}, &appsv1.DaemonSet{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected the eu-central demux DaemonSet to be deleted after the region change, got %v", err)
+	}
+	if err := client.Get(ctx, types.NamespacedName{Name: oldName, Namespace: "kura"}, &corev1.ConfigMap{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expected the eu-central demux ConfigMap to be deleted after the region change, got %v", err)
+	}
+
+	newName := peerDemuxName("eu-west")
+	configMap := &corev1.ConfigMap{}
+	if err := client.Get(ctx, types.NamespacedName{Name: newName, Namespace: "kura"}, configMap); err != nil {
+		t.Fatalf("expected the eu-west demux ConfigMap: %v", err)
+	}
+	if !strings.Contains(configMap.Data["nginx.conf"], "peer.acme-eu-west.kura.tuist.dev") {
+		t.Fatalf("eu-west demux config missing the account route:\n%s", configMap.Data["nginx.conf"])
+	}
+	daemonSet := &appsv1.DaemonSet{}
+	if err := client.Get(ctx, types.NamespacedName{Name: newName, Namespace: "kura"}, daemonSet); err != nil {
+		t.Fatalf("expected the eu-west demux DaemonSet: %v", err)
+	}
+	if daemonSet.Labels["tuist.dev/region"] != "eu-west" {
+		t.Fatalf("expected the eu-west demux DaemonSet to carry its region label, got %+v", daemonSet.Labels)
 	}
 }
 


### PR DESCRIPTION
## What changed

- `PeerDemuxReconciler` now also watches demux DaemonSets and maps each to the region in its `tuist.dev/region` label, filtered to generation changes so DaemonSet status updates do not requeue. Every existing demux is reconciled at startup and torn down when its region has no host-network peering instance left.
- The KuraInstance event handler is hoisted into `peerDemuxInstanceEventHandler` so tests drive the exact handler `SetupWithManager` wires. Its behaviour is unchanged.
- Four tests in `peer_demux_controller_test.go` cover both paths: an in-place region change on a live controller, and a region change that happened while the controller was down.

## Why

The eu-central to eu-west rename (#13061) changes `Spec.Region` on every instance in the region. The old region's demux (`kura-peer-demux-<region>`) is a hostNetwork DaemonSet binding the peer port, so if it is not torn down the new region's demux cannot bind until someone deletes the old one by hand.

The suspected cause was that the watch maps an event to the instance's current region only, so the old region would never be enqueued. That is not the case: controller-runtime's `EnqueueRequestsFromMapFunc` runs the map function against both the old and the new object of an update, the KuraInstance CRD has the status subresource so a region change bumps `Generation` and passes the existing predicate, and `Reconcile` already deletes a demux whose region has no host-network peering instance. The server applies the renamed instance in place under the same name, so the rename takes exactly this update path. The first commit adds tests proving it rather than a redundant `handler.Funcs`.

The gap that does exist is a restart window. After a restart the informer's initial list emits a Create for every current instance only. A region whose instances all moved while the controller was not running is never enqueued, and the 5-minute requeue does not help because it only covers regions reconciled at least once in the process lifetime. The DaemonSet watch closes it: the initial list also emits a Create for every existing demux, which enqueues its region.

## Alternatives considered

- Writing an explicit `handler.Funcs` with an `UpdateFunc` reading `ObjectOld` and `ObjectNew`. It would duplicate what `EnqueueRequestsFromMapFunc` already does.
- Also watching the demux ConfigMaps. The DaemonSet is what holds the port; a stray ConfigMap is harmless and both are deleted together by `Reconcile`, so the ConfigMap only orphans if its delete fails right after the DaemonSet delete succeeded.

## Impact

No behaviour change for regions with instances. The Helm role already grants list and watch on DaemonSets and the manager cache is namespace-scoped, so the new informer covers only the kura namespace. The manual `kubectl delete daemonset,configmap kura-peer-demux-eu-central` step in the rename runbook is no longer needed.

## Validation

- `go vet ./controllers/...` and `go test ./controllers/...` in `infra/kura-controller` pass.
- Mutation checks: with the KuraInstance handler changed to enqueue only the new region, the two region-change tests fail with `got map[kura/eu-west:true]`. With the DaemonSet mapping changed to enqueue nothing, the two startup tests fail with `got map[]` and `got map[kura/eu-west:true]`. Both mutations were reverted before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
