### PR TITLE
fix(codebase-search): report files that could not be read as truncated

### DIFF
--- a/codebase-search/src/lib.rs
+++ b/codebase-search/src/lib.rs
@@ -353,6 +353,9 @@ impl Codebase {
         if truncation_reason.is_none() && stats.walk_errors > 0 {
             truncation_reason = Some("walk_errors".to_string());
         }
+        if truncation_reason.is_none() && stats.file_errors > 0 {
+            truncation_reason = Some("file_errors".to_string());
+        }
         if truncation_reason.is_none() && output.line_truncated {
             truncation_reason = Some("line_byte_limit".to_string());
         }
@@ -1484,6 +1487,42 @@ mod tests {
         assert!(run_bounded(state, |_| Ok(())).await.is_ok());
     }
 
+    #[test]
+    fn reports_files_that_could_not_be_read_as_truncated() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("unreadable.rs");
+        fs::write(&path, "needle\n").unwrap();
+        let _hold = make_unreadable(&path);
+        if fs::read(&path).is_ok() {
+            // The environment ignores the restriction, for example because the
+            // test runs as root, so the unreadable file cannot be exercised.
+            return;
+        }
+        let codebase = Codebase::new(
+            directory.path().to_path_buf(),
+            REVISION.to_string(),
+            "https://github.com/tuist/tuist".to_string(),
+            Limits::default(),
+        )
+        .unwrap();
+
+        let response = codebase
+            .search(SearchRequest {
+                pattern: "needle".to_string(),
+                path: String::new(),
+                file_glob: None,
+                use_regular_expression: false,
+                case_sensitive: true,
+                context_lines: Some(0),
+                max_results: Some(50),
+            })
+            .unwrap();
+
+        assert!(response.stats.file_errors > 0);
+        assert!(response.truncated);
+        assert_eq!(response.truncation_reason.as_deref(), Some("file_errors"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn rejects_symbolic_links_that_escape_the_repository() {
@@ -1501,5 +1540,23 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(error, CodebaseError::OutsideRepository));
+    }
+
+    #[cfg(unix)]
+    fn make_unreadable(path: &Path) -> Option<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(path, fs::Permissions::from_mode(0o000)).ok()
+    }
+
+    #[cfg(windows)]
+    fn make_unreadable(path: &Path) -> Option<File> {
+        use std::os::windows::fs::OpenOptionsExt;
+
+        fs::OpenOptions::new()
+            .read(true)
+            .share_mode(0)
+            .open(path)
+            .ok()
     }
 }


### PR DESCRIPTION
Resolves <https://github.com/tuist/tuist/issues/13102>

## What changed

`Codebase::search` now promotes `stats.file_errors` to `truncation_reason: "file_errors"` when nothing more specific already explains the truncation, and a regression test covers it.

## Why it changed

`codebase-search/AGENTS.md` requires that skipped content be reported explicitly "so callers do not treat partial results as exhaustive", and `codebase-search/README.md` promises that responses "say whether the result is partial and why". Two of the three skipped-content counters already keep that promise:

| counter | promoted to `truncation_reason` |
| --- | --- |
| `files_skipped_too_large` | `large_files_skipped` |
| `walk_errors` | `walk_errors` |
| `file_errors` | *nothing* (before this change) |

## Root cause

`file_errors` is incremented in two places in `search` — when `entry.metadata()` fails and when `searcher.search_path` returns an error — but the post-walk block that turns counters into a `truncation_reason` was written for the other two counters and never grew a branch for this one. The counter was serialized in `SearchStats` and then ignored by the fields that carry the contract.

A one-file fixture whose only matching file is unreadable returns:

```text
file_errors=1  truncated=false  truncation_reason=None  matches=0
```

## Approach

The fix mirrors the two existing promotions rather than introducing a new mechanism: same `is_none()` guard chain, same `&'static str`-style reason token naming (`file_errors`, matching `walk_errors`), inserted after the `walk_errors` branch so all three skipped-content reasons stay contiguous and ahead of the content-level `line_byte_limit`.

No response shape changes. `truncated` and `truncation_reason` are existing fields; only their values change, and only in the case where files were skipped. `server/lib/tuist/mcp/components/tools/codebase_tools.ex` types `truncation_reason` as `["string", "null"]` with no enum, so no consumer schema change is needed, and no `server/` or `kura/` file is touched.

## Impact

A search that could not read one of its files now reports `truncated: true` with `truncation_reason: "file_errors"` instead of a complete-looking empty or short result. The MCP tool already tells the model to narrow the request when a response is truncated, so the existing guidance starts applying to this case. This is the signal that was missing when a file is locked, replaced mid-checkout, or otherwise not stat-able during the walk.

## Validation

- `cargo test --all-targets` — 15 passed, 0 failed (14 before; the new test is the additional one).
- The new test was confirmed to fail without the fix: with the promotion removed, `assert!(response.truncated)` panics at `src/lib.rs:1519`.
- `cargo clippy --all-targets -- -D warnings` — clean, which is what `mise run lint` runs.
- `cargo fmt --all -- --check` — clean, which is what `mise run format` runs.

### How to test locally

From `codebase-search/`:

```bash
mise run test
mise run lint
```

To see the behavior by hand, drop the promotion from `Codebase::search` and run the new test `tests::reports_files_that_could_not_be_read_as_truncated` — it fails on the `truncated` assertion. The test itself makes the matched file unreadable (`chmod 000` on Unix, `share_mode(0)` on Windows) and skips its assertions when the environment ignores the restriction, for example when the suite runs as root.

## Notes

The test needs a platform-specific way to make a file unreadable, so it uses two `cfg`-gated helpers following the existing `#[cfg(unix)]` symlink test in the same module. It runs on both Unix and Windows CI; I developed and ran it on Windows, where the `share_mode(0)` branch is the one exercised.

I left one adjacent case alone: `Codebase::add_context` has a second silent-skip path where `contexts_skipped` is incremented without setting a truncation reason. I could not find a deterministic way to reproduce it, so it is noted in the issue rather than changed here.
