### PR TITLE
feat(infra): let the macOS fleet reach the in-cluster ClickHouse over the tailnet

### DIFF
--- a/infra/helm/tuist/templates/_helpers.tpl
+++ b/infra/helm/tuist/templates/_helpers.tpl
@@ -833,12 +833,33 @@ workload is enabled, which is what keeps the schema clone, the backfill and
 the shadow writes inert everywhere else.
 */ -}}
 {{- define "tuist.clickhouseBareMetalEnv" -}}
+{{- include "tuist.clickhouseBareMetalEnvForKey" (dict "root" . "key" "url") }}
+{{- end }}
+
+{{/*
+The same env, but reading the tailnet URL. Only for writers that are not on the
+pod network: the macOS fleet's xcresult-processor runs in a Tart VM with a
+tailnet address, so the in-cluster Service name in `url` does not resolve for
+it. It wrote the whole test family to the system of record and mirrored none
+of it until this existed.
+*/}}
+{{- define "tuist.clickhouseBareMetalTailnetEnv" -}}
+{{- if .Values.clickhouse.managed.tailscale.enabled }}
+{{- include "tuist.clickhouseBareMetalEnvForKey" (dict "root" . "key" "url-tailnet") }}
+{{- else }}
+{{- include "tuist.clickhouseBareMetalEnvForKey" (dict "root" . "key" "url") }}
+{{- end }}
+{{- end }}
+
+{{- define "tuist.clickhouseBareMetalEnvForKey" -}}
+{{- $key := .key }}
+{{- with .root }}
 {{- if .Values.clickhouse.managed.enabled }}
 - name: TUIST_CLICKHOUSE_BARE_METAL_URL
   valueFrom:
     secretKeyRef:
       name: {{ include "tuist.componentName" (dict "root" . "component" "clickhouse") }}-credentials
-      key: url
+      key: {{ $key }}
       # `optional` because the migration Job is a pre-upgrade hook and this
       # Secret is an ordinary release resource, so on the deploy that first
       # introduces the managed ClickHouse the Secret does not exist yet. A
@@ -851,6 +872,7 @@ the shadow writes inert everywhere else.
 {{- if .Values.clickhouse.managed.shadowWrites.enabled }}
 - name: TUIST_CLICKHOUSE_SHADOW_WRITES_ENABLED
   value: "1"
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/infra/helm/tuist/templates/clickhouse-managed.yaml
+++ b/infra/helm/tuist/templates/clickhouse-managed.yaml
@@ -152,6 +152,12 @@ stringData:
   # one secret reference instead of assembling a URL from four env vars and
   # having to agree on the escaping.
   url: {{ printf "http://default:%s@%s:8123/%s" $password $chName $m.database | quote }}
+{{- if $m.tailscale.enabled }}
+  # The same database by its tailnet name, for writers that are not on the pod
+  # network and cannot resolve the Service above. Same credential; what differs
+  # is only how the host is reached.
+  url-tailnet: {{ printf "http://default:%s@%s:8123/%s" $password (required "clickhouse.managed.tailscale.hostname is required when tailscale.enabled is true" $m.tailscale.hostname) $m.database | quote }}
+{{- end }}
   # Mounted into users.d. ClickHouse reads it at startup and on reload.
   users.xml: |
     <clickhouse>
@@ -409,6 +415,41 @@ spec:
     - name: metrics
       port: {{ $m.metricsPort }}
       targetPort: {{ $m.metricsPort }}
