### PR TITLE
fix(swifterpm): prune orphan pins from Package.resolved before a resolve

### DIFF
--- a/swifterpm/Sources/swifterpm/CLI.swift
+++ b/swifterpm/Sources/swifterpm/CLI.swift
@@ -612,6 +612,20 @@ enum CLIRunner {
             cli.forceResolvedVersions || cli.disableAutomaticResolution
             || cli.onlyUseVersionsFromResolvedFile
 
+        // On `resolve`, the seed Package.resolved may still list dependencies
+        // that have been removed from the manifest since the last install.
+        // Drop orphan pins before either path handles the file, so SwiftPM
+        // never chases a location that only the previous manifest reached.
+        // `update` and `--force-resolved-versions` bypass this: the former
+        // clears the file outright, the latter must not mutate it.
+        if preferResolvedFile, shouldWrite(write: write, printOnly: printOnly), !readOnly {
+            try await PackageResolver.pruneStalePinsIfNeeded(
+                packageDir: package,
+                scratchDir: scratch,
+                disableSandbox: cli.disableSandbox
+            )
+        }
+
         // Use the same native cold path as the embeddable API. The direct
         // invocation is only safe for lockfiles SwiftPM itself understands;
         // preserve SwifterPM's compatibility path for older custom pin kinds.

--- a/swifterpm/Sources/swifterpm/Resolve.swift
+++ b/swifterpm/Sources/swifterpm/Resolve.swift
@@ -253,6 +253,71 @@ enum PackageResolver {
         }
     }
 
+    /// Drop pins whose declaring dependency has been removed from the
+    /// manifest since the seed `Package.resolved` was written. Native
+    /// SwiftPM's `swift package resolve` tries to fetch every pin it sees,
+    /// so an orphan whose location no longer resolves (a private mirror
+    /// gone, a revoked network, a moved repo) aborts the whole resolve
+    /// instead of being dropped as unused.
+    ///
+    /// Only prunes when the manifest actually diverged from the seed
+    /// (originHash mismatch) and only pins whose identity is definitely no
+    /// longer declared by the root manifest or any local package under it.
+    /// Direct-dep pins keep their exact recorded versions; transitives of
+    /// pruned direct deps are dropped along with them and re-resolved from
+    /// the remaining manifest, matching the behavior of a `resolve` that
+    /// never saw the removed dependency in the first place.
+    ///
+    /// Package.resolved is rewritten in place so both the warm and cold
+    /// paths see the pruned seed. `workspace-state.json` is cleared when
+    /// pruning happens, because SwiftPM otherwise re-associates the seed
+    /// with the stale checkout state and still reaches for the orphan.
+    static func pruneStalePinsIfNeeded(
+        packageDir: URL,
+        scratchDir: URL,
+        disableSandbox: Bool
+    ) async throws {
+        let resolvedPath = packageDir.appendingPathComponent("Package.resolved")
+        guard try await fileSystem.exists(resolvedPath.absolutePath) else { return }
+
+        let resolved = try await ResolvedFile.read(packageDir: packageDir)
+        guard !resolved.pins.isEmpty else { return }
+
+        let currentOriginHash = try await originHash(packageDir: packageDir)
+        guard resolved.originHash != currentOriginHash else { return }
+
+        let manifest = try await ManifestLoader.dumpPackage(
+            packageDir: packageDir, disableSandbox: disableSandbox
+        )
+        var expectedIdentities = Set(
+            try ManifestParser.dependencies(manifest).map { $0.identity.lowercased() }
+        )
+        let localPackages = try await ManifestFileSystemDependencyGraph.collect(
+            rootPackageDir: packageDir,
+            rootManifest: manifest,
+            disableSandbox: disableSandbox
+        )
+        for localPackage in localPackages {
+            for dep in try ManifestParser.dependencies(localPackage.manifest) {
+                expectedIdentities.insert(dep.identity.lowercased())
+            }
+        }
+
+        let survivors = resolved.pins.filter {
+            expectedIdentities.contains($0.identity.lowercased())
+        }
+        guard survivors.count != resolved.pins.count else { return }
+
+        var pruned = resolved
+        pruned.pins = survivors
+        try await ResolvedFile.write(packageDir: packageDir, resolved: pruned)
+
+        let workspaceStatePath = scratchDir.appendingPathComponent("workspace-state.json")
+        if try await fileSystem.exists(workspaceStatePath.absolutePath) {
+            try? await fileSystem.removePath(workspaceStatePath)
+        }
+    }
+
     /// Load the resolved pins for `packageDir`, resolving fresh only when
     /// needed. Centralizes the read-only / current-file / seed-and-resolve
     /// decision so every entry point (and any `SwifterPMCore` embedder) seeds

