### PR TITLE
fix(server): keep Cachex Locksmith off the auth path and restore bundle breakdown pagination

### DIFF
--- a/server/lib/tuist_web/live/build_run_live.ex
+++ b/server/lib/tuist_web/live/build_run_live.ex
@@ -1246,7 +1246,8 @@ defmodule TuistWeb.BuildRunLive do
   #
   # See `TuistWeb.TestRunLive.cached_run_query/4` for why the key is a
   # list with a SHA-256 flop_params fragment rather than a tuple with
-  # a phash2.
+  # a phash2, and for why `locking: false` is required to keep the
+  # `:tuist` cache's Locksmith GenServer off the CLI-token auth path.
   defp cached_build_run_query(run_id, tab, flop_params, func) do
     cache_key = [
       :build_run_flop,
@@ -1255,7 +1256,11 @@ defmodule TuistWeb.BuildRunLive do
       :sha256 |> :crypto.hash(:erlang.term_to_binary(flop_params)) |> Base.url_encode64(padding: false)
     ]
 
-    Tuist.KeyValueStore.get_or_update(cache_key, [ttl: to_timeout(second: 30)], func)
+    Tuist.KeyValueStore.get_or_update(
+      cache_key,
+      [ttl: to_timeout(second: 30), locking: false],
+      func
+    )
   end
 
   defp cacheable_tasks_filters(run, params, available_filters, search) do

--- a/server/lib/tuist_web/live/bundle_live.ex
+++ b/server/lib/tuist_web/live/bundle_live.ex
@@ -177,7 +177,7 @@ defmodule TuistWeb.BundleLive do
     file_breakdown_filter = params["file-breakdown-filter"] || ""
     file_breakdown_sort_by = params["file-breakdown-sort-by"] || "size"
     file_breakdown_sort_order = params["file-breakdown-sort-order"] || "desc"
-    file_breakdown_page = Query.bounded_page(params["file-breakdown-page"])
+    file_breakdown_page = Query.positive_integer(params["file-breakdown-page"])
 
     active_filters = Filter.Operations.decode_filters_from_query(params, available_filters)
 
@@ -262,7 +262,7 @@ defmodule TuistWeb.BundleLive do
     module_breakdown_filter = params["module-breakdown-filter"] || ""
     module_breakdown_sort_by = params["module-breakdown-sort-by"] || "size"
     module_breakdown_sort_order = params["module-breakdown-sort-order"] || "desc"
-    module_breakdown_page = Query.bounded_page(params["module-breakdown-page"])
+    module_breakdown_page = Query.positive_integer(params["module-breakdown-page"])
 
     module_breakdown_filtered_artifacts =
       all_artifacts

--- a/server/lib/tuist_web/live/test_run_live.ex
+++ b/server/lib/tuist_web/live/test_run_live.ex
@@ -915,6 +915,18 @@ defmodule TuistWeb.TestRunLive do
   # what a busy scraper generates in a session — so two different
   # sort/filter combos would share one cache slot and return each
   # other's rows for the TTL.
+  #
+  # `locking: false` is deliberate: `KeyValueStore.get_or_update/3`
+  # defaults to `locking: true`, which runs the miss path inside
+  # `Cachex.transaction/3`. Cachex executes each transaction in the
+  # cache's single Locksmith GenServer, so every ClickHouse round-trip
+  # would occupy that one process for its full duration and queue
+  # every other caller of the `:tuist` cache behind it — including
+  # `authentication_plug`'s CLI-token lookup on the API hot path.
+  # Under the burst of unique keys this cache is designed for, that
+  # queue is where the pressure would land next. Skipping the lock
+  # gives up thundering-herd de-duplication, which the path did not
+  # have before caching was added anyway.
   defp cached_run_query(run_id, tab, flop_params, func) do
     cache_key = [
       :test_run_flop,
@@ -923,7 +935,11 @@ defmodule TuistWeb.TestRunLive do
       :sha256 |> :crypto.hash(:erlang.term_to_binary(flop_params)) |> Base.url_encode64(padding: false)
     ]
 
