### PR TITLE
feat(infra): add a third OVH box to the us-east Kura fleet

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -988,7 +988,11 @@ ovhFleets:
       item: OVH_FLEET_SSH
   us-east:
     enabled: true
-    replicas: 2
+    # Three boxes since 2026-09-11. At two the region reserved 1292 GiB against
+    # an admission line of 1303 (85% of allocatable), so Admission refused every
+    # storage claim growth here — and a claim is account-scoped, so that refusal
+    # also blocked the regions the same accounts run in that did have room.
+    replicas: 3
     endpoint: ovh-us
     nodePool: kura-us-east
     machine:


### PR DESCRIPTION
## What changed

`ovhFleets.us-east.replicas` goes from 2 to 3 in the production values, adding a third OVHcloud Advance-1 box to the `kura-us-east` node pool.

## Why

us-east has been refusing every Kura storage claim growth since at least 09-10, silently.

`Admission.admit_replacements?` compares the region's desired reservation against `Capacity.pressure_line_gib`, which is 85% of the summed allocatable ephemeral-storage of the pool's Ready nodes. With two boxes:

| quantity | value |
|---|---|
| allocatable across the pool | 1534 GiB |
| admission line at 85% | 1303 GiB |
| reserved by 48 active instances | 1292 GiB |
| headroom | 11 GiB |

Eleven GiB is five per replica, so any claim growth larger than that is refused. Two accounts have had open claim proposals stuck for this reason, one since 09-10 16:30. The apply rolls back inside `repin_storage_claims`, and `ClaimSizingWorker` calls the apply inside an `Enum.each`, so the error is discarded and the sweep retries every ten minutes with nothing recorded anywhere. Both accounts are shedding cache at between two and six hours against a three day retention floor.

The refusal is not contained to us-east. A claim is account-scoped, so applying one repins every instance the account runs and admits per region, halting on the first refusal. One of the blocked accounts has its worst rings in eu-west and us-central, which have 424 and 570 GiB of headroom respectively, and both are blocked by a region that is only along for the ride.

A third box takes allocatable to roughly 2323 GiB and the line to about 1974, so headroom goes from 11 GiB to roughly 682. That clears both stuck proposals with room left.

The reservation figures were confirmed from two independent sources that agree to the GiB: the sum over `kura_servers` excluding volumeless statuses, and the cluster's own `kube_pod_container_resource_requests{resource="ephemeral_storage"}`.

## Before merging

The controller does not order hardware. `internal/ovh/client.go` adopts a pre-ordered free box, scoped by datacenter, offer and the `adoptDisplayNamePrefix` marker. The box is ordered and delivered (`vin1`, `ADVANCE-1 | AMD EPYC 4245P`, service 10274616), but **its display name must be set to `tuist-kura-ovh-production-us-east` before this merges**. Without the marker the fleet cannot see it, the MachineDeployment sits at 2 of 3, and per the note on the `eu-east` entry in this same file that wedges `helm --wait` for every production deploy, not just this region.

Even with the marker set, the deploy carrying this change waits on the new Machine becoming Ready, because `--rollback-on-failure` puts Helm 4's wait in `watcher` mode and kstatus covers custom resources. A bare-metal install is not fast. Worth merging when someone can watch it.

## What this does not fix

This buys headroom, not a fix. Of the 1292 GiB reserved in us-east, roughly 936 is held by instances storing nothing: only six of the 48 active instances hold real cache, and 21 of the 30 accounts reporting telemetry sit at 0.0 GiB and 0% occupancy on every day they report.

Neither release path can reclaim it. Shrink needs 30 rollup days and the telemetry only starts on 2026-08-27, so nothing can shrink before roughly 09-26, and the shrink clamp floors at air's 8Gi where most of those instances already sit. The accelerated idle drain is gated on `Capacity.under_pressure?`, which is `reserved > pressure_line`, while `Admission.admit?` only admits when reserved would stay at or below that same line. Reservations therefore cannot cross it through normal operation, so the 60-day window never replaces the 90-day one. A region stops admitting at precisely the point it would start reclaiming harder.

So the region will walk back to this ceiling as new free accounts land. The follow-ups are making the discarded apply error visible, and redefining pressure as a fraction below the admission line rather than above it.

## Validation

Read-only against production: node listing and allocatable per pool, the reservation sums from both Postgres and Prometheus, and the OVH API confirming the delivered box matches the fleet's `offer` and `datacenter` filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
