### PR TITLE
feat(server,infra): grow a Kura disk claim on two days of daily ring turnover

### DIFF
--- a/infra/helm/k8s-monitoring/alerts.md
+++ b/infra/helm/k8s-monitoring/alerts.md
@@ -1460,7 +1460,8 @@ its proposals unattended every ten minutes, within a fleet-wide budget of five
 applies an hour. Its own `retention_floor_days` is 3, so any instance whose
 retention falls under two days is already inside the band sizing is working
 on, and it is deliberately unhurried there: the rung that matches a one-day
-shed age needs five consecutive qualifying days before it grows the claim. A
+shed age grows the claim after two consecutive qualifying days when the ring
+cycled about once a day over them, and after five when it did not. A
 two-day rule therefore alerts on a control loop that is mid-confirmation and
 would keep alerting for days while it does its job. A rule at two days was
 deployed with this one on 2026-09-02 and removed on 2026-09-04, having fired

--- a/server/lib/tuist/kura/claim_sizing.ex
+++ b/server/lib/tuist/kura/claim_sizing.ex
@@ -6,8 +6,9 @@ defmodule Tuist.Kura.ClaimSizing do
   Growth is driven by shed age (how soon after being written content was
   evicted), shrinking by occupancy, because an oversized ring never evicts and
   so produces no shed age at all. Confirmation scales with severity: the worse
-  the shedding, the shorter the window, and the shortest rungs are bought with
-  evicted volume rather than elapsed time.
+  the shedding, the shorter the window, and a tier's window can be bought down
+  with the volume the ring cycled in place of elapsed time. The step a reading
+  may take scales with the confirmation behind it.
 
   Windows count rollup rows, one row being one UTC day per account-region.
   Today's row is live, so a one-row window can be satisfied in minutes. Rows
@@ -23,12 +24,16 @@ defmodule Tuist.Kura.ClaimSizing do
     retention_floor_days: 3,
     ceiling: %{air: "64Gi", pro: "64Gi", enterprise: "256Gi"},
     # Ordered shortest window first; the first rung a reading satisfies wins.
-    # The absolute arm does not move when the floor is recalibrated.
+    # The absolute arm does not move when the floor is recalibrated. A tier
+    # appears twice where volume can stand in for elapsed time: the ring the
+    # account cycled is evidence the same reading held all day. Turnover counts
+    # rings across the whole window, so two over two days is one a day.
     grow_windows: [
       %{shed_age_under: {:seconds, 3_600}, window_days: 1, min_ring_turnover: 1.0},
       %{shed_age_under: {:seconds, 28_800}, window_days: 1, min_ring_turnover: 2.0},
       %{shed_age_under: {:seconds, 28_800}, window_days: 2},
       %{shed_age_under: {:floor_fraction, 0.1}, window_days: 2},
+      %{shed_age_under: {:floor_fraction, 0.34}, window_days: 2, min_ring_turnover: 2.0},
       %{shed_age_under: {:floor_fraction, 0.34}, window_days: 5},
       %{shed_age_under: {:floor_fraction, 1.0}, window_days: 14}
     ],
@@ -36,7 +41,8 @@ defmodule Tuist.Kura.ClaimSizing do
     shrink_window_days: 30,
     shrink_occupancy_percent: 40,
     shrink_target_occupancy_percent: 60,
-    max_step_factor: 2.0
+    max_step_factor: 2.0,
+    max_confirmed_step_factor: 4.0
   }
 
   def default_policy, do: @default_policy
@@ -108,7 +114,7 @@ defmodule Tuist.Kura.ClaimSizing do
       with window when not is_nil(window) <-
              qualifying_window(by_date, context.today, rung.window_days, &grow_day?(&1, threshold_seconds)),
            true <- turnover_cleared?(window, rung) do