-    Tuist.KeyValueStore.get_or_update(cache_key, [ttl: to_timeout(second: 30)], func)
+    Tuist.KeyValueStore.get_or_update(
+      cache_key,
+      [ttl: to_timeout(second: 30), locking: false],
+      func
+    )
   end
 
   defp ensure_allowed_test_cases_sort_params(value) when value in ["name", "duration"], do: String.to_existing_atom(value)

--- a/server/priv/gettext/dashboard_builds.pot
+++ b/server/priv/gettext/dashboard_builds.pot
@@ -330,7 +330,7 @@ msgstr ""
 msgid "Compressed Size"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:1351
+#: lib/tuist_web/live/build_run_live.ex:1356
 #, elixir-autogen, elixir-format
 msgid "Compressed Size (MB)"
 msgstr ""
@@ -390,7 +390,7 @@ msgstr ""
 msgid "Device"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:1324
+#: lib/tuist_web/live/build_run_live.ex:1329
 #: lib/tuist_web/live/build_run_live.html.heex:1437
 #: lib/tuist_web/live/build_run_live.html.heex:1590
 #, elixir-autogen, elixir-format
@@ -608,12 +608,12 @@ msgid "Headers"
 msgstr ""
 
 #: lib/tuist_web/components/runs/module_cache_tab.ex:240
-#: lib/tuist_web/live/build_run_live.ex:1299
-#: lib/tuist_web/live/build_run_live.ex:1535
+#: lib/tuist_web/live/build_run_live.ex:1304
+#: lib/tuist_web/live/build_run_live.ex:1540
 #: lib/tuist_web/live/build_run_live.html.heex:1254
 #: lib/tuist_web/live/run_detail_live.ex:336
 #: lib/tuist_web/live/run_detail_live.ex:369
-#: lib/tuist_web/live/test_run_live.ex:1376
+#: lib/tuist_web/live/test_run_live.ex:1392
 #, elixir-autogen, elixir-format
 msgid "Hit"
 msgstr ""
@@ -647,13 +647,13 @@ msgstr ""
 
 #: lib/tuist_web/components/runs/module_cache_tab.ex:250
 #: lib/tuist_web/components/runs/module_cache_tab.ex:545
-#: lib/tuist_web/live/build_run_live.ex:1303
-#: lib/tuist_web/live/build_run_live.ex:1540
+#: lib/tuist_web/live/build_run_live.ex:1308
+#: lib/tuist_web/live/build_run_live.ex:1545
 #: lib/tuist_web/live/build_run_live.html.heex:1043
 #: lib/tuist_web/live/build_run_live.html.heex:1257
 #: lib/tuist_web/live/run_detail_live.ex:341
 #: lib/tuist_web/live/run_detail_live.ex:374
-#: lib/tuist_web/live/test_run_live.ex:1381
+#: lib/tuist_web/live/test_run_live.ex:1397
 #: lib/tuist_web/live/xcode_builds_live.ex:387
 #: lib/tuist_web/live/xcode_builds_live.ex:390
 #: lib/tuist_web/live/xcode_builds_live.html.heex:127
@@ -674,13 +674,13 @@ msgstr ""
 
 #: lib/tuist_web/components/runs/module_cache_tab.ex:256
 #: lib/tuist_web/components/runs/module_cache_tab.ex:571
-#: lib/tuist_web/live/build_run_live.ex:1305
-#: lib/tuist_web/live/build_run_live.ex:1541
+#: lib/tuist_web/live/build_run_live.ex:1310
+#: lib/tuist_web/live/build_run_live.ex:1546
 #: lib/tuist_web/live/build_run_live.html.heex:1071
 #: lib/tuist_web/live/build_run_live.html.heex:1269
 #: lib/tuist_web/live/run_detail_live.ex:342
 #: lib/tuist_web/live/run_detail_live.ex:375
-#: lib/tuist_web/live/test_run_live.ex:1382
+#: lib/tuist_web/live/test_run_live.ex:1398
 #, elixir-autogen, elixir-format
 msgid "Missed"
 msgstr ""
@@ -848,13 +848,13 @@ msgstr ""
 
 #: lib/tuist_web/components/runs/module_cache_tab.ex:244
 #: lib/tuist_web/components/runs/module_cache_tab.ex:558
