### PR TITLE
fix(server): mobile navigation and phone layout fixes on the marketing site

### DIFF
--- a/noora/js/Tooltip.js
+++ b/noora/js/Tooltip.js
@@ -62,6 +62,33 @@ export default {
     };
     this.tooltip = new Tooltip(this.el, this.context);
     this.tooltip.init();
+
+    // Touch screens have no hover, and zag's tooltip opens only on hover
+    // and keyboard focus, so a tap did nothing. On hover-less devices a tap
+    // on the trigger toggles it and a tap anywhere else closes it. The open
+    // state is read on pointerdown, before zag's own closeOnPointerDown
+    // handling runs, so a tap on an open tooltip closes it instead of
+    // closing and immediately reopening.
+    if (window.matchMedia && window.matchMedia("(hover: none)").matches) {
+      const trigger = () => this.el.querySelector("[data-part='trigger']");
+      this.onPointerDown = (event) => {
+        const t = trigger();
+        if (t && t.contains(event.target)) {
+          this.wasOpen = this.tooltip.api.open;
+        } else if (this.tooltip.api.open) {
+          this.tooltip.api.setOpen(false);
+        }
+      };
+      this.onClick = (event) => {
+        const t = trigger();
+        if (!t || !t.contains(event.target)) return;
+        event.preventDefault();
+        this.tooltip.api.setOpen(!this.wasOpen);
+        this.wasOpen = false;
+      };
+      document.addEventListener("pointerdown", this.onPointerDown, true);
+      this.el.addEventListener("click", this.onClick);
+    }
   },
 
   updated() {
@@ -69,6 +96,9 @@ export default {
   },
 
   beforeDestroy() {
+    if (this.onPointerDown)
+      document.removeEventListener("pointerdown", this.onPointerDown, true);
+    if (this.onClick) this.el.removeEventListener("click", this.onClick);
     this.tooltip.destroy();
   },
 };

--- a/server/assets/marketing/css/new/layouts/components/footer.css
+++ b/server/assets/marketing/css/new/layouts/components/footer.css
@@ -161,6 +161,15 @@
     gap: var(--noora-spacing-4) var(--noora-spacing-5);
     margin-top: var(--noora-spacing-12);
 
+    /* Mobile: the label sits above the buttons instead of beside them,
+       both centered. */
+    @media (max-width: 1023px) {
+      flex-direction: column;
+      align-items: center;
+      align-self: center;
+      gap: var(--noora-spacing-5);
+    }
+
     & > [data-part="ask-label"] {
       color: var(--noora-surface-label-secondary);
       font: var(--noora-font-weight-regular) var(--noora-font-body-medium);

--- a/server/assets/marketing/css/new/layouts/components/navbar.css
+++ b/server/assets/marketing/css/new/layouts/components/navbar.css
@@ -1,8 +1,18 @@
+/* LiveView's phx-update="ignore" boundary (see the navbar template); it
+   must not generate a box, so the header keeps the page as its sticky
+   containing block and flex parent. */
+#marketing-navbar-root {
+  display: contents;
+}
+
 #marketing-navbar {
   /* Cursor position for the bottom-hairline glow; the home page's
      PlatformBackground hook writes real values inline. */
   --hx: -9999px;
   --hy: -9999px;
+  /* Bar height, measured inline by the MobileMenu hook when the menu opens;
+     the open panel hangs from it. */
+  --marketing-navbar-height: 0px;
   display: flex;
   position: sticky;
   top: 0;
@@ -17,8 +27,15 @@
   background: var(--noora-surface-background-primary);
 
   /* Cursor-proximity recolor of the bottom hairline — fed --hx/--hy by the
-     PlatformBackground hook on the home page; inert everywhere else. */
+     PlatformBackground hook on the home page; inert everywhere else. Only
+     for pointers that can hover: on touch screens a tap fires a synthetic
+     mousemove, so the glow parked under the finger and never left, and the
+     masked layer cost every frame for nothing. */
   &::after {
+    @media (hover: none) {
+      display: none;
+    }
+
     position: absolute;
     -webkit-mask-image: radial-gradient(170px circle at var(--hx) var(--hy), var(--marketing-edge-glow-stops));
     mask-image: radial-gradient(170px circle at var(--hx) var(--hy), var(--marketing-edge-glow-stops));
@@ -366,53 +383,97 @@
         @media (min-width: 960px) {
           display: none;
         }
+
+        /* Hamburger <-> X: each bar spins about its own centre while
+           sliding 4 units to the icon's middle. Same 0.2s ease as the
+           desktop chevrons. Lengths on SVG elements are user units. */
+        & > svg > path {
+          transform-box: fill-box;
+          transform-origin: center;
+          transition: transform 0.2s ease;
+        }
+
+        &[data-state="open"] > svg > [data-part="bar-top"] {
+          transform: translateY(4px) rotate(45deg);
+        }
+
+        &[data-state="open"] > svg > [data-part="bar-bottom"] {
+          transform: translateY(-4px) rotate(-45deg);
+        }
       }
     }
   }
 
