### PR TITLE
fix(server,infra): build in the Atlas license verify key and drop it from the Helm chart

### DIFF
--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -572,13 +572,10 @@ License env vars. Resolves to one mutually exclusive source:
 {{- $existingKeys := .Values.server.license.existingSecretKeys | default dict -}}
 {{- $useEsoKey := ne (.Values.server.externalSecrets.license.item | default "") "" -}}
 {{- $useEsoCertificate := ne (.Values.server.externalSecrets.license.certificateItem | default "") "" -}}
-{{- $useEsoVerifyKey := ne (.Values.server.externalSecrets.license.verifyKeyItem | default "") "" -}}
 {{- $useInlineKey := ne (.Values.server.license.key | default "") "" -}}
 {{- $useInlineCertificate := ne (.Values.server.license.certificateBase64 | default "") "" -}}
-{{- $useInlineVerifyKey := ne (.Values.server.license.verifyKey | default "") "" -}}
 {{- $useExistingKey := and (ne $existingSecret "") (ne (get $existingKeys "key" | default "") "") -}}
 {{- $useExistingCertificate := and (ne $existingSecret "") (ne (get $existingKeys "certificateBase64" | default "") "") -}}
-{{- $useExistingVerifyKey := and (ne $existingSecret "") (ne (get $existingKeys "verifyKey" | default "") "") -}}
 {{- if and $useEsoKey $useEsoCertificate -}}
 {{- fail "server.externalSecrets.license.item and server.externalSecrets.license.certificateItem are mutually exclusive; pick one license source." -}}
 {{- end -}}
@@ -588,8 +585,8 @@ License env vars. Resolves to one mutually exclusive source:
 {{- if and $useInlineKey $useInlineCertificate -}}
 {{- fail "server.license.key and server.license.certificateBase64 are mutually exclusive; pick one license source." -}}
 {{- end -}}
-{{- if and (ne $existingSecret "") (or $useEsoKey $useEsoCertificate $useEsoVerifyKey $useInlineKey $useInlineCertificate $useInlineVerifyKey) -}}
-{{- fail "server.license.existingSecret is mutually exclusive with server.license.{key,certificateBase64,verifyKey} and with the server.externalSecrets.license path; pick one license source." -}}
+{{- if and (ne $existingSecret "") (or $useEsoKey $useEsoCertificate $useInlineKey $useInlineCertificate) -}}
+{{- fail "server.license.existingSecret is mutually exclusive with server.license.{key,certificateBase64} and with the server.externalSecrets.license path; pick one license source." -}}
 {{- end -}}
 {{- if and (ne $existingSecret "") (not (or $useExistingKey $useExistingCertificate)) -}}
 {{- fail "server.license.existingSecret is set but neither existingSecretKeys.key nor existingSecretKeys.certificateBase64 names a key; give the chart a license source." -}}
@@ -619,18 +616,6 @@ License env vars. Resolves to one mutually exclusive source:
       {{- else }}
       name: {{ ternary $esoSecret $appSecret $useEsoCertificate | quote }}
       key: server-license-certificate-base64
-      {{- end }}
-{{- end }}
-{{- if or $useEsoVerifyKey $useInlineVerifyKey $useExistingVerifyKey }}
-- name: TUIST_LICENSE_VERIFY_KEY
-  valueFrom:
-    secretKeyRef:
-      {{- if $useExistingVerifyKey }}
-      name: {{ $existingSecret | quote }}
-      key: {{ get $existingKeys "verifyKey" | quote }}
-      {{- else }}
-      name: {{ ternary $esoSecret $appSecret $useEsoVerifyKey | quote }}
-      key: server-license-verify-key
       {{- end }}
 {{- end }}
 {{- end -}}