-#: lib/tuist_web/live/build_run_live.ex:1304
-#: lib/tuist_web/live/build_run_live.ex:1539
+#: lib/tuist_web/live/build_run_live.ex:1309
+#: lib/tuist_web/live/build_run_live.ex:1544
 #: lib/tuist_web/live/build_run_live.html.heex:1057
 #: lib/tuist_web/live/build_run_live.html.heex:1263
 #: lib/tuist_web/live/run_detail_live.ex:340
 #: lib/tuist_web/live/run_detail_live.ex:373
-#: lib/tuist_web/live/test_run_live.ex:1380
+#: lib/tuist_web/live/test_run_live.ex:1396
 #, elixir-autogen, elixir-format
 msgid "Remote"
 msgstr ""
@@ -912,7 +912,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:1343
+#: lib/tuist_web/live/build_run_live.ex:1348
 #, elixir-autogen, elixir-format
 msgid "Size (MB)"
 msgstr ""
@@ -940,7 +940,7 @@ msgstr ""
 
 #: lib/tuist_web/live/bazel_invocation_live.ex:183
 #: lib/tuist_web/live/build_run_live.ex:1153
-#: lib/tuist_web/live/build_run_live.ex:1320
+#: lib/tuist_web/live/build_run_live.ex:1325
 #: lib/tuist_web/live/build_run_live.html.heex:271
 #: lib/tuist_web/live/build_run_live.html.heex:1587
 #: lib/tuist_web/live/generate_runs_live.ex:268
@@ -1100,8 +1100,8 @@ msgid "Tuist version"
 msgstr ""
 
 #: lib/tuist_web/components/build_timeline.ex:174
-#: lib/tuist_web/live/build_run_live.ex:1286
-#: lib/tuist_web/live/build_run_live.ex:1333
+#: lib/tuist_web/live/build_run_live.ex:1291
+#: lib/tuist_web/live/build_run_live.ex:1338
 #: lib/tuist_web/live/build_run_live.html.heex:717
 #: lib/tuist_web/live/build_run_live.html.heex:1274
 #: lib/tuist_web/live/build_run_live.html.heex:1601
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Unknown scheme"
 msgstr ""
 
-#: lib/tuist_web/live/build_run_live.ex:1325
+#: lib/tuist_web/live/build_run_live.ex:1330
 #: lib/tuist_web/live/build_run_live.html.heex:1454
 #: lib/tuist_web/live/build_run_live.html.heex:1596
 #, elixir-autogen, elixir-format

--- a/server/priv/gettext/dashboard_tests.pot
+++ b/server/priv/gettext/dashboard_tests.pot
@@ -96,8 +96,8 @@ msgstr ""
 msgid "Average duration of test runs during a given period."
 msgstr ""
 
-#: lib/tuist_web/live/test_run_live.ex:1251
-#: lib/tuist_web/live/test_run_live.ex:1308
+#: lib/tuist_web/live/test_run_live.ex:1267
+#: lib/tuist_web/live/test_run_live.ex:1324
 #: lib/tuist_web/live/test_run_live.html.heex:416
 #: lib/tuist_web/live/test_run_live.html.heex:1365
 #: lib/tuist_web/live/test_run_live.html.heex:1394
@@ -249,9 +249,9 @@ msgstr ""
 #: lib/tuist_web/live/test_case_live.html.heex:958
 #: lib/tuist_web/live/test_case_live.html.heex:1034
 #: lib/tuist_web/live/test_case_run_live.html.heex:149
-#: lib/tuist_web/live/test_run_live.ex:1197
-#: lib/tuist_web/live/test_run_live.ex:1259
-#: lib/tuist_web/live/test_run_live.ex:1316
+#: lib/tuist_web/live/test_run_live.ex:1213
+#: lib/tuist_web/live/test_run_live.ex:1275
+#: lib/tuist_web/live/test_run_live.ex:1332
 #: lib/tuist_web/live/test_run_live.html.heex:307
 #: lib/tuist_web/live/test_run_live.html.heex:522
 #: lib/tuist_web/live/test_run_live.html.heex:1165
