### PR TITLE
feat(server): tighten Tuist Helm chart for self-hosted Vault + arm64 audit

### DIFF
--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -35,6 +35,24 @@ app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 
 {{/*
+Fully qualified server image reference. server.image.tag is required: the
+chart's .Chart.AppVersion pins the chart's own version (bumped alongside
+templates), not the server image, which ships on its own 1.x release cadence
+under ghcr.io/tuist/tuist. Falling back to AppVersion would render a tag that
+does not exist and land the deployment in ImagePullBackOff — this fail is
+loud instead. Every deploy pipeline sets the tag via --set at helm-upgrade
+time (see .github/workflows/server-deployment.yml); self-hosters must set it
+in their values file.
+*/}}
+{{- define "tuist.serverImage" -}}
+{{- $tag := .Values.server.image.tag | default "" -}}
+{{- if eq $tag "" -}}
+{{- fail "server.image.tag is required. The chart's .Chart.AppVersion does not track the server image (published under ghcr.io/tuist/tuist on a 1.x cadence). Pin an explicit tag, e.g. `server: { image: { tag: \"1.318.0\" } }`, matching a release from https://github.com/tuist/tuist/releases?q=server." -}}
+{{- end -}}
+{{- printf "%s:%s" .Values.server.image.repository $tag -}}
+{{- end -}}
+
+{{/*
 Name of the server migration Job. Stable when it runs as a Helm hook, and
 scoped to the release revision when it runs as a regular Job, so that Helm
 replaces it on upgrade instead of tripping the immutable `spec.template`.
@@ -304,29 +322,13 @@ Call with the component's `s3` values:
 {{- end -}}
 
 {{/*
-Cache app's DATABASE_URL. Resolves to (in order):
-  1. cache.databaseUrl when set explicitly (self-hosted with own Postgres).
-  2. embedded Postgres + cache.embedded.database when postgresql.mode is
-     "embedded". The cache database is created by templates/postgresql-init.yaml
-     on first Postgres boot.
-  3. empty string (cache must be disabled or running in managedSecrets mode
-     where DATABASE_URL is unlocked from priv/secrets at runtime).
-
-Fails the render when an explicit `cache.databaseUrl` is set alongside an
-embedded Postgres. The two sources are mutually exclusive — silently
-preferring one would let an operator's intent (typically: an explicit URL
-written to override the embedded composition) be overridden by the chart's
-default. Mirrors the guard in tuist.licenseEnv.
+Cache app's DATABASE_URL. The pinned cache image (0.29.x) uses SQLite on the
+pod's /data volume and does not consume DATABASE_URL, so the helper returns
+empty and the deployment omits the env var. Kept as a helper (rather than
+deleting it inline) so a future cache image that reintroduces an external
+database only needs to change one composition site.
 */}}
 {{- define "tuist.cacheDatabaseUrl" -}}
-{{- if and .Values.cache.databaseUrl (eq .Values.postgresql.mode "embedded") -}}
-{{- fail "cache.databaseUrl and postgresql.mode=embedded are mutually exclusive — set one (explicit external URL OR embedded Postgres composition), not both." -}}
-{{- end -}}
-{{- if .Values.cache.databaseUrl -}}
-{{- .Values.cache.databaseUrl -}}
-{{- else if eq .Values.postgresql.mode "embedded" -}}
-ecto://{{ .Values.postgresql.embedded.username }}:{{ .Values.postgresql.embedded.password }}@{{ include "tuist.componentName" (dict "root" . "component" "postgresql") }}:5432/{{ .Values.cache.embedded.database }}
-{{- end -}}
 {{- end -}}
 
 {{/*
@@ -557,16 +559,26 @@ License env vars. Resolves to one mutually exclusive source:
      environments that sync the license from 1Password.
   2. Chart-managed app-secrets Secret when server.license.key or
      server.license.certificateBase64 is inlined.
+  3. Caller-managed Secret named by server.license.existingSecret, with
+     per-field key names from server.license.existingSecretKeys. Use this
+     when the license values are populated by an out-of-band flow (Vault,
+     sealed-secrets, an ExternalSecret against a non-1Password store, …).
+     A blank existingSecretKeys entry skips wiring that env var.
 */}}
 {{- define "tuist.licenseEnv" -}}
 {{- $appSecret := include "tuist.componentName" (dict "root" . "component" "app-secrets") -}}
 {{- $esoSecret := include "tuist.componentName" (dict "root" . "component" "server-external-secrets") -}}