+  /* The mobile menu panel. The header stays the sticky bar it always is, in
+     normal flow, and only this panel overlays the page, hung from the bar's
+     bottom edge and sized to the rest of the viewport. Turning the whole
+     header into a fixed full-screen box (the previous approach) pulled the
+     bar out of the flow, which relaid out and repainted the entire page
+     beneath on every open and close, and stretched the bar's masked ::after
+     glow across the full screen — the stall before the menu appeared.
+
+     Closed, the panel stays in the tree but hidden (visibility + opacity +
+     a small lift), so closing can play the same 0.18s fade-and-slide as the
+     desktop dropdowns; both are compositor properties, and visibility flips
+     only after the fade so the panel neither blocks taps nor pops. */
   & > [data-part="mobile-menus"] {
-    display: none;
+    display: flex;
+    position: fixed;
+    /* The MobileMenu hook measures the bar into --marketing-navbar-height
+       on open, so the panel starts right under it and fills the rest of
+       the viewport. dvh follows the mobile browser toolbar, where 100vh
+       would leave the last rows unreachable while the toolbar is up. (An
+       absolute panel with height: calc(100dvh - 100%) was the first
+       attempt; iOS resolved it to the content height, exposing the page
+       below the menu.) */
+    top: var(--marketing-navbar-height);
+    right: 0;
+    left: 0;
+    flex-direction: column;
+    align-items: stretch;
+    /* spacing-8 (24px) between top-level rows. */
+    gap: var(--noora-spacing-8);
+    transform: translateY(-6px);
+    visibility: hidden;
+    opacity: 0;
+    z-index: var(--noora-z-index-10);
+    transition:
+      opacity 0.18s ease,
+      transform 0.18s var(--ease-out-cubic),
+      visibility 0s linear 0.18s;
+    box-sizing: border-box;
+    background: var(--noora-surface-background-primary);
+    padding: var(--noora-spacing-7) var(--noora-spacing-4);
+    height: calc(100vh - var(--marketing-navbar-height));
+    height: calc(100dvh - var(--marketing-navbar-height));
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    pointer-events: none;
+
+    @media (min-width: 960px) {
+      display: none;
+    }
   }
 
   &[data-mobile-menu-open="true"] {
-    display: flex;
-    position: fixed;
-    flex-direction: column;
-    align-items: stretch;
-    z-index: var(--noora-z-index-10);
-    margin-top: 0;
-    margin-right: 0;
-    margin-bottom: 0;
-    margin-left: 0;
-    inset: 0;
-    border-radius: 0;
-    background: var(--noora-surface-background-primary);
-    max-width: none;
-    height: 100vh;
-    overflow-y: auto;
-
-    /* Keep the bar pinned while the opened menu scrolls beneath it. */
     & > [data-part="bar"] {
-      position: sticky;
-      top: 0;
-      z-index: var(--noora-z-index-2);
       box-shadow: none;
-      border-bottom: 1px solid var(--marketing-stroke-default);
-      background: var(--noora-surface-background-primary);
     }
 
     & > [data-part="mobile-menus"] {
-      display: flex;
-      flex-direction: column;
-      align-items: stretch;
-      /* spacing-7 rhythm between top-level rows. */
-      gap: var(--noora-spacing-7);
-      padding: var(--noora-spacing-7) var(--noora-spacing-4);
+      transform: none;
+      visibility: visible;
+      opacity: 1;
+      transition:
+        opacity 0.2s ease,
+        transform 0.2s var(--ease-out-cubic),
+        visibility 0s;
+      pointer-events: auto;
 
       /* Accordion list items. */
       & [data-part="dropdown"] > [data-part="item"] {
         color: var(--noora-surface-label-primary);
-        font: var(--noora-font-weight-regular) var(--noora-font-heading-small);
+        font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
         text-decoration: none;
       }
 
@@ -420,7 +481,7 @@
          section-heading treatment. */
       & > [data-part="item"] {
         color: var(--noora-surface-label-secondary);
-        font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
+        font: var(--noora-font-weight-regular) var(--noora-font-heading-large);
         text-decoration: none;
       }
 
@@ -449,7 +510,7 @@
 
           & > [data-part="title"] {
             color: var(--noora-surface-label-secondary);
-            font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
+            font: var(--noora-font-weight-regular) var(--noora-font-heading-large);
           }
 
           /* Chevron dressed as a neutral button, like the burger icon.
@@ -503,7 +564,7 @@
 
         & > [data-part="title"] {
           color: var(--noora-surface-label-secondary);
-          font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
+          font: var(--noora-font-weight-regular) var(--noora-font-heading-large);
         }
       }
     }
@@ -678,15 +739,6 @@
   }
 }
 
-/* Mobile menu container animation */
-#marketing-navbar {
-  &[data-mobile-menu-open="true"] {
-    & > [data-part="mobile-menus"] {
-      animation: mobileMenuContentFadeIn 0.4s cubic-bezier(0.4, 0, 0.2, 1) 0.1s backwards;
-    }
-  }
-}
-
 /* Mobile menu dropdown animations */
 #marketing-navbar > [data-part="mobile-menus"] {
   & > [data-part="menu"] {
@@ -802,17 +854,6 @@
     opacity: 0;
   }
   to {
-    opacity: 1;
-  }
-}
-
-@keyframes mobileMenuContentFadeIn {
-  from {
-    transform: translateY(-10px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
     opacity: 1;
   }
 }
@@ -1322,6 +1363,14 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  #marketing-navbar [data-part="mobile-menu-button"] > svg > path {
+    transition: none;
+  }
+
+  #marketing-navbar > [data-part="mobile-menus"] {
+    transition: none;
+  }
+
   #marketing-navbar > [data-part="viewport"] {
     transition: none;
 