@@ -337,9 +337,9 @@ msgstr ""
 #: lib/tuist_web/live/test_case_run_live.html.heex:1108
 #: lib/tuist_web/live/test_cases_live.ex:45
 #: lib/tuist_web/live/test_cases_live.html.heex:686
-#: lib/tuist_web/live/test_run_live.ex:1210
-#: lib/tuist_web/live/test_run_live.ex:1272
-#: lib/tuist_web/live/test_run_live.ex:1329
+#: lib/tuist_web/live/test_run_live.ex:1226
+#: lib/tuist_web/live/test_run_live.ex:1288
+#: lib/tuist_web/live/test_run_live.ex:1345
 #: lib/tuist_web/live/test_run_live.html.heex:273
 #: lib/tuist_web/live/test_run_live.html.heex:546
 #: lib/tuist_web/live/test_run_live.html.heex:687
@@ -444,7 +444,7 @@ msgstr ""
 #: lib/tuist_web/live/test_case_run_live.html.heex:40
 #: lib/tuist_web/live/test_cases_live.ex:74
 #: lib/tuist_web/live/test_cases_live.html.heex:579
-#: lib/tuist_web/live/test_run_live.ex:1224
+#: lib/tuist_web/live/test_run_live.ex:1240
 #: lib/tuist_web/live/test_run_live.html.heex:55
 #: lib/tuist_web/live/test_run_live.html.heex:1223
 #: lib/tuist_web/live/test_run_live.html.heex:1435
@@ -497,7 +497,7 @@ msgid "Hash"
 msgstr ""
 
 #: lib/tuist_web/components/runs/selective_testing_tab.ex:139
-#: lib/tuist_web/live/test_run_live.ex:1395
+#: lib/tuist_web/live/test_run_live.ex:1411
 #, elixir-autogen, elixir-format
 msgid "Hit"
 msgstr ""
@@ -609,7 +609,7 @@ msgid "Load more"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.ex:242
-#: lib/tuist_web/live/test_run_live.ex:1560
+#: lib/tuist_web/live/test_run_live.ex:1576
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr ""
@@ -619,7 +619,7 @@ msgstr ""
 #: lib/tuist_web/live/flaky_tests_live.html.heex:18
 #: lib/tuist_web/live/test_cases_live.ex:391
 #: lib/tuist_web/live/test_cases_live.html.heex:18
-#: lib/tuist_web/live/test_run_live.ex:1400
+#: lib/tuist_web/live/test_run_live.ex:1416
 #: lib/tuist_web/live/test_runs_live.ex:357
 #: lib/tuist_web/live/tests_live.ex:432
 #: lib/tuist_web/live/tests_live.ex:435
@@ -654,7 +654,7 @@ msgid "Marked as flaky"
 msgstr ""
 
 #: lib/tuist_web/components/runs/selective_testing_tab.ex:154
-#: lib/tuist_web/live/test_run_live.ex:1401
+#: lib/tuist_web/live/test_run_live.ex:1417
 #, elixir-autogen, elixir-format
 msgid "Missed"
 msgstr ""
@@ -682,7 +682,7 @@ msgid "Most occurring flaky tests"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:47
-#: lib/tuist_web/live/test_run_live.ex:1223
+#: lib/tuist_web/live/test_run_live.ex:1239
 #: lib/tuist_web/live/test_run_live.html.heex:1230
 #, elixir-autogen, elixir-format
 msgid "New"
@@ -800,9 +800,9 @@ msgstr ""
 #: lib/tuist_web/live/test_case_run_live.html.heex:1101
 #: lib/tuist_web/live/test_cases_live.ex:44
 #: lib/tuist_web/live/test_cases_live.html.heex:682
-#: lib/tuist_web/live/test_run_live.ex:1209
-#: lib/tuist_web/live/test_run_live.ex:1271
-#: lib/tuist_web/live/test_run_live.ex:1328
+#: lib/tuist_web/live/test_run_live.ex:1225
+#: lib/tuist_web/live/test_run_live.ex:1287
+#: lib/tuist_web/live/test_run_live.ex:1344
 #: lib/tuist_web/live/test_run_live.html.heex:266
 #: lib/tuist_web/live/test_run_live.html.heex:541
 #: lib/tuist_web/live/test_run_live.html.heex:739
