### PR TITLE
fix(server): keep signup report windows stable across retries

### DIFF
--- a/server/lib/tuist/accounts.ex
+++ b/server/lib/tuist/accounts.ex
@@ -94,12 +94,24 @@ defmodule Tuist.Accounts do
     to: AgentAuth,
     as: :get_claim_view
 
-  def new_organizations_in_last_hour do
-    Repo.all(from(o in Organization, where: o.created_at > ago(1, "hour"), preload: [:account]))
+  def new_organizations_in_period(start_at, end_at) do
+    Repo.all(
+      from(o in Organization,
+        where: o.created_at >= ^start_at and o.created_at < ^end_at,
+        order_by: [asc: o.created_at, asc: o.id],
+        preload: [:account]
+      )
+    )
   end
 
-  def new_users_in_last_hour do
-    Repo.all(from(u in User, where: u.created_at > ago(1, "hour"), preload: [:account]))
+  def new_users_in_period(start_at, end_at) do
+    Repo.all(
+      from(u in User,
+        where: u.created_at >= ^start_at and u.created_at < ^end_at,
+        order_by: [asc: u.created_at, asc: u.id],
+        preload: [:account]
+      )
+    )
   end
 
   def create_customer_when_absent(%Account{} = account) do

--- a/server/lib/tuist/accounts/AGENTS.md
+++ b/server/lib/tuist/accounts/AGENTS.md
@@ -4,6 +4,7 @@ This context owns business logic and data related to accounts, users, organizati
 
 ## Responsibilities
 - Manage accounts and organizations, including billing metadata and SSO credentials.
+- Sign-up reporting queries use explicit inclusive-start/exclusive-end creation periods and deterministic ordering, so adjacent hourly reports do not overlap.
 - Issue and validate account/user tokens, device codes, and invitations.
 - Resolve organization membership and role assignments.
 - Own the WorkOS auth.md registration state machine, including service-signed identity assertions, browser claims, scheduled registration expiry, exchanged access-token records, audit events, and provider security events.

--- a/server/lib/tuist/ops/AGENTS.md
+++ b/server/lib/tuist/ops/AGENTS.md
@@ -5,6 +5,7 @@ This context owns ops reporting workers.
 ## Responsibilities
 - Schedule Slack reports for daily/hourly business metrics.
 - The hourly sign-up report posts new users and organizations to `#gtm` every day, including weekends. Slack API failures must propagate to Oban for retries.
+- Each sign-up report covers the completed UTC hour preceding the job's immutable `inserted_at`, with inclusive start and exclusive end. Never derive its window from retry time or `scheduled_at`. Slack digests show at most 20 accounts with bounded lines and an omitted count so large batches cannot exceed Slack's section-text limit.
 - Internal reports authenticate with `TUIST_SLACK_TUIST_TOKEN`, sourced by ESO from `SLACK/tuist_token` in the per-environment `tuist-k8s-<env>` 1Password vault. An `account_inactive` response requires restoring the Slack identity or replacing that credential; code retries cannot repair it. After a secret replacement, ESO must sync and the server pods must reload their environment before validating `auth.test` and channel delivery.
 - Query growth stats for users, orgs, projects, and command events.
 - Provide bounded, read-only ClickHouse queries and schema discovery for internal operations consumers.

--- a/server/lib/tuist/ops/hourly_slack_report_worker.ex
+++ b/server/lib/tuist/ops/hourly_slack_report_worker.ex
@@ -1,6 +1,7 @@
 defmodule Tuist.Ops.HourlySlackReportWorker do
   @moduledoc """
-  A worker that notifies #gtm in Slack about the new organizations and users created in the last hour.
+  Reports new organizations and users to #gtm for the UTC hour preceding job insertion.
+  Retries retain the original window, and large reports include a bounded preview.
   """
   use Oban.Worker
 
@@ -9,22 +10,28 @@ defmodule Tuist.Ops.HourlySlackReportWorker do
   alias Tuist.Accounts.User
   alias Tuist.Slack
 
+  @max_accounts 20
+  @max_line_length 120
+
   @impl Oban.Worker