--- a/server/assets/marketing/css/new/routes/cache.css
+++ b/server/assets/marketing/css/new/routes/cache.css
@@ -757,7 +757,7 @@
 
           & > [data-part="title"] {
             color: var(--noora-surface-label-primary);
-            font: var(--noora-font-weight-regular) var(--noora-font-heading-small);
+            font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
           }
 
           & > [data-part="description"] {

--- a/server/assets/marketing/css/new/routes/changelog.css
+++ b/server/assets/marketing/css/new/routes/changelog.css
@@ -305,7 +305,7 @@
 
       & > [data-part="title"] {
         color: var(--noora-surface-label-primary);
-        font: var(--noora-font-weight-medium) var(--noora-font-heading-xlarge);
+        font: var(--noora-font-weight-regular) var(--noora-font-heading-xlarge);
         /* The site-wide balance on headings halves any two-line title at its
            midpoint; here the first line should fill the column instead. */
         text-wrap: pretty;

--- a/server/assets/marketing/css/new/routes/compute.css
+++ b/server/assets/marketing/css/new/routes/compute.css
@@ -1161,7 +1161,7 @@
 
           & > [data-part="title"] {
             color: var(--noora-surface-label-primary);
-            font: var(--noora-font-weight-regular) var(--noora-font-heading-small);
+            font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
           }
 
           & > [data-part="description"] {
@@ -1468,7 +1468,7 @@
           & > [data-part="title"] {
             margin: 0;
             color: var(--noora-surface-label-primary);
-            font: var(--noora-font-weight-regular) var(--noora-font-heading-small);
+            font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
           }
 
           & > [data-part="description"] {

--- a/server/assets/marketing/css/new/routes/home.css
+++ b/server/assets/marketing/css/new/routes/home.css
@@ -1,6 +1,16 @@
 /* Spinner for the compute task feed's "processing" rows. */
 /* Testimonials marquee: the track holds two identical groups, so scrolling
    half its width loops seamlessly. */
+@keyframes marketing-logos-marquee {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(-50%);
+  }
+}
+
 @keyframes marketing-testimonials-marquee {
   from {
     transform: translateX(0);
@@ -280,12 +290,45 @@
         }
       }
 
+      /* Phone marquee, built by LogoTransition: two identical sets of the
+         logos in one track that a CSS animation slides by exactly one set
+         (-50%), so the loop is seamless. Each set carries the inter-logo gap
+         as trailing padding so both halves measure the same. The hook sets
+         --marquee-duration from the measured width to keep the speed
+         constant; the animation itself runs on the compositor, unlike the
+         previous per-frame transform from a rAF loop, which stuttered
+         whenever the page's other animations held the main thread. */
       & > [data-part="track"] {
         display: flex;
         flex-direction: row;
         align-items: center;
-        gap: var(--noora-spacing-9);
+        /* Overridden inline by the hook from the measured track width. */
+        --marquee-duration: 40s;
+        animation: marketing-logos-marquee var(--marquee-duration) linear infinite;
         will-change: transform;
+        width: max-content;
+
+        @media (prefers-reduced-motion: reduce) {
+          animation: none;
+        }
+
+        & > [data-part="logo-set"] {
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          gap: var(--noora-spacing-9);
+          padding-right: var(--noora-spacing-9);
+
+          /* The shared org-logo rule sizes the svg at 100% of a box whose
+             own width comes from the svg — a cycle Safari resolves to a
+             narrower box than the artwork, so neighbouring logos overlapped
+             in the marquee. Size the svg from its width/height attributes
+             (206x64 for every org logo) so the box is definite. */
+          & > [data-part="org-logo"] > svg {
+            width: auto;
+            height: 64px;
+          }
+        }
       }
 
       & > [data-part="logo-group"] {
@@ -421,9 +464,13 @@
         --chart-with-stroke: light-dark(var(--noora-purple-500), var(--noora-purple-400));
         display: flex;
         flex-direction: column;
+        /* Breathing room between the stacked panels; side by side they
+           share the divider instead. */
+        gap: var(--noora-spacing-7);
 
         @media (min-width: 1024px) {
           flex-direction: row;
+          gap: 0;
           height: 322px;
         }
 
@@ -452,6 +499,15 @@
             border-bottom: 1px solid var(--marketing-stroke-default);
             height: 36px;
 
+            /* Phones: "Build time: 02m 00s" plus its badge is wider than
+               half the panel and, being nowrap, pushed the page past the
+               viewport (the sideways drag). Stack the two stats instead. */
+            @media (max-width: 599px) {
+              grid-template-columns: 1fr;
+              grid-auto-rows: 36px;
+              height: auto;
+            }
+
             & > [data-part="stat"] {
               display: flex;
               justify-content: center;
@@ -464,6 +520,11 @@
 
               &:not(:last-child) {
                 border-right: 1px solid var(--marketing-stroke-default);
+
+                @media (max-width: 599px) {
+                  border-right: none;
+                  border-bottom: 1px solid var(--marketing-stroke-default);
+                }
               }
 
               & > strong {
@@ -1752,7 +1813,8 @@
 
         /* 4×4 hairline grid over the square: only the three interior lines
            per axis, so the box borders aren't doubled at the edges. */
-        background-image: linear-gradient(
+        background-image:
+          linear-gradient(
             90deg,
             transparent calc(25% - 1px),
             var(--marketing-stroke-default) calc(25% - 1px) 25%,
@@ -1881,11 +1943,8 @@
         border-radius: var(--noora-radius-6);
         /* The tint/gloss layers are translucent and read correctly on both
            bases; only the base flips (pale lavender / translucent purple). */
-        background: radial-gradient(
-            62.73% 96.07% at 43.01% 61.96%,
-            rgba(111, 44, 255, 0.14) 0%,
-            rgba(244, 66, 119, 0.04) 100%
-          ),
+        background:
+          radial-gradient(62.73% 96.07% at 43.01% 61.96%, rgba(111, 44, 255, 0.14) 0%, rgba(244, 66, 119, 0.04) 100%),
           linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0) 100%),
           var(--marketing-tint-purple);
         padding: var(--noora-spacing-2) var(--noora-spacing-4);
@@ -2262,11 +2321,8 @@
           0 0.75px 0.75px 0 rgba(255, 255, 255, 0.04) inset,
           0 0.25px 0.5px 0 rgba(255, 255, 255, 0.06) inset;
         border-radius: var(--noora-radius-6);
-        background: radial-gradient(
-            62.73% 96.07% at 43.01% 61.96%,
-            rgba(111, 44, 255, 0.14) 0%,
-            rgba(244, 66, 119, 0.04) 100%
-          ),
+        background:
+          radial-gradient(62.73% 96.07% at 43.01% 61.96%, rgba(111, 44, 255, 0.14) 0%, rgba(244, 66, 119, 0.04) 100%),
           linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0) 100%), var(--noora-purple-50);
         padding: var(--noora-spacing-2) var(--noora-spacing-4);
       }

--- a/server/assets/marketing/css/new/routes/home.css
+++ b/server/assets/marketing/css/new/routes/home.css
@@ -1813,8 +1813,7 @@
 
         /* 4×4 hairline grid over the square: only the three interior lines
            per axis, so the box borders aren't doubled at the edges. */
-        background-image:
-          linear-gradient(
+        background-image: linear-gradient(
             90deg,
             transparent calc(25% - 1px),
             var(--marketing-stroke-default) calc(25% - 1px) 25%,
@@ -1943,8 +1942,11 @@
         border-radius: var(--noora-radius-6);
         /* The tint/gloss layers are translucent and read correctly on both
            bases; only the base flips (pale lavender / translucent purple). */
-        background:
-          radial-gradient(62.73% 96.07% at 43.01% 61.96%, rgba(111, 44, 255, 0.14) 0%, rgba(244, 66, 119, 0.04) 100%),
+        background: radial-gradient(
+            62.73% 96.07% at 43.01% 61.96%,
+            rgba(111, 44, 255, 0.14) 0%,
+            rgba(244, 66, 119, 0.04) 100%
+          ),
           linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0) 100%),
           var(--marketing-tint-purple);
         padding: var(--noora-spacing-2) var(--noora-spacing-4);
@@ -2321,8 +2323,11 @@
           0 0.75px 0.75px 0 rgba(255, 255, 255, 0.04) inset,
           0 0.25px 0.5px 0 rgba(255, 255, 255, 0.06) inset;
         border-radius: var(--noora-radius-6);
-        background:
-          radial-gradient(62.73% 96.07% at 43.01% 61.96%, rgba(111, 44, 255, 0.14) 0%, rgba(244, 66, 119, 0.04) 100%),
+        background: radial-gradient(
+            62.73% 96.07% at 43.01% 61.96%,
+            rgba(111, 44, 255, 0.14) 0%,
+            rgba(244, 66, 119, 0.04) 100%
+          ),
           linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0) 100%), var(--noora-purple-50);
         padding: var(--noora-spacing-2) var(--noora-spacing-4);
       }

