### PR TITLE
fix(kura): give control-plane calls room for one SYN retransmit

### DIFF
--- a/kura/src/mesh_heartbeat.rs
+++ b/kura/src/mesh_heartbeat.rs
@@ -44,8 +44,14 @@ const PEERS_PATH: &str = "/_internal/kura/mesh/peers";
 const KURA_MESH_PEERS_SYNC: &str = "KURA_MESH_PEERS_SYNC";
 
 const DEFAULT_INTERVAL_MS: u64 = 60_000;
-const CONNECT_TIMEOUT: Duration = Duration::from_millis(1_000);
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+// Linux retransmits a lost SYN at ~1s, so a 1s connect budget turned a single
+// dropped packet into a failed sync. See `usage` and `auth::config`, which
+// carry the same budgets for the same reason.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+// reqwest's request timeout spans the connect, so a connect budget at or above
+// it can never be reached and the node gives up on the handshake early.
+const _: () = assert!(CONNECT_TIMEOUT.as_millis() < REQUEST_TIMEOUT.as_millis());
 // Recovery re-enrollments mint fresh certificates; the backoff keeps a
 // persistent `mesh_member: false` (control-plane bug, clock skew) from
 // becoming a per-minute signing loop while staying well inside the server's

--- a/kura/src/mesh_heartbeat.rs
+++ b/kura/src/mesh_heartbeat.rs
@@ -46,7 +46,8 @@ const KURA_MESH_PEERS_SYNC: &str = "KURA_MESH_PEERS_SYNC";
 const DEFAULT_INTERVAL_MS: u64 = 60_000;
 // Linux retransmits a lost SYN at ~1s, so a 1s connect budget turned a single
 // dropped packet into a failed sync. See `usage` and `auth::config`, which
-// carry the same budgets for the same reason.
+// carry the same 3s connect budget for the same reason; the request budget is
+// sized to the 60s cadence below rather than matched to theirs.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 // reqwest's request timeout spans the connect, so a connect budget at or above

--- a/kura/src/usage.rs
+++ b/kura/src/usage.rs
@@ -19,8 +19,17 @@ use crate::{
 };
 
 const USAGE_PATH: &str = "/_internal/kura/usage";
-const USAGE_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
-const USAGE_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+// Linux retransmits a lost SYN at ~1s, so a 1s connect budget turned a single
+// dropped packet into a failed delivery. Distant regions lose enough of them
+// that the outbox never drained; the auth path already learned this
+// (`auth::config`), and these budgets match it. The connect timeout is only
+// ever spent on a path that is already failing, so a healthy region pays
+// nothing for the wider window.
+const USAGE_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const USAGE_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+// reqwest's request timeout spans the connect, so a connect budget at or above
+// it can never be reached and the node gives up on the handshake early.
+const _: () = assert!(USAGE_CONNECT_TIMEOUT.as_millis() < USAGE_REQUEST_TIMEOUT.as_millis());
 // Eviction reports awaiting a successful delivery. In memory only: the claim
 // sizing policy reads weeks of aggregates, so reports lost to a restart are
 // noise, and keeping them off the durable outbox keeps the on-disk format

--- a/kura/src/usage.rs
+++ b/kura/src/usage.rs
@@ -22,9 +22,11 @@ const USAGE_PATH: &str = "/_internal/kura/usage";
 // Linux retransmits a lost SYN at ~1s, so a 1s connect budget turned a single
 // dropped packet into a failed delivery. Distant regions lose enough of them
 // that the outbox never drained; the auth path already learned this
-// (`auth::config`), and these budgets match it. The connect timeout is only
-// ever spent on a path that is already failing, so a healthy region pays
-// nothing for the wider window.
+// (`auth::config`), and the connect budget here is the 3s it settled on. The
+// request budget is wider than auth's because a delivery carries a batch
+// rather than one introspection, and both cross the same WAN. The connect
+// timeout is only ever spent on a path that is already failing, so a healthy
+// region pays nothing for the wider window.
 const USAGE_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 const USAGE_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 // reqwest's request timeout spans the connect, so a connect budget at or above


### PR DESCRIPTION
## What changed

`kura`'s two control-plane background loops had a **1 second connect timeout**:

- `src/usage.rs` — `USAGE_CONNECT_TIMEOUT` 1s → **3s**, `USAGE_REQUEST_TIMEOUT` 5s → **10s**
- `src/mesh_heartbeat.rs` — `CONNECT_TIMEOUT` 1s → **3s**, `REQUEST_TIMEOUT` 5s → **10s**

Both also gain the `const _: () = assert!(CONNECT < REQUEST)` invariant that `auth::config` already carries, since reqwest's request timeout spans the connect and a connect budget at or above it can never be reached.

## Why — the root cause

Linux's initial retransmission timeout for a SYN is ~1 second. A 1 second connect budget therefore leaves **zero room for a single dropped SYN**: the retransmit goes out at the exact moment the budget expires, so one lost packet is an automatic failure. There is no "slow path" involved — the connect never even gets a second attempt.

