### PR TITLE
fix(kura): increase control-plane DNS connection timeout

### DIFF
--- a/kura/AGENTS.md
+++ b/kura/AGENTS.md
@@ -17,6 +17,7 @@ This node covers the `kura/` workspace, a Rust service for low-latency cache mes
   - Multipart session admission follows `src/memory/mod.rs` headroom and pressure unless explicitly overridden; `src/store.rs` owns durable slot accounting and the one-second, capacity-bounded start queue. Use the FIFO admission turn and dedicated pressure-tier signal; preserve cancellation cleanup through blocking record writes and expose queue outcomes/depth. Keep occupied-slot and effective-capacity metrics aligned with admission.
 - Observability and analytics: `src/metrics.rs`, `src/telemetry.rs`, `src/request_observability.rs`, `src/analytics.rs`
 - Control-plane mesh membership (enrollment, mesh heartbeat, managed peers sync, recovery re-enrollment): `src/enrollment.rs`, `src/mesh_heartbeat.rs`
+  - `src/control_plane_http.rs` shares the mesh heartbeat/peer-sync and usage HTTP budgets: 3 seconds for connection setup including DNS, 5 seconds for the whole request. Remote regions must have time to resolve Kubernetes search domains before connecting; keep the initial peer-view serving gate intact.
 - Peer TLS support: `src/peer_tls.rs`
 - Peer sync bandwidth shaping: `src/bandwidth.rs`
 - Operational assets: `docker-compose.yml`, `ops/`, `test/e2e/`, `spec/e2e/`

--- a/kura/AGENTS.md
+++ b/kura/AGENTS.md
@@ -17,7 +17,7 @@ This node covers the `kura/` workspace, a Rust service for low-latency cache mes
   - Multipart session admission follows `src/memory/mod.rs` headroom and pressure unless explicitly overridden; `src/store.rs` owns durable slot accounting and the one-second, capacity-bounded start queue. Use the FIFO admission turn and dedicated pressure-tier signal; preserve cancellation cleanup through blocking record writes and expose queue outcomes/depth. Keep occupied-slot and effective-capacity metrics aligned with admission.
 - Observability and analytics: `src/metrics.rs`, `src/telemetry.rs`, `src/request_observability.rs`, `src/analytics.rs`
 - Control-plane mesh membership (enrollment, mesh heartbeat, managed peers sync, recovery re-enrollment): `src/enrollment.rs`, `src/mesh_heartbeat.rs`
-  - `src/control_plane_http.rs` shares the mesh heartbeat/peer-sync and usage HTTP budgets: 3 seconds for connection setup including DNS, 5 seconds for the whole request. Remote regions must have time to resolve Kubernetes search domains before connecting; keep the initial peer-view serving gate intact.
+- Mesh and usage HTTP timeout policy: `src/control_plane_http.rs`, used by `src/mesh_heartbeat.rs` and `src/usage.rs` — 3 seconds for connection setup including DNS, within a 5-second total request deadline. Enrollment, registration, analytics, and authentication configure their clients separately. Keep the initial peer-view serving gate intact.
 - Peer TLS support: `src/peer_tls.rs`
 - Peer sync bandwidth shaping: `src/bandwidth.rs`
 - Operational assets: `docker-compose.yml`, `ops/`, `test/e2e/`, `spec/e2e/`

--- a/kura/README.md
+++ b/kura/README.md
@@ -473,6 +473,12 @@ It also exposes analytics-specific runtime metrics for:
 
 ## Usage Metering
 
