### PR TITLE
feat(server): give every country an origin map entry

### DIFF
--- a/server/lib/tuist/kura/origin_map.ex
+++ b/server/lib/tuist/kura/origin_map.ex
@@ -121,8 +121,10 @@ defmodule Tuist.Kura.OriginMap do
                        {"US", :us_east},
                        {"CA", :canada_east},
                        # Nuuk is 3301km from Vint Hill and Saint-Pierre 1964,
-                       # both nearer Beauharnois still, so they take the
-                       # Canadian preference rather than a European one.
+                       # both nearer Beauharnois still. ca-east is in the
+                       # catalog and not served, so these resolve to us-east
+                       # today exactly as CA does, and follow Montreal rather
+                       # than Virginia if it ever is.
                        {"GL", :canada_east},
                        {"PM", :canada_east},
                        # Midway, Wake and Johnston. Navassa is Caribbean rather

--- a/server/lib/tuist/kura/origin_map.ex
+++ b/server/lib/tuist/kura/origin_map.ex
@@ -17,7 +17,7 @@ defmodule Tuist.Kura.OriginMap do
 
   # Bumped when an entry moves. Recorded on decisions rather than compared
   # against anything: it dates a verdict, it does not gate one.
-  @version 4
+  @version 5
 
   # Nearest first, and every list names every candidate region. An origin
   # always has an answer, so a region being unserved or unfunded narrows the
@@ -70,21 +70,32 @@ defmodule Tuist.Kura.OriginMap do
     UA XK
   ]
 
+  # Réunion and Mayotte are nearer Singapore on the straight line, 5811km and
+  # 6650 against 9365 and 8042 to Paris, but their transit is the French cables
+  # north-west and the Mozambique Channel around them is already here. Saint
+  # Helena is 6736km from Santiago against 7251 from Paris and lands on the
+  # African coast.
   @africa_middle_east ~w[
     AE AO BF BH BI BJ BW CD CF CG CI CM CV DJ DZ EG EH ER ET GA GH GM GN GQ GW
-    IL IQ IR JO KE KM KW LB LR LS LY MA MG ML MR MU MW MZ NA NE NG OM PS QA RW
-    SA SC SD SL SN SO SS ST SY SZ TD TG TN TR TZ UG YE ZA ZM ZW
+    IL IQ IR JO KE KM KW LB LR LS LY MA MG ML MR MU MW MZ NA NE NG OM PS QA RE
+    RW SA SC SD SH SL SN SO SS ST SY SZ TD TG TN TR TZ UG YE YT ZA ZM ZW
   ]
 
   @apac ~w[
-    AF AM AS AU AZ BD BN BT CK CN FJ FM GE GU HK ID IN JP KG KH KI KP KR KZ LA
-    LK MH MM MN MO MV MY NC NF NP NR NU NZ PF PG PH PK PW SB SG TH TJ TK TL TM
-    TO TV TW UZ VN VU WS
+    AF AM AS AU AZ BD BN BT CC CK CN CX FJ FM GE GU HK HM ID IN IO JP KG KH KI
+    KP KR KZ LA LK MH MM MN MO MP MV MY NC NF NP NR NU NZ PF PG PH PK PW SB SG
+    TF TH TJ TK TL TM TO TV TW UZ VN VU WF WS
   ]
 
+  # Latin America and the Caribbean. The South Atlantic outliers are here on
+  # distance: Stanley is 2277km from Santiago, Grytviken 3528, Adamstown 5764
+  # against 7883 to Hillsboro. The Caribbean codes follow the block they sit
+  # in rather than their own nearest region, which for Gustavia is Vint Hill
+  # at 2730km against 5770 to Santiago; that block moves as one or not at all.
   @south_america ~w[
-    AG AI AR AW BB BM BO BR BS BZ CL CO CR CU CW DM DO EC GD GP GT GY HN HT JM
-    KN KY LC MQ MS MX NI PA PE PR PY SR SV SX TC TT UY VC VE VG VI
+    AG AI AQ AR AW BB BL BM BO BQ BR BS BV BZ CL CO CR CU CW DM DO EC FK GD GF
+    GP GS GT GY HN HT JM KN KY LC MF MQ MS MX NI PA PE PN PR PY SR SV SX TC TT
+    UY VC VE VG VI
   ]
 
   # The western United States and the Canadian west are nearer Hillsboro than
@@ -106,7 +117,18 @@ defmodule Tuist.Kura.OriginMap do
                      Enum.map(@africa_middle_east, &{&1, :africa_middle_east}) ++
                      Enum.map(@apac, &{&1, :apac}) ++
                      Enum.map(@south_america, &{&1, :south_america}) ++
