### PR TITLE
fix(kura): count damped REAPI action-cache refreshes apart from applied writes

### DIFF
--- a/infra/grafana-dashboards/tuist-kura-details.json
+++ b/infra/grafana-dashboards/tuist-kura-details.json
@@ -11906,7 +11906,7 @@
               "transformations": []
             }
           },
-          "description": "Artifact write throughput by producer and result\n\nPrometheus name: `kura_artifact_write_bytes_total_total` · labels: producer, result",
+          "description": "Artifact write throughput by producer and result. This is ingest, so a write that stored nothing books no bytes: `result=\"damped\"` and the failure results carry no series here.\n\nPrometheus name: `kura_artifact_write_bytes_total_total` · labels: producer, result",
           "id": 29,
           "links": [],
           "title": "artifact_write_bytes_total (rate)",
@@ -12116,7 +12116,7 @@
               "transformations": []
             }
           },
-          "description": "Artifact writes by producer and result\n\nPrometheus name: `kura_artifact_writes_total_total` · labels: producer, result",
+          "description": "Artifact writes by producer and result.\n\n`result=\"damped\"` is a REAPI action-cache refresh that stored nothing because the entry already held those bytes inside the 24h damping window: no store write, no version bump, no replication feed row. Only `result=\"ok\"` is comparable with the counters that likewise see applied changes only (`kura_region_sync_entries_listed_total`, `kura_backfill_bodies_total{outcome=\"applied\"}`) -- comparing those against all REAPI writes shows a shortfall that looks exactly like replication losing entries. The damped share of the two is the damping rate.\n\nPrometheus name: `kura_artifact_writes_total_total` · labels: producer, result",
           "id": 30,
           "links": [],
           "title": "artifact_writes_total (rate)",

--- a/kura/docs/replication-design.md
+++ b/kura/docs/replication-design.md
@@ -320,7 +320,14 @@ The structure the sibling reads is a **bounded change feed**, not a live index:
   during migration — never does: its only consumer already has it, and without
   this rule the two replicas would echo every record back and forth forever.
   Nor does an apply that changed nothing (last-writer-wins kept the local
-  record). A push received on the legacy routes *does* earn a row: it names
+  record), nor a *client* write that changed nothing: a REAPI action-cache
+  refresh re-publishing bytes the entry already holds, inside the damping
+  window, is skipped whole — no store write, no version bump, no row. It is
+  counted apart, as
+  `kura_artifact_writes_total{producer="reapi", result="damped"}`, so that the
+  write counter stays comparable with the §6 counters that also see only
+  applied changes; folded into `result="ok"` it reads as replication losing
+  entries. A push received on the legacy routes *does* earn a row: it names
   no region and may have crossed a boundary, so it is treated as
   cross-region. That cannot loop — an apply that arrived over the feed writes
   no row on the receiving side, and a same-region old-binary pusher never