+{{- if $m.tailscale.enabled }}
+---
+{{- /*
+A second Service carrying only the HTTP port, so the Tailscale operator fronts
+that and nothing else. Annotating the Service above would have been fewer
+lines and would also have put the native protocol and the Prometheus endpoint
+on the tailnet, which nothing off-cluster needs.
+
+This exists because the macOS fleet's xcresult-processor is not on the pod
+network: it runs in a Tart VM with a tailnet address, so the in-cluster
+Service name resolves for every other writer and not for it. It wrote the
+whole test family to the system of record and mirrored none of it, and the
+only reason that surfaced is the parity check reporting six tables with zero
+rows on the destination. Nothing in that pod's own logs said so, because its
+logs reach neither `kubectl logs` nor Loki.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $chName }}-tailnet
+  labels:
+    {{- include "tuist.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: {{ required "clickhouse.managed.tailscale.hostname is required when tailscale.enabled is true" $m.tailscale.hostname | quote }}
+    tailscale.com/tags: {{ required "clickhouse.managed.tailscale.tags is required when tailscale.enabled is true" $m.tailscale.tags | quote }}
+spec:
+  selector:
+    {{- include "tuist.componentLabels" (dict "root" . "component" "clickhouse") | nindent 4 }}
+  ports:
+    - name: http
+      port: 8123
+      targetPort: 8123
+{{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/infra/helm/tuist/templates/xcresult-processor-deployment.yaml
+++ b/infra/helm/tuist/templates/xcresult-processor-deployment.yaml
@@ -235,7 +235,13 @@ spec:
             # too. Without it the dual write covers only what the web pods
             # insert, and every row parsed out of an xcresult reaches the
             # system of record alone.
-            {{- include "tuist.clickhouseBareMetalEnv" . | nindent 12 }}
+            #
+            # The tailnet variant, because this is the one writer that is not
+            # on the pod network: it runs in a Tart VM with a tailnet address,
+            # so the in-cluster Service name every other writer uses does not
+            # resolve here. Having the env was never the problem; having a
+            # route was.
+            {{- include "tuist.clickhouseBareMetalTailnetEnv" . | nindent 12 }}
             {{- with .Values.xcresultProcessor.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -308,6 +308,22 @@ clickhouse:
     # Rollback: turn it off. Nothing has read from that server.
     shadowWrites:
       enabled: true
+    # Reachable over the tailnet as well as in-cluster, because the
+    # xcresult-processor is not on the pod network: it runs in a Tart VM with
+    # a tailnet address, so the Service name every other writer resolves does
+    # not resolve for it. It wrote the whole test family to Cloud and mirrored
+    # none of it, which parity reported as six tables holding zero rows on the
+    # destination.
+    #
+    # `tag:tuist-k8s-canary` rather than the fleet's own tag: the proxy node is
+    # created by this cluster's operator, and the wrong tag makes the operator
+    # refuse with `requested tags are invalid or not permitted`, leaving no
+    # proxy and a hostname that never resolves. The pooler above hit exactly
+    # that and its comment records it.
+    tailscale:
+      enabled: true
+      hostname: tuist-clickhouse-canary
+      tags: tag:tuist-k8s-canary
     keeper:
       replicas: 1
     backup:

--- a/infra/helm/tuist/values.yaml
+++ b/infra/helm/tuist/values.yaml
@@ -3268,6 +3268,25 @@ clickhouse:
         # and query budgets from the cgroup limit, and the rest of the box is
         # more useful as page cache than as headroom it will try to fill.
         memory: 32Gi
+    # Reachability for writers that are not on the pod network. The macOS
+    # fleet's xcresult-processor runs in a Tart VM with a tailnet address, not
+    # a pod IP, so it cannot resolve the in-cluster Service name the `url`
+    # secret carries. It wrote the whole test family to ClickHouse Cloud and
+    # mirrored none of it, which parity saw as six tables holding zero rows on
+    # the destination while the source had data.
+    #
+    # Same mechanism the CNPG pooler already uses for the same fleet: the
+    # Tailscale operator watches for `tailscale.com/expose` and fronts the
+    # Service with a userspace proxy node, so the VM dials it over MagicDNS as
+    # a first-class tailnet member without joining the overlay.
+    #
+    # A dedicated Service rather than annotating the main one, so only the
+    # HTTP port is reachable off-cluster: the native protocol and the metrics
+    # port have no business on the tailnet.
+    tailscale:
+      enabled: false
+      hostname: ""
+      tags: ""
     persistence:
       size: 200Gi
       storageClassName: clickhouse-local

--- a/infra/tailscale/acls.json
+++ b/infra/tailscale/acls.json
@@ -201,7 +201,14 @@
 			//        images over this; without it the image
 			//        workflows lose their registry the moment the
 			//        catch-all grant above is removed.
-			"ip":  ["tcp:5432", "tcp:4317", "tcp:3100", "tcp:443"],
+			// :8123  the in-cluster ClickHouse proxy. The xcresult
+			//        processor writes the test tables and is the one
+			//        writer not on the pod network, so it reaches the
+			//        database this way or not at all. Without this port
+			//        the Service is exposed, the proxy node exists and
+			//        the VM still cannot connect, which is silent: its
+			//        logs reach neither kubectl nor Loki.
+			"ip":  ["tcp:5432", "tcp:4317", "tcp:3100", "tcp:443", "tcp:8123"],
 		},
 		{
 			"src": ["tag:tuist-macmini-canary"],
@@ -219,7 +226,14 @@
 			//        images over this; without it the image
 			//        workflows lose their registry the moment the
 			//        catch-all grant above is removed.
-			"ip":  ["tcp:5432", "tcp:4317", "tcp:3100", "tcp:443"],
+			// :8123  the in-cluster ClickHouse proxy. The xcresult
+			//        processor writes the test tables and is the one
+			//        writer not on the pod network, so it reaches the
+			//        database this way or not at all. Without this port
+			//        the Service is exposed, the proxy node exists and
+			//        the VM still cannot connect, which is silent: its
+			//        logs reach neither kubectl nor Loki.
+			"ip":  ["tcp:5432", "tcp:4317", "tcp:3100", "tcp:443", "tcp:8123"],
 		},
 		{
 			"src": ["tag:tuist-macmini-production"],
@@ -237,7 +251,14 @@
 			//        images over this; without it the image
 			//        workflows lose their registry the moment the
 			//        catch-all grant above is removed.
-			"ip":  ["tcp:5432", "tcp:4317", "tcp:3100", "tcp:443"],
+			// :8123  the in-cluster ClickHouse proxy. The xcresult
+			//        processor writes the test tables and is the one
+			//        writer not on the pod network, so it reaches the
+			//        database this way or not at all. Without this port
+			//        the Service is exposed, the proxy node exists and
+			//        the VM still cannot connect, which is silent: its
+			//        logs reach neither kubectl nor Loki.
+			"ip":  ["tcp:5432", "tcp:4317", "tcp:3100", "tcp:443", "tcp:8123"],
 		},
 
 		// Staging Mac mini fleet → the staging cluster's Service CIDR,


### PR DESCRIPTION
## The problem

Canary's hourly parity check reports six tables with rows on the source and **zero** on the destination: `test_case_runs`, `test_cases`, `test_case_events`, `test_module_runs`, `test_suite_runs`, `test_run_destinations`. That is the entire test family, and it is what the xcresult-processor writes.

It is not a missing env var. That pod has carried `TUIST_CLICKHOUSE_BARE_METAL_URL` since dual writes went on. **It has no route.**

| pod | IP | network |
|---|---|---|
| `clickhouse-0` | `192.168.6.135` | pod CIDR |
| `server` | `192.168.7.3` | pod CIDR |
| `processor` | `192.168.7.111` | pod CIDR |
| **`xcresult-processor`** | **`100.73.153.24`** | **tailnet, Tart VM via tart-cri** |

The secret's `url` is a bare in-cluster Service name, so it resolves for every writer except the one on a Mac mini. ClickHouse Cloud kept working throughout because it is a public HTTPS endpoint, so the symptom was a silent one-way divergence rather than an error anyone would notice.

## Why nobody saw it

That pod's logs reach **neither** `kubectl logs` (zero lines through tart-cri) **nor** Loki (no `xcresult-processor` container appears in the namespace's streams at all). The only reason this surfaced is that the parity check compared the two servers. After the cutover there is no parity check, so this class of failure would be invisible.

## The fix

The mechanism already exists in this chart for this exact fleet: [postgresql-cnpg-pooler.yaml:54](infra/helm/tuist/templates/postgresql-cnpg-pooler.yaml:54) annotates the CNPG pooler with `tailscale.com/expose`, and the Tart VMs dial it over MagicDNS as first-class tailnet members. This copies that.

A **dedicated** Service carries only port 8123, rather than annotating the main one, so the native protocol and the Prometheus endpoint stay off the tailnet. The credentials secret gains a second `url-tailnet` key for that hostname, and only the xcresult-processor reads it. Verified in the render:

```
processor-deployment.yaml:        key: url
server-deployment.yaml:           key: url
xcresult-processor-deployment.yaml: key: url-tailnet
clickhouse-migration-job.yaml:    key: url
server-migration-job.yaml:        key: url
```

## The ACL half, which would have failed silently

The fleet may reach its own cluster on **5432, 4317, 3100 and 443 only**. ClickHouse HTTP is 8123 and was not permitted, so exposing the Service alone would have produced a working proxy node that the VM still could not connect to, with no logs to say why.

All three environments gain `tcp:8123`, with the reasoning recorded beside the existing ports. I verified the file still parses after stripping comments and trailing commas, since it is HuJSON rather than JSON.

## Scope

Enabled on **canary only**; staging and production render no tailnet Service and no second URL.

The tag is `tag:tuist-k8s-canary`, not the fleet's own tag, because the proxy node is created by that cluster's operator. The pooler's comment records hitting exactly this: a wrong tag makes the operator refuse with `requested tags are invalid or not permitted`, leaving no proxy and a hostname that never resolves.

## Why this is a cutover prerequisite, not a canary fix

After step 7 the in-cluster server becomes the write target. Without a route the xcresult-processor could not write test data **at all**, not merely fail to mirror it, and production runs the same macOS fleet. This is currently the top blocker, ahead of the Helm 4 execution mechanism and the migration-time engine rewrite, because it is losing a whole data domain today rather than at the flip.

## Follow-ups this does not do

The xcresult-processor's logs still reach no collector, which is what let this hide. And the mirror counts an unreachable destination identically to any other failure, so "errors are climbing" never pointed at "this pod has no route"; a connectivity check at startup would have.

## Validation

All three environments render. With tailscale off, no tailnet Service and no `url-tailnet` appear anywhere. With it on for canary, the Service carries the expected `tailscale.com/expose`, `hostname` and `tags`, the secret gains the second URL, and the key routing is as shown above.

Not yet verified on a cluster: that the operator actually provisions the proxy and the VM connects. That is the thing to watch after merge, and the parity check on those six tables is the signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