--- a/server/assets/marketing/css/new/routes/previews.css
+++ b/server/assets/marketing/css/new/routes/previews.css
@@ -697,7 +697,7 @@
 
           & > [data-part="title"] {
             color: var(--noora-surface-label-primary);
-            font: var(--noora-font-weight-regular) var(--noora-font-heading-small);
+            font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
           }
 
           & > [data-part="description"] {

--- a/server/assets/marketing/css/new/routes/tests.css
+++ b/server/assets/marketing/css/new/routes/tests.css
@@ -842,7 +842,7 @@
 
           & > [data-part="title"] {
             color: var(--noora-surface-label-primary);
-            font: var(--noora-font-weight-regular) var(--noora-font-heading-small);
+            font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
           }
 
           & > [data-part="description"] {

--- a/server/assets/marketing/js/hooks/logo-transition.js
+++ b/server/assets/marketing/js/hooks/logo-transition.js
@@ -1,3 +1,7 @@
+// Phone marquee speed in CSS px per second (the old rAF loop moved 0.5px
+// per frame, i.e. 30px/s at 60fps).
+const MARQUEE_SPEED = 30;
+
 export const LogoTransition = {
   mounted() {
     // A bfcache restore re-mounts hooks without ever calling destroyed() on
@@ -13,7 +17,6 @@ export const LogoTransition = {
     this.isAnimating = false;
     this.intervalId = null;
     this.cleanupTimeout = null;
-    this.animationFrame = null;
     this.originalHTML = this.el.innerHTML;
     this.currentMode = null;
 
@@ -129,38 +132,36 @@ export const LogoTransition = {
       }
     });
 
+    // Two identical sets in one track; the CSS animation (home.css) slides
+    // the track by one set, so the loop is seamless and runs on the
+    // compositor instead of a rAF loop nudging a transform every frame.
     container.innerHTML = "";
     const track = document.createElement("div");
     track.setAttribute("data-part", "track");
 
-    uniqueLogos.forEach((logo) => {
-      track.appendChild(logo.cloneNode(true));
-    });
-
-    uniqueLogos.forEach((logo) => {
-      const clone = logo.cloneNode(true);
-      clone.setAttribute("aria-hidden", "true");
-      clone.setAttribute("tabindex", "-1");
-      track.appendChild(clone);
-    });
+    const buildSet = (hidden) => {
+      const set = document.createElement("div");
+      set.setAttribute("data-part", "logo-set");
+      if (hidden) set.setAttribute("aria-hidden", "true");
+      uniqueLogos.forEach((logo) => {
+        const clone = logo.cloneNode(true);
+        if (hidden) clone.setAttribute("tabindex", "-1");
+        set.appendChild(clone);
+      });
+      return set;
+    };
+    track.appendChild(buildSet(false));
+    track.appendChild(buildSet(true));
 
     container.appendChild(track);
     container.setAttribute("data-animation-mode", "mobile");
 
-    let scrollPosition = 0;
-    const scroll = () => {
-      scrollPosition += 0.5;
-
-      const maxScroll = track.scrollWidth / 2;
-      if (scrollPosition >= maxScroll) {
-        scrollPosition = 0;
-      }
-
-      track.style.transform = `translateX(-${scrollPosition}px)`;
-      this.animationFrame = requestAnimationFrame(scroll);
-    };
-
-    this.animationFrame = requestAnimationFrame(scroll);
+    // Constant speed regardless of how many logos there are: one set's
+    // width at MARQUEE_SPEED px/s.
+    const setWidth = track.scrollWidth / 2;
+    if (setWidth > 0) {
+      track.style.setProperty("--marquee-duration", `${setWidth / MARQUEE_SPEED}s`);
+    }
   },
 
   transition() {
@@ -239,10 +240,8 @@ export const LogoTransition = {
   },
 
   cleanupMobile() {
-    if (this.animationFrame) {
-      cancelAnimationFrame(this.animationFrame);
-      this.animationFrame = null;
-    }
+    // The marquee is a CSS animation on the track; restoring the original
+    // markup (restoreOriginal) is all the teardown it needs.
   },
 
   handleResize() {

--- a/server/assets/marketing/js/hooks/mobile-menu.js
+++ b/server/assets/marketing/js/hooks/mobile-menu.js
@@ -37,7 +37,8 @@ export const MobileMenu = {
     }
 
     if (this.isOpen) {
-      document.body.style.overflow = "";
+      document.documentElement.style.overflow = "";
+      document.body.style.touchAction = "";
       this.isOpen = false;
     }
   },
@@ -49,9 +50,10 @@ export const MobileMenu = {
     const isOpen = this.isOpen || false;
     navbar.dataset.mobileMenuOpen = isOpen ? "true" : "false";
     this.el.setAttribute("aria-expanded", isOpen ? "true" : "false");
-    // Drives the NooraIconTransition morph (menu <-> close).
+    // Drives the CSS hamburger <-> X animation (navbar.css).
     this.el.dataset.state = isOpen ? "open" : "closed";
-    document.body.style.overflow = isOpen ? "hidden" : "";
+    document.documentElement.style.overflow = isOpen ? "hidden" : "";
+    document.body.style.touchAction = isOpen ? "none" : "";
   },
 
   initMenu() {
@@ -70,13 +72,64 @@ export const MobileMenu = {
       this.listeners.push({ element, event, handler });
     };
 
+    // Prefetch the menu's own pages the first time it opens, through a
+    // speculation rule inserted at runtime, so a tap lands on a page that is
+    // already fetched. Desktop gets the same from the layout's hover rule;
+    // phones have no hover, so without this every tap starts from zero.
+    // Same-origin, same-tab links only; skipped under Save-Data. Browsers
+    // without speculation rules (Safari) ignore the script.
+    const prefetchMenuLinks = () => {
+      if (this.prefetched) return;
+      this.prefetched = true;
+      if (!HTMLScriptElement.supports || !HTMLScriptElement.supports("speculationrules")) return;
+      if (navigator.connection && navigator.connection.saveData) return;
+      const urls = new Set();
+      for (const link of navbar.querySelectorAll('[data-part="mobile-menus"] a[href]')) {
+        if (link.origin !== location.origin) continue;
+        if (link.target && link.target !== "_self") continue;
+        if (link.hasAttribute("download")) continue;
+        if (link.pathname === location.pathname) continue;
+        urls.add(link.pathname + link.search);
+      }
+      if (!urls.size) return;
+      const script = document.createElement("script");
+      script.type = "speculationrules";
+      const nonce = document.querySelector("meta[name='csp-nonce']");
+      if (nonce) script.nonce = nonce.getAttribute("content");
+      script.textContent = JSON.stringify({ prefetch: [{ urls: [...urls] }] });
+      document.head.appendChild(script);
+    };
+
     const setOpenState = (state) => {
       this.isOpen = state;
+      if (state) prefetchMenuLinks();
+      // The panel is a fixed overlay that starts under the bar (navbar.css).
+      if (state) {
+        navbar.style.setProperty("--marketing-navbar-height", `${navbar.offsetHeight}px`);
+        // The panel stays in the tree while closed (so closing animates),
+        // which also keeps its scroll offset; reopen from the top.
+        const panel = navbar.querySelector('[data-part="mobile-menus"]');
+        if (panel) panel.scrollTop = 0;
+      }
       navbar.dataset.mobileMenuOpen = state ? "true" : "false";
       button.setAttribute("aria-expanded", state ? "true" : "false");
-      // Drives the NooraIconTransition morph (menu <-> close).
+      // Drives the CSS hamburger <-> X animation (navbar.css).
       button.dataset.state = state ? "open" : "closed";
-      document.body.style.overflow = state ? "hidden" : "";
+      lockScroll(state);
+    };
+
+    // Scroll lock. overflow: hidden goes on <html>, never on <body>: the
+    // stylesheet gives <html> overflow-x: clip, so a body value no longer
+    // propagates to the viewport — it would make <body> its own scroll
+    // container and the sticky navbar would scroll away with the page. iOS
+    // Safari keeps touch-scrolling the document through overflow: hidden
+    // anyway, so touch-action: none on the body stops document panning;
+    // touches inside the panel are governed by the panel itself (its own
+    // scroll container), so it still scrolls, and its overscroll-behavior
+    // keeps that from chaining out.
+    const lockScroll = (locked) => {
+      document.documentElement.style.overflow = locked ? "hidden" : "";
+      document.body.style.touchAction = locked ? "none" : "";
     };
 
     const toggleMenu = (e) => {

--- a/server/assets/marketing/marketing_new.css
+++ b/server/assets/marketing/marketing_new.css
@@ -230,6 +230,16 @@
   }
 }
 
+/* Sideways panning on phones: iOS lets touch pan into overflow that
+   overflow-x: hidden leaves scrollable (it propagates from body to the
+   viewport, which iOS ignores for touch), and the page then sticks off to
+   the side. clip removes the overflow from the scrollable area on both
+   elements and, unlike hidden, turns neither into a scroll container, so
+   the sticky navbar keeps the viewport as its scroller. */
+html {
+  overflow-x: clip;
+}
+
 body {
   display: flex;
   flex-direction: column;
@@ -241,7 +251,7 @@ body {
   margin-left: 0;
   background: var(--noora-surface-background-primary);
   padding: 0px;
-  overflow-x: hidden;
+  overflow-x: clip;
   font-family: var(--noora-font-body);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/server/lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex
+++ b/server/lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex
@@ -141,8 +141,13 @@ resources_items = [
 <%!-- phx-update="ignore": static markup whose hooks (data-static-hook)
 are mounted by mountStaticHooks (marketing.js) rather than by LiveView, so
 the menus work on LiveView pages before the socket has joined; LiveView
-leaves the subtree alone on join. --%>
-<header id="marketing-navbar" phx-update="ignore">
+leaves the subtree alone on join. The ignore sits on a wrapper in the
+marketing layout (display: contents) rather than on this header because
+LiveView still syncs an ignored element's own data-* attributes with the
+server render on every patch — join, reconnect, any update — which stripped
+the data-mobile-menu-open the MobileMenu hook sets here and closed the open
+mobile menu underneath the user. --%>
+<header id="marketing-navbar">
   <div data-part="bar">
     <div data-part="brand" id="marketing-navbar-brand" data-static-hook="LogoContextMenu">
       <.link href={TuistWeb.Marketing.MarketingHTML.localized_href("/")} data-part="tuist">
@@ -385,14 +390,33 @@ leaves the subtree alone on join. --%>
         id="mobile-menu-button"
         data-state="closed"
       >
-        <Noora.Icon.icon
+        <%!-- Hamburger <-> X drawn as the two bars of Noora's menu icon and
+        animated with CSS transforms off the button's data-state (see
+        navbar.css) rather than Noora's JS path morph: the morph rewrites
+        the path every frame from a rAF spring, and on phones that competes
+        with the menu's own open/close layout work, so it dropped frames
+        and stuttered. Transforms run on the compositor. --%>
+        <svg
           id="mobile-menu-icon"
-          name="menu"
-          active_name="close"
-          transition="morph"
-          watch="[data-part='mobile-menu-button']"
-          active_state="open"
-        />
+          class="icon icon-tabler icons-tabler-outline icon-tabler-menu"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <path
+            data-part="bar-top"
+            d="M20 7.25C20.4142 7.25 20.75 7.58579 20.75 8C20.75 8.41421 20.4142 8.75 20 8.75H4C3.58579 8.75 3.25 8.41421 3.25 8C3.25 7.58579 3.58579 7.25 4 7.25H20Z"
+            fill="currentColor"
+          />
+          <path
+            data-part="bar-bottom"
+            d="M20 15.25C20.4142 15.25 20.75 15.5858 20.75 16C20.75 16.4142 20.4142 16.75 20 16.75H4C3.58579 16.75 3.25 16.4142 3.25 16C3.25 15.5858 3.58579 15.25 4 15.25H20Z"
+            fill="currentColor"
+          />
+        </svg>
       </.neutral_button>
     </nav>
   </div>

--- a/server/lib/tuist_web/marketing/layouts/marketing.html.heex
+++ b/server/lib/tuist_web/marketing/layouts/marketing.html.heex
@@ -2,7 +2,13 @@
 sticks while its containing block is in view, so inside <main> the navbar
 would scroll away once the (tall) footer below <main> comes in. --%>
 <%= if assigns[:new_design] do %>
-  <TuistWeb.Marketing.MarketingComponents.navbar_new {assigns} />
+  <%!-- The phx-update="ignore" boundary for the static navbar lives on this
+  wrapper, not on the header: LiveView re-syncs an ignored element's own
+  data-* attributes on every patch, which would strip the open state the
+  MobileMenu hook keeps on the header. See the navbar template. --%>
+  <div id="marketing-navbar-root" phx-update="ignore">
+    <TuistWeb.Marketing.MarketingComponents.navbar_new {assigns} />
+  </div>
 <% end %>
 {render_slot(@inner_block)}
 <%= if assigns[:new_design] do %>

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -84,8 +84,8 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:250
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:459
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:86
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:293
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:598
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:298
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:622
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:924
 #: lib/tuist_web/marketing/controllers/marketing_html/blog_post.html.heex:10
 #: lib/tuist_web/marketing/live/marketing_blog_live/blog.html.heex:13
@@ -179,8 +179,8 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:180
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:394
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:47
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:469
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:565
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:493
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:589
 #: lib/tuist_web/marketing/live/marketing_changelog_entry_live.ex:53
 #: lib/tuist_web/marketing/live/marketing_changelog_entry_live/changelog_entry.html.heex:8
 #: lib/tuist_web/marketing/live/marketing_changelog_entry_live/new/changelog_entry.html.heex:6
@@ -304,7 +304,7 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/header.html.heex:96
 #: lib/tuist_web/marketing/components/marketing_layout_components/header.html.heex:204
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:311
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:376
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:381
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -318,8 +318,8 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/header.html.heex:165
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:141
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:361
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:259
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:545
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:264
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:569
 #, elixir-autogen, elixir-format
 msgid "Developers"
 msgstr ""
@@ -409,8 +409,8 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:107
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:334
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:3
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:243
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:523
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:248
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:547
 #: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:128
 #: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:290
 #: lib/tuist_web/marketing/controllers/marketing_html/new/tests.html.heex:49
@@ -657,7 +657,7 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/header.html.heex:94
 #: lib/tuist_web/marketing/components/marketing_layout_components/header.html.heex:202
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:310
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:354
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:359
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
@@ -808,8 +808,8 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:243
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:454
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:43
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:286
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:595
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:291
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:619
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Pricing"
@@ -885,8 +885,8 @@ msgstr ""
 
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:211
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:424
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:275
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:576
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:280
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:600
 #, elixir-autogen, elixir-format
 msgid "Resources"
 msgstr ""
@@ -925,7 +925,7 @@ msgid "Shared app preview with the team"
 msgstr ""
 
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:294
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:375
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:380
 #, elixir-autogen, elixir-format
 msgid "Sign up"
 msgstr ""
@@ -1319,7 +1319,7 @@ msgstr ""
 
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:182
 #: lib/tuist_web/marketing/components/marketing_layout_components/navbar.html.heex:396
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:471
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:495
 #, elixir-autogen, elixir-format
 msgid "View all"
 msgstr ""
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Tests skipped:"
 msgstr ""
 
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:617
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:641
 #, elixir-autogen, elixir-format
 msgid "Theme"
 msgstr ""
@@ -2645,17 +2645,17 @@ msgstr ""
 msgid "iOS Developer at Toss"
 msgstr ""
 
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:169
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Copy logo as SVG"
 msgstr ""
 
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:200
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Copy wordmark as SVG"
 msgstr ""
 
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:208
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:213
 #: lib/tuist_web/marketing/controllers/marketing_html/new/brand.html.heex:63
 #, elixir-autogen, elixir-format
 msgid "Download brand assets"
@@ -2667,7 +2667,7 @@ msgstr ""
 msgid "Brand"
 msgstr ""
 
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:220
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:225
 #: lib/tuist_web/marketing/controllers/marketing_controller.ex:477
 #: lib/tuist_web/marketing/controllers/marketing_html/new/brand.html.heex:54
 #, elixir-autogen, elixir-format
@@ -3471,7 +3471,7 @@ msgstr ""
 msgid "Download %{name}"
 msgstr ""
 
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:298
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:303
 #, elixir-autogen, elixir-format
 msgid "Account actions"
 msgstr ""
@@ -3481,7 +3481,7 @@ msgstr ""
 msgid "Animation: the Tuist menu bar app lists the latest previews; picking one installs it and opens it on a simulator or a connected device."
 msgstr ""
 
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:161
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:166
 #: lib/tuist_web/marketing/controllers/marketing_html/new/brand.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Brand assets"
@@ -3493,7 +3493,7 @@ msgid "Community links"
 msgstr ""
 
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:284
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:644
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:668
 #, elixir-autogen, elixir-format
 msgid "Dark theme"
 msgstr ""
@@ -3509,17 +3509,17 @@ msgid "Hint"
 msgstr ""
 
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:276
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:636
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:660
 #, elixir-autogen, elixir-format
 msgid "Light theme"
 msgstr ""
 
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:230
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:235
 #, elixir-autogen, elixir-format
 msgid "Main navigation"
 msgstr ""
 
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:515
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:539
 #, elixir-autogen, elixir-format
 msgid "Mobile navigation"
 msgstr ""
@@ -3541,7 +3541,7 @@ msgid "Search posts"
 msgstr ""
 
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:268
-#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:628
+#: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:652
 #, elixir-autogen, elixir-format
 msgid "System theme"
 msgstr ""


### PR DESCRIPTION
## What changed

Mobile navigation and phone layout fixes for the new marketing site, plus a few visual polish items that came out of the same review pass on phones.

**Mobile menu**
- The open menu is now a fixed overlay panel hung from the bar's bottom edge instead of turning the whole header into a full-screen fixed box. The header stays the sticky bar it always is, so opening and closing no longer relays out and repaints the entire page beneath, which was the stall before the menu appeared. The panel keeps its DOM while closed so closing can play the same fade-and-slide as the desktop dropdowns.
- Hamburger to X is drawn as the two bars of Noora's menu icon and animated with compositor transforms.
- Scroll lock moved to `<html>` with `touch-action: none` on the body. `overflow: hidden` on `<body>` no longer propagates to the viewport once `<html>` has `overflow-x: clip`, and iOS keeps touch-scrolling through `overflow: hidden` anyway.
- The menu's own pages are prefetched through a speculation rule the first time it opens, since phones have no hover to trigger the layout's existing hover prefetch.
- The LiveView `phx-update="ignore"` boundary for the static navbar now lives on a wrapper in the layout, not on the header: LiveView re-syncs an ignored element's own `data-*` attributes on every patch, which stripped the open state the hook keeps on the header.

**Horizontal overflow on iOS**
- `<html>` and the page root use `overflow-x: clip` instead of `hidden`. iOS lets touch pan into overflow that `hidden` leaves scrollable and the page stuck off to the side; `clip` removes the overflow without turning either element into a scroll container, so the sticky navbar keeps the viewport as its scroller.

**Logo marquee**
- The phone marquee is a CSS animation on a track of two identical logo sets, sliding by exactly one set, instead of a rAF loop nudging a transform every frame. The hook only measures the width to keep the speed constant. Safari sized the svg boxes from a width cycle and overlapped neighbours; they are now sized from their own attributes.

**Polish**
- Navbar hover glow is disabled on touch devices, where a tap parked it under the finger for good.
- Noora tooltips toggle on tap on hover-less devices.
- Footer call to action stacks and centres on phones.
- Feature card titles across cache, compute, previews and tests move to heading-medium; the changelog entry title drops to regular weight.

## Why

The mobile menu glitched, stalled on open, auto-closed on LiveView patches, and the page could be dragged sideways on iOS. Each item above traces back to one of those reports; the root causes are recorded in the code comments next to each change.

## Validation

- Verified in the browser on phone widths across the home, pricing, cache, compute and tests pages, including menu open and close, scroll lock, sideways panning and the logo marquee in Safari and Chrome.
- `mix gettext.extract` run; the template only re-points navbar string references. No `.po` files touched.
- Stylelint and Prettier pass on the touched CSS and JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