+{{- $existingSecret := .Values.server.license.existingSecret | default "" -}}
+{{- $existingKeys := .Values.server.license.existingSecretKeys | default dict -}}
 {{- $useEsoKey := ne (.Values.server.externalSecrets.license.item | default "") "" -}}
 {{- $useEsoCertificate := ne (.Values.server.externalSecrets.license.certificateItem | default "") "" -}}
 {{- $useEsoVerifyKey := ne (.Values.server.externalSecrets.license.verifyKeyItem | default "") "" -}}
 {{- $useInlineKey := ne (.Values.server.license.key | default "") "" -}}
 {{- $useInlineCertificate := ne (.Values.server.license.certificateBase64 | default "") "" -}}
 {{- $useInlineVerifyKey := ne (.Values.server.license.verifyKey | default "") "" -}}
+{{- $useExistingKey := and (ne $existingSecret "") (ne (get $existingKeys "key" | default "") "") -}}
+{{- $useExistingCertificate := and (ne $existingSecret "") (ne (get $existingKeys "certificateBase64" | default "") "") -}}
+{{- $useExistingVerifyKey := and (ne $existingSecret "") (ne (get $existingKeys "verifyKey" | default "") "") -}}
 {{- if and $useEsoKey $useEsoCertificate -}}
 {{- fail "server.externalSecrets.license.item and server.externalSecrets.license.certificateItem are mutually exclusive; pick one license source." -}}
 {{- end -}}
@@ -576,30 +588,86 @@ License env vars. Resolves to one mutually exclusive source:
 {{- if and $useInlineKey $useInlineCertificate -}}
 {{- fail "server.license.key and server.license.certificateBase64 are mutually exclusive; pick one license source." -}}
 {{- end -}}
-{{- if not (or $useEsoKey $useEsoCertificate $useInlineKey $useInlineCertificate) -}}
+{{- if and (ne $existingSecret "") (or $useEsoKey $useEsoCertificate $useEsoVerifyKey $useInlineKey $useInlineCertificate $useInlineVerifyKey) -}}
+{{- fail "server.license.existingSecret is mutually exclusive with server.license.{key,certificateBase64,verifyKey} and with the server.externalSecrets.license path; pick one license source." -}}
+{{- end -}}
+{{- if and (ne $existingSecret "") (not (or $useExistingKey $useExistingCertificate)) -}}
+{{- fail "server.license.existingSecret is set but neither existingSecretKeys.key nor existingSecretKeys.certificateBase64 names a key; give the chart a license source." -}}
+{{- end -}}
+{{- if not (or $useEsoKey $useEsoCertificate $useInlineKey $useInlineCertificate $useExistingKey $useExistingCertificate) -}}
 {{- fail "no Tuist license source is configured; set exactly one online key or air-gapped certificate source." -}}
 {{- end -}}
-{{- if or $useEsoKey $useInlineKey }}
+{{- if or $useEsoKey $useInlineKey $useExistingKey }}
 - name: TUIST_LICENSE_KEY
   valueFrom:
     secretKeyRef:
+      {{- if $useExistingKey }}
+      name: {{ $existingSecret | quote }}
+      key: {{ get $existingKeys "key" | quote }}
+      {{- else }}
       name: {{ ternary $esoSecret $appSecret $useEsoKey | quote }}
       key: server-license-key
+      {{- end }}
 {{- end }}
-{{- if or $useEsoCertificate $useInlineCertificate }}
+{{- if or $useEsoCertificate $useInlineCertificate $useExistingCertificate }}
 - name: TUIST_LICENSE_CERTIFICATE_BASE64
   valueFrom:
     secretKeyRef:
