### PR TITLE
fix(status): tighten the hero alert's icon-to-label gap

### DIFF
--- a/status/src/views/styles.ts
+++ b/status/src/views/styles.ts
@@ -315,6 +315,12 @@ main {
     color: var(--noora-surface-label-secondary);
     font: var(--noora-font-weight-regular) var(--noora-font-body-large);
   }
+
+  /* The status alert sets its icon closer to the label than Noora's medium
+     alert does (spacing-3 instead of spacing-5). */
+  & > .noora-alert {
+    gap: var(--noora-spacing-3);
+  }
 }
 
 /* Section: a titled header strip over a hairline-divided list. */


### PR DESCRIPTION
## What changed

The status page's hero alert (the "Operational" / "Partial outage" pill under the headline) now puts its icon `--noora-spacing-3` from the label instead of Noora's medium-alert default of `--noora-spacing-5`.

## Why

Next to the large hero headline the default gap reads loose; the tighter spacing matches how the rest of the page sets icons against labels. The override is scoped to `.status-hero > .noora-alert`, so the copied Noora alert styles stay verbatim.

## Validation

- `tsc --noEmit`, `vitest run` (22 tests) and `prettier --check` pass in `status/`.
- Checked live on the local worker (`wrangler dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)