### PR TITLE
fix(server): stop the shadow mirror losing writes it could have kept

### DIFF
--- a/server/lib/tuist/ingest_repo/shadow_write.ex
+++ b/server/lib/tuist/ingest_repo/shadow_write.ex
@@ -83,7 +83,18 @@ defmodule Tuist.IngestRepo.ShadowWrite do
   # Started by `Tuist.Application`, which is also where the bound on it lives.
   @supervisor __MODULE__.TaskSupervisor
 
+  # A mutation is mirrored inside the request that issued it, so its retry
+  # budget is charged to a customer waiting on a response and has to stay
+  # small. An insert is handed to the supervisor above and nothing waits on
+  # it, so it can afford to sit out a slow destination rather than be dropped.
+  #
+  # The two were the same number, and three attempts one second apart is
+  # shorter than a single `queue_timeout` on a saturated pool. Every attempt
+  # then landed inside the same stall, and the row was lost: that is how
+  # canary lost writes while a backfill was loading the destination.
   @attempts 3
+  @detached_attempts 6
+  @max_backoff_ms 30_000
 
   # How long a mutation waits for the inserts before it, in the request that
   # issued it.
@@ -124,7 +135,7 @@ defmodule Tuist.IngestRepo.ShadowWrite do
         # still be queued, so the delete can overtake them and the row it
         # removed is written back immediately afterwards.
         await_inflight_mirrors()
-        mirror(run, kind)
+        mirror(run, kind, 1, @attempts)
       end
     end
 
@@ -163,7 +174,7 @@ defmodule Tuist.IngestRepo.ShadowWrite do
   def write?(_sql), do: false
 
   defp detach(fun, kind) do
-    case Task.Supervisor.start_child(@supervisor, fn -> mirror(fun, kind) end) do
+    case Task.Supervisor.start_child(@supervisor, fn -> mirror(fun, kind, 1, @detached_attempts) end) do
       {:ok, _pid} ->
         :ok
 
@@ -190,7 +201,10 @@ defmodule Tuist.IngestRepo.ShadowWrite do
     # exactly where latency does not matter: under `bin/tuist eval`, and
     # during shutdown once it has stopped but the ingest buffers have not yet
     # made their final flush.
-    :exit, _reason -> mirror(fun, kind)
+    # The short budget, not the detached one: one of the two cases this covers
+    # is shutdown, where sitting out a slow destination would outlast the pod's
+    # grace period and lose the flush to a SIGKILL instead of a retry.
+    :exit, _reason -> mirror(fun, kind, 1, @attempts)
   end
 
   # Bounded, because this runs in the request that issued the mutation, and a
@@ -219,7 +233,7 @@ defmodule Tuist.IngestRepo.ShadowWrite do
     :exit, _reason -> :ok
   end
 
-  defp mirror(fun, kind, attempt \\ 1) do
+  defp mirror(fun, kind, attempt, max_attempts) do
     # Matched rather than ignored. The raw mirrors call `query/3`, which
     # answers `{:error, exception}` instead of raising, so a rejected write
     # would otherwise be counted as a success and never retried: exactly the
@@ -227,32 +241,38 @@ defmodule Tuist.IngestRepo.ShadowWrite do
     # flushes and the mutation-based deletes.
     case fun.() do
       {:error, error} ->
-        retry_or_give_up(fun, kind, attempt, "was rejected: #{inspect(error)}")
+        retry_or_give_up(fun, kind, attempt, max_attempts, "was rejected: #{inspect(error)}")
 
       _ ->
         :telemetry.execute([:tuist, :clickhouse, :shadow_write], %{count: 1}, %{kind: kind, result: :ok})
     end
   rescue
-    error -> retry_or_give_up(fun, kind, attempt, "failed: #{Exception.message(error)}")
+    error -> retry_or_give_up(fun, kind, attempt, max_attempts, "failed: #{Exception.message(error)}")
   catch
