### PR TITLE
feat(server): lift the fleet-wide apply ceiling off every placement kind but retire

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -242,7 +242,7 @@ server:
     # move it on. It exercises the parse, the per-kind budget and the sweep
     # under a non-empty value, not a real transition.
     - name: TUIST_KURA_PLACEMENT_AUTOMATIC_APPLIES_PER_DAY
-      value: expand=2,correct=2,relocate=1,retire=1
+      value: expand=all,correct=all,relocate=all,retire=25
     # Hand cluster-networked fleets the in-cluster cache endpoint. macOS
     # resolves to the node-port form (http://<node PN address>:<NodePort>
     # on scw-fr-par-runners), reached over the PN the minis attach to

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -213,24 +213,32 @@ server:
     # the time this was set over several days rather than in one pass, so the
     # first unattended moves are watched rather than found afterwards.
     #
-    # `retire` is the slowest lane because it is the only one whose cost lands
-    # before anyone can object: the instance stops serving within a minute, and
-    # an hour later the volume is deleted with no path back. Reopening the
-    # region needs `expand` to fire again, which is a fortnight of evidence
-    # away, so a wrong one costs that geography two weeks and a cold refill.
+    # `all` means no fleet-wide ceiling on that kind, which is the setting for
+    # every kind whose mistake is recoverable. What bounds those is the policy,
+    # asked per account: expansion stops at the plan's region count, relocation
+    # runs once a quarter, correction fires once in an account's life. Those
+    # scale with the fleet because they are per account. A fleet-wide count does
+    # not, and one sitting in front of a queue that grows with the account count
+    # only ever falls further behind.
     #
-    # It is on rather than held back because the rung no longer judges a window
-    # it has no history for (`Placement.history_covers_window?/2`). Without
-    # that it was the one kind partial history made *more* likely to fire, and
-    # the fleet would have retired real second regions on a floor reading a
-    # tenth of its window. With it, retirement stays quiet on its own until
-    # attribution is 90 days deep and turns itself on with no deploy.
+    # Falling behind is not merely slow here. A correction stops being available
+    # once the placement it replaces is a fortnight old, so a queue that runs
+    # long silently turns corrections into relocations, which need a quarter.
+    # The first day this ran capped, the whole fleet's allowance went in the
+    # first second: five applies, then eleven accounts waiting a full day.
     #
-    # Leaving it at zero was the alternative, and it is worse: `expand` would
-    # be a one-way ratchet, regions would only ever accumulate, and reclaiming
-    # them would be a standing manual chore nobody scheduled.
+    # `retire` keeps a ceiling because it is the only kind whose mistake cannot
+    # be taken back: the instance stops serving within a minute and the volume
+    # is deleted an hour later with no cancel path. The per-account limits say
+    # nothing about how many accounts move at once, so a rung deciding wrongly
+    # for the whole fleet has nothing else in front of it.
+    #
+    # 25 is a stop, not a throttle. Retirement is rare by construction (a region
+    # held 90 days, a full history window, under the floor, and not earning its
+    # place), so this should never bind on a real day; what it bounds is a
+    # fleet-wide misfire, to one day's worth of regions rather than all of them.
     - name: TUIST_KURA_PLACEMENT_AUTOMATIC_APPLIES_PER_DAY
-      value: expand=2,correct=2,relocate=1,retire=1
+      value: expand=all,correct=all,relocate=all,retire=25
     # Hand cluster-networked fleets the in-cluster cache endpoint. macOS
     # resolves to the node-port form (http://<node PN address>:<NodePort>
     # on scw-fr-par-runners), reached over the PN the minis attach to

--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -446,15 +446,23 @@ defmodule Tuist.Environment do
   otherwise. A placement transition costs a region's worth of cache refill,
   which is why this starts stopped where claim sizing does not.
 
-  Per kind because the kinds do not cost the same thing. An `expand` opens a
-  region and leaves every cache the account already has where it is; the
-  others give a region up, and what they spend is the refill of whatever was
-  warm in it. One budget over both would make the number chosen for how fast
-  the fleet may abandon caches also decide how fast it may grow, and would
-  leave no way to run the additive kind while a kind whose evidence is not yet
-  trustworthy stays supervised.
+  Per kind because only one kind needs a fleet-wide ceiling at all. Every rung
+  already limits how often a single account may move: expansion stops at the
+  plan's region count, relocation runs once a quarter, correction fires once in
+  an account's life. Those bound the thing worth bounding and they scale with
+  the fleet by construction. A count here bounds something different, which is
+  how much of the *whole fleet* may move in a day, and the only reason to want
+  that is a rung deciding wrongly for everyone at once. Retirement is where
+  that matters, because it deletes volumes an hour later with no cancel; the
+  others cost a cold cache and re-derive their own decision.
 
