### PR TITLE
chore(server,infra): finish the eu-west rename

### DIFF
--- a/infra/helm/platform/values.yaml
+++ b/infra/helm/platform/values.yaml
@@ -117,12 +117,6 @@ kura-eu-west-ingress-nginx:
       # changing it would make the upgrade patch an existing class and fail.
       # It is an opaque identifier that nothing displays.
       controllerValue: k8s.io/kura-eu-central-ingress-nginx
-      # Until the server has re-rendered every KuraInstance in the region, its
-      # Ingresses still name the old class, and this keeps them claimed by the
-      # renamed controller. Remove once no Ingress in the region carries
-      # kura-eu-central.
-      aliases:
-        - kura-eu-central
     publishService:
       enabled: true
     service:

--- a/server/priv/ingest_repo/migrations/20260910150000_sweep_remaining_eu_central_region_rows.exs
+++ b/server/priv/ingest_repo/migrations/20260910150000_sweep_remaining_eu_central_region_rows.exs
@@ -1,0 +1,36 @@
+defmodule Tuist.IngestRepo.Migrations.SweepRemainingEuCentralRegionRows do
+  use Ecto.Migration
+
+  alias Tuist.IngestRepo
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  # The second pass of the eu-central to eu-west rename. The first mutation ran
+  # in the pre-upgrade hook and rewrote the rows that existed then, but a Kura
+  # node stamps its events with its own region and only learns the new one when
+  # the reconciler re-renders its instance and rolls it. The rows written in
+  # that gap kept the old id: on production, four usage events and one eviction
+  # event. This sweeps them so a series grouped by region reads as one region.
+  #
+  # The fleet has converged, so nothing writes the old id any more and one pass
+  # is enough. Idempotent regardless: a second run matches nothing.
+  @tables ~w(kura_usage_events kura_eviction_events kura_storage_snapshots)
+
+  def up, do: rename_region("eu-central", "eu-west")
+
+  # The rename is not reversible from here: the first migration's `down` already
+  # restores every row it moved, and this pass cannot tell the stragglers it
+  # rewrote apart from the ones that were always eu-west.
+  def down, do: :ok
+
+  defp rename_region(from, to) do
+    for table <- @tables do
+      IngestRepo.query!(
+        "ALTER TABLE #{table} UPDATE region = '#{to}' WHERE region = '#{from}' SETTINGS mutations_sync = 1",
+        [],
+        timeout: :infinity
+      )
+    end
+  end
+end

--- a/server/priv/repo/migrations/20260910150000_sweep_remaining_eu_central_kura_rows.exs
+++ b/server/priv/repo/migrations/20260910150000_sweep_remaining_eu_central_kura_rows.exs
@@ -1,0 +1,42 @@
+defmodule Tuist.Repo.Migrations.SweepRemainingEuCentralKuraRows do
+  use Ecto.Migration
+
+  # The Postgres half of the rename's second pass. The pre-upgrade migration
+  # rewrote every region-scoped row that existed when it ran, but the instances
+  # kept reporting the old id until the reconciler re-rendered and rolled them,
+  # so a storage rollup landed under `eu-central` in that gap. Every other
+  # region-keyed table came through clean.
+  #
+  # Swept together rather than singling out the one table, because which tables
+  # take a write in that window depends on timing rather than on anything
+  # structural. Idempotent: a second run matches nothing.
+  @region_columns [
+    {:kura_servers, :region},
+    {:kura_account_region_lifecycles, :service_region},
+    {:kura_account_region_policies, :service_region},
+    {:kura_placement_proposals, :from_region},
+    {:kura_placement_proposals, :to_region},
+    {:kura_placer_regions, :region},
+    {:kura_storage_rollups, :region},
+    {:kura_egress_limits, :region},
+    {:kura_claim_proposals, :region},
+    {:kura_registered_endpoints, :region}
+  ]
+
+  def up do
+    for {table, column} <- @region_columns do
+      # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+      execute("UPDATE #{table} SET #{column} = 'eu-west' WHERE #{column} = 'eu-central'")
+    end
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    execute(
+      "UPDATE kura_deployments SET cluster_id = 'eu-west-1' WHERE cluster_id = 'eu-central-1'"
+    )
+  end
+
+  # Not reversible from here: the rename migration's `down` already restores
+  # every row it moved, and this pass cannot tell the stragglers it rewrote
+  # apart from the rows that were always eu-west.
+  def down, do: :ok
+end


### PR DESCRIPTION
Closes out the two loose ends from [#13061](https://github.com/tuist/tuist/pull/13061), now that production has converged on the new region name.

### The transitional ingress class alias comes out

The renamed gateway carried `aliases: [kura-eu-central]` so that the Ingresses the server had not yet re-rendered stayed claimed by it during the rollout. That window is closed: all 54 Ingresses in the region now name `kura-eu-west` and none names the old class, so the alias has nothing left to catch.

The gateway keeps `controllerValue: k8s.io/kura-eu-central-ingress-nginx`. That field is immutable on an IngressClass and the class was created with it, so changing it would make the upgrade patch an existing object and fail. It is an opaque identifier that nothing displays, and swapping it means deleting and recreating the class, which is a separate decision for a quiet moment or never.

### The migrations sweep what the first pass could not reach

The rename ran in the pre-upgrade hook and rewrote every row that existed then. A Kura node stamps its events with its own region and only learns the new one when the reconciler re-renders its instance and rolls it, so anything written in that gap kept the old id. On production that was:

| Table | Rows left under the old id |
|---|---|
| kura_usage_events | 4 |
| kura_eviction_events | 1 |
| kura_storage_rollups | 1 |

Everything else came through the first pass clean, including all live server, deployment, lifecycle and placement rows. This was raised in review on the original pull request and is exactly the residue that was predicted.

The Postgres sweep covers every region-keyed table rather than just the one that drifted, because which tables take a write in that window is a matter of timing rather than structure. The fleet has converged, so nothing writes the old id any more and one pass is enough.

Both migrations are one-way. The rename migration's `down` already restores every row it moved, and a second pass cannot tell the stragglers it rewrote apart from the rows that were always `eu-west`, so `down` is a no-op rather than a lie.

### How to test locally

```bash
cd server && MIX_ENV=test mix ecto.migrate
```

Then confirm the sweep actually moves a straggler rather than silently matching nothing:

```bash
cd server && MIX_ENV=test mix run -e 'alias Tuist.Repo; Repo.query!("SELECT count(*) FROM kura_storage_rollups WHERE region = $1", ["eu-central"]) |> then(& IO.inspect(&1.rows))'
```

Validation already run: both migrations applied to the test database, then driven down and up against a seeded straggler to confirm the server row and its deployment row flip to the new id, and re-run to confirm a second pass matches nothing; the Kura suites (908 passed); `mix format --check-formatted`; `mix excellent_migrations.check_safety` (nothing flagged); and the platform chart cross-checked with yq, with the gateway aliases still matching the values keys and no `aliases` key left in the file.

### Not included

The server probes a new public hostname within seconds of re-rendering an instance, ahead of external-dns creating the record. Cloudflare's edge then caches that negative answer for the zone's 1800 second minimum, which is what left the canary host unreachable for 28 minutes during this rename and what the pre-warmed records worked around on production. That is a real bug and it will bite the next hostname change, but it is a reconciler fix rather than cleanup, so it belongs in its own pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
