### PR TITLE
fix(server): use Docker Hub PostgreSQL image in CI

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -243,7 +243,7 @@ jobs:
       TUIST_DEV_ALL_LOCALES: "1"
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -302,7 +302,7 @@ jobs:
       TUIST_DEV_ALL_LOCALES: "1"
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -597,7 +597,7 @@ jobs:
     if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: postgres:16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
## Summary

- Replace the AWS ECR mirror reference for PostgreSQL 16 service containers with the official `postgres:16` image.
- Apply the change consistently across all server CI jobs that provision PostgreSQL.
- This avoids failures caused by the ECR mirror while preserving the PostgreSQL version and service configuration.

## Testing

- Not run (not requested)