### PR TITLE
feat(server): refresh marketing copy for developers, CI, and agents (+ GitLab tab on compute)

### DIFF
--- a/server/assets/marketing/css/new/routes/compute.css
+++ b/server/assets/marketing/css/new/routes/compute.css
@@ -136,6 +136,7 @@
       }
 
       &[data-ci="github"] > [data-part="variant"][data-ci="github"],
+      &[data-ci="gitlab"] > [data-part="variant"][data-ci="gitlab"],
       &[data-ci="buildkite"] > [data-part="variant"][data-ci="buildkite"] {
         display: contents;
       }

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex
@@ -2,12 +2,12 @@
   <main id="marketing-about">
     <header data-part="header">
       <h1 data-part="title">
-        {dgettext("marketing", "Building the future of scalable app development")}
+        {dgettext("marketing", "Automation only moves as fast as the loop it runs in.")}
       </h1>
       <p data-part="subtitle">
         {dgettext(
           "marketing",
-          "Tuist bridges the gaps in Apple's tooling that prevent teams from moving fast. We solve the build complexity, workflow friction, and collaboration challenges, so you can deliver exceptional apps at speed."
+          "Tuist compresses that loop. Builds, tests, and the retries in between finish in seconds instead of minutes, so your developers stay in flow, your CI stops burning time, and the agents in your pipeline can think, try, and correct their way to code that works."
         )}
       </p>
     </header>
@@ -42,26 +42,31 @@
       <span data-part="eyebrow">{dgettext("marketing", "Mission")}</span>
       <div data-part="main">
         <h2 data-part="title">
-          <span data-part="line">{dgettext("marketing", "We want to enable")}</span>
-          <span data-part="line">{dgettext("marketing", "teams to scale with joy")}</span>
+          <span data-part="line">{dgettext("marketing", "We want developers to build")}</span>
+          <span data-part="line">{dgettext("marketing", "better software, faster.")}</span>
         </h2>
+        <% shopify_link =
+          ~s(<a href="https://www.shopify.com/" data-part="link" target="_blank" rel="noopener noreferrer">Shopify</a>) %>
         <article data-part="body">
           <p>
-            {dgettext(
-              "marketing",
-              "We believe building apps should be a joyful experience. But as teams and products grow, developers often spend more time managing fragmented tools, infrastructure, and workflows than creating great software. Tuist brings these pieces together so teams can build and share high-quality apps with greater speed and scale."
+            {raw(
+              dgettext(
+                "marketing",
+                "We're obsessed with helping developers build better software, faster. That obsession comes from doing the work at scale ourselves. Our team spent years shipping the tools behind mobile at %{shopify}, and Tuist is what we learned along the way.",
+                shopify: shopify_link
+              )
             )}
           </p>
           <p>
             {dgettext(
               "marketing",
-              "We are building an integrated platform for the entire app development lifecycle, from the first idea to production. By combining continuous integration, testing, caching, analytics, and release automation into one cohesive experience, Tuist removes unnecessary complexity and lets developers focus on building."
+              "Tuist started as a client-side toolkit for the Apple ecosystem. We turned it into a business so we could do what we love most, full time: building the infrastructure and technology to support the full diversity of build toolchains developers use today. Whatever you build with, we want the toolchain underneath to feel invisible."
             )}
           </p>
           <p>
             {dgettext(
               "marketing",
-              "Tuist was born in the Apple ecosystem, but our ambition goes beyond a single platform. We want to make building software at scale delightful for every developer, with an open and flexible platform that integrates seamlessly into their repository and simply works."
+              "Then AI happened, and optimizing your toolchain stopped being a luxury only large teams could afford. Every developer, and every agent working alongside them, needs the same fast, reliable feedback loops. That's what we're building next, with a stubborn commitment to sparking joy in the people who use it."
             )}
           </p>
           <.link_button
@@ -185,7 +190,7 @@
     </div>
 
     <section data-part="cta" aria-labelledby="cta-title">
-      <span data-part="eyebrow">{dgettext("marketing", "Hola! Hello! Hallo! Olá! Namaste!")}</span>
+      <span data-part="eyebrow">{dgettext("marketing", "Hola! Hello! Hallo! Olá! Namaste! Ahoj!")}</span>
       <h2 id="cta-title">{dgettext("marketing", "Your platform team, as a service")}</h2>
       <div data-part="actions" role="group" aria-labelledby="cta-title">
         <.button href={~p"/users/register"} label={dgettext("marketing", "Get started")} />

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex
@@ -27,13 +27,13 @@ dithered dividers. --%>
           "Runners that spin up in seconds and scale with your team and your agents."
         )}
       </p>