-        {grow_target_bytes(window, current_bytes, floor_seconds, policy),
+        {grow_target_bytes(window, current_bytes, floor_seconds, rung, policy),
          grow_evidence(window, floor_seconds, threshold_seconds)}
       else
         _ -> nil
@@ -178,16 +184,24 @@ defmodule Tuist.Kura.ClaimSizing do
 
   # Projected from the retention the current claim buys, plus headroom so a
   # correct resize does not land on the boundary it is escaping.
-  defp grow_target_bytes(window, current_bytes, floor_seconds, policy) do
+  defp grow_target_bytes(window, current_bytes, floor_seconds, rung, policy) do
     span_seconds = window |> Enum.map(& &1.median_ring_span_seconds) |> median() |> max(1)
 
     projected = current_bytes * (floor_seconds / span_seconds) * policy.grow_headroom_factor
 
     projected
-    |> min(current_bytes * policy.max_step_factor)
+    |> min(current_bytes * max_step_factor(rung, policy))
     |> max(current_bytes)
     |> round()
   end
+
+  # The bound scales with the confirmation behind the reading: one day buys a
+  # doubling, a tier proven across days buys the projection's own answer. It
+  # binds only under 45 hours of retention at 2x and 22.5 hours at 4x, so an
+  # account near the floor is sized by the projection either way and the one
+  # furthest under it arrives in a single rebuild rather than three.
+  defp max_step_factor(%{window_days: 1}, policy), do: policy.max_step_factor
+  defp max_step_factor(_rung, policy), do: policy.max_confirmed_step_factor
 
   defp shrink_target_bytes(window, policy) do
     peak_bytes =

--- a/server/test/tuist/kura/claim_proposals_test.exs
+++ b/server/test/tuist/kura/claim_proposals_test.exs
@@ -127,7 +127,7 @@ defmodule Tuist.Kura.ClaimProposalsTest do
       assert proposal.direction == :grow
       assert proposal.region == "us-east"
       assert proposal.current_claim_size == "8Gi"
-      assert proposal.recommended_claim_size == "16Gi"
+      assert proposal.recommended_claim_size == "20Gi"
       assert proposal.evidence["signal"] == "shed_age_below_retention_floor"
     end
 
@@ -264,12 +264,12 @@ defmodule Tuist.Kura.ClaimProposalsTest do
 
       assert {:ok, result} = Kura.apply_claim_proposal(proposal, "ops@tuist.dev")
 
-      assert result.claim_size == "16Gi"
+      assert result.claim_size == "20Gi"
       assert [raised_server] = result.raised
       assert raised_server.id == server.id
-      assert Repo.get!(Server, server.id).storage_claim_size == "16Gi"
-      assert PlacerClaims.claim_for(account) == "16Gi"
-      assert PlacerClaims.effective_claim_size(account) == "16Gi"
+      assert Repo.get!(Server, server.id).storage_claim_size == "20Gi"
+      assert PlacerClaims.claim_for(account) == "20Gi"
+      assert PlacerClaims.effective_claim_size(account) == "20Gi"
 
       resolved = Repo.get!(ClaimProposal, proposal.id)
       assert resolved.status == :applied

--- a/server/test/tuist/kura/claim_sizing_test.exs
+++ b/server/test/tuist/kura/claim_sizing_test.exs
@@ -148,7 +148,7 @@ defmodule Tuist.Kura.ClaimSizingTest do
       # day, short of the single-day rung.
       context = context(rollups: severe_churn(2, @today))
 
-      assert {:grow, "32Gi", evidence} = ClaimSizing.evaluate(context)
+      assert {:grow, "64Gi", evidence} = ClaimSizing.evaluate(context)
       assert evidence["window_days"] == 2
       assert evidence["qualifying_threshold_seconds"] == 28_800
     end
@@ -225,7 +225,7 @@ defmodule Tuist.Kura.ClaimSizingTest do
 
       assert ClaimSizing.evaluate(context(rollups: Enum.take(rollups, -1))) == :none
 
-      assert {:grow, "32Gi", evidence} = ClaimSizing.evaluate(context(rollups: rollups))
+      assert {:grow, "64Gi", evidence} = ClaimSizing.evaluate(context(rollups: rollups))
       assert evidence["window_days"] == 2
       assert evidence["ring_budget_bytes"] == nil
       assert evidence["ring_turnover"] == nil
@@ -242,7 +242,7 @@ defmodule Tuist.Kura.ClaimSizingTest do
         Map.put(newer, :last_ring_budget_bytes, 13 * @gibibyte)
       ]
 