That is fine on a low-loss path and catastrophic on a lossy one. Splitting Loki's `Connect, TimedOut` errors for `tuist-tuist-server.tuist.svc.cluster.local` by region over 24h shows the regions farthest from the control plane producing these timeouts by the thousand per day, and the regions closest to it producing a handful — same server, same instants, so the control plane is healthy and the path is not. Every pod in the worst regions is affected and every pod in the best regions is clean, which is what a path-quality problem looks like and not what a server problem looks like.

`auth::config` already hit and fixed exactly this, and its comment says so in as many words: *"used to fall back to 500/1500, where one dropped SYN (first retransmit at ~1s) fails the connect outright."* The usage and mesh clients were simply never brought along. This change closes that gap rather than inventing a new policy.

This was found while checking whether these logs correlate with server deploys. **They don't** — across 24 successful `production / Deploy to tuist` windows the in-window error rate was, if anything, marginally *lower* than the surrounding baseline, and the multi-hour failure plateaus start and end nowhere near a deploy.

## Why not something else

- **Env-configurable knobs** — `auth` has them because the managed provisioner renders per-node values. Nothing renders per-node usage/mesh timeouts today, so a constant that matches auth's default is the smaller change; a knob can follow if a region ever needs one.
- **Retry loops** — both loops already retry on their own cadence. The problem is not a missing retry, it is that a correct connect is being abandoned mid-handshake.

## Cadence and overlap

Overlap was the explicit concern, so, concretely: **it cannot happen**, and not because of the numbers — because of the loop shape. All three control-plane loops await the request inline and *then* sleep, so a cycle is `request + interval` and two requests are never in flight at once. `registration.rs` uses a ticker rather than a sleep, but awaits the request in the same task and sets `MissedTickBehavior::Skip`, so a slow request delays the next tick instead of stacking one on top of it.

The intervals are also much wider than 2s:

| loop | interval | worst-case cycle before | after |
|---|---|---|---|
| usage delivery | 5s (`DEFAULT_USAGE_DELIVERY_INTERVAL_MS`) | 10s | **15s** |
| mesh heartbeat / peers sync | 60s (control-plane advertised, `@mesh_heartbeat_interval_seconds`) | 65s | **70s** |
| registration | 60s | unchanged | unchanged |

The 70s worst case sits ~25× inside the server's 30-minute `@stale_peer_after_minutes` window, so a node cannot be withheld from the mesh over this.

And the load-bearing point: **the connect timeout is only ever spent on a connection that is already failing.** A healthy region completes its handshake in one RTT and never touches the budget, so nothing about the success path changes for anyone.

## Impact

Far-region nodes stop failing usage delivery and mesh peer sync on routine single-packet loss. That means the usage outbox actually drains there (it has been unable to), peer views refresh at their intended cadence instead of holding the last-known view, and the warn-level log volume these regions generate drops sharply.

## Validation

### The failure mode is reproduced end to end, not just argued

Built a harness pinned to kura's exact reqwest version (`=0.12.28`, same features) making the same `connect_timeout` / `timeout` builder calls, and ran it in a Linux container against a listener whose inbound SYNs are dropped for the first 500ms of each attempt. That drops the initial SYN and lets the ~1s retransmit through — exactly one lost SYN, deterministically:

```
--- baseline: no SYN dropped ---
before  connect=1000ms request=5000ms  -> OK 200 OK in 5ms
after   connect=3000ms request=10000ms -> OK 200 OK in 1ms
--- one dropped SYN ---
before(#1)  connect=1000ms  -> ERR hyper_util::client::legacy::Error(Connect, ... TimedOut ...) in 1006ms
before(#2)  connect=1000ms  -> ERR hyper_util::client::legacy::Error(Connect, ... TimedOut ...) in 1002ms
before(#3)  connect=1000ms  -> ERR hyper_util::client::legacy::Error(Connect, ... TimedOut ...) in 1007ms
after (#1)  connect=3000ms  -> OK 200 OK in 1029ms
after (#2)  connect=3000ms  -> OK 200 OK in 1012ms
after (#3)  connect=3000ms  -> OK 200 OK in 1012ms
```

3/3 both ways. The old budget fails at ~1006ms — the retransmit and the deadline land on the same millisecond — and the error is the same `Connect, TimedOut` shape seen in production. The new budget completes on that retransmit at ~1012ms. Note what this also shows: the fix costs a healthy connection nothing (1ms baseline), because the connect budget is only ever spent on a handshake that is already in trouble.

### Checks


- `cargo check --lib` — passes, including both new const asserts (a bad budget would now be a compile error).
- `cargo clippy --lib -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.
- `cargo test --lib mesh_heartbeat` — 6 passed.
- `cargo test --lib usage` — 27 passed.

## Follow-up noted, not changed here

`registration.rs` builds its client with a bare `Client::new()` — no connect timeout and no request timeout at all, so a black-holed path there blocks on the OS default (~130s) rather than failing fast. Its ticker skips missed ticks so nothing stacks up, and giving it a request timeout could newly fail registrations that currently succeed slowly, so it is deliberately left alone here rather than folded into a timeout raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)