-                     [{"US", :us_east}, {"CA", :canada_east}]
+                     [
+                       {"US", :us_east},
+                       {"CA", :canada_east},
+                       # Nuuk is 3301km from Vint Hill and Saint-Pierre 1964,
+                       # both nearer Beauharnois still, so they take the
+                       # Canadian preference rather than a European one.
+                       {"GL", :canada_east},
+                       {"PM", :canada_east},
+                       # Midway, Wake and Johnston. Navassa is Caribbean rather
+                       # than Pacific and one code cannot say both.
+                       {"UM", :us_west}
+                     ]
                  )
 
   @subdivision_zones Map.new(

--- a/server/test/tuist/kura/origin_map_test.exs
+++ b/server/test/tuist/kura/origin_map_test.exs
@@ -47,6 +47,23 @@ defmodule Tuist.Kura.OriginMapTest do
       assert OriginMap.candidates("US-ZZ") == OriginMap.candidates("US")
     end
 
+    test "places every outlying territory rather than defaulting it" do
+      assert ["ap-southeast" | _rest] = OriginMap.candidates("IO")
+      assert ["ap-southeast" | _rest] = OriginMap.candidates("CX")
+      assert ["ap-southeast" | _rest] = OriginMap.candidates("MP")
+      assert ["sa-west" | _rest] = OriginMap.candidates("FK")
+      assert ["sa-west" | _rest] = OriginMap.candidates("GS")
+      assert ["sa-west" | _rest] = OriginMap.candidates("PN")
+      assert ["eu-west" | _rest] = OriginMap.candidates("RE")
+      assert ["eu-west" | _rest] = OriginMap.candidates("SH")
+      assert ["us-west" | _rest] = OriginMap.candidates("UM")
+
+      # ca-east is in the catalog but unserved. candidates/1 answers before
+      # availability narrows the list, so it still leads here.
+      assert ["ca-east" | _rest] = OriginMap.candidates("GL")
+      assert ["ca-east" | _rest] = OriginMap.candidates("PM")
+    end
+
     test "answers for an unmapped origin and for none at all" do
       # The default is where an account stating no constraint resolves today,
       # so an origin nobody mapped changes nothing rather than moving someone.


### PR DESCRIPTION
## What changed

Places the 22 ISO 3166-1 alpha-2 codes that had no entry in `Tuist.Kura.OriginMap`, so every assigned code now resolves through a zone rather than reaching `@default_zone :us_east` because nobody wrote it down. `@version` goes to 5.

| Codes | Zone | Why |
|---|---|---|
| `CC` `CX` `HM` `IO` `MP` `TF` `WF` | apac | Indian Ocean and Pacific. Christmas Island is 1329 km from Singapore, Cocos 1692, Diego Garcia 3614, Saipan 4850. |
| `AQ` `BV` `FK` `GS` `PN` | south_america | South Atlantic and the far South Pacific. Stanley is 2277 km from Santiago, Grytviken 3528, Adamstown 5764 against 7883 to Hillsboro. |
| `BL` `BQ` `GF` `MF` | south_america | Caribbean and the Guianas, with the block they sit in. |
| `RE` `SH` `YT` | africa_middle_east | See below. |
| `GL` `PM` | canada_east | Nuuk is 3301 km from Vint Hill, Saint-Pierre 1964, both nearer Beauharnois still. |
| `UM` | us_west | Midway is 5097 km from Hillsboro. |

## Two judgment calls worth reviewing

**Réunion and Mayotte read west against the straight line.** Saint-Denis is 5811 km from Singapore and 9365 from Paris, Mamoudzou 6650 against 8042, so distance alone would put both in apac. They go with Africa anyway: their transit is the French cables running north-west, and Mauritius, Madagascar, the Comoros and the Seychelles around them are all already in that zone. This is the same tension the eastern Europe boundary comment already records, where provisioned transit and the great-circle disagree.

**The Caribbean codes follow their block rather than their own nearest region.** Gustavia is 2730 km from Vint Hill against 5770 from Santiago, so `BL`, `BQ` and `MF` are individually misplaced by joining `@south_america`. They join it regardless, because the thirty Caribbean codes already there have the same problem and the fix is to split Latin America at the isthmus in one change rather than to have three codes behave unlike their neighbours. Splitting that zone is worth doing and is not this change.

Germany is untouched and still reads from Paris, which is the right answer: only Berlin is nearer Warsaw, while Frankfurt, Munich and Hamburg are not, and Frankfurt is where the country's traffic actually originates.

## Why now

The map is the thing that decides where an account is placed before anyone has measured a single request from it, so an unwritten entry is a silent decision to serve from Virginia. Writing all of them down makes each one visible and revisable as regions are added and real latency data arrives, which is a better starting position than a default that hides the question.

Nothing observed changes. All 59 countries that have ever appeared in `kura_origin_rollups` were already mapped, and none of these 22 has ever sent a request. The default is still reachable and still correct for an origin that parses to nothing at all, which the existing test for `"ZZ"` and `nil` covers.

## Validation

- Added `places every outlying territory rather than defaulting it`, covering one code from each group plus both Canadian-preference entries. Written first and confirmed failing, where `IO` returned the Virginia-led default list.
- `mix test test/tuist/kura/` passes in full, 813 tests.
- `mix format --check-formatted` and `mix credo` clean on both files.
- Verified after the edit that all 249 assigned ISO 3166-1 alpha-2 codes are covered, that no code appears in two zones, and that every list is still alphabetically sorted. Kosovo remains mapped as `XK`, which is user-assigned rather than one of the 249.
- Rebased on `main` after #13120 merged, so the only overlap with it, the version line, is resolved here to 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
