### PR TITLE
docs(server): correct Bazel setup, dashboard, and retention claims

### DIFF
--- a/server/priv/docs/en/guides/features/cache/bazel-cache.md
+++ b/server/priv/docs/en/guides/features/cache/bazel-cache.md
@@ -29,7 +29,9 @@ This writes a `.bazelrc.tuist` file next to your `.bazelrc`, wired to the closes
 try-import %workspace%/.bazelrc.tuist
 ```
 
-Pass `--no-add-bazelrc-import` if you want to manage the import yourself. The generated file is safe to check in.
+Pass `--no-add-bazelrc-import` if you want to manage the import yourself.
+
+Add `.bazelrc.tuist` to your `.gitignore` and run setup on each machine instead of committing it. The generated file points at an absolute credential-helper path under the current user's Tuist configuration directory and at the cache region closest to the machine that generated it, so neither value transfers to a teammate or a continuous integration runner. Commit the `try-import` line in `.bazelrc`, which is the same on every machine.
 
 Setup leaves an existing `.bazelrc` alone when it cannot find a Bazel workspace marker, when the file is a symbolic link, or when it already configures a remote cache or Build Event Service. That way, running it again is idempotent.
 
@@ -39,7 +41,9 @@ Run a normal Bazel command to verify the integration:
 bazel build //...
 ```
 
-Cache activity then appears on the project's **Overview** page in the Tuist dashboard, broken down by action-cache and content-addressable-storage operations.
+Cache activity then appears on the project's **Bazel Cache** page in the Tuist dashboard, which shows cache transfer, downloads and uploads, read and write latency, throughput, and the action-cache hit rate. The project **Overview** carries a summary of the same action-cache hit rate alongside build duration.
+
+To see how one command used the cache, open it from **Invocations**. The invocation page separates action-cache lookups from content-object requests, so you can tell a cold action cache apart from a slow artifact download.
 
 ## Build insights {#build-insights}
 

--- a/server/priv/docs/en/guides/features/runners.md
+++ b/server/priv/docs/en/guides/features/runners.md
@@ -48,26 +48,23 @@ The **Concurrency** section of the Runners dashboard shows the peak admitted vCP
 
 Your current limits are shown alongside each chart. If your workflows regularly reach them and spend time queued, [contact us](mailto:contact@tuist.dev) with your account handle, platform, and expected parallel workload. We'll review the required capacity and help raise the limits.
 
-<HomeCards>
-    <HomeCard
-        icon="<img src='/images/logo.webp' alt='Tuist' width='32' height='32' />"
-        title="GitHub Actions"
-        details="Connect GitHub, point runs-on at a Tuist profile, and run your first job on the fleet."
-        linkText="Get started"
-        link="/guides/features/runners/github-actions"/>
-    <HomeCard
-        icon="<img src='/images/logo.webp' alt='Tuist' width='32' height='32' />"
-        title="Buildkite"
-        details="Connect your cluster, name a queue after a Tuist profile, and target it from a step."
-        linkText="Get started"
-        link="/guides/features/runners/buildkite"/>
-    <HomeCard
-        icon="<img src='/images/logo.webp' alt='Tuist' width='32' height='32' />"
-        title="Profiles"
-        details="Choose a platform, size, and Xcode version with named machine profiles you reference from your jobs."
-        linkText="Manage profiles"
-        link="/guides/features/runners/profiles"/>
-</HomeCards>
+<.home_cards>
+  <.home_card
+    title="GitHub Actions"
+    details="Connect GitHub, point runs-on at a Tuist profile, and run your first job on the fleet."
+    link="/guides/features/runners/github-actions"
+/>
+  <.home_card
+    title="Buildkite"
+    details="Connect your cluster, name a queue after a Tuist profile, and target it from a step."
+    link="/guides/features/runners/buildkite"
+/>
+  <.home_card
+    title="Profiles"
+    details="Choose a platform, size, and Xcode version with named machine profiles you reference from your jobs."
+    link="/guides/features/runners/profiles"
+/>
+</.home_cards>
 
 ## Why Tuist Runners {#why-tuist-runners}
 