-      <%!-- The migration, one per CI: a GitHub/Buildkite switch over the
-      diff it selects (swap the runs-on label, or the agent queue). Code
-      stays untranslated, like the illustrations' annotations. The added
-      line types out behind a blinking terminal cursor — once per page
-      load, and again whenever the switch changes CI (ComputeHeroDiff);
-      the typed/cursor spans stay glued together on one line so no
-      whitespace opens between the text and the caret. --%>
+      <%!-- The migration, one per CI: a GitHub/GitLab/Buildkite switch
+      over the diff it selects (swap the runs-on label, the tag, or the
+      agent queue). Code stays untranslated, like the illustrations'
+      annotations. The added line types out behind a blinking terminal
+      cursor — once per page load, and again whenever the switch changes
+      CI (ComputeHeroDiff); the typed/cursor spans stay glued together
+      on one line so no whitespace opens between the text and the caret. --%>
       <div data-part="migration" id="compute-hero-migration" phx-hook="ComputeHeroDiff">
         <.button_group data-part="ci-switch" aria-label={dgettext("marketing", "CI provider")}>
           <.button_group_item
@@ -41,6 +41,11 @@ dithered dividers. --%>
             data-ci="github"
             data-selected
             aria-pressed="true"
+          />
+          <.button_group_item
+            label="GitLab"
+            data-ci="gitlab"
+            aria-pressed="false"
           />
           <.button_group_item
             label="Buildkite"
@@ -57,6 +62,16 @@ dithered dividers. --%>
             <span data-part="line" data-line="added">
               <span data-part="sign">+</span>
               <span data-part="code"><span data-part="typed">runs-on: tuist-macos</span><span data-part="cursor"></span></span>
+            </span>
+          </span>
+          <span data-part="variant" data-ci="gitlab">
+            <span data-part="line" data-line="removed">
+              <span data-part="sign">-</span>
+              <span data-part="code">tags: [macos]</span>
+            </span>
+            <span data-part="line" data-line="added">
+              <span data-part="sign">+</span>
+              <span data-part="code"><span data-part="typed">tags: [tuist-macos]</span><span data-part="cursor"></span></span>
             </span>
           </span>
           <span data-part="variant" data-ci="buildkite">

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/download.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/download.html.heex
@@ -1184,7 +1184,7 @@
 
     <section data-part="cta" aria-labelledby="cta-title">
       <span data-part="eyebrow">
-        {dgettext("marketing", "Hola! Hello! Hallo! Olá! Namaste!")}
+        {dgettext("marketing", "Hola! Hello! Hallo! Olá! Namaste! Ahoj!")}
       </span>
       <h2 id="cta-title">{dgettext("marketing", "Your platform team, as a service")}</h2>
       <div data-part="actions" role="group" aria-labelledby="cta-title">

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex
@@ -110,7 +110,7 @@
           <p>
             {dgettext(
               "marketing",
-              "Share build artifacts across your team and CI, so no one waits on code that's already compiled."
+              "Share build artifacts across your developers, CI, and agent environments, so no one waits on code that's already compiled."
             )}
           </p>
           <.button
@@ -592,7 +592,7 @@
           <p>
             {dgettext(
               "marketing",
-              "Enhance mobile-specific workflows and accelerate local and CI performance."
+              "Enhance mobile-specific workflows and accelerate builds across developer, CI, and agent environments."
             )}
           </p>
         </div>