-      assert {:grow, "32Gi", evidence} = ClaimSizing.evaluate(context(rollups: rollups))
+      assert {:grow, "64Gi", evidence} = ClaimSizing.evaluate(context(rollups: rollups))
       assert evidence["window_days"] == 2
       assert evidence["ring_budget_bytes"] == 5 * @gibibyte
       assert evidence["ring_turnover"] == 4.0
@@ -260,7 +260,7 @@ defmodule Tuist.Kura.ClaimSizingTest do
       # not because Air is allowed less in the end.
       rollups = churn_at(2, @today, 7 * 3_600, 12 * 3_600)
 
-      for {plan, current, expected} <- [{:air, "8Gi", "16Gi"}, {:pro, "16Gi", "32Gi"}, {:enterprise, "32Gi", "64Gi"}] do
+      for {plan, current, expected} <- [{:air, "8Gi", "32Gi"}, {:pro, "16Gi", "64Gi"}, {:enterprise, "32Gi", "128Gi"}] do
         context = context(plan: plan, current_claim_size: current, rollups: rollups)
 
         assert {:grow, ^expected, evidence} = ClaimSizing.evaluate(context)
@@ -270,15 +270,15 @@ defmodule Tuist.Kura.ClaimSizingTest do
     end
 
     test "enterprise may grow past where the other plans stop" do
-      # The shared promise, funded further: at 50Gi pro is done and
-      # enterprise keeps stepping, one clamped step at a time, to its own
-      # ceiling. This is also what stops enterprise being a plan that can
-      # only ever shrink from its starting constant.
+      # The shared promise, funded further: at 64Gi pro is done and
+      # enterprise keeps stepping, in bounded steps, to its own ceiling. This
+      # is also what stops enterprise being a plan that can only ever shrink
+      # from its starting constant.
       rollups = severe_churn(2, @today)
 
       assert ClaimSizing.evaluate(context(plan: :pro, current_claim_size: "64Gi", rollups: rollups)) == :none
 
-      assert {:grow, "128Gi", _evidence} =
+      assert {:grow, "256Gi", _evidence} =
                ClaimSizing.evaluate(context(plan: :enterprise, current_claim_size: "64Gi", rollups: rollups))
 
       assert {:grow, "256Gi", _evidence} =
@@ -298,9 +298,48 @@ defmodule Tuist.Kura.ClaimSizingTest do
 
       longer = churn_at(5, @today, 8 * 3_600, 12 * 3_600)
 
-      assert {:grow, "16Gi", evidence} = ClaimSizing.evaluate(context(context, rollups: longer))
+      assert {:grow, "32Gi", evidence} = ClaimSizing.evaluate(context(context, rollups: longer))
       assert evidence["window_days"] == 5
       assert evidence["qualifying_threshold_seconds"] == round(0.34 * 3 * @day_seconds)
+    end
+
+    test "a tier under a third of the floor is bought down to two days by the ring it cycles" do
+      # 20 hours of retention clears every absolute arm, so elapsed time on
+      # its own owes five days. A ring that cycles once a day is not waiting
+      # on further evidence: what it holds is already younger than the day
+      # the account will next build against.
+      rollups =
+        2
+        |> churn_at(@today, 20 * 3_600, 30 * 3_600)
+        |> Enum.map(&Map.put(&1, :evicted_bytes, 15 * @gibibyte))
+
+      assert {:grow, "48Gi", evidence} = ClaimSizing.evaluate(context(rollups: rollups))
+      assert evidence["window_days"] == 2
+      assert evidence["ring_turnover"] == 2.3
+      assert evidence["qualifying_threshold_seconds"] == round(0.34 * 3 * @day_seconds)
+    end
+
+    test "the same tier without a cycled ring serves out its five days" do
+      # Three quarters of a ring in a day is an account shedding at the
+      # margin rather than one thrashing, so it waits for the longer window
+      # like any other reading that cannot pay in volume.
+      assert ClaimSizing.evaluate(context(rollups: churn_at(2, @today, 20 * 3_600, 30 * 3_600))) == :none
+
+      assert {:grow, "48Gi", evidence} =
+               ClaimSizing.evaluate(context(rollups: churn_at(5, @today, 20 * 3_600, 30 * 3_600)))
+
+      assert evidence["window_days"] == 5
+    end
+
+    test "the step a reading may take scales with the confirmation behind it" do
+      # The projection here runs far past either bound, so the bound is what
+      # lands: a single day's reading doubles, and a tier confirmed across
+      # days takes four times. Fewer and better-aimed steps is fewer rebuilds
+      # for a badly undersized account, which is the only place it binds.
+      one_day = 1 |> severe_churn(@today) |> Enum.map(&Map.put(&1, :evicted_bytes, 33 * @gibibyte))
+
+      assert {:grow, "32Gi", %{"window_days" => 1}} = ClaimSizing.evaluate(context(rollups: one_day))
+      assert {:grow, "64Gi", %{"window_days" => 2}} = ClaimSizing.evaluate(context(rollups: severe_churn(2, @today)))
     end
 
     test "moderate shedding waits out the middle tier" do
