### PR TITLE
docs(server): correct Bazel test insights on plain `bazel test` reporting

### DIFF
--- a/server/priv/docs/en/guides/features/test-insights/bazel.md
+++ b/server/priv/docs/en/guides/features/test-insights/bazel.md
@@ -19,7 +19,10 @@ Run Bazel tests through Tuist to feed the same test dashboards used by every oth
 tuist bazel test -- //app:tests
 ```
 
-Arguments after `--` are forwarded to `bazel test`. Use `--path` to select the project and working directory, and `--bazel` to select a different executable such as `bazelisk`. Ordinary `bazel test` still runs your tests, but does not report individual cases to Tuist and does not enforce quarantine policies.
+Arguments after `--` are forwarded to `bazel test`. Use `--path` to select the project and working directory, and `--bazel` to select a different executable such as `bazelisk`. Ordinary `bazel test` still reports test results, but does not fetch or enforce Tuist quarantine policies.
+
+> [!NOTE]
+> The `tuist bazel test` wrapper is only required for <.localized_link href="/guides/features/test-insights/flaky-tests/bazel">quarantined tests</.localized_link>. Per-case reporting for regular test runs is set up by `tuist bazel setup` in `.bazelrc.tuist`, so a plain `bazel test` reports individual cases too.
 
 ## What is tracked {#what-is-tracked}
 


### PR DESCRIPTION
## Summary

Fixes #13132.

The two Bazel test insights docs disagreed on what a plain `bazel test` reports:

- `server/priv/docs/en/guides/features/test-insights/bazel.md:22` said it "does not report individual cases to Tuist".
- `server/priv/docs/en/guides/features/test-insights/flaky-tests/bazel.md:28` said it "still reports test results, but does not fetch or enforce Tuist quarantine policies".

The flaky tests page was right. Reporting is set up by `tuist bazel setup` in `.bazelrc.tuist`: the `build --bes_backend=…` line (plus BES headers, `--build_event_publish_all_actions`, upload strategy, profile flags) applies to `bazel test` too. Kura consumes `TestResult` events straight off the BES stream and resolves `test.xml` by digest from its own REAPI store, and the server parses JUnit into per-case rows. None of that path goes through the CLI wrapper.

The wrapper (`tuist bazel test`) is only needed for quarantine (Mute + Skip), because that flow depends on server-side policy fetched before each invocation plus post-hoc analysis of the local build event JSON to downgrade Bazel's failure exit when every reported failure is muted. That can't live in a `.bazelrc`.

## Why this approach

Considered rewording both docs, but the flaky tests page was already accurate and its phrasing is the one that matches the code. The smaller change is to correct the test insights page and add a note admonition pointing readers to the flaky tests page for the wrapper's actual role, so nobody assumes `tuist bazel test` is needed just to get case-level reporting.

## Validation

- Read `cli/Sources/TuistBazelCommand/BazelTestCommandService.swift` and `BazelrcFile.swift` to confirm the wrapper only mutates `bazel test` invocations when the fetched quarantine policy is non-empty, and that `--bes_backend` lives on the `build` command in `.bazelrc.tuist`.
- Confirmed Kura's BEP consumer at `kura/src/reapi/bep.rs` handles `TestResult` events without any wrapper-specific gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)