### PR TITLE
fix(server): treat Slack webhook 4xx responses as terminal client errors and report the request body

### DIFF
--- a/server/lib/tuist/slack/client.ex
+++ b/server/lib/tuist/slack/client.ex
@@ -17,6 +17,14 @@ defmodule Tuist.Slack.Client do
   @oauth_token_url "https://slack.com/api/oauth.v2.access"
   @chat_post_message_url "https://slack.com/api/chat.postMessage"
 
+  # Slack incoming-webhook error strings that mean the destination is dead
+  # and further attempts will keep failing until the user re-authorizes the
+  # app: token revoked, workspace uninstalled the app, service or team is
+  # gone. Slack returns these as a plain-text body alongside a 400/401/403
+  # (or 404 for `no_service`, already handled by the status-only clause).
+  # See https://api.slack.com/messaging/webhooks#handling_errors.
+  @permanent_webhook_errors ~w(invalid_token no_service no_service_id no_team team_disabled action_prohibited)
+
   @doc """
   Exchanges an OAuth authorization code for an `incoming-webhook` token.
   """
@@ -114,6 +122,14 @@ defmodule Tuist.Slack.Client do
     {:error, :webhook_revoked}
   end
 
+  defp handle_webhook_response({:ok, %Req.Response{status: status, body: body}}) when status in [400, 401, 403] do
+    if permanent_webhook_error?(body) do
+      {:error, :webhook_revoked}
+    else
+      {:error, "Unexpected status code: #{status}. Body: #{inspect(body)}"}
+    end
+  end
+
   defp handle_webhook_response({:ok, %Req.Response{status: status, body: body}}) do
     {:error, "Unexpected status code: #{status}. Body: #{inspect(body)}"}
   end
@@ -121,6 +137,12 @@ defmodule Tuist.Slack.Client do
   defp handle_webhook_response({:error, reason}) do
     {:error, "Request failed: #{inspect(reason)}"}
   end
+
+  defp permanent_webhook_error?(body) when is_binary(body) do
+    String.trim(body) in @permanent_webhook_errors
+  end
+
+  defp permanent_webhook_error?(_body), do: false
 
   defp handle_post_response({:ok, %Req.Response{status: 200, body: %{"ok" => true}}}) do
     :ok

--- a/server/lib/tuist/slack/client.ex
+++ b/server/lib/tuist/slack/client.ex
@@ -53,7 +53,7 @@ defmodule Tuist.Slack.Client do
 
     webhook_url
     |> Req.post(headers: headers, body: body)
