### PR TITLE
fix(kura): pin the concurrent trunk-tag test with a failpoint gate

### DIFF
--- a/kura/src/failpoints.rs
+++ b/kura/src/failpoints.rs
@@ -5,7 +5,7 @@ pub(crate) enum FailpointName {
     BeforeSegmentFsync,
     #[cfg(test)]
     BeforeWalFsync,
-    AfterInlineManifestReadBeforeCommit,
+    BeforeInlineApplyWriteLock,
     AfterArtifactBytesDurableBeforeMetadata,
     AfterMetadataCommitBeforeReturn,
     AfterReadArtifactBytesBeforeReturn,
@@ -24,7 +24,7 @@ impl FailpointName {
             Self::BeforeSegmentFsync => "before_segment_fsync",
             #[cfg(test)]
             Self::BeforeWalFsync => "before_wal_fsync",
-            Self::AfterInlineManifestReadBeforeCommit => "after_inline_manifest_read_before_commit",
+            Self::BeforeInlineApplyWriteLock => "before_inline_apply_write_lock",
             Self::AfterArtifactBytesDurableBeforeMetadata => {
                 "after_artifact_bytes_durable_before_metadata"
             }
@@ -51,6 +51,44 @@ pub(crate) enum FailpointAction {
     Sleep(Duration),
     Error(String),
     Panic(String),
+    /// Park until the test releases the gate. Unlike [`Self::Sleep`], this
+    /// makes an interleaving a fact rather than a wager on wall-clock timing:
+    /// the test learns when the parked task actually reached the failpoint and
+    /// decides itself when it may continue.
+    #[cfg(test)]
+    Pause(std::sync::Arc<FailpointGate>),
+}
+
+/// The two-way rendezvous behind [`FailpointAction::Pause`].
+#[cfg(test)]
+#[derive(Debug, Default)]
+pub(crate) struct FailpointGate {
+    entered: tokio::sync::Notify,
+    released: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+impl FailpointGate {
+    pub(crate) fn new() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self::default())
+    }
+
+    /// Resolves once a task has reached the failpoint and parked on it.
+    pub(crate) async fn entered(&self) {
+        self.entered.notified().await;
+    }
+
+    /// Lets the parked task run on.
+    pub(crate) fn release(&self) {
+        self.released.notify_one();
+    }
+
+    async fn park(&self) {
+        // Both directions store a permit when nobody is waiting yet, so
+        // neither half of the rendezvous can be missed by arriving early.
+        self.entered.notify_one();
+        self.released.notified().await;
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -98,6 +136,11 @@ impl FailpointSet {
             FailpointAction::Panic(message) => {
                 panic!("failpoint {}: {message}", name.as_str());
             }
+            #[cfg(test)]
+            FailpointAction::Pause(gate) => {
+                gate.park().await;
+                Ok(())
+            }
         }
     }
 
@@ -135,6 +178,13 @@ impl FailpointSet {
             }
             FailpointAction::Panic(message) => {
                 panic!("failpoint {}: {message}", name.as_str());
+            }
+            #[cfg(test)]
+            FailpointAction::Pause(_) => {
+                panic!(
+                    "failpoint {}: Pause needs an async context, use FailpointSet::hit",
+                    name.as_str()
+                );
             }
         }
     }