@@ -892,7 +892,7 @@ msgid "Recent Test Runs"
 msgstr ""
 
 #: lib/tuist_web/components/runs/selective_testing_tab.ex:142
-#: lib/tuist_web/live/test_run_live.ex:1399
+#: lib/tuist_web/live/test_run_live.ex:1415
 #, elixir-autogen, elixir-format
 msgid "Remote"
 msgstr ""
@@ -983,8 +983,8 @@ msgstr ""
 #: lib/tuist_web/live/test_cases_live.ex:76
 #: lib/tuist_web/live/test_cases_live.html.heex:593
 #: lib/tuist_web/live/test_cases_live.html.heex:689
-#: lib/tuist_web/live/test_run_live.ex:1211
-#: lib/tuist_web/live/test_run_live.ex:1273
+#: lib/tuist_web/live/test_run_live.ex:1227
+#: lib/tuist_web/live/test_run_live.ex:1289
 #: lib/tuist_web/live/test_run_live.html.heex:287
 #: lib/tuist_web/live/test_run_live.html.heex:1310
 #: lib/tuist_web/live/test_run_live.html.heex:1497
@@ -1017,9 +1017,9 @@ msgstr ""
 #: lib/tuist_web/live/test_case_live.html.heex:1002
 #: lib/tuist_web/live/test_case_run_live.html.heex:119
 #: lib/tuist_web/live/test_case_run_live.html.heex:909
-#: lib/tuist_web/live/test_run_live.ex:1205
-#: lib/tuist_web/live/test_run_live.ex:1267
-#: lib/tuist_web/live/test_run_live.ex:1324
+#: lib/tuist_web/live/test_run_live.ex:1221
+#: lib/tuist_web/live/test_run_live.ex:1283
+#: lib/tuist_web/live/test_run_live.ex:1340
 #: lib/tuist_web/live/test_run_live.html.heex:263
 #: lib/tuist_web/live/test_run_live.html.heex:538
 #: lib/tuist_web/live/test_run_live.html.heex:1484
@@ -1056,7 +1056,7 @@ msgstr ""
 #: lib/tuist_web/live/test_cases_live.html.heex:495
 #: lib/tuist_web/live/test_cases_live.html.heex:515
 #: lib/tuist_web/live/test_cases_live.html.heex:566
-#: lib/tuist_web/live/test_run_live.ex:1219
+#: lib/tuist_web/live/test_run_live.ex:1235
 #, elixir-autogen, elixir-format
 msgid "Test Case"
 msgstr ""
@@ -1166,8 +1166,8 @@ msgstr ""
 
 #: lib/tuist_web/live/test_cases_live.ex:329
 #: lib/tuist_web/live/test_cases_live.html.heex:220
-#: lib/tuist_web/live/test_run_live.ex:1243
-#: lib/tuist_web/live/test_run_live.ex:1300
+#: lib/tuist_web/live/test_run_live.ex:1259
+#: lib/tuist_web/live/test_run_live.ex:1316
 #: lib/tuist_web/live/test_run_live.html.heex:393
 #: lib/tuist_web/live/test_run_live.html.heex:1362
 #: lib/tuist_web/live/test_run_live.html.heex:1386
@@ -1530,7 +1530,7 @@ msgid "Pending"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:197
-#: lib/tuist_web/live/test_run_live.ex:1362
+#: lib/tuist_web/live/test_run_live.ex:1378
 #: lib/tuist_web/live/test_run_live.html.heex:506
 #: lib/tuist_web/live/test_run_live.html.heex:1273
 #: lib/tuist_web/live/test_run_live.html.heex:1447
@@ -1540,7 +1540,7 @@ msgid "Shard"
 msgstr ""
 
 #: lib/tuist_web/live/test_case_run_live.html.heex:201
-#: lib/tuist_web/live/test_run_live.ex:1356
+#: lib/tuist_web/live/test_run_live.ex:1372
 #: lib/tuist_web/live/test_run_live.html.heex:508
 #: lib/tuist_web/live/test_run_live.html.heex:1276
 #: lib/tuist_web/live/test_run_live.html.heex:1450


