### PR TITLE
fix(swifterpm,cli): key source cache on the full git SHA

### DIFF
--- a/swifterpm/Sources/swifterpm/Cache.swift
+++ b/swifterpm/Sources/swifterpm/Cache.swift
@@ -46,14 +46,14 @@ struct Cache: Sendable {
                 .appendingPathComponent("sources")
                 .appendingPathComponent(SafePathComponent.make(pin.identity))
                 .appendingPathComponent(
-                    SafePathComponent.make("\(version)-\(Hashing.shortRevision(pin.revision()))"))
+                    SafePathComponent.make("\(version)-\(pin.revision())"))
     }
 
     func archivePath(url: String, revision: String) -> URL {
         root
             .appendingPathComponent("archives")
             .appendingPathComponent(
-                "\(Hashing.stable(url))-\(Hashing.shortRevision(revision)).tar.gz")
+                "\(Hashing.stable(url))-\(revision).tar.gz")
     }
 
     func registrySourcePath(

--- a/swifterpm/Sources/swifterpm/Restore.swift
+++ b/swifterpm/Sources/swifterpm/Restore.swift
@@ -642,13 +642,14 @@ enum WorkspaceRestorer {
             else { return }
 
             let destination = try cache.sourcePath(pin: pin)
-            if try await cachedSourceIsUsable(destination) {
+            let expectedRevision = try pin.revision()
+            if try await cachedSourceIsUsable(destination, expectedRevision: expectedRevision) {
                 return
             }
 
             let lock = try await cache.lock(namespace: "sources", key: destination.path)
             _ = lock
-            if try await cachedSourceIsUsable(destination) {
+            if try await cachedSourceIsUsable(destination, expectedRevision: expectedRevision) {
                 return
             }
 
@@ -656,6 +657,7 @@ enum WorkspaceRestorer {
                 try await fileSystem.remove(destination.absolutePath)
             }
 
+            try await writeSourceRevisionMarker(directory: checkout, revision: expectedRevision)
             try await fileSystem.move(from: checkout.absolutePath, to: destination.absolutePath)
             do {
                 try await fileSystem.replaceWithCachedDirectory(
@@ -700,13 +702,14 @@ enum WorkspaceRestorer {
 
     static func ensureSource(cache: Cache, pin: ResolvedPin) async throws -> URL {
         let destination = try cache.sourcePath(pin: pin)
-        if try await cachedSourceIsUsable(destination) {
+        let expectedRevision = try pin.revision()
+        if try await cachedSourceIsUsable(destination, expectedRevision: expectedRevision) {
             return destination
         }
 
         let lock = try await cache.lock(namespace: "sources", key: destination.path)
         _ = lock
-        if try await cachedSourceIsUsable(destination) {
+        if try await cachedSourceIsUsable(destination, expectedRevision: expectedRevision) {
             return destination
         }
         if try await fileSystem.exists(destination.absolutePath) {
@@ -724,10 +727,12 @@ enum WorkspaceRestorer {
                 try await shallowFetchCheckout(pin: pin, destination: temp)
             }
 
+            try await writeSourceRevisionMarker(directory: temp, revision: expectedRevision)
+
             do {
                 try await fileSystem.move(from: temp.absolutePath, to: destination.absolutePath, options: [])
             } catch {
-                if try await cachedSourceIsUsable(destination) {
+                if try await cachedSourceIsUsable(destination, expectedRevision: expectedRevision) {
                     try? await fileSystem.remove(temp.absolutePath)
                     return destination
                 }
@@ -740,6 +745,14 @@ enum WorkspaceRestorer {
         return destination
     }
 
+    static let sourceRevisionMarkerFilename = ".swifterpm-source-sha"
+
+    private static func writeSourceRevisionMarker(directory: URL, revision: String) async throws {
+        try await fileSystem.atomicWrite(
+            revision, to: directory.appendingPathComponent(sourceRevisionMarkerFilename)
+        )
+    }
+
     private static func cachedSourceIsUsable(_ source: URL) async throws -> Bool {
         guard try await fileSystem.exists(
             source.appendingPathComponent("Package.swift").absolutePath
@@ -747,6 +760,24 @@ enum WorkspaceRestorer {
             return false
         }
         return try await submodulesAreMaterialized(in: source)
+    }
+
+    // Verifies the checkout in `source` was written for `expectedRevision` by reading the
+    // `.swifterpm-source-sha` marker left behind at write time. A missing or mismatched marker
+    // treats the entry as a miss so the next resolve refetches instead of trusting a stale
+    // Package.swift. See `ensureSource` and `cacheNativeSourceCheckouts` for the writers.
+    private static func cachedSourceIsUsable(_ source: URL, expectedRevision: String) async throws -> Bool {
+        guard try await cachedSourceIsUsable(source) else {
+            return false
+        }
+        let markerPath = source.appendingPathComponent(sourceRevisionMarkerFilename)
+        guard try await fileSystem.exists(markerPath.absolutePath) else {
+            return false
+        }
+        let markerData = try await fileSystem.readFile(at: markerPath.absolutePath)
+        let recorded = String(decoding: markerData, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return recorded == expectedRevision
     }
 
     private static func submodulesAreMaterialized(in source: URL) async throws -> Bool {

--- a/swifterpm/Sources/swifterpm/Support.swift
+++ b/swifterpm/Sources/swifterpm/Support.swift
@@ -460,9 +460,6 @@ enum Hashing {
         return hasher.finalize().map { String(format: "%02x", $0) }.joined()
     }
 
-    static func shortRevision(_ revision: String) -> String {
-        String(revision.prefix(12))
-    }
 }
 
 private let defaultParallelism = max(4, min(32, ProcessInfo.processInfo.activeProcessorCount * 4))

--- a/swifterpm/Tests/swifterpmTests/CacheTests.swift
+++ b/swifterpm/Tests/swifterpmTests/CacheTests.swift
@@ -155,7 +155,7 @@ struct CacheTests {
                 checksum: "abcdef1234567890"
             ).path
 
-            #expect(sourcePath.contains("bad_identity/feature_path_with-control-abcdef12"))
+            #expect(sourcePath.contains("bad_identity/feature_path_with-control-abcdef1234567890"))
             #expect(registrySourcePath.contains("example.bad_package/1.2.3_beta-"))
             #expect(registryArchivePath.contains("-1.2.3_beta-"))
             #expect(registryArchivePath.hasSuffix("-abcdef1234567890.zip"))
@@ -164,6 +164,65 @@ struct CacheTests {
                 #expect(!path.contains("\n"))
                 #expect(!path.contains("//"))
             }
+        }
+    }
+
+    // A tag force-move between two commits that share their first 12 hex chars
+    // would otherwise map two distinct revisions to the same cache directory,
+    // and cachedSourceIsUsable would happily serve the stale Package.swift on
+    // every subsequent resolve.
+    @Test
+    func sourcePathsDoNotCollideOnMatching12CharRevisionPrefixes() async throws {
+        try await withTemporaryDirectory { root in
+            let cache = try await Cache(root: root)
+            let firstPin = ResolvedPin(
+                identity: "flow",
+                kind: "remoteSourceControl",
+                location: "https://github.com/example/flow.git",
+                state: ResolvedState(
+                    branch: nil,
+                    revision: "b6f9aac7a8d6000000000000000000000000aaaa",
+                    version: "0.2.0"
+                )
+            )
+            let secondPin = ResolvedPin(
+                identity: "flow",
+                kind: "remoteSourceControl",
+                location: "https://github.com/example/flow.git",
+                state: ResolvedState(
+                    branch: nil,
+                    revision: "b6f9aac7a8d6000000000000000000000000bbbb",
+                    version: "0.2.0"
+                )
+            )
+
+            let firstPath = try cache.sourcePath(pin: firstPin).path
+            let secondPath = try cache.sourcePath(pin: secondPin).path
+
+            #expect(firstPath != secondPath)
+            #expect(firstPath.hasSuffix("-b6f9aac7a8d6000000000000000000000000aaaa"))
+            #expect(secondPath.hasSuffix("-b6f9aac7a8d6000000000000000000000000bbbb"))
+        }
+    }
+
+    @Test
+    func archivePathsDoNotCollideOnMatching12CharRevisionPrefixes() async throws {
+        try await withTemporaryDirectory { root in
+            let cache = try await Cache(root: root)
+            let url = "https://github.com/example/flow.git"
+
+            let firstPath = cache.archivePath(
+                url: url,
+                revision: "aaaaaaaaaaaa0000000000000000000000000000"
+            ).path
+            let secondPath = cache.archivePath(
+                url: url,
+                revision: "aaaaaaaaaaaa1111111111111111111111111111"
+            ).path
+
+            #expect(firstPath != secondPath)
+            #expect(firstPath.hasSuffix("-aaaaaaaaaaaa0000000000000000000000000000.tar.gz"))
+            #expect(secondPath.hasSuffix("-aaaaaaaaaaaa1111111111111111111111111111.tar.gz"))
         }
     }
 }

--- a/swifterpm/Tests/swifterpmTests/RestoreTests.swift
+++ b/swifterpm/Tests/swifterpmTests/RestoreTests.swift
@@ -93,6 +93,48 @@ struct RestoreTests {
         }
     }
 
+    // Once a checkout populates the cache, the marker written next to Package.swift is what
+    // future resolves compare `pin.revision()` against. If the marker is missing or points to
+    // a different SHA the cache entry is treated as unusable and re-fetched, which is the
+    // second half of the fix for the 12-char cache-key collision.
+    @Test
+    func restorePackageWritesSourceRevisionMarkerIntoTheCachedSourceDirectory() async throws {
+        try await withTemporaryDirectory { root in
+            let repo = root.appendingPathComponent("libwebp-Xcode")
+            let submodule = root.appendingPathComponent("libwebp")
+            let scratch = root.appendingPathComponent("scratch")
+            let cache = try await Cache(root: root.appendingPathComponent("cache"))
+            let revision = try await writeGitPackageWithRequiredSubmodule(
+                packageRepo: repo,
+                submoduleRepo: submodule
+            )
+            let pin = ResolvedPin(
+                identity: "libwebp-xcode",
+                kind: "localSourceControl",
+                location: repo.path,
+                state: ResolvedState(branch: nil, revision: revision, version: nil)
+            )
+            let resolved = ResolvedPins(originHash: "origin", pins: [pin], version: 3)
+
+            try await WorkspaceRestorer.restorePackage(
+                scratchDir: scratch,
+                cache: cache,
+                registryConfig: RegistryConfig(),
+                resolved: resolved,
+                progress: nil,
+                disableSandbox: true
+            )
+
+            let markerPath = try cache.sourcePath(pin: pin)
+                .appendingPathComponent(WorkspaceRestorer.sourceRevisionMarkerFilename)
+            #expect(try await fileSystem.exists(markerPath.absolutePath))
+            let markerData = try await fileSystem.readFile(at: markerPath.absolutePath)
+            let recorded = String(decoding: markerData, as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            #expect(recorded == revision)
+        }
+    }
+
     @Test
     func restorePackageRefreshesCachedSourceWhenSubmodulesAreMissing() async throws {
         try await withTemporaryDirectory { root in
@@ -555,9 +597,15 @@ struct RestoreTests {
                 to: archivePath
             )
 
+            let sourcePath = try cache.sourcePath(pin: pin)
             try await writeCachedManifest(
                 binaryTargetManifest(name: "Foo", url: artifactURL, checksum: checksum),
-                packageDir: cache.sourcePath(pin: pin)
+                packageDir: sourcePath
+            )
+            try await fileSystem.atomicWrite(
+                pin.revision(),
+                to: sourcePath.appendingPathComponent(
+                    WorkspaceRestorer.sourceRevisionMarkerFilename)
             )
             try await writeCachedManifest(emptyManifest(), packageDir: package)
 
@@ -627,9 +675,15 @@ struct RestoreTests {
                 to: archivePath
             )
 
+            let sourcePath = try cache.sourcePath(pin: pin)
             try await writeCachedManifest(
                 binaryTargetManifest(name: "Foo", url: artifactURL, checksum: checksum),
-                packageDir: cache.sourcePath(pin: pin)
+                packageDir: sourcePath
+            )
+            try await fileSystem.atomicWrite(
+                pin.revision(),
+                to: sourcePath.appendingPathComponent(
+                    WorkspaceRestorer.sourceRevisionMarkerFilename)
             )
             try await writeCachedManifest(emptyManifest(), packageDir: package)
 

--- a/swifterpm/Tests/swifterpmTests/SupportTests.swift
+++ b/swifterpm/Tests/swifterpmTests/SupportTests.swift
@@ -20,7 +20,6 @@ struct SupportTests {
         let expected = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         #expect(Hashing.sha256Hex(Data("abc".utf8)) == expected)
         #expect(Hashing.stable("abc") == expected)
-        #expect(Hashing.shortRevision("abcdef1234567890") == "abcdef123456")
     }
 
     @Test


### PR DESCRIPTION
## What changed

- The source cache path shape is now `sources/<identity>/<version>-<full-40-char-SHA>` (previously `<version>-<12-char-SHA>`). Same for the source archive path under `archives/`.
- `Hashing.shortRevision` is deleted; it had no other callers.
- After a successful checkout is promoted into the cache, `WorkspaceRestorer` writes a `.swifterpm-source-sha` marker next to `Package.swift`. `cachedSourceIsUsable` now verifies the marker matches the pin's revision on every warm hit.

## Why

A customer reported `tuist install` and `tuist generate` failing with the graph loader rejecting `SnapKit` as an unconfigured external dependency, even after SnapKit was gone from their code and lockfiles. The pinned revision was `b6f9aac7a8d668500ca50f7c746d1a962e0dde11`. On disk, the cached manifest at `~/.cache/swifterpm/sources/flow/0.2.0-b6f9aac7a8d6/Package.swift` still declared `SnapKit`, but the `Flow` repo at that full SHA no longer did. The workaround was `rm -rf ~/.cache/swifterpm/sources/flow`, which unblocked the customer.

Two mechanisms produce this:

1. A tag is force-moved between two commits whose full SHAs share the first 12 hex characters. The old key collapsed both revisions into the same cache directory, and `cachedSourceIsUsable` returned true on the first `Package.swift` it saw, so nothing ever re-fetched. This is the most likely origin here.
2. A stale checkout ever gets written into the right directory (bad archive, an earlier bug), and every subsequent resolve inherits it for the same reason.

12 hex chars is 48 bits, borderline for a birthday-collision argument, especially once tag movement enters the picture. Widening the key to the full 40-char SHA collapses (1) into two distinct cache paths that cannot collide. That is the primary commit.

The second commit is a defense-in-depth pass for (2). The widened key does not help if the wrong content lands under the right key by any other route, so on every warm hit we verify a `.swifterpm-source-sha` marker written at checkout time matches the pin's revision. A missing or mismatched marker treats the entry as unusable and the next resolve re-fetches, turning cache poisoning into a self-healing miss instead of a build failure.

## Alternatives considered

- **Prune the entire source cache on version upgrade.** Rejected: too disruptive for a fix targeting a specific class of collision, and it does not prevent future recurrence.
- **Marker only, without widening the key.** Rejected: the marker check would work but it silently forces a re-fetch on every collision, and every re-fetch of the same pin under the same key would keep colliding. Widening the key is the actual fix; the marker is a backstop.
- **Ship a `swifterpm cache prune` subcommand for old entries.** Not in scope. Old entries under `<version>-<12chars>` are orphaned on disk but harmless; the space cost is small, and a pruner can land separately if it turns out to matter.

## Impact

> [!NOTE]
> **Upgrade behavior for users with an existing `~/.cache/swifterpm/` or a project `.build/`.**
>
> - **Global cache (`~/.cache/swifterpm/sources/` and `.../archives/`).** Old entries under `<version>-<12chars>` and `<url-hash>-<12chars>.tar.gz` are simply orphaned. The post-fix code computes a different path, sees no entry, and falls through to a fresh fetch. The first resolve after the bump re-downloads every pinned dependency once; every warm resolve after that stays fast. Old directories sit there taking up disk until the user cleans them (a pruner can land separately).
> - **A user who was already poisoned by the 12-char collision** (like the reporter) is healed automatically. The stale `Package.swift` under the old key is never consulted anymore, so no `rm -rf ~/.cache/swifterpm/sources/<identity>` is required on upgrade.
> - **Project `.build/` (SwiftPM's own per-project scratch)** is unaffected. Only paths under `~/.cache/swifterpm/` change. Raw `.build/checkouts/<X>` from native SwiftPM is still accepted as promotion input without a marker; the marker is written just before promoting into the global cache.
> - **Downgrade caveat.** Downgrading to a pre-fix CLI after this bump goes back to reading and writing the 12-char keys and their pre-fix orphans, and would happily reuse a poisoned entry again. Not something guarded against in code.

- No migration is required. Pre-existing cache directories at the new key format do not exist in the wild (this PR is the first version to produce them).

## Validation

- Added `sourcePathsDoNotCollideOnMatching12CharRevisionPrefixes` and `archivePathsDoNotCollideOnMatching12CharRevisionPrefixes` in `CacheTests` that construct two pins whose revisions share the first 12 characters and assert their cache paths differ. Without the fix these tests would collide; with it they pass.
- Added `restorePackageWritesSourceRevisionMarkerIntoTheCachedSourceDirectory` in `RestoreTests` that runs a full restore against a real git package and asserts the marker file is written with the pin's revision.
- Updated `generatedCachePathsSanitizeMetadataComponents` in `CacheTests` to expect the full-SHA suffix instead of the 12-char prefix.
- Updated two `RestoreTests` cases that pre-seed the cache with `Package.swift` to also seed the marker, so the sidecar-aware `cachedSourceIsUsable` still counts them as usable.
- `Hashing.shortRevision`'s assertion is removed from `SupportTests`.
- `swift test` at `swifterpm/`: 198 tests in 22 suites pass.

## Related

- #13088 (already merged) fixes orphan pins in `Package.resolved` when a direct dependency is removed and the orphan fetch is broken. It does not cover cache poisoning, which is why the customer's `generate` still failed after `install` was patched. The two PRs address unrelated classes of failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)