--- a/infra/helm/tuist/templates/app-secrets.yaml
+++ b/infra/helm/tuist/templates/app-secrets.yaml
@@ -40,9 +40,6 @@ stringData:
   {{- if and (eq (.Values.server.license.existingSecret | default "") "") .Values.server.license.certificateBase64 }}
   server-license-certificate-base64: {{ .Values.server.license.certificateBase64 | quote }}
   {{- end }}
-  {{- if and (eq (.Values.server.license.existingSecret | default "") "") .Values.server.license.verifyKey }}
-  server-license-verify-key: {{ .Values.server.license.verifyKey | quote }}
-  {{- end }}
   {{- if and .Values.processor.enabled (not .Values.processor.managedSecrets) .Values.processor.databaseUrl }}
   processor-database-url: {{ .Values.processor.databaseUrl | quote }}
   {{- end }}

--- a/infra/helm/tuist/templates/external-secrets.yaml
+++ b/infra/helm/tuist/templates/external-secrets.yaml
@@ -1,7 +1,6 @@
 {{- $syncLicenseKey := and .Values.server.enabled (ne (.Values.server.externalSecrets.license.item | default "") "") -}}
 {{- $syncLicenseCertificate := and .Values.server.enabled (ne (.Values.server.externalSecrets.license.certificateItem | default "") "") -}}
-{{- $syncLicenseVerifyKey := and .Values.server.enabled (ne (.Values.server.externalSecrets.license.verifyKeyItem | default "") "") -}}
-{{- $syncLicense := or $syncLicenseKey $syncLicenseCertificate $syncLicenseVerifyKey -}}
+{{- $syncLicense := or $syncLicenseKey $syncLicenseCertificate -}}
 {{- $syncCacheGrant := and .Values.server.enabled (ne (.Values.server.externalSecrets.cacheGrant.item | default "") "") -}}
 {{- $serverKuraIntrospection := .Values.server.externalSecrets.kuraIntrospection -}}
 {{- $kuraSharedSecrets := .Values.kuraController.sharedSecrets -}}
@@ -60,9 +59,6 @@ spec:
         {{- if $syncLicenseCertificate }}
         server-license-certificate-base64: "{{ `{{ .server_license_certificate_base64 | trim }}` }}"
         {{- end }}
-        {{- if $syncLicenseVerifyKey }}
-        server-license-verify-key: "{{ `{{ .server_license_verify_key | trim }}` }}"
-        {{- end }}
         {{- if $syncCacheGrant }}
         cache-grant-private-key: "{{ `{{ .cache_grant_private_key | trim }}` }}"
         {{- end }}
@@ -87,11 +83,6 @@ spec:
     - secretKey: server_license_certificate_base64
       remoteRef:
         key: "{{ .Values.server.externalSecrets.license.certificateItem }}/{{ .Values.server.externalSecrets.license.certificateField | default "password" }}"
-    {{- end }}
-    {{- if $syncLicenseVerifyKey }}
-    - secretKey: server_license_verify_key
-      remoteRef:
-        key: "{{ .Values.server.externalSecrets.license.verifyKeyItem }}/{{ .Values.server.externalSecrets.license.verifyKeyField | default "password" }}"
     {{- end }}
     {{- if $syncCacheGrant }}
     - secretKey: cache_grant_private_key

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -88,11 +88,6 @@ server:
   # cache volume's binaries never validate as local hits across VMs. Same
   # keypair as staging (the CLI's baked public key pins it).
   externalSecrets:
-    # The offline-certificate license config is now the shared default in
-    # values-managed-common.yaml, so production no longer overrides it here.
-    license:
-      verifyKeyItem: TUIST_LICENSE_VERIFY_KEY
-      verifyKeyField: password
     cacheGrant:
       item: TUIST_CACHE_GRANT_PRIVATE_KEY
 

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -524,15 +524,12 @@ server:
       name: onepassword
     # Sync either the online Tuist license key or the air-gapped license
     # certificate from the external store. These sources are mutually
-    # exclusive. The optional verify key lets air-gapped certificates signed
-    # by an additional issuer validate during a key rotation.
+    # exclusive.
     license:
       item: ""
       field: password
       certificateItem: ""
       certificateField: password
