### PR TITLE
feat(infra): re-arm canary's ClickHouse backfill with a fresh cutoff

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -341,29 +341,39 @@ clickhouse:
     # the deploy that turns dual writes on above has finished rolling out: the
     # backfill covers everything before it, the mirror covers everything after,
     # and naming the boundary is what stops the two from leaving a gap.
-    # Off. Arming this failed three canary releases in a row and rolled each
-    # one back, because helm 4 waits on ordinary Jobs:
+    # Step 5, the initial replication: everything canary wrote before the
+    # cutoff still lives only on Cloud, and this copies it.
     #
-    #   Error: UPGRADE FAILED: release tuist failed, and has been rolled back
-    #   due to rollback-on-failure being set: resource
-    #   Job/tuist-canary/tuist-tuist-clickhouse-backfill-r894 not ready.
-    #   status: Failed, message: Job Failed. failed: 1/1
+    # A post-upgrade hook, by inheriting `background: false`, which is the mode
+    # staging used successfully. The previous attempt set `background: true` on
+    # the belief that helm does not wait on ordinary Jobs. Helm 3 does not;
+    # helm 4 does, so the Job blocked the release and a failing one rolled
+    # three canary deploys back. Background mode stays unusable until there is
+    # a mechanism helm does not wait on, and that is a production problem:
+    # canary's dataset is small enough to wait for.
     #
-    # `background: true` was written for helm 3, where `--wait` covered pods
-    # and workloads but not Jobs, so an ordinary Job really did run beside the
-    # release. Under helm 4 it does not: the release waits for the Job, and a
-    # Job that fails fails the release. That inverts the whole reason the
-    # setting exists, and on a production-sized copy it would hold the release
-    # for hours and then roll it back on the deadline, which is exactly the
-    # outcome it was meant to prevent.
+    # Two bugs that stopped every previous run are fixed and deployed here:
+    # the advisory lock's connection is no longer capped at fifteen seconds,
+    # and the destination is waited for rather than raced.
     #
-    # So the backfill needs a way to run that helm does not wait on before it
-    # can be armed again, here or anywhere. Until then this stays off, and
-    # `name` and `task` keep naming the step it would run.
+    # `cutoff` is later than the last mirror error rather than the moment dual
+    # writes rolled out. Terminal shadow-write errors are rows that reached
+    # Cloud and not the destination, so a cutoff before them leaves those rows
+    # covered by neither side. The counter last moved at about 11:30Z and has
+    # been flat since, so this is comfortably after it.
+    #
+    # It will not reach clean parity in one run, by construction: this deploy
+    # restarts the server pods, and the writes lost while their mirror warms up
+    # land after the cutoff. The repair is another run with a later cutoff,
+    # which is what the runbook prescribes and what production will do anyway.
+    #
+    # Gate: every chunk recorded done in the ledger with no failures, read from
+    # the Job afterwards.
     migration:
-      enabled: false
+      enabled: true
       name: backfill
       task: Tuist.Release.backfill_clickhouse
+      cutoff: "2026-09-10T12:20:00Z"
 
   poolSize: "30"
   bufferPoolSize: "30"


### PR DESCRIPTION
## What changed

Canary's backfill is armed again, with a fresh cutoff:

```yaml
migration:
  enabled: true
  name: backfill
  task: Tuist.Release.backfill_clickhouse
  cutoff: "2026-09-10T12:20:00Z"
```

## Why it is safe to try again

Every previous run failed, four times, for three different reasons. All three are fixed and already running on canary.

**It raced the server it needed.** The Job started five seconds before the ClickHouse pod was recreated and died on `connection refused`, with `backoffLimit: 0` making that final. It now waits behind a `wait-for-clickhouse` init container, which was observed doing exactly that on `r896`: seven waits, then "ClickHouse is answering".

**The pod was being recreated at all** because `checksum/config` hashed the whole `clickhouse.managed` block, so every migration step restarted the database it was migrating. Narrowed, and confirmed holding: the ClickHouse pod is now 19 hours old with 0 restarts across many deploys.

**The copy was capped at fifteen seconds.** `with_single_flight` pinned a Postgres connection for the whole run against a 15 second default, so `r896` died mid-enumeration at exactly that boundary. Now `timeout: :infinity`. This is also why staging appeared to work: its dataset finished inside the window.

## Why `background: false`

By inheriting the chart default, this runs as a `post-upgrade` hook, the mode staging used successfully.

The previous attempt set `background: true` on the stated belief that "helm does not wait for it: the deploy passes `--wait` but not `--wait-for-jobs`". That is true of Helm 3. Helm 4 waits on Jobs, so the Job blocked the release and a failing one rolled three canary deploys back with `--atomic`. Background mode stays unusable until there is a mechanism Helm does not wait on, and that is a **production** problem: canary's dataset is small enough that waiting is correct.

## Why the cutoff is 12:20Z

Not the moment dual writes rolled out. Terminal shadow-write errors are rows that reached Cloud and not the destination, and they are *after* the mirror started, so a cutoff before them would leave those rows covered by neither side.

`tuist_clickhouse_shadow_write_count{result="error"}` last moved at about 11:30Z and has been flat at 59 since, while `ok` kept climbing to 191. So 12:20Z is comfortably past the last loss.

## It will not reach clean parity in one run

By construction. This deploy restarts the server pods, and writes lost while their mirror warms up land after the cutoff. The repair is a second run with a later cutoff, which is what the runbook prescribes and what production will need regardless. Canary's goal here is proving the mechanism, not perfect data.

## What this run actually tests

Two fixes that no local test can cover:

- whether the copy survives past fifteen seconds, which is precisely where it has failed every time
- whether the mirror now retries instead of dropping while the destination is loaded, which is the second cause behind canary's parity divergence

The retry split is already showing on the current deploy: `retried` jumped to 295 while terminal errors moved only 55 to 59, a far better ratio than before.

**Gate:** every chunk recorded done in the ledger with no failures, read from the Job afterwards.

## Validation

Rendered all three environments the way the deploy does. Canary produces one `tuist-tuist-clickhouse-backfill` Job annotated `helm.sh/hook: post-upgrade,post-install`, with no revision suffix (confirming it is a hook rather than an ordinary Job), the `wait-for-clickhouse` init container, `eval "Tuist.Release.backfill_clickhouse"` and `TUIST_CLICKHOUSE_BACKFILL_CUTOFF=2026-09-10T12:20:00Z`. Staging and production render no migration Job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
