### PR TITLE
fix(server): stop command_events.legacy_id being generated per server

### DIFF
--- a/server/priv/ingest_repo/migrations/20260910210000_remove_command_events_legacy_id_default.exs
+++ b/server/priv/ingest_repo/migrations/20260910210000_remove_command_events_legacy_id_default.exs
@@ -1,0 +1,60 @@
+defmodule Tuist.IngestRepo.Migrations.RemoveCommandEventsLegacyIdDefault do
+  use Ecto.Migration
+
+  alias Tuist.IngestRepo
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  # `legacy_id` was created with a server-generated default, first
+  # `abs(rand64())` and then `generateSerialID('command_events_legacy_id')`
+  # where a Keeper is available. Both are filled by whichever server executes
+  # the insert, so two servers taking the same write produce two different
+  # values for the same row.
+  #
+  # That is visible now: the canary parity check reports `command_events` with
+  # identical rows, timestamps and every other column sum on both sides, and
+  # `sum_legacy_id` 28094 against 838. The gap is not drift. Cloud's counter
+  # has been running since 2025; the in-cluster server's started at zero when
+  # its database was created.
+  #
+  # It matters at the cutover rather than now. Once the in-cluster server is
+  # the system of record, its counter is both unrelated to the old one and far
+  # behind it, so it would re-issue values that historical rows already hold.
+  # A collision, not an error.
+  #
+  # Removing the default makes the column deterministic: no writer sets it, so
+  # both servers store the type's zero. Rows written before this keep the value
+  # they already have, which the backfill copied faithfully.
+  #
+  # `REMOVE DEFAULT` rather than restating the type, because it is metadata
+  # only. Restating the type risks changing it, and `command_events` carries a
+  # projection naming this column plus materialized views built with
+  # `SELECT *`, so anything that rewrites parts is expensive and hard to undo.
+  # Dropping the column outright is that kind of change and is deliberately not
+  # what this does; nothing in this repository reads `legacy_id`, so it can go
+  # later, on its own, once external consumers are ruled out.
+  def up do
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    # Metadata-only: it neither rewrites parts nor touches the column's type.
+    IngestRepo.query!("ALTER TABLE command_events MODIFY COLUMN legacy_id REMOVE DEFAULT", [],
+      timeout: :infinity
+    )
+  end
+
+  def down do
+    default =
+      if Tuist.ClickHouseCapabilities.use_serial_ids?(repo()) do
+        "generateSerialID('command_events_legacy_id')"
+      else
+        "abs(rand64())"
+      end
+
+    # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+    IngestRepo.query!(
+      "ALTER TABLE command_events MODIFY COLUMN legacy_id DEFAULT #{default}",
+      [],
+      timeout: :infinity
+    )
+  end
+end


### PR DESCRIPTION
## The finding

After the tailnet route landed, canary's parity dropped from 9 differing tables to **1**. The one left is `command_events`, and it is a different shape from everything else we have chased:

| field | source | destination |
|---|---|---|
| rows | 8 | 8 |
| min_time / max_time | identical | identical |
| `sum_duration` | 19283 | 19283 |
| `sum_project_id` | 616984 | 616984 |
| **`sum_legacy_id`** | **28094** | **838** |

The same rows, every other column agreeing, and one column that does not.

## Why

`legacy_id` is filled by a **server-side default**: `abs(rand64())` originally, then `generateSerialID('command_events_legacy_id')` where a Keeper is available. Both are evaluated by whichever server runs the insert, so a mirrored write produces a different value on each side.

This cannot converge, and **re-running the backfill will not repair it**. The copy carries the source's value; the mirror lets each server mint its own.

## Why it matters at step 7 rather than now

Cloud's counter has been incrementing since 2025 and is in the tens of thousands. The in-cluster server's `generateSerialID` counter started at zero when its database was created in September, which is the 28094-versus-838 gap.

Making the in-cluster server the system of record would hand it a counter far below the values historical rows already carry, so it would begin **re-issuing identifiers that already exist** on rows copied from Cloud. A silent collision, not an error.

There is a second-order version of the same problem: the migration that seeds the sequence (`20250708112228`) sets it from `max(legacy_id)` and ran against Cloud long ago. Nothing has ever seeded the in-cluster server's counter.

## The change

`ALTER TABLE command_events MODIFY COLUMN legacy_id REMOVE DEFAULT`.

No writer sets the column, so both servers now store the type's zero and the two agree. Rows written before this keep the values the backfill copied faithfully.

`REMOVE DEFAULT` rather than restating the type, because it is **metadata only**: it neither rewrites parts nor risks changing the type. That matters here because `command_events` carries `projection_by_project_name_hit_rate`, whose SELECT list names this column, plus materialized views built with `SELECT *`. Anything that rewrites parts on this table is expensive and hard to undo, which is the same trap already recorded for `xcode_targets`.

## Why not just drop the column

Nothing in this repository reads `legacy_id`. Not `lib/`, not templates, not the CLI, not the OpenAPI schema, not infra or dashboards. The only remaining references are the migrations that define it and one 2025 migration that used it to join old integer ids onto UUIDs during the Postgres-to-ClickHouse move, which is finished work. I positive-controlled that search, since an empty grep is not evidence on its own.

So it probably can go. But dropping it means altering the projection too, which rewrites every part of one of the largest tables, and doing that mid-migration with the mirror running is the worst possible timing. External consumers, an Atlas query or a Grafana panel or a saved customer query, also cannot be ruled out from inside this repository.

That is a separate change on its own schedule. This one only removes the divergence.

## Impact

`legacy_id` is not in the sort key (`ORDER BY (project_id, name, ran_at)`), so writing the type default changes nothing about layout or part structure.

New rows get `0` on both servers instead of two unrelated numbers. If anything outside this repository still reads `legacy_id` for rows written after this deploys, it would see zeros, which is the risk worth weighing before merge and the reason I did not go further and drop the column.

## Validation

`mix compile`, `mix format --check-formatted`, `mix credo` and `mix excellent_migrations.check_safety` all clean. The safety check's remaining warnings are pre-existing in other files.

The real check is canary's next parity run after this deploys: `command_events` should leave the differing set, taking it to 0 of 59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