-      verifyKeyItem: ""
-      verifyKeyField: password
     # Cache-signing grant private key: a PEM Ed25519 key the
     # server signs runner cache grants with. Leave item empty to disable
     # grant minting (dispatch omits the grant; CLI falls back to the MAC
@@ -690,14 +687,13 @@ server:
   license:
     key: ""
     certificateBase64: ""
-    verifyKey: ""
     selfHostingDevelopmentMode: false
     # Name of an existing Kubernetes Secret whose keys back the license
     # environment variables. Use this when the license values live in a
     # Secret populated out-of-band (Vault, sealed-secrets, bank-vaults, an
     # ExternalSecret targeting a store other than 1Password, etc.) and you
     # do not want the chart to render them into its own app-secrets Secret.
-    # Mutually exclusive with `server.license.{key,certificateBase64,verifyKey}`
+    # Mutually exclusive with `server.license.{key,certificateBase64}`
     # and with the ESO `server.externalSecrets.license` path.
     #
     # Override `existingSecretKeys` to match the key names in your Secret.
@@ -708,7 +704,6 @@ server:
     existingSecretKeys:
       key: server-license-key
       certificateBase64: server-license-certificate-base64
-      verifyKey: server-license-verify-key
   database:
     ssl: false
   storage:

--- a/infra/k8s/onboarding.md
+++ b/infra/k8s/onboarding.md
@@ -350,7 +350,7 @@ encoded = IO.binread(:stdio, :eof) |> String.trim()
 
 with {:ok, certificate} <- Base.decode64(encoded, ignore: :whitespace),
      {:ok, %Tuist.License{valid: true, expiration_date: expiration_date}} <-
-       Tuist.License.resolve_certificate(Tuist.License.ed25519_verify_key(), certificate) do
+       Tuist.License.resolve_certificate(Tuist.License.ed25519_verify_keys(), certificate) do
   IO.puts("valid through #{expiration_date}")
 else
   :error -> raise "air-gapped license is not valid Base64"
@@ -393,7 +393,7 @@ encoded = IO.binread(:stdio, :eof)
 
 with {:ok, certificate} <- Base.decode64(encoded, ignore: :whitespace),
      {:ok, %Tuist.License{valid: true, expiration_date: expiration_date}} <-
-       Tuist.License.resolve_certificate(Tuist.License.ed25519_verify_key(), certificate) do
+       Tuist.License.resolve_certificate(Tuist.License.ed25519_verify_keys(), certificate) do
   IO.puts("stored license valid through #{expiration_date}")
 else
   :error -> raise "stored air-gapped license is not valid Base64"

--- a/server/lib/tuist/license.ex
+++ b/server/lib/tuist/license.ex
@@ -64,8 +64,13 @@ defmodule Tuist.License do
     "58f8d43c65b5a3e200e8ef6ecefa6b700432124527edf50a5b5b0577242c51fd"
   end
 
+  # Ed25519 verify key for the air-gapped license files issued by Atlas
+  def atlas_ed25519_verify_key do
+    "8811b8ea16b76b3bc64bdd668d8843701ef45b7ab045d82ca2ac9ee3df5ad013"
+  end
+
   def ed25519_verify_keys do
-    [Tuist.Environment.license_verify_key(), ed25519_verify_key()]
+    [Tuist.Environment.license_verify_key(), atlas_ed25519_verify_key(), ed25519_verify_key()]
     |> Enum.filter(&(is_binary(&1) and &1 != ""))
     |> Enum.uniq()
   end

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -630,7 +630,6 @@ server:
     existingSecretKeys:
       key: TUIST_LICENSE
       certificateBase64: ""
