### PR TITLE
chore(cli): probe the macOS runner cache path (do not merge)

### DIFF
--- a/cli/Sources/TuistSupport/CoreDataVersionExtractor.swift
+++ b/cli/Sources/TuistSupport/CoreDataVersionExtractor.swift
@@ -58,3 +58,5 @@ public enum CoreDataVersionExtractorError: FatalError, Equatable {
         }
     }
 }
+
+// Cache probe: exercises the macOS runner cache path; branch is deleted after the run.


### PR DESCRIPTION
Throwaway PR to push cache misses from macOS Tuist runners through the tuist account's runner-region Kura node while pull replication is enabled. Will be closed and the branch deleted once the workflow run completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)