+Usage delivery, mesh heartbeats, and managed peer-view synchronization share a
+3-second connection budget (including DNS resolution) and a 5-second total
+request deadline. This leaves remote regions time to resolve Kubernetes service
+names before connecting. Managed nodes still wait for their first successful
+peer-view fetch before serving.
+
 When `KURA_CONTROL_PLANE_URL`, `KURA_CONTROL_PLANE_CLIENT_ID`, and `KURA_CONTROL_PLANE_CLIENT_SECRET` are set, Kura records first-party usage rollups for public cache traffic and pushes them to:
 
 ```text

--- a/kura/README.md
+++ b/kura/README.md
@@ -473,17 +473,14 @@ It also exposes analytics-specific runtime metrics for:
 
 ## Usage Metering
 
-Usage delivery, mesh heartbeats, and managed peer-view synchronization share a
-3-second connection budget (including DNS resolution) and a 5-second total
-request deadline. This leaves remote regions time to resolve Kubernetes service
-names before connecting. Managed nodes still wait for their first successful
-peer-view fetch before serving.
-
 When `KURA_CONTROL_PLANE_URL`, `KURA_CONTROL_PLANE_CLIENT_ID`, and `KURA_CONTROL_PLANE_CLIENT_SECRET` are set, Kura records first-party usage rollups for public cache traffic and pushes them to:
 
 ```text
 POST {KURA_CONTROL_PLANE_URL}/_internal/kura/usage
 ```
+
+Usage delivery allows up to 3 seconds for connection setup, including DNS, within
+a 5-second total request deadline covering setup, upload, and response.
 
 Both surfaces are metered: the HTTP cache path records rollups with `protocol = "http"`, and the REAPI (gRPC) path — `ByteStream` read/write, CAS `BatchReadBlobs`/`BatchUpdateBlobs`, and ActionCache `GetActionResult` (including inlined stdout/stderr/output files) / `UpdateActionResult` — records them with `protocol = "grpc"` and `artifact_kind = "reapi"`, so Bazel and other REAPI clients count toward the same usage surface.
 

--- a/kura/docs/architecture.md
+++ b/kura/docs/architecture.md
@@ -149,6 +149,13 @@ A node finds peers in three ways:
 2. **Control-plane dynamic membership** (`src/mesh_heartbeat.rs`): enrolled self-hosted nodes send a mesh heartbeat every ~60s (cadence server-advertised) whose response carries the current peer list; managed pods fetch the same view read-only when `KURA_MESH_PEERS_SYNC` is set, with serving gated on the first successful fetch (a pod booting blind would accept writes without enqueuing replication for peers it cannot see). Additions **and removals** propagate at heartbeat cadence with no restart; a failed heartbeat keeps the last-known view, so a degraded control plane can never shrink the mesh.
 3. **DNS-based discovery** via `KURA_DISCOVERY_DNS_NAME`, which resolves to the addresses of the other pods (typical when running as a Kubernetes `StatefulSet` behind a headless service).
 
+Mesh heartbeats, managed peer-view fetches, and usage delivery share the HTTP
+client budgets in `src/control_plane_http.rs`: 3 seconds for connection setup,
+including DNS, within a 5-second total request deadline. DNS search-domain
+lookups from remote regions can consume a one-second connect budget before TCP
+starts; retrying with the same insufficient budget would hold a new managed
+node behind the initial peer-view serving gate indefinitely.
+
 A `spawn_membership_task` loop polls each candidate's `GET /_internal/status` every two seconds. Only peers that respond with the same `tenant_id` and a different `node_url` are admitted as members. The local node never lists itself.
 
 Mesh **membership itself** is control-plane state for enrolled nodes: a node that stops sending mesh heartbeats is deactivated (withheld from every peer's view) and its row is purged once its peer certificate can no longer be valid. Heartbeats never create or restore membership — a withheld node is answered `mesh_member: false` and recovers with a **recovery re-enrollment** (backoff-limited), which reactivates or recreates its membership server-side. Nothing local is torn down for it and readiness is not clawed back: the writes missed while out of the mesh were never enqueued for the node (replication targets are computed at write time), and the backfill watermarks are durable, so the next pass re-walks from them and reconciles the gap in the background while the node keeps serving.

--- a/kura/docs/architecture.md
+++ b/kura/docs/architecture.md
@@ -149,14 +149,13 @@ A node finds peers in three ways:
 2. **Control-plane dynamic membership** (`src/mesh_heartbeat.rs`): enrolled self-hosted nodes send a mesh heartbeat every ~60s (cadence server-advertised) whose response carries the current peer list; managed pods fetch the same view read-only when `KURA_MESH_PEERS_SYNC` is set, with serving gated on the first successful fetch (a pod booting blind would accept writes without enqueuing replication for peers it cannot see). Additions **and removals** propagate at heartbeat cadence with no restart; a failed heartbeat keeps the last-known view, so a degraded control plane can never shrink the mesh.
 3. **DNS-based discovery** via `KURA_DISCOVERY_DNS_NAME`, which resolves to the addresses of the other pods (typical when running as a Kubernetes `StatefulSet` behind a headless service).
 
-Mesh heartbeats, managed peer-view fetches, and usage delivery share the HTTP
-client budgets in `src/control_plane_http.rs`: 3 seconds for connection setup,
-including DNS, within a 5-second total request deadline. DNS search-domain
-lookups from remote regions can consume a one-second connect budget before TCP
-starts; retrying with the same insufficient budget would hold a new managed
-node behind the initial peer-view serving gate indefinitely.
-
 A `spawn_membership_task` loop polls each candidate's `GET /_internal/status` every two seconds. Only peers that respond with the same `tenant_id` and a different `node_url` are admitted as members. The local node never lists itself.
+
+Mesh heartbeats and managed peer-view fetches use `src/control_plane_http.rs`
+(also used by usage delivery): connection setup, including DNS, has a 3-second
+budget within a 5-second total request deadline. A failed fetch retains the
+last-known view and retries on the configured cadence; before the first successful
+fetch, the managed node remains behind the serving gate.
 
 Mesh **membership itself** is control-plane state for enrolled nodes: a node that stops sending mesh heartbeats is deactivated (withheld from every peer's view) and its row is purged once its peer certificate can no longer be valid. Heartbeats never create or restore membership — a withheld node is answered `mesh_member: false` and recovers with a **recovery re-enrollment** (backoff-limited), which reactivates or recreates its membership server-side. Nothing local is torn down for it and readiness is not clawed back: the writes missed while out of the mesh were never enqueued for the node (replication targets are computed at write time), and the backfill watermarks are durable, so the next pass re-walks from them and reconciles the gap in the background while the node keeps serving.
 

--- a/kura/src/control_plane_http.rs
+++ b/kura/src/control_plane_http.rs
@@ -1,12 +1,16 @@
 use std::time::Duration;
 
+const CONNECT_TIMEOUT_SECS: u64 = 3;
+const REQUEST_TIMEOUT_SECS: u64 = 5;
+const _: () = assert!(CONNECT_TIMEOUT_SECS < REQUEST_TIMEOUT_SECS);
+
 pub(crate) fn client_builder() -> reqwest::ClientBuilder {
     // Connection setup includes DNS. A remote region can spend more than one
     // second resolving Kubernetes search domains before starting TCP. Match
     // the managed auth client's connect budget, keeping the total request bounded.
     reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(3))
-        .timeout(Duration::from_secs(5))
+        .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
 }
 
 #[cfg(test)]
@@ -15,7 +19,7 @@ mod tests {
 
     use axum::{Router, http::StatusCode, routing::any};
     use reqwest::dns::{Addrs, Name, Resolve, Resolving};
-    use tokio::net::TcpListener;
+    use tokio::{net::TcpListener, sync::oneshot};
 
     use super::*;
 
@@ -39,16 +43,16 @@ mod tests {
     async fn control_plane_requests_allow_dns_to_take_more_than_one_second() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
+        let (shutdown, shutdown_received) = oneshot::channel();
         let server = tokio::spawn(async move {
             axum::serve(
                 listener,
                 Router::new().route("/", any(|| async { StatusCode::NO_CONTENT })),
             )
+            .with_graceful_shutdown(async { shutdown_received.await.unwrap() })
             .await
-            .unwrap();
         });
-        let old_client = client_builder()
-            .connect_timeout(Duration::from_secs(1))
+        let client = client_builder()
             .no_proxy()
             .dns_resolver(Arc::new(DelayedResolver {
                 address,
@@ -56,22 +60,7 @@ mod tests {
             }))
             .build()
             .unwrap();
-        let old_error = old_client
-            .get(format!("http://control-plane.test:{}/", address.port()))
-            .send()
-            .await
-            .unwrap_err();
-        assert!(old_error.is_timeout());
-
         for method in [reqwest::Method::GET, reqwest::Method::POST] {
-            let client = client_builder()
-                .no_proxy()
-                .dns_resolver(Arc::new(DelayedResolver {
-                    address,
-                    delay: Duration::from_millis(1_200),
-                }))
-                .build()
-                .unwrap();
             let response = client
                 .request(
                     method,
@@ -82,7 +71,8 @@ mod tests {
                 .unwrap();
             assert_eq!(response.status(), StatusCode::NO_CONTENT);
         }
-        server.abort();
+        shutdown.send(()).unwrap();
+        server.await.unwrap().unwrap();
     }
 
     #[tokio::test(start_paused = true)]
@@ -102,6 +92,7 @@ mod tests {
             .await
             .unwrap_err();
         assert!(error.is_timeout());
-        assert_eq!(started.elapsed(), Duration::from_secs(3));
+        assert!(started.elapsed() >= Duration::from_secs(CONNECT_TIMEOUT_SECS));
+        assert!(started.elapsed() < Duration::from_secs(REQUEST_TIMEOUT_SECS));
     }
 }

--- a/kura/src/control_plane_http.rs
+++ b/kura/src/control_plane_http.rs
@@ -1,0 +1,107 @@
+use std::time::Duration;
+
+pub(crate) fn client_builder() -> reqwest::ClientBuilder {
+    // Connection setup includes DNS. A remote region can spend more than one
+    // second resolving Kubernetes search domains before starting TCP. Match
+    // the managed auth client's connect budget, keeping the total request bounded.
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(3))
+        .timeout(Duration::from_secs(5))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::SocketAddr, sync::Arc};
+
+    use axum::{Router, http::StatusCode, routing::any};
+    use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    struct DelayedResolver {
+        address: SocketAddr,
+        delay: Duration,
+    }
+
+    impl Resolve for DelayedResolver {
+        fn resolve(&self, _: Name) -> Resolving {
+            let address = self.address;
+            let delay = self.delay;
+            Box::pin(async move {
+                tokio::time::sleep(delay).await;
+                Ok(Box::new(std::iter::once(address)) as Addrs)
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn control_plane_requests_allow_dns_to_take_more_than_one_second() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new().route("/", any(|| async { StatusCode::NO_CONTENT })),
+            )
+            .await
+            .unwrap();
+        });
+        let old_client = client_builder()
+            .connect_timeout(Duration::from_secs(1))
+            .no_proxy()
+            .dns_resolver(Arc::new(DelayedResolver {
+                address,
+                delay: Duration::from_millis(1_200),
+            }))
+            .build()
+            .unwrap();
+        let old_error = old_client
+            .get(format!("http://control-plane.test:{}/", address.port()))
+            .send()
+            .await
+            .unwrap_err();
+        assert!(old_error.is_timeout());
+
+        for method in [reqwest::Method::GET, reqwest::Method::POST] {
+            let client = client_builder()
+                .no_proxy()
+                .dns_resolver(Arc::new(DelayedResolver {
+                    address,
+                    delay: Duration::from_millis(1_200),
+                }))
+                .build()
+                .unwrap();
+            let response = client
+                .request(
+                    method,
+                    format!("http://control-plane.test:{}/", address.port()),
+                )
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        }
+        server.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stalled_dns_still_exhausts_the_connect_budget() {
+        let client = client_builder()
+            .no_proxy()
+            .dns_resolver(Arc::new(DelayedResolver {
+                address: "127.0.0.1:1".parse().unwrap(),
+                delay: Duration::from_secs(60),
+            }))
+            .build()
+            .unwrap();
+        let started = tokio::time::Instant::now();
+        let error = client
+            .get("http://control-plane.test/")
+            .send()
+            .await
+            .unwrap_err();
+        assert!(error.is_timeout());
+        assert_eq!(started.elapsed(), Duration::from_secs(3));
+    }
+}

--- a/kura/src/lib.rs
+++ b/kura/src/lib.rs
@@ -10,6 +10,7 @@ mod bandwidth;
 mod bazel_test_artifacts;
 mod config;
 mod constants;
+mod control_plane_http;
 mod enrollment;
 mod failpoints;
 mod file_cache;

--- a/kura/src/mesh_heartbeat.rs
+++ b/kura/src/mesh_heartbeat.rs
@@ -44,8 +44,6 @@ const PEERS_PATH: &str = "/_internal/kura/mesh/peers";
 const KURA_MESH_PEERS_SYNC: &str = "KURA_MESH_PEERS_SYNC";
 
 const DEFAULT_INTERVAL_MS: u64 = 60_000;
-const CONNECT_TIMEOUT: Duration = Duration::from_millis(1_000);
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 // Recovery re-enrollments mint fresh certificates; the backoff keeps a
 // persistent `mesh_member: false` (control-plane bug, clock skew) from
 // becoming a per-minute signing loop while staying well inside the server's
@@ -427,9 +425,7 @@ fn basic_auth(client_id: &str, client_secret: &str) -> String {
 }
 
 fn http_client() -> reqwest::Client {
-    reqwest::Client::builder()
-        .connect_timeout(CONNECT_TIMEOUT)
-        .timeout(REQUEST_TIMEOUT)
+    crate::control_plane_http::client_builder()
         .build()
         .expect("mesh heartbeat HTTP client should build")
 }

--- a/kura/src/usage.rs
+++ b/kura/src/usage.rs
@@ -19,8 +19,6 @@ use crate::{
 };
 
 const USAGE_PATH: &str = "/_internal/kura/usage";
-const USAGE_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
-const USAGE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 // Eviction reports awaiting a successful delivery. In memory only: the claim
 // sizing policy reads weeks of aggregates, so reports lost to a restart are
 // noise, and keeping them off the durable outbox keeps the on-disk format
@@ -488,11 +486,7 @@ async fn flush_loop(state: SharedState) {
 }
 
 async fn delivery_loop(state: SharedState) {
-    let client = match Client::builder()
-        .connect_timeout(USAGE_CONNECT_TIMEOUT)
-        .timeout(USAGE_REQUEST_TIMEOUT)
-        .build()
-    {
+    let client = match crate::control_plane_http::client_builder().build() {
         Ok(client) => client,
         Err(error) => {
             warn!("failed to build usage delivery client: {error}");


### PR DESCRIPTION
## Motivation and observed behavior

A managed Kura node must fetch its initial control-plane peer view before serving. The mesh and usage-delivery clients previously imposed a one-second connection timeout, including DNS resolution. When name resolution and connection setup exceed that budget, every retry can expire before reaching an otherwise healthy HTTP endpoint. The node then remains behind its initial peer-view gate and never becomes ready.

This PR raises the connection budget for these background clients to three seconds while retaining the existing five-second total request deadline. The readiness gate remains intact.

The investigation that prompted this change observed recurring connection timeouts alongside unsuccessful initial peer-view synchronization. The tagged runtime source showed that both clients independently configured the same one-second deadline. This differs from managed authentication, which already receives a separate three-second connection budget. Changing authentication timeout environment variables cannot change either of these background clients.

The practical consequence is more than delayed background reporting: failed initial peer synchronization prevents a newly started managed node from serving. Usage delivery also continues failing when it encounters the same setup-budget limitation.

## Root-cause analysis and confidence

**Follow-up read-only checks confirmed the connection-budget diagnosis. Recovery with the new runtime image still needs rollout validation.**

The original local reproduction used a custom DNS resolver that completes after 1.2 seconds and a reachable local HTTP server: the one-second budget timed out and the three-second budget succeeded. The permanent regression test exercises the shipped builder with delayed resolution and successful GET and POST exchanges using a shared client. It no longer rebuilds a client for each method or retains a separate client that overrides the shipped budget with the removed value.

A service hostname such as `control-plane.namespace.svc.cluster.local` has four dots. Under Kubernetes' default `ndots:5` behavior, a resolver can try search-domain expansions before the absolute name. The connection budget includes both name resolution and TCP setup: DNS can complete within the deadline while leaving too little time for the connection itself.

Follow-up diagnostics reproduced the failure with the original deadline and succeeded with the proposed deadline. Absolute-name and direct-IP controls also succeeded with the original deadline, supporting DNS search overhead as the reason ordinary-name connection setup exceeded the budget. Detailed operational measurements remain in the private investigation record.

These read-only checks validate the diagnosis and proposed timeout budget. They do not deploy the new runtime or validate authenticated peer synchronization and completed bootstrap after rollout.

## Implementation

`kura/src/control_plane_http.rs` introduces one shared reqwest builder for:

- Enrolled-node mesh heartbeats.
- Managed-node peer-view synchronization.
- Usage delivery.

Both the mesh module and usage module now use that builder instead of configuring separate copies of the timeout policy. Named constants define the two budgets, and a compile-time assertion requires the connection budget to remain smaller than the total deadline.

| Budget | Before | After |
| --- | --- | --- |
| Connection setup, including DNS | 1 second | 3 seconds |
| Total request | 5 seconds | 5 seconds |

Three seconds matches the connection budget already emitted for managed authentication. It provides additional setup time without adding another runtime setting or requiring configuration migration. Centralizing the builder also prevents the mesh and usage paths from drifting into different timeout policies.

The README documents usage delivery deadlines in the metering section; the architecture document describes mesh deadlines alongside membership behavior. Kura AGENTS.md identifies the exact callers of the shared policy and distinguishes clients that configure their deadlines separately.

## Alternatives and tradeoffs

A stalled connection can now occupy its attempt for up to two additional seconds. The five-second overall deadline still bounds the request, and existing retry intervals remain unchanged. This changes how much of that existing request budget connection setup may consume; it does not make background requests unbounded. If setup uses almost three seconds, only about two seconds remain for uploading the usage batch and reading the response, compared with approximately four seconds after setup at the old limit. The remaining time for an identical successful connection is unchanged; the newly admitted slower connections previously failed before sending their body. Nevertheless, those slower connections can still exhaust the total deadline on a large upload. Usage batches can carry up to 1,000 rollups by default, up to 1,000 eviction events, and a storage snapshot. The timing probes did not validate maximum-sized authenticated usage uploads. Keep the existing total work bound in this fix, and verify delivery latency and outbox depth after rollout before deciding whether upload workloads need a different total budget.

The initial peer-view gate is deliberately preserved. A managed node that accepts traffic before obtaining its peer view could accept writes without knowing all replication destinations. Removing the gate would hide the connectivity problem while weakening replication behavior.

Other approaches were considered:

- **Retry more frequently:** another attempt with the same insufficient deadline still fails when setup consistently takes longer than one second.
- **Remove connection or request deadlines:** that would allow unavailable dependencies to occupy background work indefinitely.
- **Change pod-wide resolver settings or use absolute DNS names:** the absolute-name probe confirms that avoiding search-domain expansion reduces lookup overhead. That remains a possible complementary optimization, but this PR fixes the clients' setup budget without rewriting deployment URLs or changing pod-wide resolver behavior. The clients still need a reasonable bounded budget for remote DNS and connection setup.
- **Change only authentication timeout settings:** those settings do not configure the mesh and usage builders.
- **Change network policy or node firewall configuration:** the ordinary-hostname request succeeds with a longer deadline, and both direct-IP controls succeed within one second. These measurements support fixing the client budget and provide no reason to change network policy or host firewall configuration for this failure.

## Scope and remaining hardening

The shared policy covers mesh heartbeats, managed peer synchronization, and usage delivery. It is not a uniform policy for every outbound control-plane request:

- **Enrollment and certificate renewal:** `enrollment.rs` builds a client without explicit connection or total deadlines. Renewal is awaited inline by the enrolled-node heartbeat recovery path and the separate certificate-renewal task, so a stalled request can delay those loops. Managed peer synchronization does not call enrollment. Adding bounded enrollment deadlines requires validating boot enrollment, certificate signing, and renewal recovery; this pre-existing gap is not fixed here.
- **Analytics and registration:** analytics retains its separate 500-millisecond connection limit and configurable total deadline; registration has no explicit HTTP deadlines. The Bazel test-artifact delivery client also uses the analytics timeout configuration and a separate 500-millisecond connection limit. These paths need their own bounded-client policy and delivery/lease validation. This PR does not claim to restore all background telemetry or address registration stalls.
- **Bootstrap retry cadence:** a failed managed peer fetch still sleeps the configured interval, initially 60 seconds, until a successful response can advertise a different cadence. A brief outage can therefore delay readiness for another interval. A shorter, bounded bootstrap backoff would improve transient recovery, but retrying faster cannot fix repeated attempts whose connection setup always exceeds their deadline. The confirmed diagnosis supports this connection-budget fix independently of that follow-up.

Authentication, retry cadence, enrollment, registration, analytics, peer protocols, storage formats, resource limits, and the serving gate are unchanged.

## Validation performed

The final focused Bazel run passed **25 tests**, with no failures, in 1.21 seconds of test execution after compilation. It includes the HTTP-client tests and existing mesh and usage tests:

```sh
bazel test //:kura_lib_test \
  --test_arg=control_plane_http::tests \
  --test_arg=mesh_heartbeat::tests \
  --test_arg=usage::tests \
  --jobs=6