+      {{- if $useExistingCertificate }}
+      name: {{ $existingSecret | quote }}
+      key: {{ get $existingKeys "certificateBase64" | quote }}
+      {{- else }}
       name: {{ ternary $esoSecret $appSecret $useEsoCertificate | quote }}
       key: server-license-certificate-base64
+      {{- end }}
 {{- end }}
-{{- if or $useEsoVerifyKey $useInlineVerifyKey }}
+{{- if or $useEsoVerifyKey $useInlineVerifyKey $useExistingVerifyKey }}
 - name: TUIST_LICENSE_VERIFY_KEY
   valueFrom:
     secretKeyRef:
+      {{- if $useExistingVerifyKey }}
+      name: {{ $existingSecret | quote }}
+      key: {{ get $existingKeys "verifyKey" | quote }}
+      {{- else }}
       name: {{ ternary $esoSecret $appSecret $useEsoVerifyKey | quote }}
       key: server-license-verify-key
+      {{- end }}
 {{- end }}
+{{- end -}}
+
+{{/*
+Cache application secret source. Resolves to either the chart-managed
+app-secrets Secret (default) or a caller-managed Secret named by
+cache.existingSecret, in which case every cache.apiKey / secretKeyBase /
+guardianSecretKey inline value must be empty. Fields (env var → key) come
+from cache.existingSecretKeys when set, else the app-secrets defaults.
+*/}}
+{{- define "tuist.cacheSecretName" -}}
+{{- $existingSecret := .Values.cache.existingSecret | default "" -}}
+{{- if ne $existingSecret "" -}}
+{{- if or (ne (.Values.cache.apiKey | default "") "") (ne (.Values.cache.secretKeyBase | default "") "") (ne (.Values.cache.guardianSecretKey | default "") "") -}}
+{{- fail "cache.existingSecret is mutually exclusive with cache.{apiKey,secretKeyBase,guardianSecretKey}; clear the inline values or unset cache.existingSecret." -}}
+{{- end -}}
+{{- $existingSecret -}}
+{{- else -}}
+{{- include "tuist.componentName" (dict "root" . "component" "app-secrets") -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tuist.cacheSecretKey" -}}
+{{- $field := .field -}}
+{{- $default := .default -}}
+{{- $existingSecret := .root.Values.cache.existingSecret | default "" -}}
+{{- if ne $existingSecret "" -}}
+{{- $keys := .root.Values.cache.existingSecretKeys | default dict -}}
+{{- $override := get $keys $field | default "" -}}
+{{- if eq $override "" -}}
+{{- fail (printf "cache.existingSecretKeys.%s is required when cache.existingSecret is set" $field) -}}
+{{- end -}}
+{{- $override -}}
+{{- else -}}
+{{- $default -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "tuist.serverHeadlessServiceName" -}}

--- a/infra/helm/tuist/templates/app-secrets.yaml
+++ b/infra/helm/tuist/templates/app-secrets.yaml
@@ -22,8 +22,10 @@ metadata:
 type: Opaque
 stringData:
   server-secret-key-base: {{ .Values.server.secretKeyBase | default (get $existingData "server-secret-key-base" | default "" | b64dec) | default (randAlphaNum 64) | quote }}
+  {{- if eq (.Values.cache.existingSecret | default "") "" }}
   cache-secret-key-base: {{ .Values.cache.secretKeyBase | default (get $existingData "cache-secret-key-base" | default "" | b64dec) | default (randAlphaNum 64) | quote }}
   cache-guardian-secret-key: {{ .Values.cache.guardianSecretKey | default (get $existingData "cache-guardian-secret-key" | default "" | b64dec) | default (randAlphaNum 64) | quote }}
+  {{- end }}
   {{- if not (and (eq .Values.postgresql.mode "external") .Values.postgresql.external.existingSecret) }}
   postgres-password: {{ ternary .Values.postgresql.embedded.password .Values.postgresql.external.password (eq .Values.postgresql.mode "embedded") | quote }}
   {{- end }}
@@ -32,13 +34,13 @@ stringData:
   {{- if .Values.server.azureBlob.accountKey }}
   azure-blob-account-key: {{ .Values.server.azureBlob.accountKey | quote }}
   {{- end }}
-  {{- if .Values.server.license.key }}
+  {{- if and (eq (.Values.server.license.existingSecret | default "") "") .Values.server.license.key }}
   server-license-key: {{ .Values.server.license.key | quote }}
   {{- end }}
-  {{- if .Values.server.license.certificateBase64 }}
+  {{- if and (eq (.Values.server.license.existingSecret | default "") "") .Values.server.license.certificateBase64 }}
   server-license-certificate-base64: {{ .Values.server.license.certificateBase64 | quote }}
   {{- end }}
-  {{- if .Values.server.license.verifyKey }}
+  {{- if and (eq (.Values.server.license.existingSecret | default "") "") .Values.server.license.verifyKey }}
   server-license-verify-key: {{ .Values.server.license.verifyKey | quote }}
   {{- end }}
   {{- if and .Values.processor.enabled (not .Values.processor.managedSecrets) .Values.processor.databaseUrl }}

--- a/infra/helm/tuist/templates/cache-deployment.yaml
+++ b/infra/helm/tuist/templates/cache-deployment.yaml
@@ -50,8 +50,8 @@ spec:
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "tuist.componentName" (dict "root" . "component" "app-secrets") }}
-                  key: cache-secret-key-base
+                  name: {{ include "tuist.cacheSecretName" . }}
+                  key: {{ include "tuist.cacheSecretKey" (dict "root" . "field" "secretKeyBase" "default" "cache-secret-key-base") }}
             - name: SERVER_URL
               value: {{ .Values.cache.serverUrl | default (printf "http://%s:%v" (include "tuist.componentName" (dict "root" . "component" "server")) .Values.server.service.port) | quote }}
             - name: STORAGE_DIR