-  The format is `kind=count` pairs, such as `expand=2,correct=2,relocate=1`.
+  The format is `kind=count` pairs, such as `expand=all,relocate=all,retire=25`.
+  A count of `all` lifts the fleet-wide ceiling on that kind entirely, which is
+  the right setting for every kind whose mistake is recoverable: the rungs
+  already limit how often any one account may move, and a fleet-wide constant
+  in front of a queue that grows with the account count is a ceiling that stops
+  tracking the fleet the moment it grows.
+
   Which names are real kinds is
   `Tuist.Kura.PlacementProposals.automatic_apply_budgets/0`'s to decide. What
   is settled here is only that an unreadable pair is dropped rather than
@@ -471,11 +479,19 @@ defmodule Tuist.Environment do
 
   defp put_placement_budget(pair, budgets) do
     with [name, count] <- String.split(pair, "=", parts: 2),
-         {count, ""} <- count |> String.trim() |> Integer.parse(),
-         true <- count >= 0 do
+         {:ok, count} <- parse_placement_budget(String.trim(count)) do
       Map.put(budgets, String.trim(name), count)
     else
       _ -> budgets
+    end
+  end
+
+  defp parse_placement_budget("all"), do: {:ok, :unlimited}
+
+  defp parse_placement_budget(count) do
+    case Integer.parse(count) do
+      {count, ""} when count >= 0 -> {:ok, count}
+      _ -> :error
     end
   end
 

--- a/server/lib/tuist/kura/placement_proposals.ex
+++ b/server/lib/tuist/kura/placement_proposals.ex
@@ -71,12 +71,14 @@ defmodule Tuist.Kura.PlacementProposals do
   end
 
   @doc """
-  How many proposals of each kind the sweep may apply on its own in a day,
-  with every kind present.
+  How many proposals of each kind the sweep may apply on its own in a day, with
+  every kind present. A count, or `:unlimited` for a kind with no fleet-wide
+  ceiling.
 
   A kind the configuration does not name stays at zero, so a bare number turns
   nothing on: every kind has to be named to run unattended, and one that has to
-  be named cannot be enabled by a value written for the others.
+  be named cannot be enabled by a value written for the others. Zero is also
+  the stop, which is why it stays the default rather than `:unlimited`.
   """
   def automatic_apply_budgets do
     configured = Environment.kura_placement_automatic_applies_per_day()
@@ -85,8 +87,8 @@ defmodule Tuist.Kura.PlacementProposals do
   end
 
   @doc """
-  Open proposals of one kind, oldest first, capped at `limit`. What automatic
-  mode drains; the cap bounds how much placement may move in one pass.
+  Open proposals of one kind, oldest first, capped at `limit` or every one of
+  them for `:unlimited`. What automatic mode drains.
 
   Oldest first, so a backlog is drained in the order it accumulated and no
   proposal can be starved by a steady arrival of newer ones. Age is not
@@ -94,12 +96,23 @@ defmodule Tuist.Kura.PlacementProposals do
   its verdict still holds, so the oldest proposal is reasoned from the same
   hour's rollups as the newest.
   """
+  def open_proposals(kind, :unlimited) do
+    kind
+    |> open_proposals_query()
+    |> Repo.all()
+  end
+
   def open_proposals(kind, limit) do
+    kind
+    |> open_proposals_query()
+    |> limit(^limit)
+    |> Repo.all()
+  end
+
+  defp open_proposals_query(kind) do
     PlacementProposal
     |> where([proposal], proposal.status == :open and proposal.kind == ^kind)
     |> order_by([proposal], asc: proposal.inserted_at)
-    |> limit(^limit)
-    |> Repo.all()
   end
 
   @doc """

--- a/server/lib/tuist/kura/workers/placement_worker.ex
+++ b/server/lib/tuist/kura/workers/placement_worker.ex
@@ -1,7 +1,6 @@
 defmodule Tuist.Kura.Workers.PlacementWorker do
   @moduledoc """
-  Converges the placement proposal set, and applies proposals within a
-  fleet-wide daily budget per proposal kind.
+  Converges the placement proposal set, and applies the proposals it may.
 
   Hourly. Every threshold it reads is a span of whole days, so the cadence
   changes nothing about when a region is added or left; what it changes is how
@@ -10,9 +9,9 @@ defmodule Tuist.Kura.Workers.PlacementWorker do
   little and a day would mean deciding from evidence that has moved on.
 
   Every budget starts at zero, so the sweep proposes and an operator applies.
