### PR TITLE
fix(infra): drop the vendor option from the Java lock entry so locked installs resolve

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -283,9 +283,6 @@ url = "https://get.helm.sh/helm-v4.2.0-windows-amd64.tar.gz"
 version = "21.0.2"
 backend = "core:java"
 
-[tools.java.options]
-shorthand_vendor = "openjdk"
-
 [tools.java."platforms.linux-arm64"]
 checksum = "sha256:08db1392a48d4eb5ea5315cf8f18b89dbaf36cda663ba882cf03c704c9257ec2"
 url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-aarch64_bin.tar.gz"


### PR DESCRIPTION
Every job that installs Java through the mise composite action with `--locked` has failed at tool install since [#13072](https://github.com/tuist/tuist/pull/13072), on main and on every pull request, with `No lockfile URL found for java@21.0.2 on platform linux-x64`. The Gradle Cache Acceptance workflow is the visible one. Pull requests fail even when their own branch predates #13072, because Actions checks a pull request out merged into main.

### Root cause

#13072 added `shorthand_vendor = "openjdk"` under the Java entry's options in `mise.lock`. The root `mise.toml` requests plain `java = "21"`, and a locked lookup matches a request against an entry's options as well as its version, so the entry stopped matching and mise reported `java@21` as absent from the lock. The URLs and checksums were never the problem; `mise lock` run against the current file appends a second, option-less entry rather than fixing the first, which is how this was found.

### What changed

The three option lines are removed. Nothing else in the lock moves.

### Validation

`mise install --locked java` with the pinned mise (2026.5.15) and `MISE_DATA_DIR` pointed at a scratch directory: the lock with the option fails with `java@21 is not in the lockfile`; without it, 21.0.2 installs through the locked URL and the install leaves the lock untouched. The same commit is carried on [#13061](https://github.com/tuist/tuist/pull/13061) and [#13067](https://github.com/tuist/tuist/pull/13067) so their checks can run; once this lands, merging main into them is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
