### PR TITLE
chore(cache): cordon the legacy cache endpoints Kura now covers

### DIFF
--- a/cache/config/deploy.production.yml
+++ b/cache/config/deploy.production.yml
@@ -3,7 +3,6 @@ servers:
     hosts:
       - cache-eu-central.tuist.dev
       - cache-eu-north.tuist.dev
-      - cache-us-east.tuist.dev
       - cache-us-east-2.tuist.dev
       - cache-us-east-3.tuist.dev
       - cache-us-west.tuist.dev

--- a/server/priv/repo/migrations/20260909170000_cordon_legacy_cache_endpoints.exs
+++ b/server/priv/repo/migrations/20260909170000_cordon_legacy_cache_endpoints.exs
@@ -1,0 +1,33 @@
+defmodule Tuist.Repo.Migrations.CordonLegacyCacheEndpoints do
+  use Ecto.Migration
+  # credo:disable-for-this-file ExcellentMigrations.CredoCheck.MigrationsSafety
+
+  # A cordon, not a decommission. The boxes stay up and stay in the Kamal fleet,
+  # so re-enabling is the whole rollback and `down` performs it. Everything a
+  # client is handed comes from CacheEndpoints.list_active_cache_endpoints/0,
+  # which filters on enabled, so these leave rotation on the next resolution
+  # while clients that resolved in the previous hour keep reaching a live box
+  # until their answer expires.
+  #
+  # Disabled rather than deleted for the same reason as the Vultr endpoints
+  # before them: CacheEndpointFormatter reads the whole table, so the row is what
+  # renders historical runs under the region's real name and what keeps it in the
+  # cache-runs filter. command_events has no TTL, so those runs stay queryable.
+  @urls [
+    "https://cache-ap-southeast.tuist.dev",
+    "https://cache-us-east-2.tuist.dev",
+    "https://cache-eu-north.tuist.dev"
+  ]
+
+  def up do
+    for url <- @urls do
+      execute "UPDATE cache_endpoints SET enabled = false, updated_at = NOW() WHERE url = '#{url}'"
+    end
+  end
+
+  def down do
+    for url <- @urls do
+      execute "UPDATE cache_endpoints SET enabled = true, updated_at = NOW() WHERE url = '#{url}'"
+    end
+  end
+end


### PR DESCRIPTION
## What changed

Four legacy cache boxes come out of service, in two different ways because they are not in the same state.

**Cordoned** (endpoint set to `enabled = false`, box left running and left in the Kamal fleet):

| endpoint | req/s | why |
|---|---|---|
| `cache-ap-southeast` | 5.3 | Kura already serves ap-southeast |
| `cache-eu-north` | 17 | its Nordic traffic is what eu-east (Warsaw) is being built for |
| `cache-us-east-2` | 1.4 | `cache-us-east-3` beside it carries 45x the load |

**Dropped from the Kamal fleet**: `cache-us-east`. Its endpoint has been `enabled = false` since 2026-06-05, so it has already been cordoned for three months and there is nothing left to take out of rotation. Removing the host stops Kamal deploying to and health-checking a box nothing routes to.

## Cordon rather than decommission

`down` re-enables all three. That is the point: these boxes stay up, stay deployed and stay in the fleet, so the rollback is a migration rollback and nothing has to be re-provisioned.

Everything handed to a client comes from `CacheEndpoints.list_active_cache_endpoints/0`, which filters on `enabled`, so a cordoned endpoint leaves rotation on the next resolution. Clients that resolved in the previous hour keep reaching a live box until their answer expires, which is exactly why the boxes stay up rather than being destroyed in the same change.

Disabled rather than deleted, following the Vultr endpoints before them: `CacheEndpointFormatter` reads the whole table, so the row is what renders historical runs under the region's real name and what keeps it in the cache-runs filter. `command_events` has no TTL, so those runs stay queryable.

## What this costs users, and where it is worth watching

Traffic on a cordoned endpoint fails over to the nearest remaining enabled one. The three are not equivalent in what that means:

- **`cache-ap-southeast` is the one to watch.** Singapore-region clients on the legacy lane have no nearer endpoint left; they fail over to Europe or US West, which is a large latency regression rather than a small one. Kura serving ap-southeast does not help them, because the legacy cache and the Kura mesh are separate lanes and an account only benefits once it is on Kura. This is the strongest argument for cordoning rather than destroying: if the regression shows up, `down` puts it back.
- **`cache-eu-north`** falls back to `cache-eu-central` in Paris, roughly 30ms for Nordic origins against a local box. Mild, and it is the population eu-east is about to serve directly.
- **`cache-us-east-2`** falls back to `cache-us-east-3`. Negligible.

Together the three carry 23.7 req/s of 712.8 across the fleet, so 3.3% of legacy cache traffic sees some regression.

## Fleet before and after

```
before  eu-central 425   us-west 201   us-east-3 63   eu-north 17
        ap-southeast 5.3   us-east-2 1.4   us-east 0.12 (disabled since June)

after   eu-central 425   us-west 201   us-east-3 63
```

`cache-us-east` was measured at 0.118 req/s against `cache-eu-central-canary` at 0.178, a box serving no production users at all. It sits below the infrastructure-only floor, which is consistent with the remaining traffic being the Kamal health checks this change stops.

## Validation

- Endpoint state read from production before writing the migration: the three targets are `enabled = true`, `cache-us-east` has been `false` since 2026-06-05.
- Per-endpoint request rates over 24h from `cache_nginx_http_responses_total`.
- `deploy.production.yml` still parses and lists the intended six hosts.
- `mix format --check-formatted` clean.

No box is destroyed here. Destroying follows once the cordon has been observed, and that sequence needs the endpoint TTL to expire first, then DNS records removed before the instances, then a check for orphaned storage.