### PR TITLE
fix(cli): exclude host XML and zlib archives from static Linux builds

### DIFF
--- a/mise/tasks/cli/bundle-linux.sh
+++ b/mise/tasks/cli/bundle-linux.sh
@@ -49,13 +49,14 @@ else
     exit 1
 fi
 
-# Remove system glibc/curl static archives that conflict with the musl SDK.
+# Remove system static archives that conflict with the musl SDK.
 # The musl SDK provides its own minimal static libraries, but the linker also finds
 # the system's glibc-based .a files (libcurl with libidn2/libldap/libssh deps,
-# libc with _DYNAMIC symbol, libm with internal glibc symbols). Removing these
+# libc/libm/zlib with internal glibc symbols, libxml2 with ICU/glibc symbols). Removing these
 # forces the linker to use only the musl SDK's versions.
 echo "==> Removing conflicting system static libraries"
-rm -f /usr/lib/*/libc.a /usr/lib/*/libm.a /usr/lib/*/libm-*.a /usr/lib/*/libcurl.a
+rm -f /usr/lib/*/libc.a /usr/lib/*/libm.a /usr/lib/*/libm-*.a /usr/lib/*/libcurl.a \
+    /usr/lib/*/libxml2.a /usr/lib/*/libz.a
 
 echo "==> Building tuist executable (static musl, $SDK_TARGET)"
 swift build --product tuist --configuration release --build-path "$BUILD_PATH" --replace-scm-with-registry --swift-sdk "$SDK_TARGET"


### PR DESCRIPTION
## Problem and impact

The first `4.208.0-rc.1` release attempt could not publish because both Linux builds failed during static linking. The macOS job succeeded, but publication requires all platform artifacts. The Linux jobs retried the deterministic linker failure and then exhausted their 30-minute timeout.

Evidence: [RC run 34501463463](https://github.com/tuist/tuist/actions/runs/34501463463). The x86_64 linker selected `/usr/lib/x86_64-linux-gnu/libxml2.a` and `/usr/lib/x86_64-linux-gnu/libz.a`; aarch64 failed against the corresponding host archives. Errors included ICU symbols such as `ucnv_open_74` and glibc symbols such as `__memset_chk`, `__read_chk`, and `fopen64`. This was not a Swift compilation error or merely a slow build.

## Cause and approach

The Linux bundler targets the Swift Static Linux SDK (musl). Its existing preparation removes host libc, libm, and libcurl static archives so they cannot override the SDK libraries. It omitted libxml2 and zlib, allowing the linker to select Ubuntu's glibc-based archives for a musl executable.

Extend that same cleanup to `libxml2.a` and `libz.a` under the architecture-specific `/usr/lib/*/` directories. The SDK already supplies both dependencies, as documented in [Swift's Static Linux SDK guide](https://www.swift.org/documentation/articles/static-linux-getting-started.html). The architecture glob covers both release architectures. Shared libraries and SDK contents are untouched.

This keeps the existing fully static distribution model. Increasing the timeout or retrying cannot fix incompatible libraries, and switching the release to dynamic glibc linking would change its cross-distribution compatibility. The change is confined to the existing release/container preparation path; it does not change CLI runtime behavior.

## Validation and rollout

- Inspected the linker failures from both Linux jobs and confirmed the offending archives are host libraries outside the SDK.
- `bash -n mise/tasks/cli/bundle-linux.sh` passes.
- `git diff --check` passes.
- Full Linux linking has not yet been validated with this correction. The next RC build must pass on both architectures before publication is considered complete. The previous attempt's successful macOS build does not validate this Linux fix.

After this fix lands, dispatch a fresh RC run from main. The failed run published no RC and created no release branch, so `4.208.0-rc.1` remains available. No data migration or runtime rollout is involved; reverting this change restores the previous packaging behavior and its observed linker failure.
