### PR TITLE
refactor(server): gate the marketing redesign behind a single flag

### DIFF
--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -83,12 +83,12 @@ mise run dev
 
 ## Marketing Redesign Rollout
 
-The marketing site redesign ships page by page behind per-page FunWithFlags booleans (`:new_marketing_home`, ...), decided by `TuistWeb.Marketing.Design`. Anonymous traffic follows a page's global flag; authenticated users can preview a page before the flip by enabling its flag for their user as a FunWithFlags actor (their responses are marked `private, no-store` so shared caches never store a previewed variant). Rules while the rollout is in progress:
+The marketing site redesign launches as a whole behind a single FunWithFlags boolean (`:new_marketing`), decided by `TuistWeb.Marketing.Design`. Anonymous traffic follows the global flag; authenticated users can preview the redesign before the flip by enabling the flag for their user as a FunWithFlags actor (their responses are marked `private, no-store` so shared caches never store a previewed variant). Rules while the rollout is in progress:
 
-- Redesigned page templates live in `new/` directories next to the legacy ones (`marketing_html/new/home.html.heex`, `marketing_layout_components/new/navbar.html.heex`), embedded with `embed_templates(..., suffix: "_new")` so the function names stay `home_new/1`, `navbar_new/1`, etc.; the controller action picks the template via `Design.new?(conn, page)` and assigns `:new_design` so the root layout links `bundle-new.css` (built from `assets/marketing/marketing_new.css`) instead of `bundle.css`.
+- Redesigned page templates live in `new/` directories next to the legacy ones (`marketing_html/new/home.html.heex`, `marketing_layout_components/new/navbar.html.heex`), embedded with `embed_templates(..., suffix: "_new")` so the function names stay `home_new/1`, `navbar_new/1`, etc.; the controller action picks the template via `Design.new?(conn)` and assigns `:new_design` so the root layout links `bundle-new.css` (built from `assets/marketing/marketing_new.css`) instead of `bundle.css`.
 - Old and new designs restyle the same selectors, so their CSS must stay in separate bundles: legacy page styles in `marketing.css` imports, redesigned page styles under `assets/marketing/css/new/` imported from `marketing_new.css`. Never import a page's old and new CSS into the same bundle.
 - JS hooks, tokens, and components are shared between both designs — additions are fine, but do not rewrite shared files in place if the change would alter how legacy pages render.
-- When a page's flag has been on in production and the legacy version is no longer needed, delete the legacy template/CSS, move the `new/` files into place, and remove the flag.
+- Once the flag has been on in production and the legacy version is no longer needed, delete the legacy templates/CSS, move the `new/` files into place, and remove the flag.
 
 ## Key Configuration Files
 - `.mise.toml` - Tool versions