--- a/server/lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex
+++ b/server/lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex
@@ -470,7 +470,7 @@ features = [
     </div>
 
     <section data-part="cta" aria-labelledby="cta-title">
-      <span data-part="eyebrow">{dgettext("marketing", "Hola! Hello! Hallo! Olá! Namaste!")}</span>
+      <span data-part="eyebrow">{dgettext("marketing", "Hola! Hello! Hallo! Olá! Namaste! Ahoj!")}</span>
       <h2 id="cta-title">{dgettext("marketing", "Unlock your team's full potential")}</h2>
       <div data-part="actions" role="group" aria-labelledby="cta-title">
         <.button href={~p"/users/register"} label={dgettext("marketing", "Get started")} />

--- a/server/lib/tuist_web/marketing/live/marketing_cache_live/new/cache.html.heex
+++ b/server/lib/tuist_web/marketing/live/marketing_cache_live/new/cache.html.heex
@@ -39,7 +39,7 @@
       <p data-part="subtitle">
         {dgettext(
           "marketing",
-          "Share build artifacts across your team and CI, so no one waits on code that's already compiled."
+          "Share build artifacts across your developers, CI, and agent environments, so no one waits on code that's already compiled."
         )}
       </p>
       <.button

--- a/server/lib/tuist_web/marketing/live/marketing_customers_live/new/customers.html.heex
+++ b/server/lib/tuist_web/marketing/live/marketing_customers_live/new/customers.html.heex
@@ -101,7 +101,7 @@
 
     <section data-part="cta" aria-labelledby="cta-title">
       <span data-part="eyebrow">
-        {dgettext("marketing", "Hola! Hello! Hallo! Olá! Namaste!")}
+        {dgettext("marketing", "Hola! Hello! Hallo! Olá! Namaste! Ahoj!")}
       </span>
       <h2 id="cta-title">{dgettext("marketing", "Your platform team, as a service")}</h2>
       <div data-part="actions" role="group" aria-labelledby="cta-title">

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -411,7 +411,7 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/footer.html.heex:3
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:243
 #: lib/tuist_web/marketing/components/marketing_layout_components/new/navbar.html.heex:523
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:113
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:128
 #: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:290
 #: lib/tuist_web/marketing/controllers/marketing_html/new/tests.html.heex:49
 #: lib/tuist_web/marketing/controllers/marketing_html/pricing.html.heex:311
@@ -464,9 +464,9 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_components.ex:480
 #: lib/tuist_web/marketing/controllers/marketing_html.ex:137
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:37
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:191
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:196
 #: lib/tuist_web/marketing/controllers/marketing_html/new/case_study.html.heex:136
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:677
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:692
 #: lib/tuist_web/marketing/controllers/marketing_html/new/download.html.heex:1191
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:29
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:1022
@@ -1069,9 +1069,9 @@ msgstr ""
 #: lib/tuist_web/marketing/components/marketing_components.ex:485
 #: lib/tuist_web/marketing/controllers/marketing_html.ex:145
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:44
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:197
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:202
 #: lib/tuist_web/marketing/controllers/marketing_html/new/case_study.html.heex:142
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:683
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:698
 #: lib/tuist_web/marketing/controllers/marketing_html/new/download.html.heex:1197
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:36
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:1028
@@ -1367,7 +1367,7 @@ msgid "We're a group of builders who believe scaling your app shouldn't kill you
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/about.html.heex:135
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:82
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:87
 #, elixir-autogen, elixir-format
 msgid "We’re a small, passionate team that cares deeply about developer experience and takes pride in crafting tools with care and attention to detail."
 msgstr ""
@@ -1464,7 +1464,7 @@ msgid "You're only charged for the features you use, based on your usage, and on
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/about.html.heex:172
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:189
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:194
 #: lib/tuist_web/marketing/controllers/marketing_html/new/download.html.heex:1189
 #: lib/tuist_web/marketing/live/marketing_customers_live/new/customers.html.heex:106
 #, elixir-autogen, elixir-format
@@ -1853,7 +1853,7 @@ msgstr ""
 msgid "Previews · Tuist"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:107
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:122
 #: lib/tuist_web/marketing/controllers/marketing_html/new/tests.html.heex:43
 #: lib/tuist_web/marketing/live/marketing_cache_live/cache.html.heex:29
 #: lib/tuist_web/marketing/live/marketing_cache_live/new/cache.html.heex:52
@@ -2304,7 +2304,7 @@ msgstr ""
 msgid "Join the community slack"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:68
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:73
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:120
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:235
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:551
@@ -2596,7 +2596,7 @@ msgid "Upload artifacts"
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/new/case_study.html.heex:133
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:674
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:689
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:1019
 #: lib/tuist_web/marketing/controllers/marketing_html/new/newsletter.html.heex:128
 #: lib/tuist_web/marketing/controllers/marketing_html/new/tests.html.heex:361
@@ -2697,7 +2697,7 @@ msgstr ""
 msgid "Tuist · Build infrastructure for productive teams"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:188
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:193
 #: lib/tuist_web/marketing/controllers/marketing_html/new/download.html.heex:1187
 #: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:473
 #: lib/tuist_web/marketing/live/marketing_customers_live/new/customers.html.heex:104
@@ -2705,17 +2705,17 @@ msgstr ""
 msgid "Hola! Hello! Hallo! Olá! Namaste! Ahoj!"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:105
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Founder and CEO"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:124
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Founder and CTO"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:80
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:85
 #, elixir-autogen, elixir-format
 msgid "Meet the team behind Tuist"
 msgstr ""
@@ -2725,17 +2725,17 @@ msgstr ""
 msgid "Mission"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:143
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Senior Product Designer"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:162
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Senior Software Engineer"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:78
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:83
 #, elixir-autogen, elixir-format
 msgid "Team"
 msgstr ""
@@ -2745,17 +2745,17 @@ msgstr ""
 msgid "Tuist compresses that loop. Builds, tests, and the retries in between finish in seconds instead of minutes, so your developers stay in flow, your CI stops burning time, and the agents in your pipeline can think, try, and correct their way to code that works."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:62
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:67
 #, elixir-autogen, elixir-format
 msgid "Then AI happened, and optimizing your toolchain stopped being a luxury only large teams could afford. Every developer, and every agent working alongside them, needs the same fast, reliable feedback loops. That's what we're building next, with a stubborn commitment to sparking joy in the people who use it."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:56
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:61
 #, elixir-autogen, elixir-format
 msgid "Tuist started as a client-side toolkit for the Apple ecosystem. We turned it into a business so we could do what we love most, full time: building the infrastructure and technology to support the full diversity of build toolchains developers use today. Whatever you build with, we want the toolchain underneath to feel invisible."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:50
+#: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:53
 #, elixir-autogen, elixir-format
 msgid "We're obsessed with helping developers build better software, faster. That obsession comes from doing the work at scale ourselves. Our team spent years shipping the tools behind mobile at %{shopify}, and Tuist is what we learned along the way."
 msgstr ""
@@ -3074,37 +3074,37 @@ msgstr ""
 msgid "via Slack and email"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:307
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:322
 #, elixir-autogen, elixir-format
 msgid "Built into your build platform"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:466
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:481
 #, elixir-autogen, elixir-format
 msgid "Cache-ready by default"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:115
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:130
 #, elixir-autogen, elixir-format
 msgid "Compute without the infrastructure work"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:594
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:609
 #, elixir-autogen, elixir-format
 msgid "Connect to a running machine through your terminal or VNC and investigate failures in the environment where they actually happened."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:592
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:607
 #, elixir-autogen, elixir-format
 msgid "Debug where it failed"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:479
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:494
 #, elixir-autogen, elixir-format
 msgid "Everything else, built in"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:118
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:133
 #, elixir-autogen, elixir-format
 msgid "Fast macOS and Linux runners that scale with your workloads and plug directly into the rest of the Tuist platform."
 msgstr ""
@@ -3114,42 +3114,42 @@ msgstr ""
 msgid "Fast macOS and Linux runners that spin up in seconds and scale with your team and your agents."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:309
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:324
 #, elixir-autogen, elixir-format
 msgid "Go from a CI job to the Xcode or Gradle build behind it, with build performance, cache activity, and machine metrics connected in one place."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:468
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:483
 #, elixir-autogen, elixir-format
 msgid "Persistent volumes and colocated caching keep build data close to your runners for faster reads, writes, and repeat jobs."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:551
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:566
 #, elixir-autogen, elixir-format
 msgid "Powerful compute, ready"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:553
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:568
 #, elixir-autogen, elixir-format
 msgid "Run CI and agent workloads on M4 Pro Macs today, with M5 Pro coming soon, or choose Linux machines sized for the job."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:642
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:657
 #, elixir-autogen, elixir-format
 msgid "Run your workflows on current Xcode and macOS versions without maintaining images or installing toolchains yourself."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:511
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:526
 #, elixir-autogen, elixir-format
 msgid "Scale without the queue"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:513
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:528
 #, elixir-autogen, elixir-format
 msgid "Spin up runners in seconds and scale with your team and your agents without managing your own fleet."
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:640
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:655
 #, elixir-autogen, elixir-format
 msgid "Stay current with Apple"
 msgstr ""
@@ -3606,7 +3606,7 @@ msgstr ""
 msgid "Worthy Five: %{name}"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:675
+#: lib/tuist_web/marketing/controllers/marketing_html/new/compute.html.heex:690
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:1020
 #: lib/tuist_web/marketing/controllers/marketing_html/new/newsletter.html.heex:130
 #: lib/tuist_web/marketing/controllers/marketing_html/new/tests.html.heex:362
@@ -3614,4 +3614,9 @@ msgstr ""
 #: lib/tuist_web/marketing/live/marketing_previews_live/new/previews.html.heex:635
 #, elixir-autogen, elixir-format
 msgid "Supercharge your development"
+msgstr ""
+
+#: lib/tuist_web/marketing/controllers/marketing_html/about.html.heex:14
+#, elixir-autogen, elixir-format
+msgid "Building the future of scalable app development"
 msgstr ""

--- a/server/priv/gettext/marketing.pot
+++ b/server/priv/gettext/marketing.pot
@@ -120,10 +120,9 @@ msgstr ""
 msgid "Build times reduced by 80%"
 msgstr ""
 
-#: lib/tuist_web/marketing/controllers/marketing_html/about.html.heex:14
 #: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:5
 #, elixir-autogen, elixir-format
-msgid "Building the future of scalable app development"
+msgid "Automation only moves as fast as the loop it runs in."
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/home.html.heex:185
@@ -2222,7 +2221,7 @@ msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:593
 #, elixir-autogen, elixir-format
-msgid "Enhance mobile-specific workflows and accelerate local and CI performance."
+msgid "Enhance mobile-specific workflows and accelerate builds across developer, CI, and agent environments."
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:810
@@ -2471,7 +2470,7 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:111
 #: lib/tuist_web/marketing/live/marketing_cache_live/new/cache.html.heex:40
 #, elixir-autogen, elixir-format
-msgid "Share build artifacts across your team and CI, so no one waits on code that's already compiled."
+msgid "Share build artifacts across your developers, CI, and agent environments, so no one waits on code that's already compiled."
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/new/home.html.heex:603
@@ -2703,7 +2702,7 @@ msgstr ""
 #: lib/tuist_web/marketing/controllers/marketing_html/new/pricing.html.heex:473
 #: lib/tuist_web/marketing/live/marketing_customers_live/new/customers.html.heex:104
 #, elixir-autogen, elixir-format
-msgid "Hola! Hello! Hallo! Olá! Namaste!"
+msgid "Hola! Hello! Hallo! Olá! Namaste! Ahoj!"
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:105
@@ -2743,32 +2742,32 @@ msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:8
 #, elixir-autogen, elixir-format
-msgid "Tuist bridges the gaps in Apple's tooling that prevent teams from moving fast. We solve the build complexity, workflow friction, and collaboration challenges, so you can deliver exceptional apps at speed."
+msgid "Tuist compresses that loop. Builds, tests, and the retries in between finish in seconds instead of minutes, so your developers stay in flow, your CI stops burning time, and the agents in your pipeline can think, try, and correct their way to code that works."
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:62
 #, elixir-autogen, elixir-format
-msgid "Tuist was born in the Apple ecosystem, but our ambition goes beyond a single platform. We want to make building software at scale delightful for every developer, with an open and flexible platform that integrates seamlessly into their repository and simply works."
+msgid "Then AI happened, and optimizing your toolchain stopped being a luxury only large teams could afford. Every developer, and every agent working alongside them, needs the same fast, reliable feedback loops. That's what we're building next, with a stubborn commitment to sparking joy in the people who use it."
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:56
 #, elixir-autogen, elixir-format
-msgid "We are building an integrated platform for the entire app development lifecycle, from the first idea to production. By combining continuous integration, testing, caching, analytics, and release automation into one cohesive experience, Tuist removes unnecessary complexity and lets developers focus on building."
+msgid "Tuist started as a client-side toolkit for the Apple ecosystem. We turned it into a business so we could do what we love most, full time: building the infrastructure and technology to support the full diversity of build toolchains developers use today. Whatever you build with, we want the toolchain underneath to feel invisible."
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:50
 #, elixir-autogen, elixir-format
-msgid "We believe building apps should be a joyful experience. But as teams and products grow, developers often spend more time managing fragmented tools, infrastructure, and workflows than creating great software. Tuist brings these pieces together so teams can build and share high-quality apps with greater speed and scale."
+msgid "We're obsessed with helping developers build better software, faster. That obsession comes from doing the work at scale ourselves. Our team spent years shipping the tools behind mobile at %{shopify}, and Tuist is what we learned along the way."
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:45
 #, elixir-autogen, elixir-format
-msgid "We want to enable"
+msgid "We want developers to build"
 msgstr ""
 
 #: lib/tuist_web/marketing/controllers/marketing_html/new/about.html.heex:46
 #, elixir-autogen, elixir-format
-msgid "teams to scale with joy"
+msgid "better software, faster."
 msgstr ""
 
 #: lib/tuist_web/marketing/live/marketing_blog_live/new/blog.html.heex:97


### PR DESCRIPTION
Refreshes marketing copy across the redesigned site so it names the audience Tuist actually serves today (developers, CI, and agent environments), rewrites the About hero and mission around the loop that automation runs in, and extends the compute page's CI switch with a GitLab tab now that Tuist Runners support GitLab CI.

### How to test locally

1. Boot the server locally: `cd server && mise run install && mise run dev`.
2. In the dev database, enable the redesign flag (anonymous traffic still falls back to the legacy site otherwise):

   ```sh
   psql -d tuist_development -c "INSERT INTO feature_flags (id, flag_name, gate_type, target, enabled) VALUES (gen_random_uuid(), 'new_marketing', 'boolean', '_fwf_none', true) ON CONFLICT (flag_name, gate_type, target) DO UPDATE SET enabled = true;"
   ```

3. Restart the dev server so the FunWithFlags ETS cache picks up the row on boot, then open:
   - `http://127.0.0.1:8080/about` — new hero ("Automation only moves as fast as the loop it runs in.") and rewritten mission section, including the Shopify link and the "Ahoj!" addition in the greeting row.
   - `http://127.0.0.1:8080/` — cache subtitle and "More in the toolbox" line now name developers, CI, and agent environments.
   - `http://127.0.0.1:8080/cache` — cache page hero updated to the same audience framing.
   - `http://127.0.0.1:8080/compute` — GitLab tab appears between GitHub and Buildkite in the CI switch and swaps `tags: [macos]` → `tags: [tuist-macos]`.
   - `http://127.0.0.1:8080/pricing`, `/download`, `/customers` — the greeting eyebrow reads "Hola! Hello! Hallo! Olá! Namaste! Ahoj!".

### What changed

- **Home, cache, and toolbox copy.** Rewrote the two "team and CI" sentences and the mobile-workflows tagline so they read "developers, CI, and agent environments" rather than the old developer + CI-only framing.
- **About hero.** Replaced "Building the future of scalable app development" with "Automation only moves as fast as the loop it runs in." and a subtitle that ties Tuist's value to the feedback loop shared by developers, CI, and agents.
- **About mission section.** New three-paragraph arc: who we are and the Shopify pedigree (with Shopify linked out); Tuist's origin as an Apple-ecosystem toolkit and why we turned it into a business; and the AI moment that makes fast toolchains a baseline requirement rather than a scale-only privilege.
- **Greeting row.** Added "Ahoj!" to the Hola / Hello / Hallo / Olá / Namaste row on About, Pricing, Download, and Customers.
- **Compute page CI switch.** New GitLab tab alongside GitHub and Buildkite, with a diff that swaps `tags: [macos]` for `tags: [tuist-macos]`. The `ComputeHeroDiff` hook already reads `data-ci` at runtime, so no JS changes were needed; the stylesheet's variant selector picks up the new `gitlab` value.
- **Translations.** Updated `server/priv/gettext/marketing.pot` for the changed source strings; per project convention `.po` files are untouched and will be regenerated by the `tuistit` bot via Weblate.

### Why

The site was still framed around "your team and CI" when in practice Tuist now serves three environments where builds run: developer machines, CI, and agent-driven pipelines. Marek's recent Tuist Runners GitLab support (#13101) also meant the CI-provider switch on the compute page under-represented the supported providers.

The About page in particular still opened with generic Apple-tooling language and a mission that predated our current AI-era focus. Pedro's brief was to reframe the page around the loop that automation runs in (builds, tests, retries), keep the Shopify pedigree visible, explain the business transition, and land on where AI is taking us next.

### Impact

Copy-only and one narrow UI addition (a third CI-switch tab) behind the existing `:new_marketing` FunWithFlags gate. No API, schema, or feature-flag changes; anonymous production traffic continues to see the current site until the flag flips.

### Validation

- `mise run install` and `mise run dev` boot the redesigned site locally with the flag enabled.
- Manually walked the About, home, cache, compute, pricing, download, and customers pages at `http://127.0.0.1:8080` and confirmed the new copy renders, the Shopify link works, and the GitLab tab shows the expected diff and animates via `ComputeHeroDiff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rog5Ff7vV4NRT9gd1MXiDq