-      verifyKey: ""
 ```
 
 For an air-gapped installation, reference the Base64-encoded license certificate instead:
@@ -643,7 +642,6 @@ server:
     existingSecretKeys:
       key: ""
       certificateBase64: TUIST_LICENSE_CERTIFICATE_BASE64
-      verifyKey: ""
 ```
 
 Each entry under `existingSecretKeys` names a key in your Secret and defaults to the chart's own key name, so set the entries your Secret doesn't contain to an empty string. Otherwise the pods reference keys that don't exist and fail to start.

--- a/server/priv/docs/en/guides/server/self-host/server.md
+++ b/server/priv/docs/en/guides/server/self-host/server.md
@@ -618,6 +618,38 @@ helm install tuist oci://ghcr.io/tuist/charts/tuist \
   --version 0.1.0
 ```
 
+### License {#helm-license}
+
+Passing the license with `--set` works for a quick install. If you keep your values in version control, store the license in a Kubernetes Secret that you manage outside Helm, for example with Vault, Sealed Secrets, or SOPS, and point the chart at it:
+
+```yaml
+# values.yaml
+server:
+  license:
+    existingSecret: tuist-license
+    existingSecretKeys:
+      key: TUIST_LICENSE
+      certificateBase64: ""
+      verifyKey: ""
+```
+
+For an air-gapped installation, reference the Base64-encoded license certificate instead:
+
+```yaml
+# values.yaml
+server:
+  license:
+    existingSecret: tuist-license
+    existingSecretKeys:
+      key: ""
+      certificateBase64: TUIST_LICENSE_CERTIFICATE_BASE64
+      verifyKey: ""
+```
+
+Each entry under `existingSecretKeys` names a key in your Secret and defaults to the chart's own key name, so set the entries your Secret doesn't contain to an empty string. Otherwise the pods reference keys that don't exist and fail to start.
+
+Configure the license through one source only: `server.license.key`, `server.license.certificateBase64`, or `server.license.existingSecret`. The chart fails to render when none is set or when sources are combined. A license passed through `server.extraEnv` doesn't count as a source, so use `existingSecret` instead. Create the Secret in the release namespace before you install or upgrade the chart.
+
 ### Infrastructure dependencies {#helm-infrastructure-dependencies}
 
 The chart manages three infrastructure dependencies: `postgresql`, `clickhouse`, and `objectStorage`. Each defaults to **embedded** mode, meaning the chart deploys them inside the cluster. To point at your own external instances instead, set the dependency's `mode` to `external` and fill in the connection details in your `values.yaml`. For example, to use an external PostgreSQL database:

--- a/server/test/tuist/license_test.exs
+++ b/server/test/tuist/license_test.exs
@@ -349,4 +349,26 @@ defmodule Tuist.LicenseTest do
       assert {:error, _} = result
     end
   end
+
+  describe "ed25519_verify_keys/0" do
+    test "trusts the Atlas and Keygen verify keys without extra configuration" do
+      stub(Tuist.Environment, :license_verify_key, fn -> nil end)
+
+      assert License.ed25519_verify_keys() == [
+               License.atlas_ed25519_verify_key(),
+               License.ed25519_verify_key()
+             ]
+    end
+
+    test "trusts an additional verify key from the environment" do
+      verify_key = Base.encode16(:crypto.strong_rand_bytes(32), case: :lower)
+      stub(Tuist.Environment, :license_verify_key, fn -> verify_key end)
+
+      assert License.ed25519_verify_keys() == [
+               verify_key,
+               License.atlas_ed25519_verify_key(),
+               License.ed25519_verify_key()
+             ]
+    end
+  end
 end


### PR DESCRIPTION
A self-hosted customer upgrading from 1.254.0 to 1.314.1 couldn't get the server running with their air-gapped license. They keep secrets in Sealed Secrets, so they left `server.license.key` empty and injected the license through `server.extraEnv`, which ran into two problems. The chart side is already solved on main by #13087, which added `server.license.existingSecret`. This PR fixes the server side, removes the chart's verify key wiring now that the server doesn't need it, and documents the license Secret.

## Atlas air-gapped certificates failed signature verification

Air-gapped license files are now issued by Atlas, which signs them with its own Ed25519 key. The server only had Keygen's verify key built in, so an Atlas certificate was rejected with `Invalid signature` unless `TUIST_LICENSE_VERIFY_KEY` was also set. Our production values set that variable, but it isn't documented for self-hosters and Atlas doesn't hand it out with the certificate, so any self-hosted install on an Atlas certificate would hit this.

The fix builds Atlas's public verify key into `Tuist.License.ed25519_verify_keys/0`, next to the Keygen one. It's a public key, so shipping it is fine, and it's how the Keygen key is already handled. I considered only documenting the variable instead, but that pushes an internal detail onto every air-gapped customer for no benefit.

The certificate validation snippets in `infra/k8s/onboarding.md` called `ed25519_verify_key/0`, which would reject Atlas certificates the same way, so they now use `ed25519_verify_keys/0`.

## Drop the verify key from the chart

With the Atlas key built into the server, nobody needs to configure a verify key, so this removes it from the chart: `server.license.verifyKey`, `server.license.existingSecretKeys.verifyKey`, and `server.externalSecrets.license.verifyKeyItem`, together with the `app-secrets` entry, the ExternalSecret sync, and the `TUIST_LICENSE_VERIFY_KEY` env var. `existingSecretKeys.verifyKey` came in with #13087 and hasn't been in a chart release yet. The inline and External Secrets options have existed since #12576, but Helm ignores values it doesn't know, so installs that still set them keep rendering and simply stop receiving a key the server no longer needs.

Production was the only environment syncing the key, from the `TUIST_LICENSE_VERIFY_KEY` 1Password item. That item holds exactly the key this PR hardcodes, and managed deploys ship the chart and the server image from the same commit, so production never runs a server that needs the variable without it. The 1Password item can be deleted once this is deployed.

The server still reads `TUIST_LICENSE_VERIFY_KEY` when it's set, for example through `extraEnv`, which keeps a lever for a future key rotation without chart changes.

## Docs for the license Secret

#13087 added `server.license.existingSecret`, but the Helm section of the self-hosting guide still only showed `--set server.license.key`. The new License subsection documents `existingSecret` for both the online key and the air-gapped certificate.

It also spells out the one gotcha in that design: each `existingSecretKeys` entry defaults to the chart's own key name, so a Secret that only holds the certificate needs `key` set to `""`. Otherwise the pods reference a key that doesn't exist and fail to start. It also says that a license passed through `server.extraEnv` doesn't count toward the chart's license check, since that's exactly where this customer got stuck.

This PR originally shipped its own `existingSecret` implementation in the chart. After rebasing onto #13087 I dropped it in favor of main's.

## Validation

- Ran the real `Tuist.License` code against the customer's Atlas-issued certificate passed through `TUIST_LICENSE_CERTIFICATE_BASE64`. With this change it resolves to a valid license expiring 2027-10-10. With only the Keygen key, the previous behavior, it returns `Invalid signature`. The hardcoded key is the value stored in production's `TUIST_LICENSE_VERIFY_KEY` item.
- `mix test test/tuist/license_test.exs` on the rebased branch: 17 passed, including the two new `ed25519_verify_keys/0` tests.
- Rendered the chart before and after dropping the verify key with every values stack CI uses. Production only loses its five `TUIST_LICENSE_VERIFY_KEY` env entries and the ExternalSecret's verify key entries, and keeps the certificate wiring. Self-hosted CI, staging, canary, preview, pentest, and K3s smoke render identically apart from values the chart randomizes on every render.
- Rendered both docs examples plus a leftover inline `verifyKey` and a leftover `verifyKeyItem`. Each docs example wires only its own env var, and the leftovers render nothing. Also re-checked the `existingSecret` exclusivity and missing-source failures.
- `helm lint` with the Helm workflow's values combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqgYggjBW3vG7Ct4nYSWZj