--- a/server/assets/marketing/css/new/routes/newsletter.css
+++ b/server/assets/marketing/css/new/routes/newsletter.css
@@ -1,4 +1,4 @@
-/* Newsletter page (/newsletter, behind new_marketing_newsletter): one
+/* Newsletter page (/newsletter, behind new_marketing): one
    centered hero card on the 1200px page shell — title, description and the
    inline subscribe form — over a 300px illustration slot flush with the
    card's bottom edge, then the closing CTA between two dithered divider

--- a/server/assets/marketing/css/new/routes/not-found.css
+++ b/server/assets/marketing/css/new/routes/not-found.css
@@ -1,4 +1,4 @@
-/* Marketing 404 (/anything-unknown, behind new_marketing_not_found): a
+/* Marketing 404 (/anything-unknown, behind new_marketing): a
    single centered hero frame on the 1200px page shell with 2px seams to the
    navbar above and the footer below — the feature pages' header skeleton
    (routes/previews.css) with a shorter top — stacked over a 400px box with a

--- a/server/lib/tuist/feature_flags.ex
+++ b/server/lib/tuist/feature_flags.ex
@@ -67,23 +67,22 @@ defmodule Tuist.FeatureFlags do
   end
 
   @doc """
-  Whether a marketing page should render the redesigned version instead of
-  the legacy one. The redesign ships page by page: each page gets its own
-  boolean flag (`:new_marketing_home`, `:new_marketing_pricing`, ...) that is
-  flipped for everyone at once — marketing traffic is mostly anonymous. A
-  page can be previewed before the flip by enabling its flag for a specific
-  user (actor gate), which is what the optional `user` serves. Callers
-  should go through `TuistWeb.Marketing.Design` rather than checking this
-  flag directly.
+  Whether the marketing site should render the redesigned version instead of
+  the legacy one. The whole redesign launches behind a single boolean flag
+  (`:new_marketing`) that is flipped for everyone at once — marketing traffic
+  is mostly anonymous. The redesign can be previewed before the flip by
+  enabling the flag for a specific user (actor gate), which is what the
+  optional `user` serves. Callers should go through
+  `TuistWeb.Marketing.Design` rather than checking this flag directly.
   """
-  def new_marketing_page_enabled?(page, user \\ nil)
+  def new_marketing_enabled?(user \\ nil)
 
-  def new_marketing_page_enabled?(page, nil) when is_atom(page) do
-    FunWithFlags.enabled?(:"new_marketing_#{page}")
+  def new_marketing_enabled?(nil) do
+    FunWithFlags.enabled?(:new_marketing)
   end
 
-  def new_marketing_page_enabled?(page, user) when is_atom(page) do
-    FunWithFlags.enabled?(:"new_marketing_#{page}", for: user)
+  def new_marketing_enabled?(user) do
+    FunWithFlags.enabled?(:new_marketing, for: user)
   end
 
   defimpl FunWithFlags.Actor, for: Tuist.Accounts.User do

--- a/server/lib/tuist_web/controllers/error_html.ex
+++ b/server/lib/tuist_web/controllers/error_html.ex
@@ -60,7 +60,7 @@ defmodule TuistWeb.ErrorHTML do
   # missing, and it should read as the public not-found page). Other statuses
   # keep the dashboard error page.
   def render("404.html", %{conn: %Plug.Conn{} = conn} = assigns) do
-    if Design.new?(conn, :not_found) do
+    if Design.new?(conn) do
       render_marketing_not_found(assigns)
     else
       render_dashboard_not_found(assigns)

--- a/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_controller.ex
@@ -64,7 +64,7 @@ defmodule TuistWeb.Marketing.MarketingController do
       |> assign(:featured_testimonials, get_featured_testimonials(locale))
       |> assign(:testimonial_columns, get_testimonial_columns(locale))
 
-    if Design.new?(conn, :home) do
+    if Design.new?(conn) do
       conn
       |> assign(:new_design, true)
       |> assign(:home_new_testimonials, get_home_new_testimonials())
@@ -441,7 +441,7 @@ defmodule TuistWeb.Marketing.MarketingController do
       )
       |> assign(:head_title, "About Tuist")
 
-    if Design.new?(conn, :about) do
+    if Design.new?(conn) do
       conn
       |> assign(:new_design, true)
       |> render(:about_new, layout: false)
@@ -453,7 +453,7 @@ defmodule TuistWeb.Marketing.MarketingController do
   # The brand page only exists in the redesign, so instead of a legacy
   # fallback the route 404s until the :brand rollout flag is on.
   def brand(conn, _params) do
-    if Design.new?(conn, :brand) do
+    if Design.new?(conn) do
       conn
       |> assign_structured_data(get_organization_structured_data())
       |> assign_structured_data(
@@ -489,7 +489,7 @@ defmodule TuistWeb.Marketing.MarketingController do
   def download(conn, _params) do
     latest_app_release = Tuist.GitHub.Releases.get_latest_app_release()
 
-    if Design.new?(conn, :download) do
+    if Design.new?(conn) do
       render_download(conn, latest_app_release)
     else
       redirect_to_macos_app_dmg(conn, latest_app_release)
@@ -599,7 +599,7 @@ defmodule TuistWeb.Marketing.MarketingController do
   end
 
   defp render_newsletter(conn) do
-    if Design.new?(conn, :newsletter) do
+    if Design.new?(conn) do
       conn
       |> assign(:new_design, true)
       |> assign(:issues, Enum.sort_by(Newsletter.issues(), & &1.number, :desc))
@@ -954,7 +954,7 @@ defmodule TuistWeb.Marketing.MarketingController do
 
         customers_path = Localization.localized_href("/customers", locale)
         case_study_path = Localization.localized_href(case_study.slug, locale)
-        new_design = Design.new?(conn, :case_study)
+        new_design = Design.new?(conn)
 
         # The generated cover artwork (or the title card without it) — the
         # static photos are gone.
@@ -1061,7 +1061,7 @@ defmodule TuistWeb.Marketing.MarketingController do
         )
       )
 
-    if Design.new?(conn, :pricing) do
+    if Design.new?(conn) do
       conn
       |> assign(:new_design, true)
       |> render(:pricing_new, layout: false)
@@ -1072,9 +1072,9 @@ defmodule TuistWeb.Marketing.MarketingController do
 
   # The compute page only exists in the redesign, so instead of falling back
   # to a legacy template when the flag is off, it stays hidden behind a 404
-  # until :new_marketing_compute flips.
+  # until :new_marketing flips.
   def compute(conn, _params) do
-    if !Design.new?(conn, :compute) do
+    if !Design.new?(conn) do
       raise NotFoundError, dgettext("errors", "Page not found")
     end
 
@@ -1104,9 +1104,9 @@ defmodule TuistWeb.Marketing.MarketingController do
 
   # The tests page only exists in the redesign, so instead of falling back
   # to a legacy template when the flag is off, it stays hidden behind a 404
-  # until :new_marketing_tests flips.
+  # until :new_marketing flips.
   def tests(conn, _params) do
-    if !Design.new?(conn, :tests) do
+    if !Design.new?(conn) do
       raise NotFoundError, dgettext("errors", "Page not found")
     end
 
@@ -1165,7 +1165,7 @@ defmodule TuistWeb.Marketing.MarketingController do
       )
       |> assign(:page, page)
 
-    if Design.new?(conn, :page) do
+    if Design.new?(conn) do
       conn
       |> assign(:new_design, true)
       |> render(:page_new, layout: false)
@@ -1216,7 +1216,7 @@ defmodule TuistWeb.Marketing.MarketingController do
   end
 
   defp render_newsletter_verify(conn) do
-    if Design.new?(conn, :newsletter) do
+    if Design.new?(conn) do
       conn
       |> assign(:new_design, true)
       |> render(:newsletter_verify_new, layout: false)

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/newsletter.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/newsletter.html.heex
@@ -1,4 +1,4 @@
-<%!-- Redesigned newsletter page (/newsletter, behind :new_marketing_newsletter):
+<%!-- Redesigned newsletter page (/newsletter, behind :new_marketing):
 one centered hero card on the 1200px page shell — title, description and the
 inline subscribe form — over a 300px illustration slot flush with the card's
 bottom edge, then the closing CTA framed by the dithered divider bands the

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/newsletter_verify.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/newsletter_verify.html.heex
@@ -1,5 +1,5 @@
 <%!-- Redesigned newsletter verify page (/newsletter/verify, behind
-:new_marketing_newsletter): the newsletter page's hero shell — title, copy
+:new_marketing): the newsletter page's hero shell — title, copy
 and one action — over the same newspaper stack, in one of three states.
 Confirm: the link from the email landed, the button posts the token back.
 Subscribed: the address is on the list. Failed: the token was missing,

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/not_found.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/not_found.html.heex
@@ -1,5 +1,5 @@
 <%!-- Redesigned marketing 404, rendered by TuistWeb.ErrorHTML for public
-URLs (marketing pipeline or no matching route) once :new_marketing_not_found
+URLs (marketing pipeline or no matching route) once :new_marketing
 is on. One centered hero frame on the 1200px page shell, like the feature
 pages' headers: the copy with the way back home, and under it a 400px box
 with a faded "404" in the mono font.

--- a/server/lib/tuist_web/marketing/design.ex
+++ b/server/lib/tuist_web/marketing/design.ex
@@ -1,17 +1,17 @@
 defmodule TuistWeb.Marketing.Design do
   @moduledoc """
   Decides whether a marketing page renders the redesigned version or the
-  legacy one while the redesign rolls out page by page.
+  legacy one.
 
-  The rollout is driven by per-page FunWithFlags booleans (see
-  `Tuist.FeatureFlags.new_marketing_page_enabled?/2`). Anonymous traffic
-  follows a page's global flag. Authenticated users are checked as flag
-  actors, so the redesign can be previewed before the global flip by
-  enabling a page's flag for a specific user:
+  The launch is driven by a single FunWithFlags boolean (see
+  `Tuist.FeatureFlags.new_marketing_enabled?/1`). Anonymous traffic follows
+  the global flag. Authenticated users are checked as flag actors, so the
+  redesign can be previewed before the global flip by enabling the flag for
+  a specific user:
 
-      FunWithFlags.enable(:new_marketing_home, for_actor: user)
+      FunWithFlags.enable(:new_marketing, for_actor: user)
 
-  Pages that have migrated call `new?/2` to pick the template, and assign
+  Pages that have migrated call `new?/1` to pick the template, and assign
   the result as `:new_design` so the root layout links bundle-new.css
   instead of bundle.css — the two designs restyle the same selectors, so
   their stylesheets are never loaded together.
@@ -30,15 +30,15 @@ defmodule TuistWeb.Marketing.Design do
   alias Tuist.FeatureFlags
 
   @doc """
-  Whether `page` (e.g. `:home`) should render its redesigned template for
-  this request. Takes the `conn` in controllers, or the current user (or
-  `nil`) in a LiveView's `mount/3`.
+  Whether the redesigned templates should render for this request. Takes the
+  `conn` in controllers, or the current user (or `nil`) in a LiveView's
+  `mount/3`.
   """
-  def new?(%Plug.Conn{} = conn, page) do
-    new?(conn.assigns[:current_user], page)
+  def new?(%Plug.Conn{} = conn) do
+    new?(conn.assigns[:current_user])
   end
 
-  def new?(current_user, page) do
-    FeatureFlags.new_marketing_page_enabled?(page, current_user)
+  def new?(current_user) do
+    FeatureFlags.new_marketing_enabled?(current_user)
   end
 end

--- a/server/lib/tuist_web/marketing/live/marketing_blog_live.ex
+++ b/server/lib/tuist_web/marketing/live/marketing_blog_live.ex
@@ -36,7 +36,7 @@ defmodule TuistWeb.Marketing.MarketingBlogLive do
 
     socket =
       socket
-      |> assign(:new_design, Design.new?(socket.assigns[:current_user], :blog))
+      |> assign(:new_design, Design.new?(socket.assigns[:current_user]))
       |> assign(:categories, Content.get_entry_categories())
       |> assign(:search_query, "")
       |> assign(:selected_category, nil)

--- a/server/lib/tuist_web/marketing/live/marketing_blog_post_live.ex
+++ b/server/lib/tuist_web/marketing/live/marketing_blog_post_live.ex
@@ -29,7 +29,7 @@ defmodule TuistWeb.Marketing.MarketingBlogPostLive do
     {:ok,
      socket
      |> assign(:csp_nonce, get_csp_nonce())
-     |> assign(:new_design, Design.new?(socket.assigns[:current_user], :blog_post))}
+     |> assign(:new_design, Design.new?(socket.assigns[:current_user]))}
   end
 
   def handle_params(_params, url, socket) do

--- a/server/lib/tuist_web/marketing/live/marketing_cache_live.ex
+++ b/server/lib/tuist_web/marketing/live/marketing_cache_live.ex
@@ -36,7 +36,7 @@ defmodule TuistWeb.Marketing.MarketingCacheLive do
       # enforced against the initial response's header).
       |> assign(:csp_nonce, get_csp_nonce())
 
-    socket = assign(socket, :new_design, Design.new?(socket.assigns[:current_user], :cache))
+    socket = assign(socket, :new_design, Design.new?(socket.assigns[:current_user]))
 
     {:ok, socket}
   end

--- a/server/lib/tuist_web/marketing/live/marketing_changelog_entry_live.ex
+++ b/server/lib/tuist_web/marketing/live/marketing_changelog_entry_live.ex
@@ -21,7 +21,7 @@ defmodule TuistWeb.Marketing.MarketingChangelogEntryLive do
   def render(assigns), do: changelog_entry(assigns)
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :new_design, Design.new?(socket.assigns[:current_user], :changelog_entry))}
+    {:ok, assign(socket, :new_design, Design.new?(socket.assigns[:current_user]))}
   end
 
   def handle_params(%{"id" => id}, _url, socket) do

--- a/server/lib/tuist_web/marketing/live/marketing_changelog_live.ex
+++ b/server/lib/tuist_web/marketing/live/marketing_changelog_live.ex
@@ -35,7 +35,7 @@ defmodule TuistWeb.Marketing.MarketingChangelogLive do
 
     socket =
       socket
-      |> assign(:new_design, Design.new?(socket.assigns[:current_user], :changelog))
+      |> assign(:new_design, Design.new?(socket.assigns[:current_user]))
       |> assign(:entries, paginated_entries)
       |> assign(:all_entries, filtered_entries)
       |> assign(:categories, categories)

--- a/server/lib/tuist_web/marketing/live/marketing_customers_live.ex
+++ b/server/lib/tuist_web/marketing/live/marketing_customers_live.ex
@@ -28,7 +28,7 @@ defmodule TuistWeb.Marketing.MarketingCustomersLive do
   def mount(_params, _session, socket) do
     socket =
       socket
-      |> assign(:new_design, Design.new?(socket.assigns[:current_user], :customers))
+      |> assign(:new_design, Design.new?(socket.assigns[:current_user]))
       |> assign(:search_query, "")
       |> assign(:current_page, 1)
       |> assign(:total_pages, 1)

--- a/server/lib/tuist_web/marketing/live/marketing_previews_live.ex
+++ b/server/lib/tuist_web/marketing/live/marketing_previews_live.ex
@@ -26,7 +26,7 @@ defmodule TuistWeb.Marketing.MarketingPreviewsLive do
       end)
       |> TuistWeb.Authentication.mount_current_user(session)
 
-    socket = assign(socket, :new_design, Design.new?(socket.assigns[:current_user], :previews))
+    socket = assign(socket, :new_design, Design.new?(socket.assigns[:current_user]))
 
     {:ok, socket}
   end

--- a/server/test/tuist_web/controllers/error_html_test.exs
+++ b/server/test/tuist_web/controllers/error_html_test.exs
@@ -43,7 +43,7 @@ defmodule TuistWeb.Controllers.ErrorHTMLTest do
 
     defp render_not_found(conn, flag_enabled) do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_not_found -> flag_enabled
+        :new_marketing -> flag_enabled
         _flag -> false
       end)
 

--- a/server/test/tuist_web/controllers/marketing_controller_test.exs
+++ b/server/test/tuist_web/controllers/marketing_controller_test.exs
@@ -132,7 +132,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
 
     test "renders the new design and stylesheet when the page flag is enabled", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_home -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -150,7 +150,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
       stub(FunWithFlags, :enabled?, fn _flag -> false end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_home, [for: %{id: ^user_id}] -> true
+        :new_marketing, [for: %{id: ^user_id}] -> true
         _flag, _opts -> false
       end)
 
@@ -200,7 +200,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
 
     test "renders the redesigned page when the page flag is enabled", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_compute -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -231,7 +231,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
 
     test "renders the redesigned page when the page flag is enabled", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_tests -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -269,7 +269,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
       stub(AppStore, :get_latest_ios_app_version, fn -> "1.2.3" end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_download -> true
+        :new_marketing -> true
         _flag -> false
       end)
 
@@ -289,7 +289,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
       stub(AppStore, :get_latest_ios_app_version, fn -> "1.2.3" end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_download -> true
+        :new_marketing -> true
         _flag -> false
       end)
 
@@ -309,7 +309,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
       stub(AppStore, :get_latest_ios_app_version, fn -> nil end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_download -> true
+        :new_marketing -> true
         _flag -> false
       end)
 
@@ -333,7 +333,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
 
     test "renders the redesigned newsletter page when the flag is on", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_newsletter -> true
+        :new_marketing -> true
         _flag -> false
       end)
 
@@ -349,7 +349,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
 
     test "lists every past issue newest first with the sort control when the flag is on", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_newsletter -> true
+        :new_marketing -> true
         _flag -> false
       end)
 
@@ -488,7 +488,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
 
     test "renders the new design and stylesheet when the page flag is enabled", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_page -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -506,7 +506,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
       stub(FunWithFlags, :enabled?, fn _flag -> false end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_page, [for: %{id: ^user_id}] -> true
+        :new_marketing, [for: %{id: ^user_id}] -> true
         _flag, _opts -> false
       end)
 
@@ -558,7 +558,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
 
     test "renders the new design and stylesheet when the page flag is enabled", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_case_study -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -578,7 +578,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
       stub(FunWithFlags, :enabled?, fn _flag -> false end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_case_study, [for: %{id: ^user_id}] -> true
+        :new_marketing, [for: %{id: ^user_id}] -> true
         _flag, _opts -> false
       end)
 
@@ -593,7 +593,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
   describe "GET /newsletter/verify with the redesign flag on" do
     setup do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_newsletter -> true
+        :new_marketing -> true
         _flag -> false
       end)
 

--- a/server/test/tuist_web/live/marketing_blog_live_test.exs
+++ b/server/test/tuist_web/live/marketing_blog_live_test.exs
@@ -18,7 +18,7 @@ defmodule TuistWeb.Marketing.MarketingBlogLiveTest do
 
     test "renders the new design and stylesheet when the page flag is enabled", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_blog -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -35,7 +35,7 @@ defmodule TuistWeb.Marketing.MarketingBlogLiveTest do
       stub(FunWithFlags, :enabled?, fn _flag -> false end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_blog, [for: %{id: ^user_id}] -> true
+        :new_marketing, [for: %{id: ^user_id}] -> true
         _flag, _opts -> false
       end)
 
@@ -49,7 +49,7 @@ defmodule TuistWeb.Marketing.MarketingBlogLiveTest do
       {:ok, _lv, legacy_html} = live(conn, ~p"/blog")
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_blog -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -66,7 +66,7 @@ defmodule TuistWeb.Marketing.MarketingBlogLiveTest do
   describe "GET /blog (cover artwork)" do
     setup do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_blog -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -96,7 +96,7 @@ defmodule TuistWeb.Marketing.MarketingBlogLiveTest do
   describe "GET /blog (new design view switcher)" do
     setup do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_blog -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -169,7 +169,7 @@ defmodule TuistWeb.Marketing.MarketingBlogLiveTest do
   describe "GET /blog (compact filters)" do
     setup do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_blog -> true
+        :new_marketing -> true
         _ -> false
       end)
 

--- a/server/test/tuist_web/live/marketing_blog_post_live_test.exs
+++ b/server/test/tuist_web/live/marketing_blog_post_live_test.exs
@@ -24,7 +24,7 @@ defmodule TuistWeb.Marketing.MarketingBlogPostLiveTest do
 
     test "renders the new design and stylesheet when the page flag is enabled", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_blog_post -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -42,7 +42,7 @@ defmodule TuistWeb.Marketing.MarketingBlogPostLiveTest do
       stub(FunWithFlags, :enabled?, fn _flag -> false end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_blog_post, [for: %{id: ^user_id}] -> true
+        :new_marketing, [for: %{id: ^user_id}] -> true
         _flag, _opts -> false
       end)
 
@@ -54,7 +54,7 @@ defmodule TuistWeb.Marketing.MarketingBlogPostLiveTest do
 
     test "the new design renders the post's cover artwork inline and on the social card", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_blog_post -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -77,7 +77,7 @@ defmodule TuistWeb.Marketing.MarketingBlogPostLiveTest do
 
     test "the new design closes with the three most recent other posts", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_blog_post -> true
+        :new_marketing -> true
         _ -> false
       end)
 

--- a/server/test/tuist_web/live/marketing_cache_live_test.exs
+++ b/server/test/tuist_web/live/marketing_cache_live_test.exs
@@ -16,7 +16,7 @@ defmodule TuistWeb.Marketing.MarketingCacheLiveTest do
 
     test "renders the new design and stylesheet when the page flag is enabled", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_cache -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -35,7 +35,7 @@ defmodule TuistWeb.Marketing.MarketingCacheLiveTest do
       stub(FunWithFlags, :enabled?, fn _flag -> false end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_cache, [for: %{id: ^user_id}] -> true
+        :new_marketing, [for: %{id: ^user_id}] -> true
         _flag, _opts -> false
       end)
 

--- a/server/test/tuist_web/live/marketing_changelog_entry_live_test.exs
+++ b/server/test/tuist_web/live/marketing_changelog_entry_live_test.exs
@@ -21,7 +21,7 @@ defmodule TuistWeb.Marketing.MarketingChangelogEntryLiveTest do
 
     test "renders the new design and stylesheet when the page flag is enabled", %{conn: conn, entry: entry} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_changelog_entry -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -38,7 +38,7 @@ defmodule TuistWeb.Marketing.MarketingChangelogEntryLiveTest do
       stub(FunWithFlags, :enabled?, fn _flag -> false end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_changelog_entry, [for: %{id: ^user_id}] -> true
+        :new_marketing, [for: %{id: ^user_id}] -> true
         _flag, _opts -> false
       end)
 
@@ -52,7 +52,7 @@ defmodule TuistWeb.Marketing.MarketingChangelogEntryLiveTest do
   describe "GET /changelog/:id (new design)" do
     setup do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_changelog_entry -> true
+        :new_marketing -> true
         _ -> false
       end)
 

--- a/server/test/tuist_web/live/marketing_changelog_live_test.exs
+++ b/server/test/tuist_web/live/marketing_changelog_live_test.exs
@@ -17,7 +17,7 @@ defmodule TuistWeb.Marketing.MarketingChangelogLiveTest do
 
     test "renders the new design and stylesheet when the page flag is enabled", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_changelog -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -34,7 +34,7 @@ defmodule TuistWeb.Marketing.MarketingChangelogLiveTest do
       stub(FunWithFlags, :enabled?, fn _flag -> false end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_changelog, [for: %{id: ^user_id}] -> true
+        :new_marketing, [for: %{id: ^user_id}] -> true
         _flag, _opts -> false
       end)
 
@@ -48,7 +48,7 @@ defmodule TuistWeb.Marketing.MarketingChangelogLiveTest do
   describe "GET /changelog (new design)" do
     setup do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_changelog -> true
+        :new_marketing -> true
         _ -> false
       end)
 

--- a/server/test/tuist_web/live/marketing_customers_live_test.exs
+++ b/server/test/tuist_web/live/marketing_customers_live_test.exs
@@ -16,7 +16,7 @@ defmodule TuistWeb.Marketing.MarketingCustomersLiveTest do
 
     test "renders the new design and stylesheet when the page flag is enabled", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_customers -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -33,7 +33,7 @@ defmodule TuistWeb.Marketing.MarketingCustomersLiveTest do
       stub(FunWithFlags, :enabled?, fn _flag -> false end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_customers, [for: %{id: ^user_id}] -> true
+        :new_marketing, [for: %{id: ^user_id}] -> true
         _flag, _opts -> false
       end)
 

--- a/server/test/tuist_web/live/marketing_previews_live_test.exs
+++ b/server/test/tuist_web/live/marketing_previews_live_test.exs
@@ -16,7 +16,7 @@ defmodule TuistWeb.Marketing.MarketingPreviewsLiveTest do
 
     test "renders the new design and stylesheet when the page flag is enabled", %{conn: conn} do
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_previews -> true
+        :new_marketing -> true
         _ -> false
       end)
 
@@ -36,7 +36,7 @@ defmodule TuistWeb.Marketing.MarketingPreviewsLiveTest do
       stub(FunWithFlags, :enabled?, fn _flag -> false end)
 
       stub(FunWithFlags, :enabled?, fn
-        :new_marketing_previews, [for: %{id: ^user_id}] -> true
+        :new_marketing, [for: %{id: ^user_id}] -> true
         _flag, _opts -> false
       end)
 


### PR DESCRIPTION
The redesign shipped page by page behind 18 per-page FunWithFlags booleans (:new_marketing_home, :new_marketing_pricing, ...). Now that every page has been migrated, the site launches as a whole, so the per-page flags collapse into one :new_marketing flag.

- Tuist.FeatureFlags.new_marketing_page_enabled?/2 becomes new_marketing_enabled?/1 (optional user actor for previews).
- TuistWeb.Marketing.Design.new?/2 drops the page argument; the controller actions, LiveViews and ErrorHTML call new?/1.
- Test stubs, template/CSS comments and server/AGENTS.md reference the single flag.

