### PR TITLE
Drop the Slack and translation badges from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,9 @@
   <a href="https://fosstodon.org/@tuist"><img src="https://img.shields.io/badge/tuist-gray.svg?logo=mastodon&logoColor=f5f5f5" alt="Mastodon badge"></a>
   <a href="https://bsky.app/profile/tuist.dev"><img src="https://img.shields.io/badge/tuist-gray.svg?logo=bluesky" alt="Bluesky badge"></a>
   <a href="https://x.com/tuistdev"><img src="https://img.shields.io/badge/tuistdev-gray.svg?logo=x" alt="X badge"></a>
-  <a href="https://join.slack.com/t/tuistapp/shared_invite/zt-1lqw355mp-zElRwLeoZ2EQsgGEkyaFgg"><img src="https://img.shields.io/badge/tuist-gray.svg?logo=slack" alt="Slack Workspace"></a>
   <div>
     <a href="https://cal.tuist.dev/team/tuist/tuist" target="_blank"><img alt="Book us with Cal.com" src="https://cal.com/book-with-cal-dark.svg" width="150"/></a>
   </div>
-  <a href="https://translate.tuist.dev/engage/tuist/">
-  <img src="https://translate.tuist.dev/widget/tuist/svg-badge.svg" alt="Translation status" />
-  </a>
 </div>
 
 # Tuist


### PR DESCRIPTION
## Summary

Two more badges I want to retire from the README socials row:

- The Slack workspace invite. We're no longer investing in the Slack community and want to steer new folks to the forum, Bluesky, X, and Mastodon instead, so leaving an invite badge at the top of the README pulls people toward a channel we don't want to grow.
- The Crowdin translation-status widget. It renders a percentage bar under the header that's noisy for someone landing on the README for the first time and doesn't help the reader decide anything. The status is still visible in Crowdin itself for anyone contributing translations.

## What changed

- Removed the Slack `<a>` badge from the socials row in `README.md`.
- Removed the trailing `<a href="https://translate.tuist.dev/engage/tuist/">…</a>` block that embedded the translation-status SVG.

## Considered alternatives

- Moving Slack under a "Community" section further down the README rather than removing it. Skipped because the intent is to stop pointing new readers at Slack at all, not to just make the badge less prominent.
- Keeping the translation widget but hiding it behind a `<details>` fold. Skipped because the widget mainly serves Crowdin contributors, who can reach it directly on Crowdin.

## Verification

- `git diff` reviewed; only `README.md` changes, four lines deleted, nothing else touched.
- Preview of the rendered README on GitHub shows the header row now ends at the X badge and the Cal.com button, with no orphan whitespace where the translation SVG was.

## Related

Split out of #13110 so the socials/link/intro refresh and this badge cleanup can be reviewed and merged independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ioVpnQkdf4JEsGE74fZ9g