### PR TITLE
fix(ci): restore the java lockfile entry the pinned mise can match

### DIFF
--- a/.github/workflows/gradle-cache-acceptance.yml
+++ b/.github/workflows/gradle-cache-acceptance.yml
@@ -9,6 +9,8 @@ on:
       - server/**
       - cache/**
       - .github/workflows/gradle-cache-acceptance.yml
+      - mise.toml
+      - mise.lock
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -16,6 +18,8 @@ on:
       - server/**
       - cache/**
       - .github/workflows/gradle-cache-acceptance.yml
+      - mise.toml
+      - mise.lock
   merge_group: {}
 
 permissions:

--- a/mise.lock
+++ b/mise.lock
@@ -283,9 +283,6 @@ url = "https://get.helm.sh/helm-v4.2.0-windows-amd64.tar.gz"
 version = "21.0.2"
 backend = "core:java"
 
-[tools.java.options]
-shorthand_vendor = "openjdk"
-
 [tools.java."platforms.linux-arm64"]
 checksum = "sha256:08db1392a48d4eb5ea5315cf8f18b89dbaf36cda663ba882cf03c704c9257ec2"
 url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-aarch64_bin.tar.gz"


### PR DESCRIPTION
## What changed

Removed the `[tools.java.options] shorthand_vendor = "openjdk"` block from the root `mise.lock`, and added root `mise.toml` / `mise.lock` to the Gradle Cache Acceptance workflow's path filters.

## Why

The Gradle Cache Acceptance job has failed on every pull request and on main since #13072 merged:

```
mise ERROR Failed to install core:java@21: No lockfile URL found for java@21.0.2 on platform linux-x64 (--locked mode)
hint: Run `mise lock` to generate lockfile URLs, or disable locked mode
```

The last green main run was `2cac7e4d4` at 16:24 UTC; the first run after #13072 landed (`04440169b`, 16:54 UTC) failed with this error, and every run since fails the same way.

## Root cause

#13072 was a Helm change, but it also carried an incidental rewrite of the root `mise.lock` java entry, adding an options block written by a newer mise than the one CI pins.

`get_locked_version` in mise's `src/lockfile.rs` matches a lock entry on the version prefix **and** exact equality of the options map:

```rust
let options_match = &v.options == request_options;
version_matches && options_match
```

What the request resolves to differs by mise version. From 2026.9 onwards, `JavaOptions::lockfile_options` takes the requested version and the `java.shorthand_vendor` setting, and a shorthand request (no `-` in the version, so `java = "21"`) gets `{shorthand_vendor: "openjdk"}`. On the 2026.5.15 that `.github/actions/mise` pins, the same function takes no arguments and returns an empty map for that request.

So the entry the newer mise wrote can only be matched by a newer mise. Under CI's pinned mise the lookup misses, `--locked` has no URL to download from, and the install aborts before it touches the network.

## Why this fix over the alternatives

Removing the block restores `mise.lock` byte-for-byte to the blob main was last green on (`650eb13467`), so the change carries no other risk.

Bumping the pinned mise to 2026.9.x would also make the lookup succeed and is where the toolchain eventually goes, but it is a toolchain upgrade across every job in the repository, landed while CI is red for everyone. That belongs in its own pull request, alongside regenerating the lockfiles.

Note the hazard is symmetric: when Renovate bumps the mise pin past 2026.9, this entry has to come back, because a lock entry without the key stops matching a shorthand java request under the newer mise.

`kura/mise.lock` picked up the same kind of leak in #13072, a `[tools.rust.options]` block. It is left alone: the mise-install action installs `rust` without `--locked`, so the strict option match never runs, and the kura workflow is green.

## Path filters

The job installs its entire toolchain (java, gradle, tuist, bats) from the root lockfile, yet the workflow only triggers on `gradle/`, `server/`, `cache/` and its own file. A lockfile change could break it with nothing to catch it, which is exactly what happened, and it is also how a bad canary Tuist bump would land. `cli.yml` and `helm.yml` already guard their lockfiles this way. This also makes the present pull request self-validating.

## Validation

Reproduced and fixed locally on mise 2026.5.15, the exact version CI pins. An isolated config containing only `java = "21"` and this lock entry:

| lock entry | `mise install --locked java` |
| --- | --- |
| with the options block | fails on the lockfile lookup |
| without it | installs 21.0.2 from the lockfile URL |

Impact: unblocks the Gradle Cache Acceptance job on main and on every open pull request that touches `gradle/`, `server/` or `cache/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)