### PR TITLE
feat(server): read the Balkans, Greece and Cyprus from Warsaw

### DIFF
--- a/server/lib/tuist/kura/origin_map.ex
+++ b/server/lib/tuist/kura/origin_map.ex
@@ -17,7 +17,7 @@ defmodule Tuist.Kura.OriginMap do
 
   # Bumped when an entry moves. Recorded on decisions rather than compared
   # against anything: it dates a verdict, it does not gate one.
-  @version 3
+  @version 4
 
   # Nearest first, and every list names every candidate region. An origin
   # always has an answer, so a region being unserved or unfunded narrows the
@@ -49,8 +49,8 @@ defmodule Tuist.Kura.OriginMap do
   @default_zone :us_east
 
   @europe ~w[
-    AD AL AT AX BA BE CH CY DE ES FO FR GB GG GI GR HR IE IM IS IT JE LI LU MC
-    ME MK MT NL PT RS SI SJ SM VA XK
+    AD AT AX BE CH DE ES FO FR GB GG GI IE IM IS IT JE LI LU MC MT NL PT SI
+    SJ SM VA
   ]
 
   # Nearer Warsaw than Paris, by enough that the routes follow the geography.
@@ -58,12 +58,16 @@ defmodule Tuist.Kura.OriginMap do
   # against 1030, Vilnius 400 against 1600, so the Nordics sit here with the
   # Baltics rather than with western Europe.
   #
-  # The boundary stops short of the Balkans, Greece and Cyprus. They are also
-  # nearer Warsaw on a straight line, but their transit is provisioned westward
-  # and the traffic behind them is small, so they stay on the Paris routes until
-  # eu-east has a record. Widening this list is one edit and re-reads history.
+  # The Balkans, Greece and Cyprus sit here on the same test: Belgrade is 829km
+  # from Warsaw against 1445 from Paris, Zagreb 802 against 1080, Athens 1598
+  # against 2096, Nicosia 2133 against 2950.
+  #
+  # Slovenia stays west. Ljubljana is 833km from Warsaw against 964 from Paris,
+  # a margin narrower than anything else here and too narrow to take the
+  # straight line for the route.
   @europe_east ~w[
-    BG BY CZ DK EE FI HU LT LV MD NO PL RO RU SE SK UA
+    AL BA BG BY CY CZ DK EE FI GR HR HU LT LV MD ME MK NO PL RO RS RU SE SK
+    UA XK
   ]
 
   @africa_middle_east ~w[

--- a/server/test/tuist/kura/origin_map_test.exs
+++ b/server/test/tuist/kura/origin_map_test.exs
@@ -24,6 +24,22 @@ defmodule Tuist.Kura.OriginMapTest do
       assert ["us-west" | _rest] = OriginMap.candidates("CA-BC")
     end
 
+    test "reads the east of Europe from Warsaw rather than Paris" do
+      for origin <- ~w[FI SE NO DK EE LT LV PL CZ] do
+        assert ["eu-east" | _rest] = OriginMap.candidates(origin)
+      end
+
+      for origin <- ~w[AL BA CY GR HR ME MK RS XK] do
+        assert ["eu-east" | _rest] = OriginMap.candidates(origin)
+      end
+
+      # Ljubljana is 833km from Warsaw against 964 from Paris, which is not the
+      # margin the rest of the boundary is drawn on.
+      assert ["eu-west" | _rest] = OriginMap.candidates("SI")
+      assert ["eu-west" | _rest] = OriginMap.candidates("AT")
+      assert ["eu-west" | _rest] = OriginMap.candidates("IT")
+    end
+
     test "falls back to the country when the subdivision is unmapped" do
       # An unrecognised subdivision still knows which continent it is on, which
       # is the coarser answer rather than a wrong one.


### PR DESCRIPTION
## What changed

Moves `AL`, `BA`, `CY`, `GR`, `HR`, `ME`, `MK`, `RS` and `XK` from the `europe` zone to `europe_east` in `Tuist.Kura.OriginMap`, so their preference lists lead with `eu-east` (Warsaw) rather than `eu-west` (Paris). `@version` goes to 4, which dates the verdict on decisions recorded from here on.

## Why

`#13065` drew the eastern Europe boundary around the Nordics and Baltics and stopped deliberately short of the Balkans, with the reason written into the code: they are nearer Warsaw on a straight line, but their transit is provisioned westward and the traffic behind them is small, so they stayed on the Paris routes "until eu-east has a record". `#13119` opened the region's three gates, so the deferral has served its purpose and the boundary can be drawn where the geography is.

Every country moved clears the same bar the existing entries were chosen on. Distances are great-circle between capitals:

| capital | to Warsaw | to Paris | margin |
|---|---|---|---|
| Belgrade | 829 km | 1445 km | 616 km |
| Skopje | 1138 km | 1666 km | 528 km |
| Pristina | 1064 km | 1608 km | 544 km |
| Athens | 1598 km | 2096 km | 498 km |
| Sarajevo | 951 km | 1349 km | 398 km |
| Podgorica | 1098 km | 1491 km | 393 km |
| Tirana | 1216 km | 1601 km | 385 km |
| Nicosia | 2133 km | 2950 km | 817 km |
| Zagreb | 802 km | 1080 km | 278 km |

For scale, the entries already in the list sit at 355 km (Copenhagen), 993 km (Helsinki) and 1303 km (Vilnius) of margin.

## Slovenia stays west

Ljubljana is 833 km from Warsaw against 964 from Paris, a 131 km margin at 1.16x. That is narrower than anything else on the list and narrower than Copenhagen, which is the closest western call already made. A margin that small is inside the range where provisioned transit decides the route rather than the straight line, so Slovenia keeps the Paris preference until there is a measurement rather than a map to go on.

Croatia is the opposite case and is included: at 278 km and 1.35x it sits with Albania and Montenegro rather than with Slovenia.

## Impact

Nothing moves today. No account currently has its majority origin in any of these countries, and `Kura.AccountPolicies.majority_origin_of/1` is what turns an origin into a placement, so this changes no existing assignment. Over the last 30 days these origins carried 343 runs in total, spread across six account-country pairs, led by Croatia at 248. What the change does is make the next account that leads from one of them resolve to Warsaw instead of Paris, without a second edit.

The zone lists stay disjoint, so no origin is claimed twice. `@country_zones` is built by `Map.new/1` over concatenated pairs, where a duplicate would silently resolve to whichever list came last, and the test below would not have caught that.

## Validation

- Added `reads the east of Europe from Warsaw rather than Paris`, covering the nine moved countries, the nine Nordic and Baltic entries that were already there, and Slovenia, Austria and Italy staying west. Written before the change and confirmed failing on the moved countries first.
- `mix test test/tuist/kura/` passes in full, 812 tests.
- `mix format --check-formatted` and `mix credo` clean on both files.
- Verified after the edit that the two lists remain disjoint, both stay alphabetically sorted, and every moved country left `europe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
