### PR TITLE
feat(server): route TUIST_SECRET_KEY_BASE + TUIST_CLICKHOUSE_URL through an existingSecret

### DIFF
--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -465,6 +465,67 @@ http://{{ include "tuist.componentName" (dict "root" . "component" "clickhouse")
 {{- end -}}
 {{- end -}}
 
+{{/*
+TUIST_CLICKHOUSE_URL env-var block. Emits a `value:` literal by default, or a
+`valueFrom.secretKeyRef` pointing at clickhouse.external.existingSecret when
+that field is set — the escape hatch for Vault-synced installs that don't
+want ClickHouse credentials rendered into the manifest. Mutually exclusive
+with `clickhouse.external.url`.
+*/}}
+{{- define "tuist.clickhouseUrlEnv" -}}
+{{- $existingSecret := "" -}}
+{{- if eq .Values.clickhouse.mode "external" -}}
+{{- $existingSecret = .Values.clickhouse.external.existingSecret | default "" -}}
+{{- end -}}
+{{- if ne $existingSecret "" -}}
+{{- if ne (.Values.clickhouse.external.url | default "") "" -}}
+{{- fail "clickhouse.external.existingSecret is mutually exclusive with clickhouse.external.url; pick one source for TUIST_CLICKHOUSE_URL." -}}
+{{- end -}}
+{{- $key := .Values.clickhouse.external.existingSecretKey | default "" -}}
+{{- if eq $key "" -}}
+{{- fail "clickhouse.external.existingSecretKey is required when clickhouse.external.existingSecret is set." -}}
+{{- end }}
+- name: TUIST_CLICKHOUSE_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ $existingSecret | quote }}
+      key: {{ $key | quote }}
+{{- else }}
+- name: TUIST_CLICKHOUSE_URL
+  value: {{ include "tuist.clickhouseUrl" . | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+TUIST_SECRET_KEY_BASE env-var block. Points at the chart-managed app-secrets
+Secret by default, or at server.secretKeyBaseExistingSecret when that field
+is set — the escape hatch for Vault-synced installs. Mutually exclusive with
+`server.secretKeyBase`.
+*/}}
+{{- define "tuist.secretKeyBaseEnv" -}}
+{{- $existingSecret := .Values.server.secretKeyBaseExistingSecret | default "" -}}
+{{- if ne $existingSecret "" -}}
+{{- if ne (.Values.server.secretKeyBase | default "") "" -}}
+{{- fail "server.secretKeyBaseExistingSecret is mutually exclusive with server.secretKeyBase; pick one source for TUIST_SECRET_KEY_BASE." -}}
+{{- end -}}
+{{- $key := .Values.server.secretKeyBaseExistingSecretKey | default "" -}}
+{{- if eq $key "" -}}
+{{- fail "server.secretKeyBaseExistingSecretKey is required when server.secretKeyBaseExistingSecret is set." -}}
+{{- end }}
+- name: TUIST_SECRET_KEY_BASE
+  valueFrom:
+    secretKeyRef:
+      name: {{ $existingSecret | quote }}
+      key: {{ $key | quote }}
+{{- else }}
+- name: TUIST_SECRET_KEY_BASE
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "tuist.componentName" (dict "root" . "component" "app-secrets") | quote }}
+      key: server-secret-key-base
+{{- end -}}
+{{- end -}}
+
 {{- define "tuist.clickhouseReadyUrl" -}}
 {{- if eq .Values.clickhouse.mode "embedded" -}}
 http://{{ include "tuist.componentName" (dict "root" . "component" "clickhouse") }}:8123/ping

--- a/infra/helm/tuist/templates/app-secrets.yaml
+++ b/infra/helm/tuist/templates/app-secrets.yaml
@@ -21,7 +21,9 @@ metadata:
   {{- end }}
 type: Opaque
 stringData:
+  {{- if eq (.Values.server.secretKeyBaseExistingSecret | default "") "" }}
   server-secret-key-base: {{ .Values.server.secretKeyBase | default (get $existingData "server-secret-key-base" | default "" | b64dec) | default (randAlphaNum 64) | quote }}
+  {{- end }}
   {{- if eq (.Values.cache.existingSecret | default "") "" }}
   cache-secret-key-base: {{ .Values.cache.secretKeyBase | default (get $existingData "cache-secret-key-base" | default "" | b64dec) | default (randAlphaNum 64) | quote }}
   cache-guardian-secret-key: {{ .Values.cache.guardianSecretKey | default (get $existingData "cache-guardian-secret-key" | default "" | b64dec) | default (randAlphaNum 64) | quote }}

