### PR TITLE
fix(server): report combined Bazel cache latency in milliseconds

### DIFF
--- a/server/lib/tuist/reapi_cache.ex
+++ b/server/lib/tuist/reapi_cache.ex
@@ -392,7 +392,7 @@ defmodule Tuist.ReapiCache do
            read_latency_ms: latency_ms(numeric(row.read_duration_us), numeric(row.read_count)),
            write_latency_ms: latency_ms(numeric(row.write_duration_us), numeric(row.write_count)),
            latency_ms:
-             divide(
+             latency_ms(
                numeric(row.read_duration_us) + numeric(row.write_duration_us),
                numeric(row.read_count) + numeric(row.write_count)
              ),

--- a/server/test/tuist_web/live/bazel_invocations_live_test.exs
+++ b/server/test/tuist_web/live/bazel_invocations_live_test.exs
@@ -737,6 +737,9 @@ defmodule TuistWeb.BazelInvocationsLiveTest do
     bucket_index = Enum.find_index(analytics.observation_values, &(&1 > 0))
 
     assert_in_delta Enum.at(analytics.throughput_values, bucket_index), 162_909.09, 0.01
+    assert_in_delta Enum.at(analytics.read_latency_values, bucket_index), 29 / 3, 0.001
+    assert Enum.at(analytics.write_latency_values, bucket_index) == 20.0
+    assert Enum.at(analytics.latency_values, bucket_index) == 12.25
     assert ReapiCache.observations_present?(project.id)
   end
 


### PR DESCRIPTION
Follow-up to #13099 addressing the two review comments left by @esnunes.

## Migration collision

@esnunes flagged that `20260910100000_add_duration_us_to_reapi_cache_events.exs` collided with the timestamp used by #13078's `add_direct_input_hashes_to_xcode_targets_by_project` migration, which would abort the whole IngestRepo run on boot. That one was addressed inside #13099 before merge: the file went out at `20260910120000_...`, keeping it before the materialized view migration at `20260910130000_...` that references `duration_us`.

## Combined cache latency stuck in microseconds

The second comment pointed at `Tuist.ReapiCache.analytics/2`. The per-series `read_latency_ms` and `write_latency_ms` values had been converted to the new `latency_ms/2` helper (which divides by 1000 to leave milliseconds), but the combined `latency_ms:` key immediately below still called `divide/2` on the raw microsecond sums. `summary/2` had been fixed at the same time, so the widget headline read in ms while the chart series next to it plotted in µs.

Concretely, with the four-event fixture from the existing analytics test:

```
summary.latency_ms              = 12.25    # summary/2, already correct
analytics.read_latency_values   = 9.666    # analytics/2, correct
analytics.write_latency_values  = 20.0     # analytics/2, correct
analytics.latency_values        = 12250.0  # analytics/2, µs — this bug
```

`chart_options/3` formats that y-axis with `fn:formatMilliseconds`, so the combined "Cache latency" line rendered ~12250ms next to two correctly scaled lines and dragged the axis with it.

## Fix

One call switches from `divide(...)` to `latency_ms(...)` so the combined value goes through the same µs→ms conversion the other two series already use. I also extended the existing analytics test in `bazel_invocations_live_test.exs` to assert all three latency series against the same fixture the summary is already checked with, so a future regression on any of them fails locally instead of only in the chart.

## Validation

```
mise run install
ERL_FLAGS="+S 2:2" mix test test/tuist_web/live/bazel_invocations_live_test.exs \
  -n "calculates remote-cache"
  1 passed, 24 excluded
```

The `ERL_FLAGS="+S 2:2"` is unrelated: my local Postgres was near its connection ceiling because another dev server was running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBkHY6Ki1WpMeF5YWkFkt7