### PR DESCRIPTION
## Motivation

Follow-up to #13096 addressing three inline review comments from @esnunes.

## Layer 1: `KeyValueStore.get_or_update/3` locking on the `:tuist` cache

The `cached_run_query` / `cached_build_run_query` wrappers introduced in #13096 defaulted to `locking: true`. With only `ttl` passed, `KeyValueStore.get_or_update/3` takes the Cachex branch, which wraps the miss path in `Cachex.transaction/3`. In Cachex 4.1.1 (the pinned version), a transaction runs *inside* the cache's single Locksmith GenServer via `handle_call({:transaction, ...})`, and the call that waits on it uses `:infinity`.

The result: every ClickHouse round-trip on these dashboards would occupy the `:tuist` cache's Locksmith process for its full duration. @esnunes reproduced it locally against 4.1.1: eight concurrent misses on distinct keys, each a 300ms query, took 2423ms rather than the expected ~300ms; an unrelated cheap `get_or_update` waited 1400ms behind a single slow one. Distinct keys did not help because the serialization is one process per cache, not per key.

The `:tuist` cache has 32 `get_or_update` call sites. Two of them are on the API hot path: `authentication_plug.ex:70-73` and `loader_plug.ex:154-158` both pass `cache: :tuist, locking: true` for CLI token authentication. Under the burst of unique keys this cache was designed for, the queue would be where the pressure landed next.

Fix: pass `locking: false` in both wrappers. That matches the pattern already at `lib/tuist/kura/capacity.ex:278` and gives up thundering-herd de-duplication, which the path did not have before #13096 added caching. Docstrings on both wrappers now spell out why the lock is off so the next person editing them does not put it back.

## Layer 2: `bundle_live` file-breakdown / module-breakdown

#13096's description said the bundle file/module breakdowns would keep their unbounded parse (review finding 6), but only the bazel half of that revert landed. Both bundle call sites (`bundle_live.ex:180` and `:265`) still called `Query.bounded_page/1` in the merged tree.

That matters because these two tables cost zero ClickHouse queries: `all_artifacts` is flattened once at mount (`bundle_live.ex:27`, assigned at `:63`), and each page is an `Enum.slice/3` over that in-memory list. Walking to page 500 is one slice with no connection checkout. So the cap bought no pool relief and only truncated a customer's view of their own bundle at artifact 2,000, which is an ordinary size for an app bundle to pass.

Fix: both call sites now use `Query.positive_integer/1` (unbounded but still safe against non-integer input like `?file-breakdown-page=abc`). This brings the code in line with what the original PR description already said it did.

## Considered alternatives

- **Restructure the cache to key on filters only, holding just a pre-computed count.** @esnunes suggested this as the correct architectural answer for the third comment (the cache key hashing the full flop_params, so a first-pass enumeration walk misses on every request). Deferred to a separate follow-up: it needs a precomputed `count:` opt threaded through `Tests.list_test_case_runs` (5 MV branches), `Tests.list_test_suite_runs`, `Tests.list_test_module_runs`, and `Builds.list_cacheable_tasks`, plus four new `count_*` helpers running `Flop.count` on the same base queries. Confirmed Flop 0.26.3 does accept `:count` on `Flop.validate_and_run/3`, so the plumbing works, but it is bigger than fits alongside these two fixes. The current whole-result cache still helps real users hitting the same URL twice within 30 seconds (page refresh, browser back, two people on the same run), and Cloudflare Layer 1 from #13096 continues to be the primary defense against the enumeration attack pattern.
- **Keep `locking: true` and switch to `Cachex.fetch/4` for per-key Courier dispatch.** That keeps thundering-herd de-duplication, which is nice-to-have. Not adopted because the path never had de-duplication before #13096, and `locking: false` is the one-word change that unblocks the auth path without changing what `KeyValueStore` returns.

## Verification

- `mix compile` clean.
- `mix test test/tuist_web/utilities/query_test.exs` green (50 examples, unchanged from #13096).
- Behavior verified by re-reading the diff: the two `KeyValueStore.get_or_update/3` call sites now pass `locking: false`, and both `bundle_live` breakdown pages resolve `Query.positive_integer/1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)