@@ -308,7 +347,7 @@ defmodule Tuist.Kura.ClaimSizingTest do
       # cannot carry it, but it does not serve the full fortnight either.
       assert ClaimSizing.evaluate(context(rollups: moderate_churn(4, @today))) == :none
 
-      assert {:grow, "32Gi", evidence} = ClaimSizing.evaluate(context(rollups: moderate_churn(5, @today)))
+      assert {:grow, "40Gi", evidence} = ClaimSizing.evaluate(context(rollups: moderate_churn(5, @today)))
       assert evidence["window_days"] == 5
       assert evidence["qualifying_threshold_seconds"] == round(0.34 * 3 * @day_seconds)
     end
@@ -322,7 +361,7 @@ defmodule Tuist.Kura.ClaimSizingTest do
 
     test "air climbs to the shared ceiling one clamped step at a time" do
       # A 12-hour ring against the 3-day floor projects far past the step
-      # bound, so each pass doubles rather than jumping. Air is not capped
+      # bound, so each pass takes the bound. Air is not capped
       # short of Pro any more; it just starts lower, so it takes more
       # separately confirmed steps to arrive.
       rollups =
@@ -331,7 +370,7 @@ defmodule Tuist.Kura.ClaimSizingTest do
           median_ring_span_seconds: div(@day_seconds, 2)
         )
 
-      for {current, expected} <- [{"8Gi", "16Gi"}, {"16Gi", "32Gi"}, {"32Gi", "64Gi"}] do
+      for {current, expected} <- [{"8Gi", "32Gi"}, {"16Gi", "64Gi"}, {"32Gi", "64Gi"}] do
         context = context(plan: :air, current_claim_size: current, rollups: rollups)
 
         assert {:grow, ^expected, _evidence} = ClaimSizing.evaluate(context)
@@ -380,7 +419,7 @@ defmodule Tuist.Kura.ClaimSizingTest do
           last_resized_at: DateTime.new!(Date.add(@today, -2), ~T[12:00:00], "Etc/UTC")
         )
 
-      assert {:grow, "32Gi", _evidence} = ClaimSizing.evaluate(context)
+      assert {:grow, "64Gi", _evidence} = ClaimSizing.evaluate(context)
     end
   end
 
@@ -454,7 +493,7 @@ defmodule Tuist.Kura.ClaimSizingTest do
       rollups =
         moderate_churn(14, @today) ++ Enum.map(idle_days(30, @today), &Map.put(&1, :region, "eu-west"))
 
-      assert {:grow, "32Gi", evidence} = ClaimSizing.evaluate(context(rollups: rollups))
+      assert {:grow, "40Gi", evidence} = ClaimSizing.evaluate(context(rollups: rollups))
       assert evidence["region"] == "us-east"
     end
 

--- a/server/test/tuist/kura/workers/claim_sizing_worker_test.exs
+++ b/server/test/tuist/kura/workers/claim_sizing_worker_test.exs
@@ -104,7 +104,7 @@ defmodule Tuist.Kura.Workers.ClaimSizingWorkerTest do
   test "applies open proposals", %{account: account} do
     assert :ok = perform_job(ClaimSizingWorker, %{})
 
-    assert PlacerClaims.claim_for(account) == "16Gi"
+    assert PlacerClaims.claim_for(account) == "20Gi"
     assert [%ClaimProposal{status: :applied, resolved_by: "automatic"}] = Repo.all(ClaimProposal)
   end
 
@@ -155,6 +155,6 @@ defmodule Tuist.Kura.Workers.ClaimSizingWorkerTest do
 
     assert :ok = perform_job(ClaimSizingWorker, %{})
 