@@ -84,13 +84,21 @@ spec:
                   name: {{ include "tuist.componentName" (dict "root" . "component" "app-secrets") }}
                   key: object-storage-secret-key
             {{- end }}
+            {{- if eq (.Values.cache.existingSecret | default "") "" }}
             - name: TUIST_CACHE_API_KEY
               value: {{ .Values.cache.apiKey | quote }}
+            {{- else }}
+            - name: TUIST_CACHE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tuist.cacheSecretName" . }}
+                  key: {{ include "tuist.cacheSecretKey" (dict "root" . "field" "apiKey" "default" "cache-api-key") }}
+            {{- end }}
             - name: GUARDIAN_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "tuist.componentName" (dict "root" . "component" "app-secrets") }}
-                  key: cache-guardian-secret-key
+                  name: {{ include "tuist.cacheSecretName" . }}
+                  key: {{ include "tuist.cacheSecretKey" (dict "root" . "field" "guardianSecretKey" "default" "cache-guardian-secret-key") }}
             {{- if and .Values.observability.enabled (include "tuist.observabilityOtlpEndpoint" .) }}
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: {{ include "tuist.observabilityOtlpEndpoint" . | quote }}

--- a/infra/helm/tuist/templates/clickhouse-migration-job.yaml
+++ b/infra/helm/tuist/templates/clickhouse-migration-job.yaml
@@ -144,7 +144,7 @@ spec:
       {{- end }}
       containers:
         - name: clickhouse-migration
-          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "tuist.serverImage" . | quote }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command:
             - /app/bin/tuist

--- a/infra/helm/tuist/templates/processor-deployment.yaml
+++ b/infra/helm/tuist/templates/processor-deployment.yaml
@@ -90,7 +90,7 @@ spec:
           # processor mode via TUIST_MODE below instead of shipping a
           # separate image. That keeps the worker module, Ecto schemas, and
           # priv/secrets exactly in sync with what enqueued the job.