-  def perform(_job) do
+  def perform(%Oban.Job{inserted_at: inserted_at}) do
+    # Oban moves scheduled_at on retry; inserted_at keeps the original reporting hour.
+    end_at = DateTime.from_unix!(div(DateTime.to_unix(inserted_at), 3600) * 3600)
+    start_at = DateTime.add(end_at, -1, :hour)
+
     organizations_and_users =
-      Accounts.new_organizations_in_last_hour() ++ Accounts.new_users_in_last_hour()
+      Accounts.new_organizations_in_period(start_at, end_at) ++ Accounts.new_users_in_period(start_at, end_at)
 
     if organizations_and_users == [] do
       :ok
     else
       bullet_list =
-        Enum.map_join(organizations_and_users, "\n", fn
-          %Organization{account: account} ->
-            "• Organization: #{account.name}"
+        organizations_and_users
+        |> Enum.take(@max_accounts)
+        |> Enum.map_join("\n", &account_line/1)
 
-          %User{account: account} = user ->
-            "• User: #{account.name} - #{user.email}"
-        end)
+      omitted_count = max(length(organizations_and_users) - @max_accounts, 0)
+      overflow = if omitted_count > 0, do: "\n… #{omitted_count} more accounts not shown.", else: ""
 
       Slack.send_message(
         [
@@ -34,13 +41,28 @@ defmodule Tuist.Ops.HourlySlackReportWorker do
               type: "plain_text",
               text: ~s"""
               The following organizations and users have been created in #{Tuist.Environment.env()}:
-              #{bullet_list}
+              #{Calendar.strftime(start_at, "%Y-%m-%d %H:%M")} – #{Calendar.strftime(end_at, "%Y-%m-%d %H:%M")} UTC
+              #{bullet_list}#{overflow}
               """
             }
           }
         ],
         channel: "#gtm"
       )
+    end
+  end
+
+  defp account_line(account) do
+    line =
+      case account do
+        %Organization{account: account} -> "• Organization: #{account.name}"
+        %User{account: account} = user -> "• User: #{account.name} - #{user.email}"
+      end
+
+    if String.length(line) > @max_line_length do
+      String.slice(line, 0, @max_line_length - 1) <> "…"
+    else
+      line
     end
   end
 end

--- a/server/test/tuist/accounts_test.exs
+++ b/server/test/tuist/accounts_test.exs
@@ -37,39 +37,40 @@ defmodule Tuist.AccountsTest do
     :ok
   end
 
-  describe "new_organizations_in_last_hour/0" do
-    test "returns organizations created less than an hour ago" do
-      # Given
-      organization = AccountsFixtures.organization_fixture()
+  describe "new_organizations_in_period/2" do
+    test "includes the start, excludes the end, and orders organizations by creation time" do
+      start_at = ~U[2026-09-10 18:00:00Z]
+      end_at = ~U[2026-09-10 19:00:00Z]
+      creator = AccountsFixtures.user_fixture()
+      later = AccountsFixtures.organization_fixture(creator: creator, created_at: DateTime.add(start_at, 30, :minute))
+      first = AccountsFixtures.organization_fixture(creator: creator, created_at: start_at)
+      AccountsFixtures.organization_fixture(creator: creator, created_at: DateTime.add(start_at, -1, :second))
+      at_end = AccountsFixtures.organization_fixture(creator: creator, created_at: end_at)
 
-      # When
-      assert Accounts.new_organizations_in_last_hour() == [organization]
+      assert Accounts.new_organizations_in_period(start_at, end_at) == [first, later]
+      assert Accounts.new_organizations_in_period(end_at, DateTime.add(end_at, 1, :hour)) == [at_end]
     end
 
-    test "doesn't return organizations created more than an hour ago" do
-      # Given
-      AccountsFixtures.organization_fixture(created_at: DateTime.add(DateTime.utc_now(), -2, :hour))
-
-      # When
-      assert Accounts.new_organizations_in_last_hour() == []
+    test "returns an empty list when no organizations were created in the period" do
+      assert Accounts.new_organizations_in_period(~U[2026-09-10 18:00:00Z], ~U[2026-09-10 19:00:00Z]) == []
     end
   end
 