-    assert PlacerClaims.claim_for(account) == "16Gi"
+    assert PlacerClaims.claim_for(account) == "20Gi"
   end
 end


### PR DESCRIPTION
## What changed

`Tuist.Kura.ClaimSizing` gains one rung and one bound.

- A new rung grows the claim when shed age sits under a third of the retention floor (24h29m against today's three day floor) on **two** consecutive qualifying days, provided the window also cycled two rings. Turnover is summed across the window, so two rings over two days is one ring a day. The same tier without that volume still serves out its five day window, exactly as before.
- The step bound now scales with the confirmation behind the reading. A rung confirmed on a single day still doubles at most. A rung confirmed across days may take the projection's own answer, up to four times the current claim. Shrinking is untouched and still halves at most.
- `alerts.md` had a sentence saying the rung matching a one day shed age needs five consecutive days. That is no longer true when the ring cycles daily, so it now states both routes.

## Why

The critical rule **Kura - instance retention horizon under a day** paged on both replicas of an enterprise account's us-east instance at medians of 20h24m and 19h15m, and sizing correctly did nothing about it.

Nothing was blocked. The account sat on the plan default of 16Gi against a 256Gi ceiling, with no placer claim row, so none of the three cases the alert's description names applied. The ladder simply had no rung for the band the alert calls critical:

| day | median shed age | rings cycled that day |
|---|---|---|
| 1 | 8h 31m | 1.27 |
| 2 | 23h 02m | 1.75 |
| 3 | 18h 52m | 1.89 |

The one day rungs cap at eight hours and the second also wants two rings in a day, so the reading missed both arms. The tier that does cover it needed five consecutive qualifying days, and the ring had only been shedding for three, because the days it spent filling after being built record no evictions and cannot qualify. So the page arrived roughly two days before the loop could act, for any instance that fills and then sheds between eight and twenty four hours.

## Why the step bound too

Because the ladder converging slowly costs more than the alert firing early, and it is the same root.

`grow_target_bytes` already computes the target from the measured ring span. It is arithmetic, not a guess. Both of the accounts that have ever grown in production were clamped hard against it: one projected 4.5x and got 2x, the other projected 14.6x and got 2x, twice, and is still shedding under the floor after two rebuilds. The account that paged would have gone to 32Gi, then waited on the fourteen day rung, because a ring holding about 41 hours no longer qualifies for anything shorter. That is roughly sixteen days and two rebuilds to reach a size the projection named on day one.

The bound only binds below 45 hours of retention at 2x, and below 22.5 hours at 4x. An account approaching the floor is sized by the projection under either value, so this changes nothing for the accounts that are nearly right and everything for the ones that are badly undersized, which is where a single correctly aimed step is worth the most.

## Impact

The account that paged would have grown on its second qualifying day, before the page rather than two days after it, and landed at 64Gi in one rebuild instead of 32Gi followed by 64Gi a fortnight later.

Blast radius, measured against every storage rollup in the fleet over the last fourteen days: two account regions would have tripped the new rung, the one that paged and the one already growing. The largest sustained shedder in the fleet fails both arms, at shed ages of 2.4 to 5.7 days and about 1.7 rings across any two days. Nothing else is close.

Two things worth a reviewer's attention:

- A claim is an admission decision, requested per replica as ephemeral-storage, so a 4x step asks more of a region than a 2x one. us-east currently carries about 630Gi of claims. If the region cannot place the bigger claim, that surfaces as **Kura region cannot place another instance**.
- The resize path is the one that wedged an instance for 69 minutes before [#12947](https://github.com/tuist/tuist/pull/12947). Fewer and larger steps is fewer passes through it.

## Validation

`mix test test/tuist/kura/claim_sizing_test.exs test/tuist/kura/claim_proposals_test.exs test/tuist/kura/workers/claim_sizing_worker_test.exs`, 54 passing.

Three tests were written first and watched fail: the new rung firing on two days with the volume, the same tier still serving five days without it, and the step bound taking 2x on a single day's reading and 4x on a confirmed one. The ten existing growth expectations that moved all moved for the step bound, and each is a target changing while its rung and window stay put. Credo is clean on the changed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