--- a/kura/src/metrics.rs
+++ b/kura/src/metrics.rs
@@ -313,6 +313,7 @@ struct HotReadMetrics {
 struct HotWriteMetrics {
     reapi_ok_writes: Counter,
     reapi_ok_write_bytes: Counter,
+    reapi_damped_writes: Counter,
     reapi_write_size_bytes: Histogram,
     bytestream_public_latency: Histogram,
 }
@@ -890,6 +891,10 @@ impl Metrics {
         let hot_write = Arc::new(HotWriteMetrics {
             reapi_ok_writes: artifact_writes.get_or_create_owned(&reapi_ok_labels),
             reapi_ok_write_bytes: artifact_write_bytes.get_or_create_owned(&reapi_ok_labels),
+            reapi_damped_writes: artifact_writes.get_or_create_owned(&ArtifactOpLabels {
+                producer: "reapi".to_owned(),
+                result: "damped".to_owned(),
+            }),
             reapi_write_size_bytes: artifact_write_size_bytes.get_or_create_owned(
                 &ArtifactRouteLabels {
                     producer: "reapi".to_owned(),
@@ -2254,13 +2259,26 @@ impl Metrics {
     }
 
     pub fn record_artifact_write(&self, producer: ArtifactProducer, result: &str, bytes: u64) {
-        if producer == ArtifactProducer::Reapi && result == "ok" {
-            self.hot_write.reapi_ok_writes.inc();
-            if bytes > 0 {
-                self.hot_write.reapi_ok_write_bytes.inc_by(bytes);
-                self.hot_write.reapi_write_size_bytes.observe(bytes as f64);
+        if producer == ArtifactProducer::Reapi {
+            match result {
+                "ok" => {
+                    self.hot_write.reapi_ok_writes.inc();
+                    if bytes > 0 {
+                        self.hot_write.reapi_ok_write_bytes.inc_by(bytes);
+                        self.hot_write.reapi_write_size_bytes.observe(bytes as f64);
+                    }
+                    return;
+                }
+                // A damped action-cache refresh shares the hot path of the
+                // write it declines to perform, so it gets the same pre-created
+                // counter rather than the label-allocating Family lookup. It
+                // stores nothing, so it carries no bytes and observes no size.
+                "damped" => {
+                    self.hot_write.reapi_damped_writes.inc();
+                    return;
+                }
+                _ => {}
             }
-            return;
         }
         let labels = ArtifactOpLabels {
             producer: producer.as_str().to_owned(),
@@ -3905,6 +3923,38 @@ mod tests {
         assert_eq!(
             std::mem::size_of::<Metrics>(),
             std::mem::size_of::<Arc<MetricsInner>>()
+        );
+    }
+
+    // A damped REAPI action-cache refresh shares the write path's cardinality
+    // and its request rate, so it gets a pre-created counter like the applied
+    // write rather than the label-allocating Family lookup, and it never
+    // reaches write_bytes or the size histogram.
+    #[test]
+    fn damped_reapi_writes_use_a_registered_counter_without_bytes() {
+        let metrics = Metrics::new("eu-west".into(), "acme".into());
+        metrics.record_artifact_write(ArtifactProducer::Reapi, "damped", 0);
+
+        let rendered = metrics.render();
+        assert!(rendered.lines().any(|line| {
+            line.starts_with("kura_artifact_writes_total")
+                && line.contains("producer=\"reapi\"")
+                && line.contains("result=\"damped\"")
+                && line.ends_with(" 1")
+        }));
+        assert!(
+            !rendered.lines().any(|line| {
+                line.starts_with("kura_artifact_write_bytes_total") && line.contains("damped")
+            }),
+            "a damped refresh stored nothing, so it books no throughput"
+        );
+        assert!(
+            rendered.lines().any(|line| {
+                line.starts_with("kura_artifact_write_size_bytes_count")
+                    && line.contains("producer=\"reapi\"")
+                    && line.ends_with(" 0")
+            }),
+            "a damped refresh must not land in the stored-size distribution"
         );
     }
 

--- a/kura/src/reapi/service.rs
+++ b/kura/src/reapi/service.rs
@@ -1733,9 +1733,21 @@ impl ActionCache for ReapiService {
             .await
             .map_err(|error| store_write_status("failed to store action result", error))?;
         self.state.notify.notify_one();
-        self.state
-            .metrics
-            .record_artifact_write(ArtifactProducer::Reapi, "ok", manifest.size);
+        // A damped refresh (identical bytes, fresh version) counts under its own
+        // result and books no bytes: it stored nothing and wrote no replication
+        // feed row, so folding it into "ok" both overstates ingest and makes the
+        // write counter incomparable with every counter that only sees applied
+        // changes -- a shortfall that reads exactly like replication losing
+        // entries. Separating them also makes the damping rate measurable.
+        if applied {
+            self.state
+                .metrics
+                .record_artifact_write(ArtifactProducer::Reapi, "ok", manifest.size);
+        } else {
+            self.state
+                .metrics
+                .record_artifact_write(ArtifactProducer::Reapi, "damped", 0);
+        }
         let mut response = Response::new(action_result);
         self.retain_unary_response_materialization(&mut response, "action result response")?;
         // Book usage only after the response is fully built. Every applied
@@ -9729,6 +9741,132 @@ mod tests {
         // One batch read of two blobs is one request carrying both blobs' bytes.
         assert_eq!(download.bytes, total_bytes);
         assert_eq!(download.request_count, 1);
+    }
+
+    // A byte-identical re-publish inside the damping window stores nothing,
+    // bumps no version and writes no replication feed row. Counting it as an
+    // ordinary successful write made kura_artifact_writes_total incomparable
+    // with every counter that only sees applied changes -- the gap reads like
+    // replication dropping entries -- and inflated write_bytes with bytes that
+    // never landed. It gets its own result label and no bytes.
+    #[tokio::test]
+    async fn damped_action_cache_refresh_counts_separately_from_an_applied_write() {
+        let context = test_context(|config| {
+            config.usage = Some(test_usage_config());
+        })
+        .await;
+        let service = ReapiService {
+            snapshot_cache: Default::default(),
+            state: context.state.clone(),
+        };
+
+        // Carry a payload: an all-default ActionResult encodes to zero bytes,
+        // and the byte assertions below would then match the pre-created,
+        // still-zero `result="ok"` series no matter what this path recorded.
+        let action_result = reapi::ActionResult {
+            stdout_raw: b"damped action stdout".to_vec(),
+            exit_code: 3,
+            ..Default::default()
+        };
+        let encoded_bytes = action_result.encode_to_vec().len() as u64;
+        let action_digest = reapi::Digest {
+            hash: hex::encode(Sha256::digest(b"damped-action")),
+            size_bytes: "damped-action".len() as i64,
+        };
+
+        let publish = |action_result: reapi::ActionResult| {
+            let context = &context;
+            let service = &service;
+            let action_digest = action_digest.clone();
+            async move {
+                let mut update = Request::new(reapi::UpdateActionResultRequest {
+                    instance_name: "ios".into(),
+                    action_digest: Some(action_digest),
+                    action_result: Some(action_result),
+                    digest_function: reapi::digest_function::Value::Sha256 as i32,
+                    ..Default::default()
+                });
+                update
+                    .metadata_mut()
+                    .insert("x-tuist-account-handle", "acme".parse().unwrap());
+                add_direct_write_admission(
+                    &context.state,
+                    &mut update,
+                    ACTION_CACHE_UPDATE_DECODE_COPIES,
+                );
+                service
+                    .update_action_result(update)
+                    .await
+                    .expect("update action result should succeed");
+            }
+        };
+
+        publish(action_result.clone()).await;
+        let key = action_cache_key(&digest_key(&action_digest).expect("digest key should build"));
+        let first = context
+            .state
+            .store
+            .manifest_for_key(ArtifactProducer::Reapi, "ios", &key)
+            .expect("manifest lookup should succeed")
+            .expect("the first publish should store the entry");
+
+        publish(action_result).await;
+        let second = context
+            .state
+            .store
+            .manifest_for_key(ArtifactProducer::Reapi, "ios", &key)
+            .expect("manifest lookup should succeed")
+            .expect("the damped refresh should leave the entry in place");
+        assert_eq!(
+            first.version_ms, second.version_ms,
+            "the refresh must be damped for this test to mean anything"
+        );
+
+        let metrics = context.state.metrics.render();
+        let counter = |result: &str| {
+            metrics
+                .lines()
+                .find(|line| {
+                    line.starts_with("kura_artifact_writes_total")
+                        && line.contains("producer=\"reapi\"")
+                        && line.contains(&format!("result=\"{result}\""))
+                })
+                .and_then(|line| line.rsplit(' ').next())
+                .and_then(|value| value.parse::<u64>().ok())
+                .unwrap_or_default()
+        };
+        assert_eq!(counter("ok"), 1, "only the applied write counts as ok");
+        assert_eq!(counter("damped"), 1, "the damped refresh is counted apart");
+
+        let write_bytes = metrics
+            .lines()
+            .filter(|line| line.starts_with("kura_artifact_write_bytes_total"))
+            .filter(|line| line.contains("producer=\"reapi\""))
+            .collect::<Vec<_>>();
+        assert!(
+            !write_bytes.iter().any(|line| line.contains("damped")),
+            "a damped refresh stores nothing, so it books no write bytes: {write_bytes:?}"
+        );
+        assert!(
+            write_bytes.iter().any(|line| line.contains("result=\"ok\"")
+                && line.ends_with(&format!(" {encoded_bytes}"))),
+            "write bytes should hold only the applied write's payload: {write_bytes:?}"
+        );
+
+        // Billing already respected the flag; assert it stays that way, so the
+        // metric and the rollup keep telling the same story.
+        let uploads = context
+            .state
+            .usage
+            .as_ref()
+            .expect("usage should be enabled")
+            .current_rollups_for_tests()
+            .into_iter()
+            .filter(|rollup| rollup.operation == "upload")
+            .collect::<Vec<_>>();
+        assert_eq!(uploads.len(), 1, "one rollup for the one applied write");
+        assert_eq!(uploads[0].request_count, 1);
+        assert_eq!(uploads[0].bytes, encoded_bytes);
     }
 
     // The ActionCache methods move real bytes too: UpdateActionResult uploads an


### PR DESCRIPTION
Closes #13123

## What changed

`UpdateActionResult` now records `kura_artifact_writes_total{producer="reapi", result="damped"}` with zero bytes when the store reports `applied = false`, instead of folding the refresh into `result="ok"` with the existing manifest's full size.

Also:
- `kura/docs/replication-design.md` §3.1 — the list of cases that produce no replication feed row now names a damped client write.
- `infra/grafana-dashboards/tuist-kura-details.json` — the `artifact_writes_total` and `artifact_write_bytes_total` panel descriptions explain the new label and why only `result="ok"` is comparable with the replication counters. (Per `kura/CLAUDE.md`, that interpretation belongs in the panel description, not the Prometheus HELP text — the HELP string is unchanged.)

## Why

A byte-identical action-cache re-publish inside the 24 h damping window is skipped whole: no store write, no version bump, no replication feed row. The store returns that as `applied = false`. Billing fifteen lines further down already respected the flag, with a comment stating the intent ("A damped refresh (identical bytes, fresh version) applies nothing and bills nothing"); the write counter discarded it.

Two things followed:

1. **The write counter was not comparable with any replication counter** for accounts on Bazel remote execution. `kura_region_sync_entries_listed_total`, `kura_backfill_bodies_total{outcome="applied"}` and `kura_backfill_listed_tuples_total` correctly never see a damped refresh, so the difference read as replication losing entries. That cost a full investigation to rule out.
2. **`kura_artifact_write_bytes_total` overstated ingest**, adding `manifest.size` for a refresh that stored nothing.

And the damping rate was unmeasurable, because damped and applied writes were the same series.

The module/binary-cache upload path was never affected — it returns before its counter when the artifact already exists. The other REAPI `record_artifact_write(..., "ok", ...)` call site, for blob recipes, is also correct: it follows a non-damped persist that cannot no-op, so it is unchanged.

## Why a pre-created counter rather than the obvious one-liner

The suggested fix in the issue — `record_artifact_write(Reapi, if applied { "ok" } else { "damped" }, manifest.size)` — routes damped writes through `Family::get_or_create`, which allocates two `String`s and takes a map lock per call. A damped refresh happens at exactly the rate of the write it declines to perform, i.e. on the REAPI hot path, which is why `result="ok"` has a pre-created handle in `HotWriteMetrics` in the first place. The damped result gets one beside it.

Measured on this machine (release, 500k iterations, 8 samples, median):

| path | allocations | throughput |
| --- | --- | --- |
| damped, pre-created counter (this PR) | 0 allocs / 0 bytes per 10k calls | 493M/s |
| damped, `Family` lookup (the one-liner) | 3 allocs / 14 bytes per call | 17.5M/s |
| applied `result="ok"`, before | — | 194.0M/s |
| applied `result="ok"`, after | — | 194.6M/s |

Allocation counts come from a temporary counting global allocator over 10k calls of each path (removed before commit). The applied path changed only from an `if` to a `match` on the same `&str`; the two figures are within noise of each other. Steady-state heap grows by one `Counter` and one exported series per pod, created at startup — the series renders as `0` on nodes that never damp, which is what `rate()` wants anyway.

## Rollout safety

Metrics-only. No wire format, no on-disk format, no behavioural change to what is stored or replicated, so a half-rolled fleet is consistent. During the rollout, old pods keep reporting damped refreshes as `result="ok"` and new pods report them apart; the unlabelled sum over `result` is unchanged on both, so panels that do not split by `result` see nothing.

## Validation

- New `damped_action_cache_refresh_counts_separately_from_an_applied_write` (`kura/src/reapi/service.rs`) drives the real `UpdateActionResult` handler twice with identical bytes, asserts the second is genuinely damped (`version_ms` does not move), then asserts `ok == 1`, `damped == 1`, no damped write-bytes series, and that the billing rollup still books exactly one upload. Verified to fail on the pre-fix code with `ok == 2`.
- New `damped_reapi_writes_use_a_registered_counter_without_bytes` (`kura/src/metrics.rs`) covers the metric surface directly: the counter renders, and neither `write_bytes` nor the stored-size histogram moves.
- `mise run test-unit` (Bazel, what CI gates on): 1000 passed, 0 failed.
- `mise run clippy` and `cargo fmt --check`: clean.
- Benchmarks above run with `cargo test --release ... -- --ignored`.

One unrelated flake surfaced during this work: `store::tests::a_concurrent_feature_publish_cannot_overwrite_the_trunk_tag` failed once on a loaded machine and passed on every subsequent run, including a clean run at `main`. It orders two spawned publishes with a fixed 50 ms `tokio::time::sleep`, which a loaded CI machine can miss. It touches no code in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)