-  describe "new_users_in_last_hour/0" do
-    test "returns organizations created less than an hour ago" do
-      # Given
-      user = AccountsFixtures.user_fixture()
+  describe "new_users_in_period/2" do
+    test "includes the start, excludes the end, and orders users by creation time" do
+      start_at = ~U[2026-09-10 18:00:00Z]
+      end_at = ~U[2026-09-10 19:00:00Z]
+      later = AccountsFixtures.user_fixture(created_at: DateTime.add(start_at, 30, :minute))
+      first = AccountsFixtures.user_fixture(created_at: start_at)
+      AccountsFixtures.user_fixture(created_at: DateTime.add(start_at, -1, :second))
+      at_end = AccountsFixtures.user_fixture(created_at: end_at)
 
-      # When
-      assert Accounts.new_users_in_last_hour() == [user]
+      assert Accounts.new_users_in_period(start_at, end_at) == [first, later]
+      assert Accounts.new_users_in_period(end_at, DateTime.add(end_at, 1, :hour)) == [at_end]
     end
 
-    test "doesn't return organizations created more than an hour ago" do
-      # Given
-      AccountsFixtures.user_fixture(created_at: DateTime.add(DateTime.utc_now(), -2, :hour))
-
-      # When
-      assert Accounts.new_users_in_last_hour() == []
+    test "returns an empty list when no users were created in the period" do
+      assert Accounts.new_users_in_period(~U[2026-09-10 18:00:00Z], ~U[2026-09-10 19:00:00Z]) == []
     end
   end
 

--- a/server/test/tuist/ops/hourly_slack_report_worker_test.exs
+++ b/server/test/tuist/ops/hourly_slack_report_worker_test.exs
@@ -2,23 +2,28 @@ defmodule Tuist.Ops.HourlySlackReportWorkerTest do
   use TuistTestSupport.Cases.DataCase, async: true
   use Mimic
 
+  alias Tuist.Accounts
+  alias Tuist.Accounts.Account
+  alias Tuist.Accounts.Organization
+  alias Tuist.Accounts.User
   alias Tuist.Ops.HourlySlackReportWorker
   alias Tuist.Slack
   alias TuistTestSupport.Fixtures.AccountsFixtures
 
   describe "perform/1" do