--- a/server/priv/docs/en/guides/features/test-insights/bazel.md
+++ b/server/priv/docs/en/guides/features/test-insights/bazel.md
@@ -19,7 +19,7 @@ Run Bazel tests through Tuist to feed the same test dashboards used by every oth
 tuist bazel test -- //app:tests
 ```
 
-Arguments after `--` are forwarded to `bazel test`. Use `--path` to select the project and working directory, and `--bazel` to select a different executable such as `bazelisk`. Ordinary `bazel test` still runs your tests, but does not report individual cases to Tuist and does not enforce quarantine policies.
+Arguments after `--` are forwarded to `bazel test`. Use `--path` to select the project and working directory, and `--bazel` to select a different executable such as `bazelisk`. Ordinary `bazel test` still reports test results, but does not fetch or enforce Tuist quarantine policies.
 
 ## What is tracked {#what-is-tracked}
 
@@ -55,4 +55,4 @@ Retries, cross-run flakiness detection, and per-case quarantine (Mute and Skip) 
 
 ## Data retention {#data-retention}
 
-Tuist retains Bazel test data for 90 days. See <.localized_link href="/guides/server/data-retention">data retention</.localized_link> for the full policy.
+Tuist retains the Bazel invocation that produced a test run, its logs, and the pending test ingestion records for 90 days. Test cases and their run history use the same model as every other build system and are not covered by that window. See <.localized_link href="/guides/server/data-retention">data retention</.localized_link> for the full policy.

--- a/server/priv/docs/en/guides/features/test-insights/bazel.md
+++ b/server/priv/docs/en/guides/features/test-insights/bazel.md
@@ -19,7 +19,7 @@ Run Bazel tests through Tuist to feed the same test dashboards used by every oth
 tuist bazel test -- //app:tests
 ```
 
-Arguments after `--` are forwarded to `bazel test`. Use `--path` to select the project and working directory, and `--bazel` to select a different executable such as `bazelisk`. Ordinary `bazel test` still reports test results, but does not fetch or enforce Tuist quarantine policies.
+Arguments after `--` are forwarded to `bazel test`. Use `--path` to select the project and working directory, and `--bazel` to select a different executable such as `bazelisk`. Ordinary `bazel test` still runs your tests, but does not report individual cases to Tuist and does not enforce quarantine policies.
 
 ## What is tracked {#what-is-tracked}
 

