### PR TITLE
docs(server): document ClickHouse replication topology for self-hosters

### DIFF
--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -97,7 +97,7 @@ Multi-replica ClickHouse behind Tuist is supported on ClickHouse Cloud only. Sel
 
 The ingest migrations emit a plain `MergeTree` engine. On Cloud that becomes a `SharedMergeTree` transparently, so writes land in shared object storage and any replica count works. On self-managed ClickHouse, `MergeTree` writes to local disk on one replica only; a multi-replica setup will either split ingest silently across replicas or reject the CREATE with `UNKNOWN_STORAGE: Only tables with a Replicated engine or tables which do not store data on disk are allowed in a Replicated database.` depending on how `database_replicated_allow_only_replicated_engine` is set on the connecting user.
 
-Run one shard with one replica on self-managed ClickHouse.
+Run one shard with one replica on self-managed ClickHouse, and take regular backups of the ClickHouse data directory. There is no second replica to fall back to if the node is lost.
 
 #### Capping operational log retention {#capping-operational-log-retention}
 

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -91,52 +91,27 @@ Tuist uses [ClickHouse](https://clickhouse.com/) for storing and querying large 
 
 The bundled Docker Compose and Helm embedded ClickHouse configurations lower the ClickHouse text log level from the image's `trace` default to `information`, which is where most of the `system.text_log` volume comes from. Both can also cap ClickHouse's own `system.*` operational log tables, which are otherwise unbounded, but that is off by default — see below. External ClickHouse deployments should configure these operational logs directly in their ClickHouse service.
 
-#### Multi-replica ClickHouse {#multi-replica-clickhouse}
+#### ClickHouse replication topology {#clickhouse-replication-topology}
 
-Both single-replica and multi-replica ClickHouse topologies are supported. Multi-replica (one shard, N replicas, Keeper quorum) is the shape Tuist runs in production and is what the chart's `clickhouse.managed` mode provisions.
+Self-hosted ClickHouse is supported at **one shard, one replica** today. That covers the embedded chart mode, the Docker Compose setup, and external ClickHouse pointed at either a single-node self-managed ClickHouse or ClickHouse Cloud. External ClickHouse pointed at a **multi-replica self-managed OSS cluster is not supported**.
 
-Every ingest migration hardcodes a plain `MergeTree` (or one of the `AggregatingMergeTree`, `ReplacingMergeTree`, `SummingMergeTree` variants). This is intentional. The migrations don't know how many replicas they will land on, so they rely on ClickHouse to rewrite each engine to its `Replicated*` counterpart at CREATE time. That rewrite only happens inside a database whose engine is `Replicated`, and only when the server profile is configured to require it.
+Every ingest migration creates its table with a plain `MergeTree` engine (or one of the `AggregatingMergeTree`, `ReplacingMergeTree`, or `SummingMergeTree` variants). Data replication in ClickHouse is a property of the table engine, not the database: only `Replicated*` engines replicate rows through Keeper. So on a multi-replica OSS cluster the current migrations end up in one of two states, neither of which is what you want:
 
-For an external multi-replica ClickHouse to work with Tuist, the operator has to arrange three things in the cluster before the migrations run:
+- With `database_replicated_allow_only_replicated_engine=0` on the connecting user, the CREATE succeeds on the replica the migration ran against and produces a per-replica local table. Ingest then silently splits across replicas at write time, and `tuist.schema_migrations` diverges: the migration chain can restart on a replica with no record of it and fail with `TABLE_ALREADY_EXISTS`.
+- With `database_replicated_allow_only_replicated_engine=1` on, the CREATE is rejected outright with `UNKNOWN_STORAGE: Only tables with a Replicated engine or tables which do not store data on disk are allowed in a Replicated database.` The migration halts before the schema is applied.
 
-1. Create the application database with the `Replicated` engine, passing a Keeper path and the standard `{shard}` and `{replica}` macros:
+ClickHouse Cloud avoids both because a plain `MergeTree` there is transparently a `SharedMergeTree`, so the same migrations produce a replicated table on any number of Cloud replicas. On self-managed OSS there is no such layer.
 
-   ```sql
-   CREATE DATABASE tuist ENGINE = Replicated('/clickhouse/databases/tuist', '{shard}', '{replica}');
-   ```
+The `clickhouse.managed` mode in the chart provisions a `Replicated` database and three `database_replicated_*` profile flags anyway. That is not a general multi-replica OSS recipe. It is the shape a schema *cloned out of ClickHouse Cloud* lands in: Cloud emits DDL that carries explicit `ReplicatedMergeTree` engines with `('/clickhouse/tables/{uuid}/{shard}', '{replica}', ...)` arguments, and the flags accept those cloned statements without rewriting them. See the users.xml comment in [`clickhouse-managed.yaml`](https://github.com/tuist/tuist/blob/main/infra/helm/tuist/templates/clickhouse-managed.yaml) for what each flag actually accepts.
 
-2. Define the `{shard}` and `{replica}` macros on every server in the cluster, in a `macros.xml` drop-in:
+For self-hosters today:
 
-   ```xml
-   <clickhouse>
-     <macros>
-       <shard>01</shard>
-       <replica from_env="HOSTNAME"></replica>
-     </macros>
-   </clickhouse>
-   ```
+- **Embedded chart mode:** the chart runs one ClickHouse pod and one Keeper. Supported.
+- **Docker Compose:** one ClickHouse container and one Keeper. Supported.
+- **External ClickHouse on ClickHouse Cloud:** any Cloud replica count works, because Cloud's `SharedMergeTree` handles replication under the plain `MergeTree` DDL the migrations emit.
+- **External ClickHouse on a self-managed OSS cluster:** run one shard with one replica. A multi-replica OSS setup will produce split ingest or a rejected schema depending on which side of `allow_only_replicated_engine` the connecting user is on.
 
-3. Apply three profile flags to the user Tuist connects as:
-
-   ```xml
-   <profiles>
-     <default>
-       <database_replicated_allow_only_replicated_engine>1</database_replicated_allow_only_replicated_engine>
-       <database_replicated_allow_replicated_engine_arguments>2</database_replicated_allow_replicated_engine_arguments>
-       <database_replicated_allow_heavy_create>1</database_replicated_allow_heavy_create>
-     </default>
-   </profiles>
-   ```
-
-`database_replicated_allow_only_replicated_engine=1` is the guard. Without it, a plain `MergeTree` CREATE succeeds and produces a table whose data lives on one replica only, invisible until a second replica exists and disagrees. With it, ClickHouse rewrites `MergeTree` to `ReplicatedMergeTree` (and the family variants to their `Replicated*` counterparts) so both DDL and rows replicate. ClickHouse Cloud defaults this setting to `1` for the same reason.
-
-`database_replicated_allow_replicated_engine_arguments=2` accepts an explicit Keeper path and replica argument on any DDL and substitutes the server defaults instead of honouring them.
-
-`database_replicated_allow_heavy_create=1` permits `CREATE MATERIALIZED VIEW ... POPULATE`, which several ingest migrations use to backfill a view against the base table's existing rows.
-
-The chart's `clickhouse.managed` mode configures all of this for you. It creates the `Replicated` database in a post-install hook, sets the three profile flags on the `default` user, and defines the `{shard}`/`{replica}` macros. The [`clickhouse-managed.yaml`](https://github.com/tuist/tuist/blob/main/infra/helm/tuist/templates/clickhouse-managed.yaml) template in the chart is a copyable reference if you run ClickHouse under a Kubernetes operator or another provisioning tool.
-
-Symptoms of a multi-replica cluster that skipped one of these steps: `tuist.schema_migrations` holds different row counts on different replicas, migrations fail with `TABLE_ALREADY_EXISTS` after a restart of the migration chain, and ingest silently splits across replicas at write time. All three go away once the guard is on and the database is recreated with `ENGINE = Replicated`.
+Making the ingest engine configurable so a self-hoster can select `ReplicatedMergeTree` per table is on the list. Until that ships, a multi-replica self-managed ClickHouse behind Tuist is not a supported topology.
 
 #### Capping operational log retention {#capping-operational-log-retention}
 

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -93,29 +93,11 @@ The bundled Docker Compose and Helm embedded ClickHouse configurations lower the
 
 #### ClickHouse replication topology {#clickhouse-replication-topology}
 
-The multi-replica ClickHouse topology Tuist supports is one where the replicas are **stateless compute over shared durable storage**. Data lives once, in object storage, and every replica reads and writes against the same copy. Writes are durable because the storage layer replicates them, not because the ClickHouse replicas do. Adding a replica adds query throughput; it does not add a copy of the rows.
+Multi-replica ClickHouse behind Tuist is supported on ClickHouse Cloud only. Self-managed ClickHouse is single-replica.
 
-This shape is what makes the ingest migrations work. Every migration creates its table with a plain `MergeTree` engine (or one of the `AggregatingMergeTree`, `ReplacingMergeTree`, or `SummingMergeTree` variants), which by itself does not replicate anything. On a shared-storage deployment there is nothing to replicate at the ClickHouse layer, so plain `MergeTree` is exactly right: one row written on any replica, one part written to object storage, every other replica reads it from the same object storage.
+The ingest migrations emit a plain `MergeTree` engine. On Cloud that becomes a `SharedMergeTree` transparently, so writes land in shared object storage and any replica count works. On self-managed ClickHouse, `MergeTree` writes to local disk on one replica only; a multi-replica setup will either split ingest silently across replicas or reject the CREATE with `UNKNOWN_STORAGE: Only tables with a Replicated engine or tables which do not store data on disk are allowed in a Replicated database.` depending on how `database_replicated_allow_only_replicated_engine` is set on the connecting user.
 
-ClickHouse Cloud is the deployment that fits this shape today. Its `SharedMergeTree` engine transparently replaces the `MergeTree` in each migration's DDL, so the same migrations produce a working table on any Cloud replica count. `SharedMergeTree` is closed-source and Cloud-only.
-
-Self-managed OSS ClickHouse does not offer an equivalent. OSS has `ReplicatedMergeTree`, which is a different model entirely: each replica holds its own copy of the data on local disk and replication is a physical part-copy over Keeper. Our migrations do not emit `ReplicatedMergeTree`, so a multi-replica OSS cluster ends up in one of two states, neither of which is what you want:
-
-- With `database_replicated_allow_only_replicated_engine=0` on the connecting user, the CREATE succeeds on the replica the migration ran against and produces a per-replica local table. Ingest then silently splits across replicas at write time, and `tuist.schema_migrations` diverges: the migration chain can restart on a replica with no record of it and fail with `TABLE_ALREADY_EXISTS`.
-- With `database_replicated_allow_only_replicated_engine=1` on, the CREATE is rejected outright with `UNKNOWN_STORAGE: Only tables with a Replicated engine or tables which do not store data on disk are allowed in a Replicated database.` The migration halts before the schema is applied.
-
-OSS ClickHouse can be pointed at S3-backed disks with a "zero-copy replication" mode on `ReplicatedMergeTree` that resembles the Cloud shape at a distance, and third-party forks such as Altinity's ship OSS shared-storage engines. Neither path is what our migrations produce, and ClickHouse Inc. does not recommend zero-copy replication for production, so we do not validate multi-replica OSS behind Tuist. Run one shard with one replica instead.
-
-The `clickhouse.managed` mode in the chart provisions a `Replicated` database and three `database_replicated_*` profile flags anyway. That is not a general multi-replica OSS recipe. It is the shape a schema *cloned out of ClickHouse Cloud* lands in: Cloud emits DDL that carries explicit `ReplicatedMergeTree` engines with `('/clickhouse/tables/{uuid}/{shard}', '{replica}', ...)` arguments, and the flags accept those cloned statements without rewriting them. See the users.xml comment in [`clickhouse-managed.yaml`](https://github.com/tuist/tuist/blob/main/infra/helm/tuist/templates/clickhouse-managed.yaml) for what each flag actually accepts.
-
-For self-hosters today:
-
-- **Embedded chart mode:** the chart runs one ClickHouse pod and one Keeper. Supported.
-- **Docker Compose:** one ClickHouse container and one Keeper. Supported.
-- **External ClickHouse on ClickHouse Cloud:** any Cloud replica count works, because `SharedMergeTree` gives you the compute-over-shared-storage shape and Cloud swaps it in under the plain `MergeTree` DDL our migrations emit.
-- **External ClickHouse on a self-managed OSS cluster:** run one shard with one replica. A multi-replica OSS setup will produce split ingest or a rejected schema depending on which side of `allow_only_replicated_engine` the connecting user is on.
-
-Making the ingest engine configurable so a self-hoster can select `ReplicatedMergeTree` per table is on the list, and would let self-managed OSS clusters run multi-replica using the OSS part-copy replication model rather than the shared-storage one. Until that ships, a multi-replica self-managed ClickHouse behind Tuist is not a supported topology.
+Run one shard with one replica on self-managed ClickHouse. Making the ingest engine configurable so `ReplicatedMergeTree` is selectable per table is the follow-up that would lift the constraint.
 
 #### Capping operational log retention {#capping-operational-log-retention}
 

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -93,14 +93,18 @@ The bundled Docker Compose and Helm embedded ClickHouse configurations lower the
 
 #### ClickHouse replication topology {#clickhouse-replication-topology}
 
-Self-hosted ClickHouse is supported at **one shard, one replica** today. That covers the embedded chart mode, the Docker Compose setup, and external ClickHouse pointed at either a single-node self-managed ClickHouse or ClickHouse Cloud. External ClickHouse pointed at a **multi-replica self-managed OSS cluster is not supported**.
+The multi-replica ClickHouse topology Tuist supports is one where the replicas are **stateless compute over shared durable storage**. Data lives once, in object storage, and every replica reads and writes against the same copy. Writes are durable because the storage layer replicates them, not because the ClickHouse replicas do. Adding a replica adds query throughput; it does not add a copy of the rows.
 
-Every ingest migration creates its table with a plain `MergeTree` engine (or one of the `AggregatingMergeTree`, `ReplacingMergeTree`, or `SummingMergeTree` variants). Data replication in ClickHouse is a property of the table engine, not the database: only `Replicated*` engines replicate rows through Keeper. So on a multi-replica OSS cluster the current migrations end up in one of two states, neither of which is what you want:
+This shape is what makes the ingest migrations work. Every migration creates its table with a plain `MergeTree` engine (or one of the `AggregatingMergeTree`, `ReplacingMergeTree`, or `SummingMergeTree` variants), which by itself does not replicate anything. On a shared-storage deployment there is nothing to replicate at the ClickHouse layer, so plain `MergeTree` is exactly right: one row written on any replica, one part written to object storage, every other replica reads it from the same object storage.
+
+ClickHouse Cloud is the deployment that fits this shape today. Its `SharedMergeTree` engine transparently replaces the `MergeTree` in each migration's DDL, so the same migrations produce a working table on any Cloud replica count. `SharedMergeTree` is closed-source and Cloud-only.
+
+Self-managed OSS ClickHouse does not offer an equivalent. OSS has `ReplicatedMergeTree`, which is a different model entirely: each replica holds its own copy of the data on local disk and replication is a physical part-copy over Keeper. Our migrations do not emit `ReplicatedMergeTree`, so a multi-replica OSS cluster ends up in one of two states, neither of which is what you want:
 
 - With `database_replicated_allow_only_replicated_engine=0` on the connecting user, the CREATE succeeds on the replica the migration ran against and produces a per-replica local table. Ingest then silently splits across replicas at write time, and `tuist.schema_migrations` diverges: the migration chain can restart on a replica with no record of it and fail with `TABLE_ALREADY_EXISTS`.
 - With `database_replicated_allow_only_replicated_engine=1` on, the CREATE is rejected outright with `UNKNOWN_STORAGE: Only tables with a Replicated engine or tables which do not store data on disk are allowed in a Replicated database.` The migration halts before the schema is applied.
 
-ClickHouse Cloud avoids both because a plain `MergeTree` there is transparently a `SharedMergeTree`, so the same migrations produce a replicated table on any number of Cloud replicas. On self-managed OSS there is no such layer.
+OSS ClickHouse can be pointed at S3-backed disks with a "zero-copy replication" mode on `ReplicatedMergeTree` that resembles the Cloud shape at a distance, and third-party forks such as Altinity's ship OSS shared-storage engines. Neither path is what our migrations produce, and ClickHouse Inc. does not recommend zero-copy replication for production, so we do not validate multi-replica OSS behind Tuist. Run one shard with one replica instead.
 
 The `clickhouse.managed` mode in the chart provisions a `Replicated` database and three `database_replicated_*` profile flags anyway. That is not a general multi-replica OSS recipe. It is the shape a schema *cloned out of ClickHouse Cloud* lands in: Cloud emits DDL that carries explicit `ReplicatedMergeTree` engines with `('/clickhouse/tables/{uuid}/{shard}', '{replica}', ...)` arguments, and the flags accept those cloned statements without rewriting them. See the users.xml comment in [`clickhouse-managed.yaml`](https://github.com/tuist/tuist/blob/main/infra/helm/tuist/templates/clickhouse-managed.yaml) for what each flag actually accepts.
 
@@ -108,10 +112,10 @@ For self-hosters today:
 
 - **Embedded chart mode:** the chart runs one ClickHouse pod and one Keeper. Supported.
 - **Docker Compose:** one ClickHouse container and one Keeper. Supported.
-- **External ClickHouse on ClickHouse Cloud:** any Cloud replica count works, because Cloud's `SharedMergeTree` handles replication under the plain `MergeTree` DDL the migrations emit.
+- **External ClickHouse on ClickHouse Cloud:** any Cloud replica count works, because `SharedMergeTree` gives you the compute-over-shared-storage shape and Cloud swaps it in under the plain `MergeTree` DDL our migrations emit.
 - **External ClickHouse on a self-managed OSS cluster:** run one shard with one replica. A multi-replica OSS setup will produce split ingest or a rejected schema depending on which side of `allow_only_replicated_engine` the connecting user is on.
 
-Making the ingest engine configurable so a self-hoster can select `ReplicatedMergeTree` per table is on the list. Until that ships, a multi-replica self-managed ClickHouse behind Tuist is not a supported topology.
+Making the ingest engine configurable so a self-hoster can select `ReplicatedMergeTree` per table is on the list, and would let self-managed OSS clusters run multi-replica using the OSS part-copy replication model rather than the shared-storage one. Until that ships, a multi-replica self-managed ClickHouse behind Tuist is not a supported topology.
 
 #### Capping operational log retention {#capping-operational-log-retention}
 

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -91,6 +91,53 @@ Tuist uses [ClickHouse](https://clickhouse.com/) for storing and querying large 
 
 The bundled Docker Compose and Helm embedded ClickHouse configurations lower the ClickHouse text log level from the image's `trace` default to `information`, which is where most of the `system.text_log` volume comes from. Both can also cap ClickHouse's own `system.*` operational log tables, which are otherwise unbounded, but that is off by default — see below. External ClickHouse deployments should configure these operational logs directly in their ClickHouse service.
 
+#### Multi-replica ClickHouse {#multi-replica-clickhouse}
+
+Both single-replica and multi-replica ClickHouse topologies are supported. Multi-replica (one shard, N replicas, Keeper quorum) is the shape Tuist runs in production and is what the chart's `clickhouse.managed` mode provisions.
+
+Every ingest migration hardcodes a plain `MergeTree` (or one of the `AggregatingMergeTree`, `ReplacingMergeTree`, `SummingMergeTree` variants). This is intentional. The migrations don't know how many replicas they will land on, so they rely on ClickHouse to rewrite each engine to its `Replicated*` counterpart at CREATE time. That rewrite only happens inside a database whose engine is `Replicated`, and only when the server profile is configured to require it.
+
+For an external multi-replica ClickHouse to work with Tuist, the operator has to arrange three things in the cluster before the migrations run:
+
+1. Create the application database with the `Replicated` engine, passing a Keeper path and the standard `{shard}` and `{replica}` macros:
+
+   ```sql
+   CREATE DATABASE tuist ENGINE = Replicated('/clickhouse/databases/tuist', '{shard}', '{replica}');
+   ```
+
+2. Define the `{shard}` and `{replica}` macros on every server in the cluster, in a `macros.xml` drop-in:
+
+   ```xml
+   <clickhouse>
+     <macros>
+       <shard>01</shard>
+       <replica from_env="HOSTNAME"></replica>
+     </macros>
+   </clickhouse>
+   ```
+
+3. Apply three profile flags to the user Tuist connects as:
+
+   ```xml
+   <profiles>
+     <default>
+       <database_replicated_allow_only_replicated_engine>1</database_replicated_allow_only_replicated_engine>
+       <database_replicated_allow_replicated_engine_arguments>2</database_replicated_allow_replicated_engine_arguments>
+       <database_replicated_allow_heavy_create>1</database_replicated_allow_heavy_create>
+     </default>
+   </profiles>
+   ```
+
+`database_replicated_allow_only_replicated_engine=1` is the guard. Without it, a plain `MergeTree` CREATE succeeds and produces a table whose data lives on one replica only, invisible until a second replica exists and disagrees. With it, ClickHouse rewrites `MergeTree` to `ReplicatedMergeTree` (and the family variants to their `Replicated*` counterparts) so both DDL and rows replicate. ClickHouse Cloud defaults this setting to `1` for the same reason.
+
+`database_replicated_allow_replicated_engine_arguments=2` accepts an explicit Keeper path and replica argument on any DDL and substitutes the server defaults instead of honouring them.
+
+`database_replicated_allow_heavy_create=1` permits `CREATE MATERIALIZED VIEW ... POPULATE`, which several ingest migrations use to backfill a view against the base table's existing rows.
+
+The chart's `clickhouse.managed` mode configures all of this for you. It creates the `Replicated` database in a post-install hook, sets the three profile flags on the `default` user, and defines the `{shard}`/`{replica}` macros. The [`clickhouse-managed.yaml`](https://github.com/tuist/tuist/blob/main/infra/helm/tuist/templates/clickhouse-managed.yaml) template in the chart is a copyable reference if you run ClickHouse under a Kubernetes operator or another provisioning tool.
+
+Symptoms of a multi-replica cluster that skipped one of these steps: `tuist.schema_migrations` holds different row counts on different replicas, migrations fail with `TABLE_ALREADY_EXISTS` after a restart of the migration chain, and ingest silently splits across replicas at write time. All three go away once the guard is on and the database is recreated with `ENGINE = Replicated`.
+
 #### Capping operational log retention {#capping-operational-log-retention}
 
 Retention can be applied to `system.text_log`, `system.query_log`, `system.query_thread_log`, `system.query_views_log`, `system.trace_log`, `system.metric_log`, `system.asynchronous_metric_log`, and `system.part_log`.

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -97,7 +97,7 @@ Multi-replica ClickHouse behind Tuist is supported on ClickHouse Cloud only. Sel
 
 The ingest migrations emit a plain `MergeTree` engine. On Cloud that becomes a `SharedMergeTree` transparently, so writes land in shared object storage and any replica count works. On self-managed ClickHouse, `MergeTree` writes to local disk on one replica only; a multi-replica setup will either split ingest silently across replicas or reject the CREATE with `UNKNOWN_STORAGE: Only tables with a Replicated engine or tables which do not store data on disk are allowed in a Replicated database.` depending on how `database_replicated_allow_only_replicated_engine` is set on the connecting user.
 
-Run one shard with one replica on self-managed ClickHouse. Making the ingest engine configurable so `ReplicatedMergeTree` is selectable per table is the follow-up that would lift the constraint.
+Run one shard with one replica on self-managed ClickHouse.
 
 #### Capping operational log retention {#capping-operational-log-retention}
 


### PR DESCRIPTION
## Summary

Documents what ClickHouse replication topology self-hosters can actually run behind Tuist, framed around the architecture that is load-bearing (stateless compute over shared durable storage) rather than a per-vendor list. Rewrites two earlier passes in this branch that either got the OSS story wrong or made the boundary sound arbitrary.

The self-hosting guide didn't say anything about replication topology, so an operator setting up Tuist against a multi-replica self-managed ClickHouse (chart 0.90.1, server 1.308.0, three ClickHouse replicas + Keeper) had no way to know that our ingest migrations don't produce replicated tables on OSS. They hit exactly the failure mode: DDL propagated via the `Replicated` database engine to every replica, rows did not, `tuist.schema_migrations` held 0/10/0 across replicas, the migration chain restarted on a replica with no record of it, and finally failed with `TABLE_ALREADY_EXISTS`. Left running, ingest would have split three ways silently.

## The supported shape

The multi-replica ClickHouse topology Tuist supports is one where the replicas are **stateless compute over shared durable storage**. Data lives once, in object storage, and every replica reads and writes against the same copy. Writes are durable because the storage layer replicates them, not because the ClickHouse replicas do. Adding a replica adds query throughput; it does not add a copy of the rows.

That is the shape the ingest migrations are built for. Every migration emits a plain `MergeTree` (or `AggregatingMergeTree`, `ReplacingMergeTree`, `SummingMergeTree`) engine, which by itself does not replicate anything. On a shared-storage deployment there is nothing to replicate at the ClickHouse layer, so plain `MergeTree` is exactly right.

**ClickHouse Cloud fits this shape today.** Its `SharedMergeTree` engine transparently replaces the `MergeTree` in each migration's DDL, so the same migrations produce a working table on any Cloud replica count. `SharedMergeTree` is closed-source and Cloud-only.

**Self-managed OSS ClickHouse does not fit.** OSS has `ReplicatedMergeTree`, which is a different model: each replica holds its own copy of the data on local disk, replication is a physical part-copy over Keeper. Our migrations do not emit `ReplicatedMergeTree`, so a multi-replica OSS cluster ends up as either per-replica local tables (silently splitting ingest) or a rejected schema (`UNKNOWN_STORAGE`, when `database_replicated_allow_only_replicated_engine=1` is on).

OSS has options that come close (`ReplicatedMergeTree` with S3-backed disks in the "zero-copy replication" mode, third-party forks such as Altinity's). Neither is what our migrations target, and ClickHouse Inc. does not recommend zero-copy replication for production, so we do not validate either behind Tuist. Run one shard with one replica on OSS instead.

## Why the earlier passes on this branch were wrong

The first pass claimed that turning on the three `database_replicated_*` flags on a `Replicated` database would make ClickHouse *rewrite* plain `MergeTree` CREATEs into `ReplicatedMergeTree` on any cluster. The self-hoster who prompted this doc tried it on ClickHouse 26.3.32 self-managed and it failed the way the source says it should. `InterpreterCreateQuery.cpp` evaluates the guard after the storage is built and throws `UNKNOWN_STORAGE`; there is no rewriting step in `DatabaseReplicated.cpp`. That claim came from misreading Cloud-inherited behavior as an OSS feature.

The second pass corrected the Cloud-vs-OSS distinction but framed the boundary as "Cloud works, OSS does not," which sounds arbitrary. This pass reframes it around the architecture (compute over shared durable storage) so a reader can see *why* Cloud fits and *why* OSS does not, and can reason about whether some future OSS setup they run would qualify.

## Why a docs change and not a migration change

The full fix is to make the ingest engine configurable so a self-hoster can select `ReplicatedMergeTree` per table. That would let a self-managed OSS cluster run multi-replica using the OSS part-copy replication model rather than the shared-storage one. It is the right follow-up. Doing it in this PR would touch 60+ migrations and needs its own test surface (embedded, Cloud, and OSS multi-replica), so it is out of scope here. What this PR gives self-hosters right now is an honest boundary: run one replica on OSS, or use Cloud if you need N replicas, and don't chase the multi-replica OSS shape via the `database_replicated_*` profile flags because they do not work today.

## What the section covers

- The supported multi-replica shape, framed as stateless compute over shared durable storage.
- Why the ingest migrations use plain `MergeTree` (because on shared storage there is nothing to replicate at the ClickHouse layer).
- Why Cloud fits (`SharedMergeTree` on S3, transparent engine swap).
- Why self-managed OSS does not fit today, and the OSS options that come close and why we do not validate them.
- The two failure modes an OSS multi-replica operator will observe, with the exact `UNKNOWN_STORAGE` error text so the page is findable by grepping.
- What `clickhouse.managed` in the chart is actually for (accepting a schema cloned out of Cloud), rather than what it looks like it might be for.
- A pointer at the follow-up: making the ingest engine configurable, which would remove the OSS constraint.

## Test plan

- [ ] Verify the `{#clickhouse-replication-topology}` anchor resolves and the section renders under `ClickHouse database`.
- [ ] Verify the `clickhouse-managed.yaml` link points at `main` in `tuist/tuist`.
- [ ] Sanity-check the error string against ClickHouse 26.3's `InterpreterCreateQuery.cpp` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)