### PR TITLE
feat(infra): serve the eu-east and us-central Kura regions

### DIFF
--- a/infra/helm/platform/values-tuist.yaml
+++ b/infra/helm/platform/values-tuist.yaml
@@ -197,11 +197,8 @@ kura-sa-west-ingress-nginx:
 # EU East (Warsaw, OVHcloud). Same host-network shape as the other bare-metal
 # regions: the region's gateway binds the box's public IP, and OVH has no cloud
 # LoadBalancer to put in front of it.
-#
-# Disabled until the box is prepped and adopted. Enabling a region whose pool has
-# no node leaves its Ingresses unclaimed.
 kura-eu-east-ingress-nginx:
-  enabled: false
+  enabled: true
   controller:
     kind: DaemonSet
     hostNetwork: true
@@ -224,11 +221,8 @@ kura-eu-east-ingress-nginx:
 
 # US Central (Chicago, Vultr). Same host-network shape as sa-west, which runs on
 # the same provider and plan.
-#
-# Disabled until the box is prepped and adopted. Enabling a region whose pool has
-# no node leaves its Ingresses unclaimed.
 kura-us-central-ingress-nginx:
-  enabled: false
+  enabled: true
   controller:
     kind: DaemonSet
     hostNetwork: true

--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -187,7 +187,7 @@ server:
     # per-account cache pods and dispatch routes the Mac fleet's build
     # cache to it over the Private Network.
     - name: TUIST_KURA_AVAILABLE_REGIONS
-      value: eu-west,us-east,us-west,ap-southeast,sa-west,scw-fr-par-runners
+      value: eu-west,us-east,us-west,ap-southeast,sa-west,eu-east,us-central,scw-fr-par-runners
     # Wave 0 (canary) of a progressive Kura runtime rollout: Tuist-owned
     # accounts, and only those (spec #79).
     - name: TUIST_KURA_CANARY_ACCOUNT_HANDLES
@@ -874,11 +874,19 @@ vultrFleets:
   # kind, the disk conversion and the fleet wiring are the ones already proven
   # there.
   #
-  # Disabled until the box is ordered and converted. The self-join refuses a box
-  # whose /data cannot enforce project quotas, and an enabled fleet with no
-  # adoptable box wedges `helm --wait` for every production deploy.
+  # Every box counted by replicas must already carry the adoptTag and have been
+  # through `mise run baremetal:prep-vultr`. Vultr's installer cannot lay down
+  # the mirrored root plus separate XFS /data the self-join gates on, so an
+  # unconverted box is never adopted, and a fleet whose replicas exceed the
+  # adoptable boxes sits at MD 0/1 and wedges `helm --wait` for every production
+  # deploy rather than just this region.
+  #
+  # Running a box here is not the same as serving the region: that is decided by
+  # us-central's presence in TUIST_KURA_AVAILABLE_REGIONS and by its ingress
+  # controller in the platform chart. Both are open. Closing either one takes the
+  # region out of service without touching the box.
   us-central:
-    enabled: false
+    enabled: true
     replicas: 1
     nodePool: kura-us-central
     machine:
@@ -956,11 +964,17 @@ ovhFleets:
   # OVHDedicatedMachine kind and its unmetered bandwidth rather than adding a
   # metered provider where an unmetered one is available.
   #
-  # Disabled until a box is ordered, prepped and marked. An enabled fleet with no
-  # adoptable box sits at MD 0/1 and wedges `helm --wait` for every production
-  # deploy, not just this region.
+  # Every box counted by replicas must already be prepped (`mise run
+  # baremetal:prep-ovh`) and carry the adoptDisplayNamePrefix, or the fleet sits
+  # at MD 0/1 and wedges `helm --wait` for every production deploy rather than
+  # just this region.
+  #
+  # Running a box here is not the same as serving the region: that is decided by
+  # eu-east's presence in TUIST_KURA_AVAILABLE_REGIONS and by its ingress
+  # controller in the platform chart. Both are open. Closing either one takes the
+  # region out of service without touching the box.
   eu-east:
-    enabled: false
+    enabled: true
     replicas: 1
     nodePool: kura-eu-east
     machine:


### PR DESCRIPTION
## What changed

Opens the three gates the `eu-east` (Warsaw, OVHcloud WAW) and `us-central` (Chicago, Vultr ORD) Kura regions shipped closed behind in #13065:

1. `ovhFleets.eu-east.enabled` and `vultrFleets.us-central.enabled`, so each region's fleet orders and adopts its box into the `kura-eu-east` / `kura-us-central` node pool.
2. `kura-eu-east-ingress-nginx.enabled` and `kura-us-central-ingress-nginx.enabled`, so each region's host-network gateway claims the region's Ingresses.
3. Both region ids in `TUIST_KURA_AVAILABLE_REGIONS`.

The stale "disabled until the box is prepped" comments are replaced with the same wording the served `sa-west` block carries: what a box counted by `replicas` must already be, and the fact that running a box is not the same as serving the region.

## Why

`#13065` added both regions to the catalog, the account-region policy list and the production Helm values, but deliberately left every gate closed so an assignment could be recorded before hardware existed. Neither region has served anything since: production has zero `kura_servers` rows, zero region policies and zero placement proposals naming either, and no node carries either pool label. The regions were merged, not shipped.

`Regions.available?/1` filters placement candidates, so until the third gate opens no proposal can name either region, and an explicit assignment to one is refused rather than silently relocated (#12798). That is why the traffic these regions exist for still reads across a continent: Chicago-zone origins are answered from Vint Hill, and the Nordics and Baltics from Paris. Measured over the last 30 days by each account's leading origin, that is 23 accounts and 22,499 runs for `us_central`, and 25 accounts and 19,857 runs for `europe_east`.

## Why this shape

This mirrors #13025, which served `sa-west` a day after #12962 added it. Splitting "add the region" from "serve the region" is what lets the catalog, the migration and the fleet wiring land and be reviewed while the hardware is still being ordered.

No template change is needed beyond the flags. The `kura-volume-quota-exporter` node affinity in `kura-fleet-storage.yaml` derives its pool list by ranging over `ovhFleets` and `vultrFleets` and taking every enabled fleet whose nodes carry the `tuist.dev/kura-cache` taint, so both pools join it automatically. `hcloud-csi-values.yaml` excludes non-Hetzner boxes by provider rather than by pool name, so a new region on an existing provider needs no edit there either. Both ingress subcharts and their base values were already declared in #13065.

## Merge precondition

**Do not merge until both boxes are ordered, prepped and adoptable.** A fleet whose `replicas` exceed its adoptable boxes sits at MachineDeployment 0/1 and wedges `helm --wait` for every production deploy, not just its own region. Per region:

- `eu-east`: an OVH Advance-1 in `waw`, prepped with `mise run baremetal:prep-ovh`, with its operator-set display name starting `tuist-kura-ovh-production-eu-east`.
- `us-central`: a Vultr `vbm-6c-32gb-amd` in `ord`, tagged `tuist-kura-vultr-production`, converted with `mise run baremetal:prep-vultr`. The self-join refuses a box whose `/data` cannot enforce project quotas.

`sa-west` also waited on `kura_volume_quota_enforced` reading 1 on the node before its ingress and availability entry were opened. That check applies here too, and it is the reason to consider splitting this into one merge per region so each lands when its own box does.

## Impact

Once merged with both boxes adopted, placement can propose either region and accounts whose majority origin sits in the Chicago interior or in the Nordics and Baltics stop being served across a continent. Nothing changes for any other region: the remaining entries in `TUIST_KURA_AVAILABLE_REGIONS` are untouched, and no existing account moves except through the ordinary placement sweep.

## Validation

- `yq` reads both files, and every flag reads back as intended: `ovhFleets.eu-east`, `vultrFleets.us-central` and both `kura-*-ingress-nginx` releases enabled, `TUIST_KURA_AVAILABLE_REGIONS` carrying both new ids.
- Rendered the `kura-fleet-storage.yaml` pool-selection block against the production values. The quota exporter's node affinity now lists `kura-eu-east` and `kura-us-central` alongside the existing pools, and the `runners-linux` pool correctly stays out because it sets its own taints.
- `helm template` of the whole chart against `values-managed-production.yaml` fails locally on `swift-registry-sync-runtime-secret.yaml` for want of deploy-time values. Confirmed pre-existing by reproducing it on `origin/main` with this branch's changes stashed.
- Production state read before writing any of this: `kura_servers`, `kura_account_region_policies` and `kura_placement_proposals` grouped by region, the node list with pool labels, the deployed `TUIST_KURA_AVAILABLE_REGIONS` env, and the Prometheus `region` label values over `kura_.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