-    |> handle_webhook_response()
+    |> handle_webhook_response(body)
   end
 
   @doc """
@@ -110,7 +110,7 @@ defmodule Tuist.Slack.Client do
     {:error, "Slack OAuth request failed: #{inspect(reason)}"}
   end
 
-  defp handle_webhook_response({:ok, %Req.Response{status: status}}) when status in 200..299 do
+  defp handle_webhook_response({:ok, %Req.Response{status: status}}, _request_body) when status in 200..299 do
     :ok
   end
 
@@ -118,30 +118,31 @@ defmodule Tuist.Slack.Client do
   # the same way on retry. Split it into "the webhook is permanently dead"
   # (caller clears the destination) and "we sent something Slack rejected"
   # (caller discards the job without touching the destination, so we still
-  # see the failure once for investigation).
+  # see the failure once for investigation, along with the request body we
+  # sent so it's reproducible from the alert alone).
   #
   # 404 always maps to :webhook_revoked — a Slack hooks URL only 404s when
   # it isn't a live webhook any more (revoked, uninstalled, deleted). The
   # other 4xx cases only clear the destination when the body matches one of
   # Slack's documented permanent-error strings.
-  defp handle_webhook_response({:ok, %Req.Response{status: 404}}) do
+  defp handle_webhook_response({:ok, %Req.Response{status: 404}}, _request_body) do
     {:error, :webhook_revoked}
   end
 
-  defp handle_webhook_response({:ok, %Req.Response{status: status, body: body}}) when status in 400..499 do
+  defp handle_webhook_response({:ok, %Req.Response{status: status, body: body}}, request_body) when status in 400..499 do
     if permanent_webhook_error?(body) do
       {:error, :webhook_revoked}
     else
-      {:error, {:bad_request, status, body}}
+      {:error, {:bad_request, status, body, request_body}}
     end
   end
 
   # 5xx is Slack's side — return a transient error so Oban retries.
-  defp handle_webhook_response({:ok, %Req.Response{status: status, body: body}}) do
+  defp handle_webhook_response({:ok, %Req.Response{status: status, body: body}}, _request_body) do
     {:error, "Slack incoming-webhook responded #{status} with response body: #{inspect(body)}"}
   end
 
-  defp handle_webhook_response({:error, reason}) do
+  defp handle_webhook_response({:error, reason}, _request_body) do
     {:error, "Slack incoming-webhook request failed: #{inspect(reason)}"}
   end
 

--- a/server/lib/tuist/slack/client.ex
+++ b/server/lib/tuist/slack/client.ex
@@ -103,11 +103,11 @@ defmodule Tuist.Slack.Client do
   end
 
   defp handle_oauth_response({:ok, %Req.Response{status: status, body: body}}) do
-    {:error, "Unexpected status code: #{status}. Body: #{inspect(body)}"}
+    {:error, "Slack OAuth responded #{status} with body: #{inspect(body)}"}
   end
 
   defp handle_oauth_response({:error, reason}) do
-    {:error, "Request failed: #{inspect(reason)}"}
+    {:error, "Slack OAuth request failed: #{inspect(reason)}"}
   end
 
   defp handle_webhook_response({:ok, %Req.Response{status: status}}) when status in 200..299 do
@@ -126,16 +126,20 @@ defmodule Tuist.Slack.Client do
     if permanent_webhook_error?(body) do
       {:error, :webhook_revoked}
     else
-      {:error, "Unexpected status code: #{status}. Body: #{inspect(body)}"}
+      {:error, unexpected_webhook_error(status, body)}
     end
   end
 
   defp handle_webhook_response({:ok, %Req.Response{status: status, body: body}}) do
-    {:error, "Unexpected status code: #{status}. Body: #{inspect(body)}"}
+    {:error, unexpected_webhook_error(status, body)}
   end
 
   defp handle_webhook_response({:error, reason}) do
-    {:error, "Request failed: #{inspect(reason)}"}
+    {:error, "Slack incoming-webhook request failed: #{inspect(reason)}"}
+  end
+
+  defp unexpected_webhook_error(status, body) do
+    "Slack incoming-webhook responded #{status} with response body: #{inspect(body)}"
   end
 
   defp permanent_webhook_error?(body) when is_binary(body) do
@@ -153,10 +157,10 @@ defmodule Tuist.Slack.Client do
   end
 
   defp handle_post_response({:ok, %Req.Response{status: status, body: body}}) do
-    {:error, "Unexpected status code: #{status}. Body: #{inspect(body)}"}
+    {:error, "Slack chat.postMessage responded #{status} with response body: #{inspect(body)}"}
   end
 
   defp handle_post_response({:error, reason}) do
-    {:error, "Request failed: #{inspect(reason)}"}
+    {:error, "Slack chat.postMessage request failed: #{inspect(reason)}"}
   end
 end

--- a/server/lib/tuist/slack/client.ex
+++ b/server/lib/tuist/slack/client.ex
@@ -114,32 +114,35 @@ defmodule Tuist.Slack.Client do
     :ok
   end
 
-  # 404 from a Slack webhook URL is permanent — the webhook was revoked,
-  # the channel was deleted, or the app was uninstalled from the workspace.
-  # Surface it distinctly so callers can clear the destination instead of
-  # retrying forever.
+  # Any 4xx from Slack is a client-side error: the same request will fail
+  # the same way on retry. Split it into "the webhook is permanently dead"
+  # (caller clears the destination) and "we sent something Slack rejected"
+  # (caller discards the job without touching the destination, so we still
+  # see the failure once for investigation).
+  #
+  # 404 always maps to :webhook_revoked — a Slack hooks URL only 404s when
+  # it isn't a live webhook any more (revoked, uninstalled, deleted). The
+  # other 4xx cases only clear the destination when the body matches one of
+  # Slack's documented permanent-error strings.
   defp handle_webhook_response({:ok, %Req.Response{status: 404}}) do
     {:error, :webhook_revoked}
   end
 
-  defp handle_webhook_response({:ok, %Req.Response{status: status, body: body}}) when status in [400, 401, 403] do
+  defp handle_webhook_response({:ok, %Req.Response{status: status, body: body}}) when status in 400..499 do
     if permanent_webhook_error?(body) do
       {:error, :webhook_revoked}
     else
-      {:error, unexpected_webhook_error(status, body)}
+      {:error, {:bad_request, status, body}}
     end
   end
 
+  # 5xx is Slack's side — return a transient error so Oban retries.
   defp handle_webhook_response({:ok, %Req.Response{status: status, body: body}}) do
-    {:error, unexpected_webhook_error(status, body)}
+    {:error, "Slack incoming-webhook responded #{status} with response body: #{inspect(body)}"}
   end
 
   defp handle_webhook_response({:error, reason}) do
     {:error, "Slack incoming-webhook request failed: #{inspect(reason)}"}
-  end
-
-  defp unexpected_webhook_error(status, body) do
-    "Slack incoming-webhook responded #{status} with response body: #{inspect(body)}"
   end
 
   defp permanent_webhook_error?(body) when is_binary(body) do

--- a/server/lib/tuist/slack/workers/report_worker.ex
+++ b/server/lib/tuist/slack/workers/report_worker.ex
@@ -146,13 +146,20 @@ defmodule Tuist.Slack.Workers.ReportWorker do
     end
   end
 
-  # Any other 4xx is a client-side error we don't recognize — retrying will
-  # fail the same way, so discard the job instead of burning the remaining
-  # attempts. Leave the destination in place: it may be a bug in the payload
-  # we build, and clearing the user's config would hide that.
+  # Any other 4xx is a client-side error we don't recognize — Slack is
+  # telling us our request is wrong, so it likely is a bug on our side
+  # (malformed Block Kit, wrong Content-Type, etc.). Report it explicitly
+  # so we still see it in Hive, then discard the job: the same request
+  # will fail the same way on retry, and clearing the user's destination
+  # would hide the bug behind a wiped config.
   defp handle_bad_request(project, status, body) do
     Logger.warning(
       "Slack rejected the incoming-webhook payload for project #{project.id} (status #{status}, body #{inspect(body)})"
+    )
+
+    Sentry.capture_message("Slack rejected the incoming-webhook payload",
+      level: :error,
+      extra: %{project_id: project.id, status: status, response_body: inspect(body)}
     )
 
     {:discard, {:slack_bad_request, status}}

--- a/server/lib/tuist/slack/workers/report_worker.ex
+++ b/server/lib/tuist/slack/workers/report_worker.ex
@@ -83,12 +83,7 @@ defmodule Tuist.Slack.Workers.ReportWorker do
 
       {:webhook, webhook_url} ->
         blocks = Reports.report(project, last_report_at: project.last_reported_at)
-
-        case SlackClient.post_to_webhook(webhook_url, blocks) do
-          :ok -> mark_reported(project)
-          {:error, :webhook_revoked} -> handle_revoked_webhook(project)
-          {:error, reason} -> {:error, reason}
-        end
+        handle_webhook_result(SlackClient.post_to_webhook(webhook_url, blocks), project)
 
       {:bot_token, %Installation{access_token: token}, channel_id} ->
         blocks = Reports.report(project, last_report_at: project.last_reported_at)
@@ -99,6 +94,14 @@ defmodule Tuist.Slack.Workers.ReportWorker do
         end
     end
   end
+
+  defp handle_webhook_result(:ok, project), do: mark_reported(project)
+  defp handle_webhook_result({:error, :webhook_revoked}, project), do: handle_revoked_webhook(project)
+
+  defp handle_webhook_result({:error, {:bad_request, status, body}}, project),
+    do: handle_bad_request(project, status, body)
+
+  defp handle_webhook_result({:error, reason}, _project), do: {:error, reason}
 
   # Only a successful send advances the window; a failed/discarded attempt
   # leaves last_reported_at untouched so the next run still covers the gap.
@@ -141,6 +144,18 @@ defmodule Tuist.Slack.Workers.ReportWorker do
       {:ok, _project} -> {:discard, :webhook_revoked}
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  # Any other 4xx is a client-side error we don't recognize — retrying will
+  # fail the same way, so discard the job instead of burning the remaining
+  # attempts. Leave the destination in place: it may be a bug in the payload
+  # we build, and clearing the user's config would hide that.
+  defp handle_bad_request(project, status, body) do
+    Logger.warning(
+      "Slack rejected the incoming-webhook payload for project #{project.id} (status #{status}, body #{inspect(body)})"
+    )
+
+    {:discard, {:slack_bad_request, status}}
   end
 
   defp handle_post_message_error("account_inactive", project) do

--- a/server/lib/tuist/slack/workers/report_worker.ex
+++ b/server/lib/tuist/slack/workers/report_worker.ex
@@ -98,8 +98,8 @@ defmodule Tuist.Slack.Workers.ReportWorker do
   defp handle_webhook_result(:ok, project), do: mark_reported(project)
   defp handle_webhook_result({:error, :webhook_revoked}, project), do: handle_revoked_webhook(project)
 
-  defp handle_webhook_result({:error, {:bad_request, status, body}}, project),
-    do: handle_bad_request(project, status, body)
+  defp handle_webhook_result({:error, {:bad_request, status, body, request_body}}, project),
+    do: handle_bad_request(project, status, body, request_body)
 
   defp handle_webhook_result({:error, reason}, _project), do: {:error, reason}
 
@@ -149,20 +149,40 @@ defmodule Tuist.Slack.Workers.ReportWorker do
   # Any other 4xx is a client-side error we don't recognize — Slack is
   # telling us our request is wrong, so it likely is a bug on our side
   # (malformed Block Kit, wrong Content-Type, etc.). Report it explicitly
-  # so we still see it in Hive, then discard the job: the same request
-  # will fail the same way on retry, and clearing the user's destination
-  # would hide the bug behind a wiped config.
-  defp handle_bad_request(project, status, body) do
-    Logger.warning(
-      "Slack rejected the incoming-webhook payload for project #{project.id} (status #{status}, body #{inspect(body)})"
-    )
+  # so we still see it in Hive alongside the request we sent (Block Kit
+  # is user-visible content, no secrets), then discard the job: the same
+  # request will fail the same way on retry, and clearing the user's
+  # destination would hide the bug behind a wiped config.
+  defp handle_bad_request(project, status, response_body, request_body) do
+    Logger.warning("""
+    Slack rejected the incoming-webhook payload for project #{project.id} (status #{status}).
+    Response body: #{inspect(response_body)}
+    Request body: #{request_body}
+    """)
 
     Sentry.capture_message("Slack rejected the incoming-webhook payload",
       level: :error,
-      extra: %{project_id: project.id, status: status, response_body: inspect(body)}
+      extra: %{
+        project_id: project.id,
+        status: status,
+        response_body: inspect(response_body),
+        request_body: truncate_for_report(request_body)
+      }
     )
 
     {:discard, {:slack_bad_request, status}}
+  end
+
+  # Cap the request body at 16 KB so a runaway Block Kit payload can't
+  # push the Sentry event past the per-field size limit. Loki (via
+  # Logger.warning above) keeps the full body.
+  @report_body_limit 16 * 1024
+  defp truncate_for_report(body) when is_binary(body) do
+    if byte_size(body) > @report_body_limit do
+      binary_part(body, 0, @report_body_limit) <> "…[truncated]"
+    else
+      body
+    end
   end
 
   defp handle_post_message_error("account_inactive", project) do

--- a/server/test/tuist/slack/client_test.exs
+++ b/server/test/tuist/slack/client_test.exs
@@ -154,13 +154,25 @@ defmodule Tuist.Slack.ClientTest do
       end
     end
 
-    test "returns {:bad_request, status, body} on an unrecognized 4xx" do
-      stub(Req, :post, fn _url, _opts ->
+    test "returns {:bad_request, status, response_body, request_body} on an unrecognized 4xx" do
+      stub(Req, :post, fn _url, opts ->
+        # The client passes its serialized request body through so the
+        # caller can attach it to the alert. Echo it into the error tuple
+        # via the stub so we can assert the same bytes come back.
+        send(self(), {:request_body, opts[:body]})
         {:ok, %Req.Response{status: 400, body: "invalid_payload"}}
       end)
 
-      assert {:error, {:bad_request, 400, "invalid_payload"}} =
-               Client.post_to_webhook("https://hooks.slack.com/services/T0/B0/abcd", [])
+      assert {:error, {:bad_request, 400, "invalid_payload", request_body}} =
+               Client.post_to_webhook(
+                 "https://hooks.slack.com/services/T0/B0/abcd",
+                 [%{type: "section", text: "Hi"}]
+               )
+
+      assert_received {:request_body, sent}
+      assert request_body == sent
+      assert request_body =~ ~s("blocks")
+      assert request_body =~ ~s("Hi")
     end
 
     test "returns a transient error on a 5xx" do

--- a/server/test/tuist/slack/client_test.exs
+++ b/server/test/tuist/slack/client_test.exs
@@ -133,6 +133,38 @@ defmodule Tuist.Slack.ClientTest do
                Client.post_to_webhook("https://hooks.slack.com/services/T0/B0/abcd", [])
     end
 
+    test "returns :webhook_revoked on Slack's permanent auth/team errors" do
+      cases = [
+        {400, "invalid_token"},
+        {401, "invalid_token"},
+        {403, "action_prohibited"},
+        {400, "team_disabled"},
+        {400, "no_team"},
+        {400, "no_service_id"}
+      ]
+
+      for {status, reason} <- cases do
+        stub(Req, :post, fn _url, _opts ->
+          {:ok, %Req.Response{status: status, body: reason}}
+        end)
+
+        assert {:error, :webhook_revoked} =
+                 Client.post_to_webhook("https://hooks.slack.com/services/T0/B0/abcd", []),
+               "expected :webhook_revoked for #{status} #{reason}"
+      end
+    end
+
+    test "returns transient error on 400 with an unknown body" do
+      stub(Req, :post, fn _url, _opts ->
+        {:ok, %Req.Response{status: 400, body: "invalid_payload"}}
+      end)
+
+      result = Client.post_to_webhook("https://hooks.slack.com/services/T0/B0/abcd", [])
+
+      assert {:error, message} = result
+      assert message =~ "Unexpected status code: 400"
+    end
+
     test "returns error on unexpected status code (transient)" do
       stub(Req, :post, fn _url, _opts ->
         {:ok, %Req.Response{status: 500, body: "boom"}}

--- a/server/test/tuist/slack/client_test.exs
+++ b/server/test/tuist/slack/client_test.exs
@@ -60,7 +60,7 @@ defmodule Tuist.Slack.ClientTest do
       result = Client.exchange_code_for_token("auth-code", "https://example.com/callback")
 
       assert {:error, message} = result
-      assert message =~ "Unexpected status code: 500"
+      assert message =~ "Slack OAuth responded 500"
     end
 
     test "returns error when request fails" do
@@ -74,7 +74,7 @@ defmodule Tuist.Slack.ClientTest do
       result = Client.exchange_code_for_token("auth-code", "https://example.com/callback")
 
       assert {:error, message} = result
-      assert message =~ "Request failed"
+      assert message =~ "Slack OAuth request failed"
     end
 
     test "includes incoming_webhook data when present in response" do
@@ -162,7 +162,7 @@ defmodule Tuist.Slack.ClientTest do
       result = Client.post_to_webhook("https://hooks.slack.com/services/T0/B0/abcd", [])
 
       assert {:error, message} = result
-      assert message =~ "Unexpected status code: 400"
+      assert message =~ "Slack incoming-webhook responded 400 with response body"
     end
 
     test "returns error on unexpected status code (transient)" do
@@ -173,7 +173,7 @@ defmodule Tuist.Slack.ClientTest do
       result = Client.post_to_webhook("https://hooks.slack.com/services/T0/B0/abcd", [])
 
       assert {:error, message} = result
-      assert message =~ "Unexpected status code: 500"
+      assert message =~ "Slack incoming-webhook responded 500 with response body"
     end
 
     test "returns error when request fails" do
@@ -184,7 +184,7 @@ defmodule Tuist.Slack.ClientTest do
       result = Client.post_to_webhook("https://hooks.slack.com/services/T0/B0/abcd", [])
 
       assert {:error, message} = result
-      assert message =~ "Request failed"
+      assert message =~ "Slack incoming-webhook request failed"
     end
   end
 end

--- a/server/test/tuist/slack/client_test.exs
+++ b/server/test/tuist/slack/client_test.exs
@@ -154,18 +154,16 @@ defmodule Tuist.Slack.ClientTest do
       end
     end
 
-    test "returns transient error on 400 with an unknown body" do
+    test "returns {:bad_request, status, body} on an unrecognized 4xx" do
       stub(Req, :post, fn _url, _opts ->
         {:ok, %Req.Response{status: 400, body: "invalid_payload"}}
       end)
 
-      result = Client.post_to_webhook("https://hooks.slack.com/services/T0/B0/abcd", [])
-
-      assert {:error, message} = result
-      assert message =~ "Slack incoming-webhook responded 400 with response body"
+      assert {:error, {:bad_request, 400, "invalid_payload"}} =
+               Client.post_to_webhook("https://hooks.slack.com/services/T0/B0/abcd", [])
     end
 
-    test "returns error on unexpected status code (transient)" do
+    test "returns a transient error on a 5xx" do
       stub(Req, :post, fn _url, _opts ->
         {:ok, %Req.Response{status: 500, body: "boom"}}
       end)

--- a/server/test/tuist/slack/workers/report_worker_test.exs
+++ b/server/test/tuist/slack/workers/report_worker_test.exs
@@ -225,7 +225,7 @@ defmodule Tuist.Slack.Workers.ReportWorkerTest do
       stub_report_metrics(now)
 
       expect(Client, :post_to_webhook, fn _url, _blocks ->
-        {:error, {:bad_request, 400, "invalid_payload"}}
+        {:error, {:bad_request, 400, "invalid_payload", ~s({"blocks":[{"type":"section"}]})}}
       end)
 
       reject(&Client.post_message/3)
@@ -236,6 +236,7 @@ defmodule Tuist.Slack.Workers.ReportWorkerTest do
         assert opts[:extra][:project_id] == project.id
         assert opts[:extra][:status] == 400
         assert opts[:extra][:response_body] =~ "invalid_payload"
+        assert opts[:extra][:request_body] =~ ~s("blocks")
         :ok
       end)
 

--- a/server/test/tuist/slack/workers/report_worker_test.exs
+++ b/server/test/tuist/slack/workers/report_worker_test.exs
@@ -230,6 +230,15 @@ defmodule Tuist.Slack.Workers.ReportWorkerTest do
 
       reject(&Client.post_message/3)
 
+      expect(Sentry, :capture_message, fn message, opts ->
+        assert message == "Slack rejected the incoming-webhook payload"
+        assert opts[:level] == :error
+        assert opts[:extra][:project_id] == project.id
+        assert opts[:extra][:status] == 400
+        assert opts[:extra][:response_body] =~ "invalid_payload"
+        :ok
+      end)
+
       assert {:discard, {:slack_bad_request, 400}} =
                ReportWorker.perform(%Oban.Job{args: %{"project_id" => project.id}})
 

--- a/server/test/tuist/slack/workers/report_worker_test.exs
+++ b/server/test/tuist/slack/workers/report_worker_test.exs
@@ -177,6 +177,67 @@ defmodule Tuist.Slack.Workers.ReportWorkerTest do
       assert updated_project.slack_channel_name == nil
     end
 
+    test "clears the project webhook when Slack returns :webhook_revoked", %{project: project} do
+      now = ~U[2025-01-15 09:00:00Z]
+
+      {:ok, _project} =
+        Projects.update_project(project, %{
+          slack_channel_id: "C123456",
+          slack_channel_name: "test-channel",
+          slack_webhook_url: "https://hooks.slack.com/services/T0/B0/abcd",
+          report_frequency: :daily,
+          report_days_of_week: [Date.day_of_week(~D[2025-01-15])],
+          report_schedule_time: now,
+          report_timezone: "Etc/UTC"
+        })
+
+      stub_report_metrics(now)
+
+      expect(Client, :post_to_webhook, fn "https://hooks.slack.com/services/T0/B0/abcd", blocks ->
+        assert is_list(blocks)
+        {:error, :webhook_revoked}
+      end)
+
+      reject(&Client.post_message/3)
+
+      assert {:discard, :webhook_revoked} = ReportWorker.perform(%Oban.Job{args: %{"project_id" => project.id}})
+
+      updated_project = Projects.get_project_by_id(project.id)
+      assert updated_project.slack_channel_id == nil
+      assert updated_project.slack_channel_name == nil
+      assert updated_project.slack_webhook_url == nil
+    end
+
+    test "discards without clearing when Slack returns an unrecognized bad request", %{project: project} do
+      now = ~U[2025-01-15 09:00:00Z]
+
+      {:ok, _project} =
+        Projects.update_project(project, %{
+          slack_channel_id: "C123456",
+          slack_channel_name: "test-channel",
+          slack_webhook_url: "https://hooks.slack.com/services/T0/B0/abcd",
+          report_frequency: :daily,
+          report_days_of_week: [Date.day_of_week(~D[2025-01-15])],
+          report_schedule_time: now,
+          report_timezone: "Etc/UTC"
+        })
+
+      stub_report_metrics(now)
+
+      expect(Client, :post_to_webhook, fn _url, _blocks ->
+        {:error, {:bad_request, 400, "invalid_payload"}}
+      end)
+
+      reject(&Client.post_message/3)
+
+      assert {:discard, {:slack_bad_request, 400}} =
+               ReportWorker.perform(%Oban.Job{args: %{"project_id" => project.id}})
+
+      updated_project = Projects.get_project_by_id(project.id)
+      assert updated_project.slack_channel_id == "C123456"
+      assert updated_project.slack_webhook_url == "https://hooks.slack.com/services/T0/B0/abcd"
+    end
+
     test "returns an error when sending the report fails transiently", %{project: project} do
       now = ~U[2025-01-15 09:00:00Z]
 


### PR DESCRIPTION
## What changed

`Tuist.Slack.Client` was treating every non-2xx Slack webhook response as retryable, so an HTTP `4xx` (Slack saying "your request is wrong") burned all 3 Oban attempts per fire and then vanished into an Oban discard. That's the wrong shape both for [HTTP semantics](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses) and for [Slack's incoming-webhook error handling](https://api.slack.com/messaging/webhooks#handling_errors): a 4xx means the same request will fail the same way on retry, and if we don't recognize the specific error we should still see it — it's probably a bug on our side.

This PR reshapes `handle_webhook_response/1` and the Slack report worker around that:

- `2xx` → `:ok`.
- `404`, or any `4xx` whose body matches Slack's documented permanent-error strings (`invalid_token`, `no_service`, `no_service_id`, `no_team`, `team_disabled`, `action_prohibited`) → `{:error, :webhook_revoked}`. The worker clears `slack_channel_id`, `slack_channel_name`, `slack_webhook_url` and discards the job. The user re-authorizes to restore delivery.
- Any other `4xx` → `{:error, {:bad_request, status, response_body, request_body}}`. The worker logs the response *and* the request, explicitly captures the failure to Sentry (which forwards to Hive) with the project id, status, Slack's response body, and the JSON request body we sent (truncated to 16 KB for the Sentry payload; Loki keeps the full body), then discards the job. The customer's config is left untouched so a bug on our side stays visible instead of hiding behind a wiped destination.
- `5xx` and transport errors → `{:error, reason}`, still retried by Oban.

Also renamed the client's error strings so an unclassified failure now reads as `Slack incoming-webhook responded 400 with response body: …` (and the same shape for OAuth and `chat.postMessage`) instead of the earlier `Unexpected status code: 400. Body: …`, which read ambiguously as if the "body" were our request payload.

## Why

The trigger was Hive error [`ac79fc86-f99c-5185-8195-406023f42e0b`](https://hive.tuist.dev/errors/ac79fc86-f99c-5185-8195-406023f42e0b): `Tuist.Slack.Workers.ReportWorker` failing every hour for one project. Verified in prod via a read-only Postgres query that only project 3812 is affected (last successful report 2026-07-21) and the other 9 webhook-configured projects post fine every day, so the client itself works end-to-end. The 3× hourly retry against a permanently revoked webhook produced ~15 Hive events per day from that one project.

The narrow fix would have been to classify the `invalid_token` body as revoked. The broader lesson is that the client was equating "Slack rejected the request" with "the network hiccuped," which is wrong for every 4xx: retries can't help, and swallowing unknown 4xx as a transient error would also hide real payload bugs on our side (malformed Block Kit, wrong Content-Type, an extra field, etc.).

## Approach

Considered:

1. Match on the specific `invalid_token` body only. Rejected: fixes the reported alert but leaves every other `4xx` still burning retries and does nothing for a future payload bug.
2. Treat all `4xx` as `:webhook_revoked`. Rejected: an unrelated payload bug on our side would silently clear the customer's Slack config, hiding the bug.
3. Split by cause. Chosen: `:webhook_revoked` for Slack-documented permanent errors clears the destination; every other `4xx` is discarded without touching config, reported to Sentry with the full request/response context.

On the request body: we don't log outbound HTTP bodies anywhere else in the server, so relying on Loki alone would leave you rebuilding the Block Kit by hand each time. Threading the JSON body through the error tuple and attaching it to the alert makes future incidents reproducible from the alert alone. Block Kit is user-visible content, so it doesn't add any secrets to the alert.

## Impact

- Hive stops receiving the daily burst from project 3812 (and any other project in the same state) — one warning log per fire, no retries.
- Any project's Slack destination gets cleared the first time Slack returns one of the documented permanent errors, so the same failure doesn't repeat forever.
- If we ever ship a payload bug that Slack rejects with `400`, the job discards on the first attempt (no retry storm), the customer's config stays intact, and Hive still sees one event per fire with the project id, status, Slack's response body, and the exact JSON we sent — reproducible from the alert alone.
- No behavior change for successful (`2xx`), transient (`5xx`, network), or bot-token (`chat.postMessage`) responses.

## Validation

- `mix test test/tuist/slack/client_test.exs test/tuist/slack/workers/report_worker_test.exs` — 24 tests, 0 failures. New coverage: each of the six Slack permanent-error `(status, body)` pairs mapping to `:webhook_revoked`; an unrecognized `400` returning `{:bad_request, status, response_body, request_body}` with the request body threaded through; a `ReportWorker` test that clears the destination and discards on `:webhook_revoked` via the webhook path; a `ReportWorker` test that discards without clearing on `{:bad_request, ...}`, asserts the log/Sentry payload, and verifies the request body reaches the alert.
- `mix format` + `mix credo --strict lib/tuist/slack/client.ex lib/tuist/slack/workers/report_worker.ex` — clean.
- Prod read-only Postgres check: only project 3812 has a stuck webhook; 9 other webhook-configured projects last posted within the last 3 days.

### How to test locally

1. Point `Tuist.Slack.Client.post_to_webhook/2` at an incoming-webhook URL whose parent app has been uninstalled (or stub `Req.post/2` to return `%Req.Response{status: 400, body: "invalid_token"}`).
2. Enqueue `Tuist.Slack.Workers.ReportWorker` for that project.
3. Confirm the job is discarded on the first attempt (not retried) and that the project's `slack_channel_id`, `slack_channel_name`, and `slack_webhook_url` are cleared.
4. Repeat with `%Req.Response{status: 400, body: "invalid_payload"}` and confirm the job is discarded on the first attempt, the destination is preserved, both the response body and the JSON request body appear in the warning log, and a Sentry event is captured with the project id, status, response body, and (16 KB-truncated) request body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
