### PR TITLE
test(server): update billing minute display expectations

### DIFF
--- a/server/test/tuist_web/live/billing_live_test.exs
+++ b/server/test/tuist_web/live/billing_live_test.exs
@@ -331,7 +331,7 @@ defmodule TuistWeb.BillingLiveTest do
       # Prepaid minutes are already paid for, so they raise the ceiling
       # rather than appearing as a balance of their own.
       assert html =~ "10100"
-      assert html =~ "100 free plus 10,000 prepaid"
+      assert html =~ "100 free plus 10K prepaid"
       # Nothing here may move as credit is spent.
       refute html =~ "3000.00"
       refute html =~ "left."
@@ -474,7 +474,7 @@ defmodule TuistWeb.BillingLiveTest do
       {:ok, lv, _html} = live(conn, ~p"/#{account.name}/billing")
 
       assert has_element?(lv, "#runner-minutes-progress")
-      assert render(lv) =~ "10,100"
+      assert render(lv) =~ "10.1K"
     end
 
     test "separates what usage is worth from what is billed while on a trial", %{conn: conn, account: account} do

--- a/server/test/tuist_web/live/ops_account_live_test.exs
+++ b/server/test/tuist_web/live/ops_account_live_test.exs
@@ -833,14 +833,14 @@ defmodule TuistWeb.OpsAccountLiveTest do
 
       {:ok, lv, _html} = live(conn, ~p"/ops/accounts/#{user.account.id}")
 
-      assert has_element?(lv, "#prepaid-balance-table", "10,000")
+      assert has_element?(lv, "#prepaid-balance-table", "10K")
 
       html =
         lv
         |> form("#prepaid-minutes-form", %{"minutes" => "100"})
         |> render_submit()
 
-      assert html =~ "10,100"
+      assert html =~ "10.1K"
     end
 
     test "sets the balance to the figure typed rather than adding to it", %{conn: conn, user: user} do
@@ -963,7 +963,7 @@ defmodule TuistWeb.OpsAccountLiveTest do
 
       {:ok, lv, _html} = live(conn, ~p"/ops/accounts/#{user.account.id}")
 
-      assert has_element?(lv, "#prepaid-balance-table", "10,000")
+      assert has_element?(lv, "#prepaid-balance-table", "10K")
       assert has_element?(lv, "#prepaid-balance-table", "January 1, 2027")
       refute render(lv) =~ "750.00$"
     end


### PR DESCRIPTION
## Summary

- Update billing LiveView test expectations to match compact minute formatting.
- Verify prepaid balances render as `10K` and combined usage renders as `10.1K`.
- Keep assertions aligned across billing and operations account views.

## Testing

- Updated unit/UI LiveView tests in `billing_live_test.exs` and `ops_account_live_test.exs` to validate the compact display behavior.