--- a/swifterpm/Sources/swifterpm/SwifterPM.swift
+++ b/swifterpm/Sources/swifterpm/SwifterPM.swift
@@ -218,6 +218,20 @@ public struct SwifterPM: Sendable {
         let scratch = request.scratchDirectory ?? package.appendingPathComponent(".build")
         let cacheRoot = try Cache.resolvedRoot(request.cacheDirectory)
 
+        // On `resolve`, the seed Package.resolved may still list dependencies
+        // that have been removed from the manifest since the last install.
+        // Drop orphan pins before either path handles the file, so SwiftPM
+        // never chases a location that only the previous manifest reached.
+        // `update` and `--force-resolved-versions` bypass this: the former
+        // clears the file outright, the latter must not mutate it.
+        if preferResolvedFile, request.writeResolvedFile, !request.forceResolvedVersions {
+            try await PackageResolver.pruneStalePinsIfNeeded(
+                packageDir: package,
+                scratchDir: scratch,
+                disableSandbox: request.disableSandbox
+            )
+        }
+
         // A cache only helps when it has every pin for this package. Going
         // straight to the native resolver for any missing pin avoids manifest
         // precomputation and restoration work before SwiftPM fetches it.

--- a/swifterpm/Tests/swifterpmTests/ResolveTests.swift
+++ b/swifterpm/Tests/swifterpmTests/ResolveTests.swift
@@ -359,6 +359,122 @@ struct ResolveTests {
     }
 
     @Test
+    func resolveDropsAnOrphanPinInsteadOfFetchingIt() async throws {
+        // Reported on Slack: after removing a dependency from Package.swift, a
+        // subsequent `tuist install` (SwifterPM.resolve) failed with SwiftPM's
+        // "exhausted attempts to resolve the dependencies graph" error, still
+        // asking for the removed pin. Root cause: `swift package resolve` tries
+        // to fetch every pin it sees in Package.resolved — orphans included —
+        // and if the orphan's location is broken (moved repo, private mirror
+        // gone, revoked network access), the fetch aborts the entire resolve.
+        //
+        // The fix: when the resolved-file's originHash disagrees with the
+        // current manifest, prune pins whose identity is not a declared
+        // dependency of the root manifest (or any local package under it)
+        // before handing the file to SwiftPM. Direct-dep versions stay locked;
+        // the seed only loses pins whose identity is definitely no longer
+        // referenced.
+        //
+        // Reproducing the failure exactly: after an initial resolve pins the
+        // dependency, we splice an orphan pin whose remote does not exist into
+        // Package.resolved, and stale the originHash so the read-if-current
+        // fast path falls through. Without the prune, `swift package resolve`
+        // tries to clone the orphan and errors out; with the prune, the orphan
+        // never reaches SwiftPM and the resolve completes.
+        try await withTemporaryDirectory { root in
+            let kept = root.appendingPathComponent("Kept")
+            try await writeLibraryPackageManifest(at: kept, name: "Kept")
+            try await initGitDependency(at: kept, tags: ["1.0.0"])
+
+            let package = root.appendingPathComponent("App")
+            try await writeAppPackageManifest(
+                at: package,
+                dependencies: [(url: kept.path, product: "Kept")]
+            )
+
+            let cacheDirectory = root.appendingPathComponent("cache")
+            let scratch = root.appendingPathComponent("scratch")
+
+            _ = try await SwifterPM().resolve(
+                .init(
+                    packageDirectory: package,
+                    cacheDirectory: cacheDirectory,
+                    scratchDirectory: scratch,
+                    disableSandbox: true,
+                    quiet: true
+                )
+            )
+
+            var pinned = try await ResolvedFile.read(packageDir: package)
+            pinned.pins.append(
+                ResolvedPin(
+                    identity: "snapkit",
+                    kind: "remoteSourceControl",
+                    location:
+                        "https://github.com/tuist/nonexistent-orphan-repository-do-not-create.git",
+                    state: ResolvedState(
+                        branch: nil,
+                        revision: "0000000000000000000000000000000000000000",
+                        version: "99.99.99"
+                    )
+                )
+            )
+            pinned.originHash = "0000000000000000000000000000000000000000000000000000000000000000"
+            try await ResolvedFile.write(packageDir: package, resolved: pinned)
+
+            // A previous install would have written the orphan into
+            // workspace-state.json alongside Package.resolved. Native SwiftPM
+            // reads both, and only tries to fetch the orphan when its
+            // workspace state agrees the checkout should exist. Reproduce that
+            // pairing here or the resolve short-circuits and hides the bug.
+            let workspaceStatePath = scratch.appendingPathComponent("workspace-state.json")
+            var workspaceState = try JSONSerialization.jsonObject(
+                with: await fileSystem.readFile(at: workspaceStatePath.absolutePath)
+            ) as? [String: Any] ?? [:]
+            var object = workspaceState["object"] as? [String: Any] ?? [:]
+            var workspaceDependencies = object["dependencies"] as? [[String: Any]] ?? []
+            workspaceDependencies.append([
+                "basedOn": NSNull(),
+                "packageRef": [
+                    "identity": "snapkit",
+                    "kind": "remoteSourceControl",
+                    "location":
+                        "https://github.com/tuist/nonexistent-orphan-repository-do-not-create.git",
+                    "name": "SnapKit",
+                ],
+                "state": [
+                    "checkoutState": [
+                        "revision": "0000000000000000000000000000000000000000",
+                        "version": "99.99.99",
+                    ],
+                    "name": "sourceControlCheckout",
+                ],
+                "subpath": "SnapKit",
+            ])
+            object["dependencies"] = workspaceDependencies
+            workspaceState["object"] = object
+            try await fileSystem.atomicWrite(
+                JSONSerialization.data(withJSONObject: workspaceState, options: [.prettyPrinted]),
+                to: workspaceStatePath
+            )
+
+            let reresolved = try await SwifterPM().resolve(
+                .init(
+                    packageDirectory: package,
+                    cacheDirectory: cacheDirectory,
+                    scratchDirectory: scratch,
+                    disableSandbox: true,
+                    quiet: true
+                )
+            )
+            #expect(reresolved.pins.map(\.identity) == ["kept"])
+
+            let onDisk = try await ResolvedFile.read(packageDir: package)
+            #expect(onDisk.pins.map(\.identity) == ["kept"])
+        }
+    }
+
+    @Test
     func nativeColdPathIsUsedWhenTheSharedCacheOnlyContainsOtherPackages() async throws {
         try await withTemporaryDirectory { root in
             let package = root.appendingPathComponent("App")
@@ -493,6 +609,51 @@ struct ResolveTests {
         )
         try await fileSystem.atomicWrite(
             "import Dependency\npublic struct App {}\n",
+            to: packageDir.appendingPathComponent("Sources/App/App.swift")
+        )
+    }
+
+    private func writeAppPackageManifest(
+        at packageDir: URL,
+        dependencies: [(url: String, product: String)]
+    ) async throws {
+        try await fileSystem.makeDirectory(
+            at: packageDir.appendingPathComponent("Sources/App").absolutePath,
+            options: [.createTargetParentDirectories]
+        )
+        let dependencyLines = dependencies
+            .map { #".package(url: "\#($0.url)", exact: "1.0.0"),"# }
+            .joined(separator: "\n        ")
+        let productLines = dependencies
+            .map { #".product(name: "\#($0.product)", package: "\#($0.product)"),"# }
+            .joined(separator: "\n            ")
+        let importLines = dependencies
+            .map { "import \($0.product)" }
+            .joined(separator: "\n")
+        try await fileSystem.atomicWrite(
+            """
+            // swift-tools-version: 6.0
+            import PackageDescription
+
+            let package = Package(
+                name: "App",
+                products: [
+                    .library(name: "App", targets: ["App"]),
+                ],
+                dependencies: [
+                    \(dependencyLines)
+                ],
+                targets: [
+                    .target(name: "App", dependencies: [
+                        \(productLines)
+                    ]),
+                ]
+            )
+            """,
+            to: packageDir.appendingPathComponent("Package.swift")
+        )
+        try await fileSystem.atomicWrite(
+            "\(importLines)\npublic struct App {}\n",
             to: packageDir.appendingPathComponent("Sources/App/App.swift")
         )
     }


### PR DESCRIPTION
> Describe here the purpose of your PR.

`tuist install` (which delegates to SwifterPM under the hood) can abort with SwiftPM's `exhausted attempts to resolve the dependencies graph` error and keep asking for a dependency that has already been removed from `Package.swift`. This PR fixes that class of failure by pruning orphan pins before the resolve reaches native SwiftPM.

## Root cause

When a dependency is removed from `Package.swift`, the pin for it stays behind in `Package.resolved` and `.build/workspace-state.json` from the previous install. Native `swift package resolve` treats every pin it sees as something it must reconcile, so it tries to fetch the orphan. If the orphan's location no longer resolves (a private mirror gone, revoked network access, a moved repo, or any transient fetch failure), the fetch aborts the entire resolve instead of the pin being dropped as unused.

Concretely, the reported user removed a package two weeks ago, `Package.swift` no longer references it, but the pin was still in `Package.resolved` — and every subsequent `tuist install` failed against that pin.

## Approach

Added `PackageResolver.pruneStalePinsIfNeeded(packageDir:scratchDir:disableSandbox:)` in `swifterpm/Sources/swifterpm/Resolve.swift`. When the resolved-file's `originHash` disagrees with the current manifest (i.e. `Package.swift` genuinely diverged from the seed), it:

- Loads the root manifest plus every local package's manifest and computes the set of declared dependency identities.
- Keeps pins whose identity is in that set; drops the rest.
- Rewrites `Package.resolved` with the surviving pins.
- Clears `.build/workspace-state.json`, because SwiftPM otherwise re-associates the seed with the stale checkout state and still reaches for the orphan.

Direct-dep pins keep their exact recorded versions. Transitives of pruned direct deps get dropped along with them and are re-resolved from the remaining manifest — matching the behavior of a resolve that never saw the removed dependency in the first place.

The helper is called from both entry points:

- `SwifterPM.runResolution` in `swifterpm/Sources/swifterpm/SwifterPM.swift` — the embedded API that `tuist install` reaches through `TuistSupport/SwiftPackageManagerController`.
- `CLIRunner.runResolutionCommand` in `swifterpm/Sources/swifterpm/CLI.swift` — the `swifterpm resolve` CLI path.

Both call sites gate on `preferResolvedFile && writeResolvedFile && !forceResolvedVersions`. That leaves `update` alone (it already clears `Package.resolved` and `workspace-state.json` in the same code path) and leaves `--force-resolved-versions` alone (it must not mutate the lockfile).

### Alternatives considered

- Deleting `Package.resolved` outright when `originHash` mismatches (like `update` does). Rejected because it would blow away direct-dep version pins on every manifest change, not just the affected ones.
- Filtering `workspace-state.json` in place instead of deleting it. Rejected as more code with no benefit — SwiftPM re-derives the workspace state from `Package.resolved` and `Package.swift` on the next run.

## Impact

- `tuist install` now recovers automatically when a dependency was removed from `Package.swift`. Users no longer need to manually delete `Package.resolved` and `.build/workspace-state.json`, and `tuist install --update` stops being the workaround for what should be a plain install.
- Direct-dep version stability is preserved: pruning keeps existing exact pins for every direct dependency that's still in the manifest.
- Transitives of pruned direct deps may be re-resolved on the next install; this is the same behavior a fresh resolve without the removed dep would have produced, so it is not a regression.
- `update` and `--force-resolved-versions` are unaffected.

## Validation

- Added `ResolveTests.resolveDropsAnOrphanPinInsteadOfFetchingIt` in `swifterpm/Tests/swifterpmTests/ResolveTests.swift`. It sets up an initial resolve, splices a "SnapKit-like" orphan pin with an unreachable location into `Package.resolved` and `.build/workspace-state.json`, stales the `originHash`, and re-resolves. Without the fix the test fails with SwiftPM's `remote: Repository not found` fetch error; with the fix, the resolve succeeds and the orphan is dropped from both files.
- Full SwifterPM test suite: 195 tests passing.

### How to test locally

From the `swifterpm/` directory:

```
swift test --filter "ResolveTests/resolveDropsAnOrphanPinInsteadOfFetchingIt"
```

Or exercise the CLI directly against a package that had a dependency removed but still has the old pin in `Package.resolved`, and confirm the pin is dropped on `swifterpm resolve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnQjv2bpe71w5h5oyeT5MW