-          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "tuist.serverImage" . | quote }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           # Preserve the last container output in the pod's termination
           # message whenever the processor exits unsuccessfully. This gives

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -61,7 +61,7 @@ spec:
       {{- end }}
       containers:
         - name: server
-          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "tuist.serverImage" . | quote }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           {{- with .Values.server.seedAccountCredentials.secretName }}
           volumeMounts:

--- a/infra/helm/tuist/templates/server-migration-job.yaml
+++ b/infra/helm/tuist/templates/server-migration-job.yaml
@@ -84,7 +84,7 @@ spec:
       # on its own if it can't reach them.
       initContainers:
         - name: wait-for-dependencies
-          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "tuist.serverImage" . | quote }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command:
             - /bin/sh
@@ -111,7 +111,7 @@ spec:
       {{- end }}
       containers:
         - name: migrate
-          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "tuist.serverImage" . | quote }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command:
             - /app/bin/tuist

--- a/infra/helm/tuist/templates/swift-registry-sync-deployment.yaml
+++ b/infra/helm/tuist/templates/swift-registry-sync-deployment.yaml
@@ -67,7 +67,7 @@ spec:
           # on the :web leader, not here, so this pod is purely a
           # consumer. Future ecosystems get their own mode + Deployment
           # (e.g. maven-registry-sync-deployment.yaml).
-          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "tuist.serverImage" . | quote }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command:
             - /app/bin/tuist

--- a/infra/helm/tuist/values-ci.yaml
+++ b/infra/helm/tuist/values-ci.yaml
@@ -4,6 +4,10 @@
 # — server-deployment.yml resolves them from the latest `<component>@`
 # git tags and passes them via --set at deploy time. This overlay feeds
 # dummy values so static rendering/validation passes.
+server:
+  image:
+    tag: validation
+
 kuraController:
   image:
     tag: validation

--- a/infra/helm/tuist/values-k3s-smoke.yaml
+++ b/infra/helm/tuist/values-k3s-smoke.yaml
@@ -7,6 +7,11 @@
 
 server:
   replicaCount: 0
+  # The Deployment is scaled to zero, so the tag is never pulled. This value
+  # satisfies the chart's mandatory-tag guard while preserving the rendered
+  # server workload in this Kubernetes smoke test.
+  image:
+    tag: k3s-smoke
   migrationJob:
     enabled: false
   license:

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -433,6 +433,11 @@ codebaseSearch:
 server:
   enabled: true
   replicaCount: 1
+  # server.image.tag is REQUIRED. The chart's .Chart.AppVersion tracks the
+  # chart itself, not the server image, which ships on its own 1.x cadence
+  # under ghcr.io/tuist/tuist. Pin an explicit tag matching a release from
+  # https://github.com/tuist/tuist/releases?q=server (for example "1.318.0").
+  # Managed deploys inject it via `helm upgrade --set server.image.tag=...`.
   image:
     repository: ghcr.io/tuist/tuist
     tag: ""
@@ -687,6 +692,23 @@ server:
     certificateBase64: ""
     verifyKey: ""
     selfHostingDevelopmentMode: false
+    # Name of an existing Kubernetes Secret whose keys back the license
+    # environment variables. Use this when the license values live in a
+    # Secret populated out-of-band (Vault, sealed-secrets, bank-vaults, an
+    # ExternalSecret targeting a store other than 1Password, etc.) and you
+    # do not want the chart to render them into its own app-secrets Secret.
+    # Mutually exclusive with `server.license.{key,certificateBase64,verifyKey}`
+    # and with the ESO `server.externalSecrets.license` path.
+    #
+    # Override `existingSecretKeys` to match the key names in your Secret.
+    # An empty value under `existingSecretKeys` skips wiring the corresponding
+    # env var, which lets the Secret carry only the online key (or only the
+    # air-gapped certificate) without a placeholder for the other.
+    existingSecret: ""
+    existingSecretKeys:
+      key: server-license-key
+      certificateBase64: server-license-certificate-base64
+      verifyKey: server-license-verify-key
   database:
     ssl: false
   storage:
@@ -2673,6 +2695,11 @@ runnersController:
     limits:
       cpu: 500m
       memory: 256Mi
+# The standalone cache service is deprecated for new deployments. Hosted
+# Tuist has moved cache serving into Kura (see kuraController / kuraRuntime)
+# and disables this workload (`cache.enabled: false` in
+# values-managed-common.yaml). It is kept for existing self-hosted installs
+# that still rely on it; new deployments should skip it and plan on Kura.
 cache:
   enabled: true
   replicaCount: 1
@@ -2683,6 +2710,16 @@ cache:
     name: ""
     annotations: {}
   podSecurityContext: {}
+  # ghcr.io/tuist/cache is published as a single-arch linux/amd64 image (see
+  # .github/workflows/cache-release.yml — the build does not pass `platforms`
+  # to buildx). arm64 is not planned: the service is on the deprecation path
+  # in favor of Kura, and every managed environment runs on Hetzner amd64
+  # nodes (cx/cpx/ccx) so arm64 has never been on the roadmap for this
+  # image. The chart currently has no cache-specific scheduling fields;
+  # constrain the pod through `global.nodeSelector` / `global.tolerations`
+  # (applied to every workload in the release), or through cluster-level
+  # scheduling (a runtimeClass, admission policy, or dedicated node pool)
+  # rather than expecting a multi-arch tag.
   image:
     repository: ghcr.io/tuist/cache
     tag: "0.29.0"
@@ -2715,23 +2752,31 @@ cache:
   apiKey: ""
   secretKeyBase: ""
   guardianSecretKey: ""
-  # DATABASE_URL for the cache Phoenix app's own Postgres. Two paths:
-  #
-  #   - Self-hosted with an external Postgres: set explicitly here, like
-  #     ecto://user:pass@host:5432/db.
-  #   - Embedded mode (postgresql.mode=embedded): leave empty. The chart
-  #     composes a URL pointing at the embedded Postgres + a dedicated
-  #     `cache.embedded.database` (auto-created at first Postgres boot via
-  #     templates/postgresql-init.yaml so the cache app's migrations don't
-  #     collide with the server's).
-  #
-  # Managed-cloud envs (managedSecrets: true) bypass this entirely — the
-  # cache app reads its own DATABASE_URL from priv/secrets/<env>.yml.enc
-  # baked into the image.
+  # Name of an existing Kubernetes Secret backing the cache's three inline
+  # secrets (Tuist API key, Phoenix SECRET_KEY_BASE, Guardian SECRET_KEY).
+  # Use this when those values live in a Secret populated out-of-band
+  # (Vault, sealed-secrets, an ExternalSecret targeting a store other than
+  # 1Password, etc.) and you do not want the chart to render them into its
+  # own app-secrets Secret. Mutually exclusive with `cache.apiKey`,
+  # `cache.secretKeyBase`, and `cache.guardianSecretKey`. All three keys
+  # must be present in the referenced Secret; override `existingSecretKeys`
+  # if their names differ.
+  existingSecret: ""
+  existingSecretKeys:
+    apiKey: cache-api-key
+    secretKeyBase: cache-secret-key-base
+    guardianSecretKey: cache-guardian-secret-key
+  # Unused by the pinned cache image (0.29.x). The cache app writes its state
+  # to a SQLite database on the pod's own /data volume; there is no external
+  # Postgres to point at. Leave empty — the value is ignored and the
+  # historical embedded-Postgres composition has been removed so the chart no
+  # longer emits a DATABASE_URL that Exqlite would try to open as a file path
+  # ("Exqlite.Error: database_open_failed"). The cache service itself is
+  # deprecated for hosted use in favor of Kura (see kuraController).
   databaseUrl: ""
   embedded:
-    # Database name created in the embedded Postgres for the cache app.
-    # Only meaningful when postgresql.mode=embedded; ignored otherwise.
+    # Deprecated: the cache image no longer uses Postgres, so this field has
+    # no effect. Retained to preserve the values-file schema across upgrades.
     database: tuist_cache
   storage:
     pvc:


### PR DESCRIPTION
## Context

A self-hosted customer running the Tuist Helm chart against a Vault-backed secret store surfaced four separate issues with `infra/helm/tuist/`. This PR fixes each of them in-tree: a Vault escape hatch for the license and cache secrets, a loud failure when `server.image.tag` is missing, a corrected `cache.databaseUrl` doc that matches the pinned image's SQLite reality, and an explicit annotation of the cache image's amd64-only build and its deprecation in favor of Kura.

## What changed and why

### 1. `existingSecret` support for the license and cache secrets

Before this PR, only `postgresql.external.existingSecret` supported reading a value from a pre-populated Kubernetes Secret. The Tuist license, cache API key, cache `SECRET_KEY_BASE`, and cache Guardian secret all had to either be inlined into `values.yaml` or synced through the chart's own ExternalSecret path, which is hard-wired to a 1Password `ClusterSecretStore`. Vault users were left with two bad options: paste literals into `values.yaml` (defeats the point of a Secret store), or run a Kyverno-style admission policy that rewrites the chart's `secretKeyRef`s at apply time.

The clean fix mirrors the `postgresql.external.existingSecret` shape:

```yaml
server:
  license:
    existingSecret: vault-tuist-license
    existingSecretKeys:
      key: license-key
      certificateBase64: ""   # blank skips wiring TUIST_LICENSE_CERTIFICATE_BASE64
      verifyKey: license-verify

cache:
  existingSecret: vault-tuist-cache
  existingSecretKeys:
    apiKey: cache-api
    secretKeyBase: cache-skb
    guardianSecretKey: cache-guard
```

When `existingSecret` is set, the chart:
- Skips writing the corresponding entries into its own `app-secrets` Secret.
- Points `TUIST_LICENSE_*`, `TUIST_CACHE_API_KEY`, `SECRET_KEY_BASE`, and `GUARDIAN_SECRET_KEY` at the caller-provided Secret via `secretKeyRef`, using the field names from `existingSecretKeys`.
- Fails render with a clear message if the caller sets `existingSecret` alongside inline values, the ESO path, or without at least one of `key`/`certificateBase64` for the license.
- For the cache, requires all three `existingSecretKeys` entries and refuses to render if any inline `cache.{apiKey,secretKeyBase,guardianSecretKey}` is also set.

The alternative, folding this into the existing 1Password-based `externalSecrets` block, would have forced Vault users to still deploy External Secrets Operator and register a 1Password store just to reach the chart's secret machinery. Direct `existingSecret` references stay agnostic to the sync mechanism (Vault Agent Injector, `bank-vaults`, sealed-secrets, plain `kubectl create secret`) and match the pattern the chart already established for external Postgres.

### 2. `server.image.tag` fails render instead of silently defaulting

Every server-image consumer used `{{ .Values.server.image.tag | default .Chart.AppVersion }}`, and `Chart.yaml`'s `appVersion` is `"0.2.0"` (it tracks the chart, not the server image, which ships under `ghcr.io/tuist/tuist` on a 1.x cadence). Managed deploys never hit the bug because `.github/workflows/server-deployment.yml` injects the tag via `--set` at `helm upgrade`. Self-hosters following the chart alone got `ImagePullBackOff` five minutes after `helm install`.

A new `tuist.serverImage` helper renders `repo:tag` and `fail`s with a link to the server releases page when the tag is empty. Every deployment, migration, and processor job that reads the server image now goes through it (`server-deployment.yaml`, `processor-deployment.yaml`, `swift-registry-sync-deployment.yaml`, `server-migration-job.yaml`, `clickhouse-migration-job.yaml`). Pinning the current stable tag as the chart default was an option, but it would have required a bump on every server release and still hidden the mismatch from anyone running an older chart against a newer server. A loud fail with a curated error message beats a silent surprise.