-    test "sends a message when there are new users and/or organizations" do
-      # Given
-      user = AccountsFixtures.user_fixture()
-      organization = AccountsFixtures.organization_fixture(creator: user)
+    test "reports the completed UTC hour even when cron insertion is slightly late" do
+      user = AccountsFixtures.user_fixture(created_at: ~U[2026-09-10 19:15:00Z])
+      organization = AccountsFixtures.organization_fixture(creator: user, created_at: ~U[2026-09-10 19:30:00Z])
+      AccountsFixtures.user_fixture(created_at: ~U[2026-09-10 20:00:00Z])
 
       expected_message = [
         %{
           type: "section",
           text: %{
             type: "plain_text",
-            text: ~s"""
+            text: """
             The following organizations and users have been created in test:
+            2026-09-10 19:00 – 2026-09-10 20:00 UTC
             • Organization: #{organization.account.name}
             • User: #{user.account.name} - #{user.email}
             """
@@ -28,31 +33,78 @@ defmodule Tuist.Ops.HourlySlackReportWorkerTest do
 
       expect(Slack, :send_message, fn ^expected_message, [channel: "#gtm"] -> :ok end)
 
-      # When
-      Oban.Testing.with_testing_mode(:inline, fn ->
-        {:ok, _} = %{} |> HourlySlackReportWorker.new() |> Oban.insert()
-      end)
+      assert :ok =
+               perform_job(HourlySlackReportWorker, %{}, inserted_at: ~U[2026-09-10 20:00:00.652089Z])
     end
 
-    test "doesn't send a message when there were no new users or organizations in the last hour" do
-      # Given
+    test "returns ok without sending when the original reporting hour is empty" do
+      AccountsFixtures.user_fixture(created_at: ~U[2026-09-10 20:05:00Z])
       Mimic.reject(&Slack.send_message/2)
 
-      # When
-      Oban.Testing.with_testing_mode(:inline, fn ->
-        {:ok, _} = %{} |> HourlySlackReportWorker.new() |> Oban.insert()
-      end)
+      assert :ok =
+               perform_job(HourlySlackReportWorker, %{},
+                 inserted_at: ~U[2026-09-10 19:00:00Z],
+                 scheduled_at: ~U[2026-09-10 20:15:00Z],
+                 attempt: 12
+               )
     end
 
-    test "returns delivery errors so Oban retries the report" do
-      AccountsFixtures.user_fixture()
+    test "a delayed retry retains its original accounts and does not overlap the next hour's report" do
+      earlier = AccountsFixtures.user_fixture(created_at: ~U[2026-09-10 18:30:00Z])
+      newer = AccountsFixtures.user_fixture(created_at: ~U[2026-09-10 20:05:00Z])
 
-      expect(Slack, :send_message, fn _, [channel: "#gtm"] ->
-        {:error, "Slack API error: account_inactive"}
+      expect(Slack, :send_message, fn [%{text: %{text: text}}], [channel: "#gtm"] ->
+        assert text =~ earlier.email
+        refute text =~ newer.email
+        {:error, "Slack API error: invalid_blocks"}
       end)
 
-      assert {:error, "Slack API error: account_inactive"} =
-               perform_job(HourlySlackReportWorker, %{})
+      assert {:error, "Slack API error: invalid_blocks"} =
+               perform_job(HourlySlackReportWorker, %{}, inserted_at: ~U[2026-09-10 19:00:00.064802Z])
+
+      expect(Slack, :send_message, fn [%{text: %{text: text}}], [channel: "#gtm"] ->
+        assert text =~ "2026-09-10 18:00 – 2026-09-10 19:00 UTC"
+        assert text =~ earlier.email
+        refute text =~ newer.email
+        :ok
+      end)
+
+      assert :ok =
+               perform_job(HourlySlackReportWorker, %{},
+                 inserted_at: ~U[2026-09-10 19:00:00.064802Z],
+                 scheduled_at: ~U[2026-09-10 20:15:45.380297Z],
+                 attempted_at: ~U[2026-09-10 20:15:46Z],
+                 attempt: 12
+               )
+
+      expect(Slack, :send_message, fn [%{text: %{text: text}}], [channel: "#gtm"] ->
+        assert text =~ newer.email
+        refute text =~ earlier.email
+        :ok
+      end)
+
+      assert :ok = perform_job(HourlySlackReportWorker, %{}, inserted_at: ~U[2026-09-10 21:00:00.659457Z])
+    end
+
+    test "bounds large reports and long account lines below Slack's section limit" do
+      organizations = List.duplicate(%Organization{account: %Account{name: String.duplicate("o", 300)}}, 10)
+
+      users =
+        List.duplicate(%User{account: %Account{name: String.duplicate("u", 300)}, email: "signup@example.com"}, 10_000)
+
+      stub(Accounts, :new_organizations_in_period, fn _, _ -> organizations end)
+      stub(Accounts, :new_users_in_period, fn _, _ -> users end)
+
+      expect(Slack, :send_message, fn [%{text: %{text: text}}], [channel: "#gtm"] ->
+        assert String.length(text) <= 3000
+        assert length(Regex.scan(~r/^• /m, text)) == 20
+        assert text =~ "9990 more accounts not shown."
+        assert text =~ "• Organization: "
+        assert text =~ "• User: "
+        :ok
+      end)
+
+      assert :ok = perform_job(HourlySlackReportWorker, %{}, inserted_at: ~U[2026-09-10 20:00:00Z])
     end
   end
 end


### PR DESCRIPTION
## Problem and production evidence

After restoring the Tuist EngOps credential and enabling delivery to `#gtm` in #13116, hourly signup reports started arriving, but the same accounts appeared at 22:15, 22:19, and 22:26 Europe/Berlin on September 10. One appeared again in the normal 23:00 report. These were separate hourly jobs completing late, rather than a single successful job being scheduled four times.

Read-only production Oban queries matched the reported messages to these jobs (all table timestamps are UTC on 2026-09-10):

| Job | Original insertion | Successful completion | Successful attempt | Earlier errors |
| --- | --- | --- | --- | --- |
| 117364994 | 19:00:00.064802 | 20:15:46.771028 | 12 | 11 `invalid_blocks` failures |
| 117430384 | 20:00:00.652089 | 20:19:58.661207 | 10 | 9 `invalid_blocks` failures |
| 117299798 | 18:00:00.015824 | 20:26:10.457435 | 13 | 12 `invalid_blocks` failures |
| 117473625 | 21:00:00.659457 | 21:00:01.003204 | 1 | None |

The worker queried accounts created during the last hour **at execution time**. As those older jobs retried, their reporting windows moved forward and overlapped each other and the next scheduled report. They eventually succeeded with a much smaller, newer set of accounts, explaining both the repeats and the loss of the original reports' contents.

There was also a concrete payload-size problem. Production contained 1,012 users created during 17:00–18:00 UTC, 7,021 during 18:00–19:00, and 1,802 during 19:00–20:00. The worker placed every account in one section. Even the email text alone for those hours exceeded Slack's [3,000-character section limit](https://docs.slack.dev/reference/block-kit/blocks/section-block/), consistent with the recorded `invalid_blocks` failures. The source of this signup volume has not been investigated; this PR handles the reporting behavior regardless of its source.

## Changes and reasoning

Each job now reports the completed UTC hour preceding its immutable `inserted_at`, rounded down to the hour. For example, a job inserted at 20:00:00.652089 always queries `[19:00, 20:00)`, even when it retries after 21:00. `scheduled_at` is unsuitable because Oban changes it during retries. Using the existing insertion timestamp also works for already-persisted jobs without changing their arguments or migrating data.

The account queries accept explicit start/end timestamps, include the start, exclude the end, and sort by creation time then ID. Adjacent hours therefore do not overlap, accounts exactly on a boundary belong to the next report, and a bounded preview has a stable order. Organizations remain ahead of users in the digest.

The Slack message includes its UTC reporting window and shows at most 20 accounts, each line capped at 120 characters. When more accounts exist, the message states how many were omitted. This keeps the section below the documented limit, including its header and reporting window. Normal small reports retain their account details; large reports deliberately show a preview instead of repeatedly failing delivery. Long names or email addresses may be truncated.

A single bounded message was chosen over splitting a report into many messages because partial success followed by a retry would otherwise resend earlier chunks without additional delivery bookkeeping. Disabling retries would hide genuine delivery failures and lose reports. This change preserves Slack error propagation and fixes the moving query window instead. The context instructions document these invariants.

## Validation

Ran the following against isolated local test databases, with **72 tests passing, 328 unrelated account tests excluded**:

```sh
mix test test/tuist/ops/hourly_slack_report_worker_test.exs \
  test/tuist/accounts_test.exs:40 \
  test/tuist/accounts_test.exs:59 \
  test/tuist/slack_test.exs \
  test/tuist/oban/runtime_config_test.exs
```

The worker regression covers an `invalid_blocks` failure followed by a delayed retry whose `scheduled_at` and attempt number have changed, verifying that it still reports only its original hour. It also covers cron insertion jitter, an empty original hour despite newer accounts, and a 10,010-account input with long names producing one section below 3,000 characters, 20 visible entries, and the correct omitted count. Database-backed query tests cover both types of account at the inclusive start and exclusive end, adjacent periods, deterministic creation-time ordering, and empty results. Existing Slack and scheduling tests continue to pass.

`mix format --check-formatted` passed for all four changed Elixir files, `git diff --check` passed, and `mix credo diff --from-git-ref HEAD --strict` reported no added issues across 2,093 source files.

The test compilation emitted existing `Tuist.Locale` warnings about the English-only test locale configuration. No Slack messages were sent for validation, and production access for this follow-up was read-only.

## Rollout and limitations

Deploy through the normal server release flow after merge. No credential, cron, schema, or data migration changes are required. Existing pending jobs retain their original hour when they next execute the new worker. Completed reports are not replayed, historical gaps are not backfilled, and this change does not remove messages already posted.

During a rolling deployment, jobs still running the previous release can retain the old behavior. After rollout, check that consecutive messages show distinct hourly windows and that delayed jobs show their original windows. Large digests should complete with an omitted count instead of `invalid_blocks`.

This addresses overlap between distinct hourly jobs; it does not provide exactly-once delivery after an ambiguous network response or prevent independently inserted duplicate jobs for the same hour. Account rows are still queried on each attempt, and the complete hour's records are loaded before building the preview. A persisted delivery ledger or paginated queries would be separate changes if those guarantees or scale limits become necessary. Rolling back requires only reverting the code, but restores the moving-window and oversized-payload behavior.