-  That is the supervised phase the rollout asks for, and raising a budget is
-  what graduates one kind to automatic — a configuration change rather than a
-  code path, so the two phases cannot diverge.
+  Raising a budget is what graduates one kind to automatic: a configuration
+  change rather than a code path, so the two phases cannot diverge, and zero
+  stays the way to stop a kind without a deploy of its own.
   """
 
   use Oban.Worker,
@@ -36,15 +35,26 @@ defmodule Tuist.Kura.Workers.PlacementWorker do
     :ok
   end
 
-  # A rate over a trailing day rather than a per-pass count, so changing the
-  # cadence cannot multiply how much the fleet moves. Operator applies do not
-  # spend it: the budget guards what happens unattended.
+  # Most kinds have no ceiling here, and drain whatever the sweep left open.
+  # What bounds them is the policy, per account: expansion stops at the plan's
+  # region count, relocation runs once a quarter, correction fires once in an
+  # account's life. Those scale with the fleet because they are asked per
+  # account; a fleet-wide count does not, and one sat in front of a queue that
+  # grows with the account count only ever falls further behind. It would also
+  # do real damage rather than merely delay: a correction expires once the
+  # placement it replaces is a fortnight old, so a queue that runs long turns
+  # corrections into three-month relocations.
   #
-  # Each kind draws on its own budget, so a fleet-wide count cannot be spent by
-  # whichever kind happens to sit oldest in the backlog. Two accounts waiting
-  # to expand must not be able to hold back the account that is being served
-  # from the wrong continent, and neither must be able to spend the allowance
-  # that decides how fast warm caches are given up.
+  # A ceiling is kept where a mistake cannot be taken back, which is retirement
+  # alone. Per-account limits say nothing about how many accounts move at once,
+  # so a rung deciding wrongly for the whole fleet is bounded by nothing else.
+  # Sized as a stop rather than a throttle: high enough that it never binds on
+  # a real day, low enough that a fleet-wide misfire costs one day's worth of
+  # regions instead of all of them.
+  #
+  # What ceilings remain are a rate over a trailing day rather than a per-pass
+  # count, so changing the cadence cannot multiply how much the fleet moves.
+  # Operator applies do not spend them: they guard what happens unattended.
   defp apply_within_budget do
     spent =
       DateTime.utc_now()
@@ -52,15 +62,20 @@ defmodule Tuist.Kura.Workers.PlacementWorker do
       |> PlacementProposals.automatic_applies_since()
 
     Enum.each(PlacementProposals.automatic_apply_budgets(), fn {kind, allowed} ->
-      case allowed - Map.fetch!(spent, kind) do
-        budget when budget > 0 ->
-          kind
-          |> PlacementProposals.open_proposals(budget)
-          |> Enum.each(&Kura.apply_placement_proposal(&1, "automatic"))
-
-        _exhausted ->
-          :ok
+      case remaining(allowed, Map.fetch!(spent, kind)) do
+        :unlimited -> apply_open(kind, :unlimited)
+        budget when budget > 0 -> apply_open(kind, budget)
+        _exhausted -> :ok
       end
     end)
+  end
+
+  defp remaining(:unlimited, _spent), do: :unlimited
+  defp remaining(allowed, spent), do: allowed - spent
+
+  defp apply_open(kind, limit) do
+    kind
+    |> PlacementProposals.open_proposals(limit)
+    |> Enum.each(&Kura.apply_placement_proposal(&1, "automatic"))
   end
 end

--- a/server/test/tuist/environment_test.exs
+++ b/server/test/tuist/environment_test.exs
@@ -42,6 +42,13 @@ defmodule Tuist.EnvironmentTest do
       assert Environment.kura_placement_automatic_applies_per_day(environment) == %{}
     end
 
+    test "reads `all` as no ceiling for that kind" do
+      environment = %{"TUIST_KURA_PLACEMENT_AUTOMATIC_APPLIES_PER_DAY" => "expand=all,retire=25"}
+
+      assert Environment.kura_placement_automatic_applies_per_day(environment) ==
+               %{"expand" => :unlimited, "retire" => 25}
+    end
+
     test "drops an unreadable pair without losing the readable ones" do
       environment = %{"TUIST_KURA_PLACEMENT_AUTOMATIC_APPLIES_PER_DAY" => "expand=2,correct=two,retire=-1"}
 

--- a/server/test/tuist/kura/workers/placement_worker_test.exs
+++ b/server/test/tuist/kura/workers/placement_worker_test.exs
@@ -115,6 +115,57 @@ defmodule Tuist.Kura.Workers.PlacementWorkerTest do
     assert applied == 1
   end
 
+  test "applies every open proposal of an uncapped kind in one pass" do
+    # What bounds an uncapped kind is the policy, per account. A fleet-wide
+    # count in front of a queue that grows with the account count only ever
+    # falls further behind.
+    stub_budgets(%{correct: :unlimited})
+    accounts = for _ <- 1..4, do: account_with_moved_traffic()
+
+    assert :ok = perform_job(PlacementWorker, %{})
+
+    applied =
+      accounts
+      |> Enum.map(&PlacerRegions.primary_region/1)
+      |> Enum.count(&(&1 == "eu-central"))
+
+    assert applied == 4
+  end
+
+  test "an uncapped kind is not held back by what it already spent today" do
+    # The trailing-day spend is what a ceiling is measured against, so a kind
+    # without one must not accumulate against it either.
+    stub_budgets(%{correct: :unlimited})
+    first = for _ <- 1..3, do: account_with_moved_traffic()
+
+    assert :ok = perform_job(PlacementWorker, %{})
+
+    second = for _ <- 1..3, do: account_with_moved_traffic()
+
+    assert :ok = perform_job(PlacementWorker, %{})
+
+    applied =
+      (first ++ second)
+      |> Enum.map(&PlacerRegions.primary_region/1)
+      |> Enum.count(&(&1 == "eu-central"))
+
+    assert applied == 6
+  end
+
+  test "a capped kind still stops at its ceiling while another runs uncapped" do
+    stub_budgets(%{correct: :unlimited, expand: 1})
+    accounts = for _ <- 1..3, do: account_with_moved_traffic()
+
+    assert :ok = perform_job(PlacementWorker, %{})
+
+    applied =
+      accounts
+      |> Enum.map(&PlacerRegions.primary_region/1)
+      |> Enum.count(&(&1 == "eu-central"))
+
+    assert applied == 3
+  end
+
   defp stub_budgets(budgets) do
     configured = Map.new(budgets, fn {kind, count} -> {to_string(kind), count} end)
     stub(Environment, :kura_placement_automatic_applies_per_day, fn -> configured end)


### PR DESCRIPTION
Draft. Follow-up to [#13052](https://github.com/tuist/tuist/pull/13052), which turned automatic placement applies on and capped every kind at a handful a day.

## Why

The daily budget was doing two different jobs, and it is the wrong unit for one of them.

It reads as a throughput limit, and as one it does not scale. It is a fleet-wide constant sitting in front of a queue that grows with the account count, so the queue only ever falls further behind. The rungs already limit how often any *single* account may move, and those limits are the ones that matter:

| Limit | Scope |
| --- | --- |
| `max_instances`, 2/3/5 by plan | Per account |
| One relocation per 90 days | Per account |
| Correction fires once, ever | Per account |
| One open proposal at a time | Per account |
| The apply budget | **Whole fleet** |

The per-account limits scale by construction because they are asked per account. The fleet-wide count does not.

**Falling behind is not merely slow.** A correction stops being available once the placement it replaces is a fortnight old: `guessed_recently?` goes false, the sweep supersedes the open proposal, and the account waits for a relocation instead, which needs a quarter and a 60% majority. A queue that runs long therefore converts cheap corrections into expensive ones and drops them without saying so.

Measured on the first day this ran capped, on a fleet of 76 instances: the whole fleet's allowance went in the first second of the 16:40 pass, five applies across five accounts, and eleven accounts then waited a full day for the next allowance.

## What changed

- A count of `all` in `TUIST_KURA_PLACEMENT_AUTOMATIC_APPLIES_PER_DAY` lifts the fleet-wide ceiling on that kind.
- `PlacementProposals.open_proposals/2` takes `:unlimited` as well as a count.
- Production and canary move from `expand=2,correct=2,relocate=1,retire=1` to `expand=all,correct=all,relocate=all,retire=25`.

A kind the configuration does not name still stays at zero, so dropping the variable fails stopped rather than wide open, and zero remains the way to halt a kind without a code change.

## Why retirement keeps a ceiling

It is the only kind whose mistake cannot be taken back. The instance stops serving within a minute of the apply, and 62 minutes later teardown deletes the volume, with no cancel branch: unlike an inactivity drain, returning traffic does not rescue a placement retirement. Reopening the region needs `expand` to fire again, which is a fortnight of evidence away, and it comes back cold.

The per-account limits are no help against that. They bound how often one account moves and say nothing about how many accounts move at once, which is exactly what a rung deciding wrongly for the whole fleet does. That is not hypothetical: before the history-depth guard in #13052, every eligible secondary in the fleet was retirable simultaneously on a floor reading a tenth of its window.

`retire=25` is a stop, not a throttle. Retirement is rare by construction, needing a region held 90 days, a full history window, traffic under the floor, and a failure to earn its place, so 25 should never bind on a real day. What it bounds is a fleet-wide misfire, to one day's worth of regions rather than all of them.

The other three keep no ceiling because their worst case is a cold cache and a decision that re-derives itself on the next sweep.

## Validation

- `mix test test/tuist/environment_test.exs test/tuist/kura/` passes, 840 tests.
- The three new uncapped-path tests were each run against a simulated finite ceiling and fail there, so they discriminate rather than passing vacuously.
- `mix credo --strict` on the changed modules reports nothing new. `mix format` clean.
- Both values files parse, the value lands in `server.extraEnv`, and neither file has a duplicate env name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