`values-ci.yaml` and `values-k3s-smoke.yaml` were updated to satisfy the new guard so the existing `helm.yml` render + kubeconform validation still passes.

### 3. Corrected `cache.databaseUrl` documentation

The `cache.databaseUrl` comment in `values.yaml` claimed the value was a PostgreSQL/Ecto URL and documented an embedded-Postgres composition that ran when `postgresql.mode: embedded` (the chart default). The pinned `ghcr.io/tuist/cache:0.29.0` image no longer uses Postgres (`cache/config/runtime.exs` uses Exqlite at `/data/repo.sqlite`), and the release doesn't consume `DATABASE_URL` at all. So the default `postgresql.mode: embedded` composition would render a `DATABASE_URL=ecto://...` env var that Exqlite would try to open as a file path, producing `Exqlite.Error: database_open_failed`. The customer worked around it by leaving `cache.databaseUrl` empty and using a non-embedded Postgres mode.

The `tuist.cacheDatabaseUrl` helper is now a no-op, the `cache-deployment.yaml` only emitted `DATABASE_URL` when the helper returned non-empty, so the env var simply disappears from the rendered pod. The `cache.databaseUrl` comment was rewritten to document the SQLite reality, and `cache.embedded.database` is marked as deprecated (kept for schema stability). The Postgres init ConfigMap that pre-creates `tuist_cache` was left untouched: it produces an unused database on fresh installs but removing it would break assumptions on existing installs that migrated forward.

### 4. Cache image is amd64-only and the service is on its way out

`.github/workflows/cache-release.yml` builds `ghcr.io/tuist/cache` without a `platforms:` arg, so it publishes whatever the runner is (`linux/amd64`). arm64 support isn't planned: every managed cluster runs on Hetzner amd64 nodes (`cx`/`cpx`/`ccx`, no `cax` types), and hosted Tuist has moved cache serving into Kura. `values-managed-common.yaml` already sets `cache.enabled: false`, but the chart default and README still fully wire the standalone service.

`values.yaml` now carries an annotation at the top of the `cache:` block that:
- Marks the standalone cache service as deprecated for new deployments, pointing at `kuraController`.
- Records that `ghcr.io/tuist/cache` is `linux/amd64` only and that arm64 isn't on the roadmap.
- Acknowledges the chart has no cache-specific scheduling knobs and points at `global.nodeSelector` / `global.tolerations` (or cluster-level admission) as the workaround for pinning the pod to an amd64 pool.

Adding arm64 to the build workflow would have been a two-line change, but committing to keep the multi-arch build honest for a service we're actively deprecating overreaches. The annotation makes the tradeoff explicit for anyone reading the values file.

## Verification

- `helm template` with each `values-*` combination the `helm.yml` `Render` CI check exercises:
  - `values-self-hosted-ci.yaml` + `values-ci.yaml`
  - `values-managed-common.yaml` + `values-managed-production.yaml` + `values-ci.yaml`
  - `values-preview.yaml` + `values-preview-kura.yaml` + `values-preview-ci.yaml` + `values-ci.yaml`
  - `values-pentest.yaml` + `values-ci.yaml`
  - `values-k3s-smoke.yaml`
  All five render successfully.
- Negative tests confirmed:
  - Rendering `values-self-hosted-ci.yaml` alone (no image tag) now fails with the new server tag guard and its release-page link.
  - Setting `server.license.existingSecret=X` alongside `server.license.key=Y` fails with the mutual-exclusion guard.
- Positive `existingSecret` test with `--set server.license.existingSecret=vault-tuist-license --set cache.existingSecret=vault-tuist-cache` rendered `TUIST_LICENSE_KEY`, `TUIST_LICENSE_VERIFY_KEY`, `TUIST_CACHE_API_KEY`, `SECRET_KEY_BASE`, and `GUARDIAN_SECRET_KEY` as `secretKeyRef`s into the caller-provided Secrets, and the chart's own `app-secrets` no longer carried the corresponding stringData keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgaHxejbvKEZCCPQ4uLaQ5