-    :exit, reason -> retry_or_give_up(fun, kind, attempt, "exited: #{inspect(reason)}")
+    :exit, reason -> retry_or_give_up(fun, kind, attempt, max_attempts, "exited: #{inspect(reason)}")
   end
 
-  defp retry_or_give_up(fun, kind, attempt, _reason) when attempt < @attempts do
+  defp retry_or_give_up(fun, kind, attempt, max_attempts, _reason) when attempt < max_attempts do
     # Counted rather than logged: the failure worth retrying is a pool that is
     # not ready yet, and it produces a burst of them at once, so a log line per
     # attempt would bury the deploy it happened on.
     :telemetry.execute([:tuist, :clickhouse, :shadow_write], %{count: 1}, %{kind: kind, result: :retried})
 
-    Process.sleep(attempt * 1000)
-    mirror(fun, kind, attempt + 1)
+    Process.sleep(backoff_ms(attempt))
+    mirror(fun, kind, attempt + 1, max_attempts)
   end
 
-  defp retry_or_give_up(_fun, kind, _attempt, reason) do
+  defp retry_or_give_up(_fun, kind, _attempt, _max_attempts, reason) do
     :telemetry.execute([:tuist, :clickhouse, :shadow_write], %{count: 1}, %{kind: kind, result: :error})
 
     Logger.error("Shadow ClickHouse write (#{kind}) #{reason}")
     :error
+  end
+
+  # Doubling rather than linear, capped so a long stall does not turn into an
+  # unbounded sleep holding a supervisor slot.
+  defp backoff_ms(attempt) do
+    min(Bitwise.bsl(1, attempt - 1) * 1_000, @max_backoff_ms)
   end
 
   # Two conditions, not one. The repository is only in the supervision tree

--- a/server/lib/tuist/release.ex
+++ b/server/lib/tuist/release.ex
@@ -57,21 +57,44 @@ defmodule Tuist.Release do
 
     assert_supported_clickhouse_version()
 
-    for repo <- repos() do
-      {:ok, _, _} =
-        Ecto.Migrator.with_repo(repo, fn repo ->
-          ensure_database_schema(repo)
-          Ecto.Migrator.run(repo, :up, all: true)
-          assert_all_migrations_up(repo)
-          grant_runtime_role(repo)
-          grant_processor_role(repo)
-          grant_swift_registry_sync_role(repo)
-          grant_grafana_role(repo)
-          reconcile_ops_clickhouse(repo)
-        end)
-    end
+    with_shadow_ingest_repo(fn ->
+      for repo <- repos() do
+        {:ok, _, _} =
+          Ecto.Migrator.with_repo(repo, fn repo ->
+            ensure_database_schema(repo)
+            Ecto.Migrator.run(repo, :up, all: true)
+            assert_all_migrations_up(repo)
+            grant_runtime_role(repo)
+            grant_processor_role(repo)
+            grant_swift_registry_sync_role(repo)
+            grant_grafana_role(repo)
+            reconcile_ops_clickhouse(repo)
+          end)
+      end
+    end)
 
     reconcile_bare_metal_clickhouse_schema()
+  end
+
+  # Migrating with shadow writes on mirrors every `Tuist.IngestRepo` write to
+  # the in-cluster server, including the `schema_migrations` insert Ecto makes
+  # after each migration. `Ecto.Migrator.with_repo/3` below starts the repo
+  # being migrated and nothing else, so the destination was never started and
+  # every one of those mirrors failed at lookup:
+  #
+  #   Shadow ClickHouse write (insert) failed: could not lookup Ecto repo
+  #   Tuist.ShadowIngestRepo because it was not started or it does not exist
+  #
+  # That failure is terminal rather than retried, because a repo that is not
+  # started will not become started, so each one was a row the destination
+  # never received, on every deploy that ran migrations.
+  defp with_shadow_ingest_repo(fun) do
+    if is_nil(Environment.clickhouse_bare_metal_url()) do
+      fun.()
+    else
+      {:ok, result, _apps} = Ecto.Migrator.with_repo(Tuist.ShadowIngestRepo, fn _started -> fun.() end)
+      result
+    end
   end
 
   # Brings the in-cluster ClickHouse's schema back in line with the source, for