--- a/kura/src/store.rs
+++ b/kura/src/store.rs
@@ -3033,6 +3033,13 @@ impl Store {
         let artifact_id =
             artifact_storage_id(spec.producer, &self.tenant_id, spec.namespace_id, spec.key);
 
+        // Reached with the caller's damping read already taken and no artifact
+        // lock held yet: the window a racing publish has to commit underneath a
+        // writer that has already read this key. A test parking here still
+        // holds the namespace read lock above, so do not pair it with a
+        // namespace delete.
+        self.hit_failpoint(FailpointName::BeforeInlineApplyWriteLock)
+            .await?;
         // Hold the per-artifact write lock across the read, the sticky-tag
         // decision and the commit. The tag is a read-modify-write over the
         // stored manifest, so computing it from a read taken outside the lock
@@ -3094,9 +3101,6 @@ impl Store {
         spec: &PersistArtifactSpec<'_>,
     ) -> Result<InlineApplyPrecheck, String> {
         let existing = self.manifest_from_db(artifact_id)?;
-        // Widens the read-to-commit window a racing writer would have to hit.
-        self.hit_failpoint(FailpointName::AfterInlineManifestReadBeforeCommit)
-            .await?;
         let version_ms = spec.precheck_version_ms();
         if let Some(existing_manifest) = &existing
             && existing_manifest.inline
@@ -10556,7 +10560,7 @@ mod tests {
 
     use crate::{
         config::{AcceleratedFileServingConfig, AcceleratedFileServingMode, Config},
-        failpoints::{FailpointAction, FailpointName},
+        failpoints::{FailpointAction, FailpointGate, FailpointName},
         io::IoController,
         memory::MemoryController,
         metrics::Metrics,
@@ -12132,19 +12136,24 @@ mod tests {
     // to interleave their read and their commit, or the feature build writes the
     // `feature` tag it decided on when the key looked absent, over the `main` the
     // trunk build committed meanwhile, and with a version nothing downstream
-    // rejects. The failpoint pins that interleaving instead of racing for it.
+    // rejects. The gate pins that interleaving instead of racing for it.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_concurrent_feature_publish_cannot_overwrite_the_trunk_tag() {
         let (_temp_dir, _config, store) = temp_store();
         let store = Arc::new(store);
+        // The feature publish parks between its damping read of an absent key
+        // and the write lock, which is the one window where another publish can
+        // land under it. The gate is what makes that a fact: the test resumes
+        // only once the publish has actually reached the failpoint, and the
+        // publish resumes only once the test says so. A fixed sleep here merely
+        // widened the window, and a loaded machine closed it again.
+        let gate = FailpointGate::new();
         store.failpoints().set_once(
-            FailpointName::AfterInlineManifestReadBeforeCommit,
-            FailpointAction::Sleep(std::time::Duration::from_millis(300)),
+            FailpointName::BeforeInlineApplyWriteLock,
+            FailpointAction::Pause(Arc::clone(&gate)),
         );
 
         let feature_store = Arc::clone(&store);
-        // Reads first (and stalls on the failpoint holding nothing but its own
-        // read), so it is the one whose decision is stale by the time it writes.
         let feature = tokio::spawn(async move {
             feature_store
                 .persist_inline_artifact_from_bytes_damped_and_enqueue(
@@ -12158,27 +12167,45 @@ mod tests {
                     Some("main"),
                 )
                 .await
-                .expect("feature publish should persist");
+                .expect("feature publish should persist")
         });
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        let trunk_store = Arc::clone(&store);
-        let trunk = tokio::spawn(async move {
-            trunk_store
-                .persist_inline_artifact_from_bytes_damped_and_enqueue(
-                    ArtifactProducer::Reapi,
-                    "ios",
-                    "action_cache/aa/10",
-                    "application/x-protobuf",
-                    b"graph-from-trunk",
-                    &[],
-                    Some("main"),
-                    Some("main"),
-                )
-                .await
-                .expect("trunk publish should persist");
-        });
-        feature.await.expect("feature task");
-        trunk.await.expect("trunk task");
+        tokio::time::timeout(std::time::Duration::from_secs(60), gate.entered())
+            .await
+            .expect("the feature publish must park before it takes the write lock");
+
+        // Commits `main` in full while the feature publish is held, so the
+        // feature build's decision is provably the stale one.
+        let (trunk_manifest, _applied) = store
+            .persist_inline_artifact_from_bytes_damped_and_enqueue(
+                ArtifactProducer::Reapi,
+                "ios",
+                "action_cache/aa/10",
+                "application/x-protobuf",
+                b"graph-from-trunk",
+                &[],
+                Some("main"),
+                Some("main"),
+            )
+            .await
+            .expect("trunk publish should persist");
+        assert_eq!(
+            trunk_manifest.branch.as_deref(),
+            Some("main"),
+            "the trunk publish must have landed the trunk tag before the feature \
+             publish resumes, or the assertion below proves nothing"
+        );
+
+        gate.release();
+        let (feature_manifest, _applied) = feature.await.expect("feature task");
+        // Asserted on the resumed writer itself, not only through the scan
+        // below: whether it re-resolved the tag under the lock or was rejected
+        // outright as not-newer, what it must never do is come back holding the
+        // `feature` tag it decided on before the trunk commit.
+        assert_eq!(
+            feature_manifest.branch.as_deref(),
+            Some("main"),
+            "the feature publish kept the tag it decided on from its stale read"
+        );
 
         let trunk_view = store
             .action_cache_manifests("ios", 10, Some("main"))
@@ -12190,7 +12217,8 @@ mod tests {
         assert_eq!(
             keys,
             vec!["action_cache/aa/10"],
-            "the key stays in the trunk baseline whichever publish commits first"
+            "the feature publish resolved its tag from a read taken before the \
+             trunk commit and dropped the key out of the trunk baseline"
         );
     }
 


### PR DESCRIPTION
## What changed

`store::tests::a_concurrent_feature_publish_cannot_overwrite_the_trunk_tag` no longer synchronizes its two publishes with a fixed `tokio::time::sleep`. It uses an explicit failpoint rendezvous instead, and the synchronization point moved to where a racing publish can actually land.

- `FailpointName::BeforeInlineApplyWriteLock` replaces `AfterInlineManifestReadBeforeCommit` in `persist_inline_artifact_with_version`, fired after the caller's damping read and before the per-artifact write lock.
- `FailpointAction::Pause(Arc<FailpointGate>)` is a new test-only two-way rendezvous in `kura/src/failpoints.rs`: `gate.entered().await` resolves once a task has actually parked on the failpoint, and `gate.release()` lets it run on.
- The test parks the feature publish on the gate, runs the trunk publish to completion inline, asserts the trunk tag actually landed, then releases and asserts the resumed publish did not carry its stale `feature` tag.

## Why

The test was flaky. It spawned the feature publish, slept a fixed 50 ms, then spawned the trunk publish and relied on that sleep to land the trunk publish while the feature one was mid-flight. Reproduced at 2/300 on a loaded machine (28 spinners plus a concurrent release build, load average ~50); 0/40 unloaded, which is why it passed on every rerun and on a clean `main`.

## Root cause

Not simply a missed window. The failpoint the test used fires inside the per-artifact write lock, so the trunk publish could never commit while the feature publish was stalled — it just blocked on the lock. The interleaving was always "feature commits, then trunk republishes".

That makes the assertion depend on a millisecond boundary. `precheck_version_ms()` is `now_ms()` evaluated under the lock, so when the trunk publish's stamp lands in the same millisecond as the feature publish's freshly committed version, the LWW check `existing_version >= version_ms` ignores the trunk publish outright. The entry keeps the `feature` tag, and the trunk view scan comes back empty — exactly the observed failure:

```
assertion `left == right` failed: the key stays in the trunk baseline whichever publish commits first
  left: []
 right: ["action_cache/aa/10"]
```

This is why the obvious fix does not work: gating the *existing* failpoint would have made the collision happen on every run rather than 1-in-150, turning a flake into a permanent failure.

## Why this solution

Moving the gate above the write lock is what makes the stall observable to another writer at all, and it is the only window in this path where a racing publish can commit underneath a writer that has already read the key. It also makes the test exercise the invariant its own comment claims — the feature publish's damping read is now genuinely stale and the tag must be re-resolved under the lock — instead of degenerating into two serialized publishes.

The result is immune to the millisecond collision in both directions: the resumed publish is either rejected as not-newer or `sticky_branch` keeps `main`. Both outcomes satisfy the invariant, and the test now asserts it on the resumed writer's own returned manifest rather than only through the trunk scan.

`AfterInlineManifestReadBeforeCommit` was dropped: no test used it any more, and its "widens the read-to-commit window a racing writer would have to hit" comment was false once that window closed inside the write lock.

## Impact

Test-only. No production behaviour change and no resource cost:

- `Pause` and `FailpointGate` are `#[cfg(test)]`, so the release-build enum and the hot path are unchanged.
- The inline publish path still performs exactly one failpoint check — moved, not added.
- The backfill group commit loses one check per staged entry, because the check left `inline_apply_precheck` (which both paths share).
- No new allocations, syscalls, disk writes or network traffic. Resident/heap, CPU, egress and disk are unaffected.

## Validation

- `mise run test-unit` green — 998 lib tests, 0 failures.
- `cargo clippy --all-targets -- -D warnings` clean; release build clean.
- Stressed the single test 400x under the same load that reproduced the flake: 0 failures. The pre-fix code failed 2/300 under that load.
- Mutation check: removing the sticky-tag arm from `sticky_branch` makes the test fail immediately and deterministically, confirming the gate did not neuter what it asserts.
- Probed whether the resumed publish could still be silently LWW-ignored (losing sticky-path coverage without failing): 0/500 under load, so not a live concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