```

The new tests cover two distinct behaviors:

1. A real local Axum server remains reachable after a simulated 1.2-second DNS lookup. GET and POST share one client, allowing the second request to reuse its pooled connection. The server shuts down gracefully and its join result is checked, so a background server error cannot be silently discarded.
2. A stalled resolver still exhausts the three-second connection budget. This uses Tokio's paused clock and verifies that the timeout occurs at or after the connection budget but before the total deadline, without requiring exact timer equality or waiting on an external network.

The existing `peer_view_gate_withholds_serving_until_first_fetch` test also passes, confirming that the readiness protection remains in place.

Additional checks passed:

- Clippy across all targets using the repository's required aspect:
  `bazel build //... --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect --output_groups=clippy_checks --jobs=6`.
- Rustfmt checks on the changed Rust files.
- `git diff --check`.
- Shell syntax validation and successful read-only execution of the separately prepared production diagnostic script on both affected pods. The confirmation is summarized above; no production configuration was changed.

### Full-suite limitation

An earlier invocation used `--test_filter`, which this Rust rule did not forward, and consequently ran the full library suite: **992 passed, 1 failed, 48 ignored**.

The failure was `store::tests::concurrent_artifact_writes_batch_segment_fsyncs`: it observed five WAL flushes against an assertion allowing at most four. It passed in the earlier 26-test focused run, which included that storage test alongside the HTTP, mesh, and usage tests. Storage batching code is unchanged, but the cause of the full-suite failure was not established. This is **not a clean full-suite result**, and the passing focused rerun should not be presented as one.

## Production confirmation and rollout

The read-only timing checks now confirm the connection-budget diagnosis. No production configuration was changed, the new image has not been deployed during this investigation, and production recovery remains unvalidated.

Release through the normal health-gated Kura rollout. Verify new replicas fetch their authenticated peer view, complete bootstrap, and reach Ready; instance status reports ready and serving; the client Service has a ready serving backend; peer-sync recovery is logged; usage connection timeouts stop; authenticated usage batches, including large batches, drain successfully without growing the outbox; and the endpoint serves.

## Compatibility and rollback

No data migration or new environment variable is required. Mixed runtime versions use the same peer wire protocol and disk format.

Rolling back restores the previous one-second timeout and may reproduce the bootstrap failure on a fresh process. An older pod that has already latched into serving does not prove that a newly started pod can obtain its initial peer view. Rollout and rollback verification must therefore include a newly started replica, rather than relying only on an existing serving process.
