### PR TITLE
fix(server): guard test notifications for deleted projects

### DIFF
--- a/server/lib/tuist/tests.ex
+++ b/server/lib/tuist/tests.ex
@@ -532,11 +532,13 @@ defmodule Tuist.Tests do
 
           project = Tuist.Projects.get_project_by_id(test.project_id)
 
-          Tuist.PubSub.broadcast(
-            test,
-            "#{project.account.name}/#{project.name}",
-            :test_created
-          )
+          if project do
+            Tuist.PubSub.broadcast(
+              test,
+              "#{project.account.name}/#{project.name}",
+              :test_created
+            )
+          end
         end)
 
         {:ok, %{test | test_case_runs: test_case_runs}}
@@ -741,11 +743,13 @@ defmodule Tuist.Tests do
 
             project = Tuist.Projects.get_project_by_id(updated_test.project_id)
 
-            Tuist.PubSub.broadcast(
-              updated_test,
-              "#{project.account.name}/#{project.name}",
-              :test_created
-            )
+            if project do
+              Tuist.PubSub.broadcast(
+                updated_test,
+                "#{project.account.name}/#{project.name}",
+                :test_created
+              )
+            end
           end)
 
           {:ok, %{updated_test | test_case_runs: test_case_runs}}

--- a/server/test/tuist/tests_test.exs
+++ b/server/test/tuist/tests_test.exs
@@ -1400,6 +1400,35 @@ defmodule Tuist.TestsTest do
       assert test.is_ci == true
     end
 
+    test "does not fail when the project is deleted before broadcasting test creation" do
+      # Given
+      project = ProjectsFixtures.project_fixture()
+      parent = self()
+
+      stub(Tuist.Tasks, :run_async, fn fun ->
+        send(parent, {:task, fun})
+        {:ok, self()}
+      end)
+
+      # When
+      assert {:ok, _test} =
+               Tests.create_test(%{
+                 id: UUIDv7.generate(),
+                 project_id: project.id,
+                 account_id: project.account_id,
+                 duration: 1500,
+                 status: "success",
+                 ran_at: NaiveDateTime.utc_now(),
+                 is_ci: false
+               })
+
+      assert_receive {:task, task}
+      assert {:ok, _} = Tuist.Projects.delete_project(project)
+
+      # Then
+      task.()
+    end
+
     test "looks up existing test cases by binding the IDs as a single array parameter" do
       # Given
       project = ProjectsFixtures.project_fixture()


### PR DESCRIPTION
Resolves <https://hive.tuist.dev/errors/8f8f13cd-5e70-5593-93b9-a4cb3950f0e4>

> Prevent the background test-created notification from crashing when its project is deleted before the notification runs.

## What changed

- Skip the publish-subscribe notification when the project lookup returns no project in both normal and sharded test ingestion paths.
- Add a regression test that defers the asynchronous callback, deletes the project, and executes the callback.

## Why

The canary error was raised by an asynchronous task in the Xcode result processor after test ingestion had completed. A project can be deleted between persisting the test run and running the notification task.

## Root cause

The notification task dereferenced `project.account` and `project.name` without handling `Tuist.Projects.get_project_by_id/1` returning `nil` for a deleted project.

## Approach

Treat a missing project as a valid race outcome and skip the notification. There is no project topic to notify after deletion, and the persisted test data does not need to be rolled back.

## Impact

Test ingestion remains successful and the processor no longer emits an unhandled `BadMapError` when a project is removed during asynchronous processing.

### How to test locally

- `git diff --check`
- Elixir syntax parsing for the modified files
- The targeted Mix test could not run because this worktree does not have dependencies installed; Mix reports the missing `ecto_sql` dependency.