--- a/infra/helm/tuist/templates/clickhouse-migration-job.yaml
+++ b/infra/helm/tuist/templates/clickhouse-migration-job.yaml
@@ -185,13 +185,8 @@ spec:
             - name: TUIST_USE_SSL_FOR_DATABASE
               value: {{ .Values.server.database.ssl | ternary "1" "0" | quote }}
             {{- end }}
-            - name: TUIST_CLICKHOUSE_URL
-              value: {{ include "tuist.clickhouseUrl" . | quote }}
-            - name: TUIST_SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: server-secret-key-base
+            {{- include "tuist.clickhouseUrlEnv" . | nindent 12 }}
+            {{- include "tuist.secretKeyBaseEnv" . | nindent 12 }}
             {{- end }}
             - name: TUIST_APP_URL
               value: {{ .Values.server.appUrl | quote }}

--- a/infra/helm/tuist/templates/server-deployment.yaml
+++ b/infra/helm/tuist/templates/server-deployment.yaml
@@ -114,13 +114,8 @@ spec:
             - name: TUIST_USE_SSL_FOR_DATABASE
               value: {{ .Values.server.database.ssl | ternary "1" "0" | quote }}
             {{- end }}
-            - name: TUIST_CLICKHOUSE_URL
-              value: {{ include "tuist.clickhouseUrl" . | quote }}
-            - name: TUIST_SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: server-secret-key-base
+            {{- include "tuist.clickhouseUrlEnv" . | nindent 12 }}
+            {{- include "tuist.secretKeyBaseEnv" . | nindent 12 }}
             {{- end }}
             - name: TUIST_APP_URL
               value: {{ .Values.server.appUrl | quote }}

--- a/infra/helm/tuist/templates/server-migration-job.yaml
+++ b/infra/helm/tuist/templates/server-migration-job.yaml
@@ -152,13 +152,8 @@ spec:
             - name: TUIST_USE_SSL_FOR_DATABASE
               value: {{ .Values.server.database.ssl | ternary "1" "0" | quote }}
             {{- end }}
-            - name: TUIST_CLICKHOUSE_URL
-              value: {{ include "tuist.clickhouseUrl" . | quote }}
-            - name: TUIST_SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $secretName }}
-                  key: server-secret-key-base
+            {{- include "tuist.clickhouseUrlEnv" . | nindent 12 }}
+            {{- include "tuist.secretKeyBaseEnv" . | nindent 12 }}
             {{- end }}
             - name: TUIST_APP_URL
               value: {{ .Values.server.appUrl | quote }}

--- a/infra/helm/tuist/templates/swift-registry-sync-deployment.yaml
+++ b/infra/helm/tuist/templates/swift-registry-sync-deployment.yaml
@@ -107,8 +107,7 @@ spec:
             - name: TUIST_DATABASE_SCHEMA
               value: {{ .Values.postgresql.schema | quote }}
             {{- if not .Values.server.managedSecrets }}
-            - name: TUIST_CLICKHOUSE_URL
-              value: {{ include "tuist.clickhouseUrl" . | quote }}
+            {{- include "tuist.clickhouseUrlEnv" . | nindent 12 }}
             {{- end }}
             {{- include "tuist.githubEnv" . | nindent 12 }}
             {{- include "tuist.licenseEnv" . | nindent 12 }}
@@ -117,11 +116,7 @@ spec:
             - name: TUIST_LOG_LEVEL
               value: {{ .Values.server.logLevel | quote }}
             {{- if not .Values.server.managedSecrets }}
-            - name: TUIST_SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "tuist.componentName" (dict "root" . "component" "app-secrets") }}
-                  key: server-secret-key-base
+            {{- include "tuist.secretKeyBaseEnv" . | nindent 12 }}
             {{- end }}
             # Registry-specific S3 credentials (separate Tigris key with
             # policy on the registry bucket). The ex_aws config in

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -510,6 +510,15 @@ server:
     shardBundles: ""
   skipEmailConfirmation: true
   secretKeyBase: ""