--- a/server/priv/docs/en/guides/features/test-sharding.md
+++ b/server/priv/docs/en/guides/features/test-sharding.md
@@ -13,26 +13,23 @@ In those cases, you need a system that distributes tests across multiple CI runn
 
 Tuist uses historical test timing data to intelligently balance the load across shards using a [bin-packing algorithm](https://en.wikipedia.org/wiki/Bin_packing_problem), so each runner finishes at roughly the same time. Results from all shards are automatically aggregated in <.localized_link href="/guides/features/test-insights">Test Insights</.localized_link>, giving you a single unified view of your test suite across all shards.
 
-<HomeCards>
-    <HomeCard
-        icon="<img src='/images/guides/features/xcode-icon.png' alt='Xcode' width='32' height='32' />"
-        title="Xcode"
-        details="Shard Xcode tests across parallel CI runners."
-        linkText="Xcode test sharding"
-        link="/guides/features/test-sharding/xcode"/>
-    <HomeCard
-        icon="<img src='/images/guides/features/xcode-icon.png' alt='Xcode' width='32' height='32' />"
-        title="Generated projects"
-        details="Shard tests in Tuist generated projects across parallel CI runners."
-        linkText="Generated projects test sharding"
-        link="/guides/features/test-sharding/generated-projects"/>
-    <HomeCard
-        icon="<img src='/images/guides/features/gradle-icon.svg' alt='Gradle' width='32' height='32' />"
-        title="Gradle"
-        details="Shard Gradle tests across parallel CI runners."
-        linkText="Gradle test sharding"
-        link="/guides/features/test-sharding/gradle"/>
-</HomeCards>
+<.home_cards>
+  <.home_card
+    title="Xcode"
+    details="Shard Xcode tests across parallel CI runners."
+    link="/guides/features/test-sharding/xcode"
+/>
+  <.home_card
+    title="Generated projects"
+    details="Shard tests in Tuist generated projects across parallel CI runners."
+    link="/guides/features/test-sharding/generated-projects"
+/>
+  <.home_card
+    title="Gradle"
+    details="Shard Gradle tests across parallel CI runners."
+    link="/guides/features/test-sharding/gradle"
+/>
+</.home_cards>
 
 > [!WARNING]
 > **Requirements**


### PR DESCRIPTION
Follow-up to #13066. That PR gave Bazel a proper presence across the docs and the structure it chose is the right one — this only corrects claims in the prose that don't match what the tooling does, plus one leftover from the card migration.

Each finding below was checked against the source rather than inferred from the diff.

## What changed and why

### `.bazelrc.tuist` is not safe to check in

The page told readers the generated file was safe to commit. It isn't:

- `BazelrcFile.render` writes `build --credential_helper=<host>=<credentialHelperPath>`, and that path is created under `Environment.current.configDirectory/credentials/` (`BazelSetupCommandService.swift:279-282`), so a committed file carries one developer's home directory.
- The endpoint host is region-specific (`<account>-<region>.kura.tuist.dev`), resolved for the machine that ran setup.
- Our own Bazel workspace already treats it as generated: `kura/.gitignore:8` lists `/.bazelrc.tuist`, and the Kura CI workflows regenerate it per run.
- `BazelrcFileTests.swift:41` says so in a comment: *"The file is per-machine, so a developer may well have added to it."*

It also sat awkwardly against the page's own CI section, which tells readers to re-run `tuist bazel setup` on each runner so the file reflects the right region. That section now reads as a continuation rather than an exception.

### The cache page pointed at the wrong dashboard

"Cache activity then appears on the project's **Overview** page … broken down by action-cache and content-addressable-storage operations" was half right. `ReapiCache.hit_rate_analytics/2` filters `where: event.operation == "action_cache"` (`reapi_cache.ex:212`), so Overview is action-cache only; the AC-vs-content-object split is on the invocation detail page (`bazel_invocation_live.ex:727-728`).

More to the point, a Bazel project's dashboard has a dedicated **Bazel Cache** page (`router.ex:1274`, in the sidebar via `app_layout_components.ex:142`) with cache transfer, downloads/uploads, read/write latency, throughput and hit rate — and the page called "Bazel cache" didn't mention it. It's now the primary destination, with Overview described as the summary and the invocation page as where the operation split lives.

### The test retention window was broader than what we delete

"Tuist retains Bazel test data for 90 days" read, on a page about test cases and failure history, as that history expiring. The only 90-day Bazel test job is `DeleteExpiredTestIngestionRecordsWorker`, and `Bazel.delete_expired_test_ingestion_records/2` scopes it to `TestResult`, `TestSummary` and `TestInvocation` (`bazel.ex:324-328`) — the raw staging rows. The retention policy page names exactly those ("pending Bazel test ingestion records"); derived cases and runs use the shared `test_runs` model and have no row there. The sentence now says what the window actually covers, and what it doesn't.

### The last two landing pages were still rendering no cards

`strip_unsupported_tags` (`docs_loader.ex:467`) deletes `<HomeCards>` blocks wholesale, so `runners.md` and `test-sharding.md` were shipping six invisible cards — GitHub Actions / Buildkite / Profiles, and Xcode / Generated projects / Gradle. Both are migrated to `<.home_cards>`.

This is also worth recording about #13066 itself: that migration was a bug fix, not a restyle. `cache.md` at its parent commit rendered zero cards too, so Cache, Test Insights and Flaky Tests had all been shipping an empty gap where the grid should be.

**The `<HomeCards>` strip rules stay for now.** Seven translated `cache.md` files (`es`, `ja`, `ko`, `ru`, `yue_Hant`, `zh_Hans`, `zh_Hant`) still carry the old markup, so removing the rules would leak raw tags into those pages. They can come out once Weblate has synced the English change.

## Deliberately not fixed here

`test-insights/bazel.md` and `flaky-tests/bazel.md` contradict each other about what plain `bazel test` reports. One of them is wrong, but establishing which needs a real run rather than a reading of the code, so this PR leaves both as they were merged. Tracked in #13132.

The short version of why it isn't obvious: reporting does ride the Build Event Service stream rather than the CLI wrapper — Kura handles BEP `TestResult` events directly (`bep.rs:803-836`) and `BazelTestCommandService` has no upload path. But Kura resolves `test.xml` **by digest out of its own REAPI store** (`bazel_test_artifacts.rs:478-486`) rather than receiving the bytes. A blob that never reached Tuist's cache yields `bazel_test_artifact/missing`, and the ingestor's `parse_report/1` then produces no test cases at all — you get the invocation and the per-target summary, but nothing case-level. Whether a *failing* test's outputs reach the cache is the load-bearing question, and it isn't answerable from the repo: `kura/spec/e2e/` has no BES or test-result spec, `test_report_ingestor_test.exs` has no missing-artifact case, and `.bazelrc.tuist` sets no upload flags.

## Impact

A Bazel user following the cache guide no longer commits a file that breaks for everyone else, lands on a dashboard that doesn't have what the page promised, or believes their test history expires at 90 days. Six previously invisible cards now render.

## Validation

Ran every touched page through the real docs pipeline — the `docs_loader.ex` MDEx options (`phoenix_heex: true`, `unsafe: true`), `strip_unsupported_tags`, `escape_heex_expressions`, then `Phoenix.LiveView.TagEngine.compile`:

```
:ok  cards=3  features/runners.md          # was 0
:ok  cards=3  features/test-sharding.md    # was 0
:ok  cards=0  cache/bazel-cache.md
:ok  cards=0  test-insights/bazel.md
```

All twelve pages compile rather than falling back to `raw(body)`. Every internal link and deep anchor on the four edited pages resolves to a real page and a real `{#id}` marker (20/20). No translation files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