### PR DESCRIPTION
## Why

Canary's `tuist_clickhouse_shadow_write_count{result="error"}` kept climbing with no explanation, and the parity check reported up to 13 of 59 tables diverging as a result. I attributed it to the shadow pool warming up at pod start, carried over from a note about staging. That was wrong. The logs name two distinct causes, and neither is warmup.

Staging is the control and it is clean: 2845 mirrored writes with **no** `error` and **no** `retried` series at all. So this is not inherent to dual writes.

## Cause 1: the migration Job mirrored into a repository that was never started

```
container=migrate  [error] Shadow ClickHouse write (insert) failed:
could not lookup Ecto repo Tuist.ShadowIngestRepo because it was not started or it does not exist
```

`Tuist.Release.migrate` runs under `bin/tuist eval`, which loads the application without starting it, and `Ecto.Migrator.with_repo/3` starts only the repository being migrated. With shadow writes on, every `Tuist.IngestRepo` write during a migration is intercepted and mirrored, including the `schema_migrations` insert Ecto makes after each migration. All of them failed at lookup.

Retrying cannot help here, because a repository that is not started will not become started, so each failure was a row the destination never received, on **every deploy that ran migrations**. `migrate` now starts the destination for the duration and skips that when no destination is configured.

This is the same shape as the bug that opened this workstream, where `bin/tuist eval` had not started `Tuist.Repo`. The pattern is that release-task contexts do not go through `application.ex`, so anything the mirror needs has to be started explicitly.

## Cause 2: the retry budget was shorter than the stall it exists to cover

```
[error] Shadow ClickHouse write (insert_all) failed: connection not available and
request was dropped from queue after 3999ms ... reason: :queue_timeout
```

Timestamped inside the `r896` backfill window. The backfill loads the destination, mirrored writes slow down, the pool saturates, and DBConnection drops queued requests. Three attempts one second apart is shorter than a single `queue_timeout` on a saturated pool, so all three attempts landed inside the same stall and the row was lost.

The budget is now split by **who waits**:

| path | attempts | backoff | why |
|---|---|---|---|
| mutation, mirrored in-request | 3 | 1s, 2s | retries are charged to a customer waiting on a response |
| insert, handed to the task supervisor | 6 | doubling, capped at 30s | nothing waits on it, so it can sit out a slow destination |
| inline fallback when the supervisor is gone | 3 | 1s, 2s | one case it covers is shutdown, where a long sleep outlasts the grace period and loses the flush to a SIGKILL |

The mutation path is unchanged on purpose. Those mirrors run inside the request that issued them, and the logs show them carrying `request_id` and `auth_account_handle`, so lengthening their retries would block real requests.

## What this does not fix

It reduces loss rather than eliminating it. A copy that loads the destination for hours outlasts any retry budget worth having near a request path, so **a backfill run concurrently with traffic still needs a repair pass afterwards, with a cutoff later than the run**. That is what the runbook already prescribes, and it is now the documented expectation rather than a surprise.

Cause 1 is the one that matters most for production: it fires on every deploy with migrations, silently, and would have continued through the cutover.

## Validation

`mix compile` clean, `mix format --check-formatted` clean, `mix credo` clean, and the 51 tests across `test/tuist/clickhouse/` and `test/tuist/ingest_repo/shadow_write_test.exs` pass.

Draft, because the behaviour that matters is only observable on a cluster: the check worth having is a canary deploy that runs migrations producing no `could not lookup Ecto repo` lines, and a subsequent backfill producing retries rather than terminal errors. I would rather confirm both before this is treated as done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
