### PR TITLE
refactor(server): drop "app" from the new marketing CTA copy

### DIFF
--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex
@@ -672,7 +672,7 @@ dithered dividers. --%>
 
     <section data-part="cta" aria-labelledby="cta-title">
       <span data-part="eyebrow">{dgettext("marketing", "What are you waiting for?")}</span>
-      <h2 id="cta-title">{dgettext("marketing", "Supercharge your app development")}</h2>
+      <h2 id="cta-title">{dgettext("marketing", "Supercharge your development")}</h2>
       <div data-part="actions" role="group" aria-labelledby="cta-title">
         <.button href={~p"/users/register"} label={dgettext("marketing", "Get started")} />
         <.button

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex
@@ -1017,7 +1017,7 @@
 
     <section data-part="cta" aria-labelledby="cta-title">
       <span data-part="eyebrow">{dgettext("marketing", "What are you waiting for?")}</span>
-      <h2 id="cta-title">{dgettext("marketing", "Supercharge your app development")}</h2>
+      <h2 id="cta-title">{dgettext("marketing", "Supercharge your development")}</h2>
       <div data-part="actions" role="group" aria-labelledby="cta-title">
         <.button href={~p"/users/register"} label={dgettext("marketing", "Get started")} />
         <.button

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/newsletter.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/newsletter.html.heex
@@ -127,7 +127,7 @@ the page stays put and the server's message shows under the row. --%>
     <section data-part="cta" aria-labelledby="newsletter-cta-title">
       <span data-part="eyebrow">{dgettext("marketing", "What are you waiting for?")}</span>
       <h2 id="newsletter-cta-title">
-        {dgettext("marketing", "Supercharge your app development")}
+        {dgettext("marketing", "Supercharge your development")}
       </h2>
       <div data-part="actions" role="group" aria-labelledby="newsletter-cta-title">
         <.button href={~p"/users/register"} label={dgettext("marketing", "Get started")} />

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/tests.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/tests.html.heex
@@ -359,7 +359,7 @@ dividers. All four showcase cards carry their illustrations. --%>
 
     <section data-part="cta" aria-labelledby="cta-title">
       <span data-part="eyebrow">{dgettext("marketing", "What are you waiting for?")}</span>
-      <h2 id="cta-title">{dgettext("marketing", "Supercharge your app development")}</h2>
+      <h2 id="cta-title">{dgettext("marketing", "Supercharge your development")}</h2>
       <div data-part="actions" role="group" aria-labelledby="cta-title">
         <.button href={~p"/users/register"} label={dgettext("marketing", "Get started")} />
         <.button

--- a/server/lib/tuist_web/marketing/live/marketing_cache_live/new/cache.html.heex
+++ b/server/lib/tuist_web/marketing/live/marketing_cache_live/new/cache.html.heex
@@ -345,7 +345,7 @@
 
     <section data-part="cta" aria-labelledby="cta-title">
       <span data-part="eyebrow">{dgettext("marketing", "What are you waiting for?")}</span>
-      <h2 id="cta-title">{dgettext("marketing", "Supercharge your app development")}</h2>
+      <h2 id="cta-title">{dgettext("marketing", "Supercharge your development")}</h2>
       <div data-part="actions" role="group" aria-labelledby="cta-title">
         <.button href={~p"/users/register"} label={dgettext("marketing", "Get started")} />
         <.button

--- a/server/lib/tuist_web/marketing/live/marketing_previews_live/new/previews.html.heex
+++ b/server/lib/tuist_web/marketing/live/marketing_previews_live/new/previews.html.heex
@@ -632,7 +632,7 @@
 
     <section data-part="cta" aria-labelledby="cta-title">
       <span data-part="eyebrow">{dgettext("marketing", "What are you waiting for?")}</span>
-      <h2 id="cta-title">{dgettext("marketing", "Supercharge your app development")}</h2>
+      <h2 id="cta-title">{dgettext("marketing", "Supercharge your development")}</h2>
       <div data-part="actions" role="group" aria-labelledby="cta-title">
         <.button href={~p"/users/register"} label={dgettext("marketing", "Get started")} />
         <.button

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -1040,12 +1040,6 @@ msgid "Successfully Subscribed!"
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:764
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:675
-#: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:1020
-#: lib/tuist_web/marketing/controllers/marketing_html/new/newsletter.html.heex:130
-#: lib/tuist_web/marketing/controllers/marketing_html/new/tests.html.heex:362
-#: lib/tuist_web/marketing/live/marketing_cache_live/new/cache.html.heex:348
-#: lib/tuist_web/marketing/live/marketing_previews_live/new/previews.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "Supercharge your app development"
 msgstr ""
@@ -3611,4 +3605,14 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/newsletter_issue.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Worthy Five: %{name}"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:675
+#: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:1020
+#: lib/tuist_web/marketing/controllers/marketing_html/new/newsletter.html.heex:130
+#: lib/tuist_web/marketing/controllers/marketing_html/new/tests.html.heex:362
+#: lib/tuist_web/marketing/live/marketing_cache_live/new/cache.html.heex:348
+#: lib/tuist_web/marketing/live/marketing_previews_live/new/previews.html.heex:635
+#, elixir-autogen, elixir-format
+msgid "Supercharge your development"
 msgstr ""

--- a/server/test/tuist_web/controllers/marketing_controller_test.exs
+++ b/server/test/tuist_web/controllers/marketing_controller_test.exs
@@ -343,7 +343,7 @@ defmodule TuistWeb.Marketing.MarketingControllerTest do
       assert html =~ "Tuist Digest"
       assert html =~ ~s(id="marketing-newsletter-form")
       assert html =~ ~s(phx-hook="NewsletterForm")
-      assert html =~ "Supercharge your app development"
+      assert html =~ "Supercharge your development"
       assert html =~ "/marketing/assets/bundle-new.css"
     end
 


### PR DESCRIPTION
### Purpose

The shared CTA banner across the new marketing site currently reads *"Supercharge your app development"*. Tuist is no longer exclusively focused on mobile app development, so the wording now reads *"Supercharge your development"* to better reflect the broader positioning (build systems, caching, previews, tests, compute, and so on).

Only the pages under the redesigned marketing surface (the `new/` variants gated behind the marketing redesign flag) are updated. The legacy `home.html.heex` is left alone since it belongs to the pre-redesign site.

### What changed

- `server/lib/tuist_web/marketing/controllers/marketing_html/new/{compute,home,newsletter,tests}.html.heex`: swap the CTA copy.
- `server/lib/tuist_web/marketing/live/marketing_cache_live/new/cache.html.heex` and `.../marketing_previews_live/new/previews.html.heex`: same swap.
- `server/priv/gettext/marketing.pot`: regenerated via `mix gettext.extract` so the new msgid is picked up; the old msgid stays because the legacy home still uses it. `.po` files are intentionally not touched (owned by `tuistit`).

### How to test locally

1. Start the server: `mise run dev` from `server/`.
2. Visit any of the redesigned pages (home, compute, newsletter, tests, cache, previews) and scroll to the CTA banner near the bottom.
3. The eyebrow still reads *"What are you waiting for?"* and the headline now reads *"Supercharge your development"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThbvBm6inYA2xWUH9jnvyc
