### PR TITLE
Refresh README socials, booking link, and intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
   <img src="https://img.shields.io/github/commit-activity/w/tuist/tuist?style=flat-square&label=commits" alt="Commit Activity">
   <a href="https://fosstodon.org/@tuist"><img src="https://img.shields.io/badge/tuist-gray.svg?logo=mastodon&logoColor=f5f5f5" alt="Mastodon badge"></a>
   <a href="https://bsky.app/profile/tuist.dev"><img src="https://img.shields.io/badge/tuist-gray.svg?logo=bluesky" alt="Bluesky badge"></a>
+  <a href="https://x.com/tuistdev"><img src="https://img.shields.io/badge/tuistdev-gray.svg?logo=x" alt="X badge"></a>
   <a href="https://join.slack.com/t/tuistapp/shared_invite/zt-1lqw355mp-zElRwLeoZ2EQsgGEkyaFgg"><img src="https://img.shields.io/badge/tuist-gray.svg?logo=slack" alt="Slack Workspace"></a>
-  <a href="https://t.me/tuist"><img src="https://img.shields.io/badge/tuist-gray.svg?logo=telegram" alt="Slack Workspace"></a>
   <div>
-    <a href="https://cal.com/team/tuist/cloud?utm_source=banner&utm_campaign=oss" target="_blank"><img alt="Book us with Cal.com" src="https://cal.com/book-with-cal-dark.svg" width="150"/></a>
+    <a href="https://cal.tuist.dev/team/tuist/tuist" target="_blank"><img alt="Book us with Cal.com" src="https://cal.com/book-with-cal-dark.svg" width="150"/></a>
   </div>
   <a href="https://translate.tuist.dev/engage/tuist/">
   <img src="https://translate.tuist.dev/widget/tuist/svg-badge.svg" alt="Translation status" />
@@ -23,26 +23,23 @@
 
 # Tuist
 
-Tuist is a virtual platform team for Swift app devs who ship. Through an integrated platform that integrates with your toolchain and projects, we help you stay focused and productive while building apps.
+Tuist supercharges your build system, whether you build with Xcode, Gradle, or Bazel. At its core, our cache reuses previously-built artifacts across environments to dramatically speed up your builds, and a suite of tools around it helps you keep them fast, reliable, and observable as you scale.
 
 The following solutions are part of Tuist:
 
-- [🗂️ **Generated projects**](https://tuist.dev/en/docs/guides/features/projects): A solution for more accessible and easier-to-manage Xcode projects.
 - [🚝 **Cache**](https://tuist.dev/en/docs/guides/features/cache): Speed up builds across environments with a content-addressable store.
 - [✅ **Selective testing**](https://tuist.dev/en/docs/guides/features/selective-testing): Run tests faster by selecting them based on the file changes.
 - [📦 **Registry**](https://tuist.dev/en/docs/guides/features/registry): Speed up the resolution of [Swift Package Index](https://swiftpackageindex.com/)-indexed packages.
 - [📈 **Build insights**](https://tuist.dev/en/docs/guides/features/build-insights): Get actionable insights from your projects, builds, and test runs to make informed decisions.
 - [📱 **Bundle insights**](https://tuist.dev/en/docs/guides/features/bundle-size): Analyze your built apps and get suggestions to improve them.
-- [📱 **Previews**](https://tuist.dev/en/docs/guides/features/previews): Sharing apps (previews) as easy as sharing a link.
+- [📲 **Previews**](https://tuist.dev/en/docs/guides/features/previews): Sharing apps (previews) as easy as sharing a link.
+- [🗂️ **Generated projects**](https://tuist.dev/en/docs/guides/features/projects): A solution for more accessible and easier-to-manage Xcode projects.
 
 Openness and community are cornerstones in shaping Tuist, as we believe they are the key to building the best solution. We recommend checking out the following resources:
 
 - [📑 **Documentation**](https://tuist.dev/en/docs)
 - [📚 **Handbook**](https://handbook.tuist.dev)
 - [💬 **Community forum**](https://community.tuist.dev)
-
-> [!NOTE]
-> Even though our current focus is on the development phase of Apple native apps, we'll gradually expand our focus to include other ecosystems (e.g., Android, RN, and Flutter), and expand beyond just development.
 
 ## Get started
 


### PR DESCRIPTION
## Summary

Three small README fixes I noticed while polishing the header in #13109:

- The X (Twitter) badge was missing from the socials row even though the account is active at https://x.com/tuistdev.
- The Telegram badge points at a channel we no longer maintain, so it's a dead end for anyone who clicks it.
- The "Book us with Cal.com" button links to `cal.com/team/tuist/cloud`, which no longer resolves. Our booking now lives at https://cal.tuist.dev/team/tuist/tuist.
- The intro paragraph and the trailing NOTE describe Tuist as Apple-only, which stopped being accurate once we shipped Gradle and Bazel support.

## What changed

- Added an X badge pointing at https://x.com/tuistdev and removed the Telegram one from the socials row.
- Updated the Cal.com anchor to https://cal.tuist.dev/team/tuist/tuist (kept the same badge image).
- Rewrote the intro paragraph to lead with the build systems we support (Xcode, Gradle, Bazel) and the cache as the centerpiece, then dropped the Apple-only expansion NOTE that no longer reflects where the product is.
- Reordered the solutions list so cache leads, and moved "Generated projects" (Xcode-only) to the end, matching the framing in the org profile README (tuist/.github@6d1496e).

## Considered alternatives

- Keeping Telegram alongside X — but we don't want to send readers to an unmaintained channel, so retiring it is cleaner than leaving it as-is.
- Adding a `utm_source=readme` query to the Cal link — skipped for now to keep this PR narrowly about fixing the broken link; can be layered on later if useful.
- Leaving the intro alone and only fixing the badges — but since we just refreshed the same paragraphs in `tuist/.github`, keeping both surfaces telling the same story felt worth folding in here.

## Verification

- Opened https://cal.tuist.dev/team/tuist/tuist and https://x.com/tuistdev in the browser to confirm both resolve.
- `git diff` reviewed; only README.md changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ioVpnQkdf4JEsGE74fZ9g