+  # Name of an existing Kubernetes Secret backing TUIST_SECRET_KEY_BASE (the
+  # Phoenix session/signing key). When set, the chart routes the env var
+  # through a secretKeyRef against this Secret instead of rendering
+  # `server-secret-key-base` into its own app-secrets Secret. Use with a
+  # Vault-synced Secret, sealed-secrets, or any other out-of-band source.
+  # Mutually exclusive with `server.secretKeyBase`. Override
+  # `secretKeyBaseExistingSecretKey` to match the key in your Secret.
+  secretKeyBaseExistingSecret: ""
+  secretKeyBaseExistingSecretKey: server-secret-key-base
   # When true, the chart skips emitting DATABASE_URL / TUIST_CLICKHOUSE_URL /
   # TUIST_SECRET_KEY_BASE / TUIST_S3_* env vars and expects those to come from
   # elsewhere — the consolidated config Secret (config.managedSecrets) and CNPG
@@ -3320,6 +3329,15 @@ clickhouse:
     # the /ping endpoint returns 404. Set this to http://<host>:8123/ping to use
     # a dedicated health-check URL instead.
     pingUrl: ""
+    # Name of an existing Kubernetes Secret whose `existingSecretKey` field
+    # holds the full TUIST_CLICKHOUSE_URL (including any embedded
+    # credentials). When set, the chart wires TUIST_CLICKHOUSE_URL through a
+    # secretKeyRef instead of rendering the URL as a literal env value, so
+    # credentials never enter the manifest. Use with a Vault-synced Secret,
+    # a sealed Secret, or any other out-of-band source. Mutually exclusive
+    # with `clickhouse.external.url`.
+    existingSecret: ""
+    existingSecretKey: clickhouse-url
   embedded:
     image:
       repository: clickhouse/clickhouse-server


### PR DESCRIPTION
## Context

Follow-up to #13087. That PR extended `existingSecret` to the license and the cache-owned secrets, and shipped in `helm@0.106.0`. The same self-hosted customer reported that two more secrets still forced the Vault admission-policy redirect they were trying to remove:

- `TUIST_SECRET_KEY_BASE` — the Phoenix session/signing key, rendered into the chart-managed `app-secrets` Secret from `server.secretKeyBase` (or an auto-generated random string).
- `TUIST_CLICKHOUSE_URL` — the ClickHouse connection URL, rendered as a literal `value:` env var from `clickhouse.external.url` in the non-`managedSecrets` path, so any embedded credentials landed straight in the pod manifest.

Both existed in the `managedSecrets` path (they come from the 1Password-backed `server-config-external-secrets` ExternalSecret), but self-hosted deployments and non-1Password Vault installs had no escape hatch.

## What changed

- `server.secretKeyBaseExistingSecret` + `server.secretKeyBaseExistingSecretKey` route `TUIST_SECRET_KEY_BASE` through a `secretKeyRef` against a caller-provided Secret. When set, the chart also skips writing `server-secret-key-base` into `app-secrets`. Mutually exclusive with `server.secretKeyBase`.
- `clickhouse.external.existingSecret` + `clickhouse.external.existingSecretKey` route `TUIST_CLICKHOUSE_URL` through a `secretKeyRef` instead of the literal `value:`. Mutually exclusive with `clickhouse.external.url`, so the URL never enters the manifest when the caller opts in.
- Two new helpers (`tuist.secretKeyBaseEnv`, `tuist.clickhouseUrlEnv`) own the literal-vs-`secretKeyRef` decision, so every consumer (`server-deployment.yaml`, `server-migration-job.yaml`, `swift-registry-sync-deployment.yaml`, `clickhouse-migration-job.yaml`) stays in sync.

The values fields follow the same shape as `postgresql.external.existingSecret` and the license / cache blocks added in #13087, so a Vault user configures every credential-carrying env var through the same idiom.

## Verification

- `helm template` on each `values-*` combination the `helm.yml` Render CI check exercises (`values-self-hosted-ci.yaml`, `values-managed-common.yaml + values-managed-production.yaml`, `values-preview.yaml + values-preview-kura.yaml + values-preview-ci.yaml`, `values-pentest.yaml`, `values-k3s-smoke.yaml`) renders successfully.
- Positive `--set` test with `server.secretKeyBaseExistingSecret=vault-tuist-app` + `clickhouse.external.existingSecret=vault-tuist-clickhouse` (external ClickHouse mode) rendered `TUIST_SECRET_KEY_BASE` and `TUIST_CLICKHOUSE_URL` as `secretKeyRef`s into the caller Secrets, and the chart-managed `app-secrets` no longer emitted `server-secret-key-base`.
- Negative tests confirmed the mutual-exclusion guards fire with helpful messages when the caller sets both an inline value and an `existingSecret`, or omits the `existingSecretKey` when `existingSecret` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgaHxejbvKEZCCPQ4uLaQ5