### PR TITLE
fix(infra): stop the runners-controller claiming minWarmPoolFloor from helm

### DIFF
--- a/infra/helm/tuist/values-managed-production.yaml
+++ b/infra/helm/tuist/values-managed-production.yaml
@@ -1722,7 +1722,22 @@ runnersFleetLinux:
     # and 4 GB/vCPU, and kata pins guest RAM (request == limit == the
     # shape), so memory reservation is what runs out on this fleet while
     # CPU does not. This rung is bought for memory and priced for it.
-    - { vcpus: 16, memoryGb: 64 }
+    #
+    # Warm floor 1, unlike every other long-tail shape. This Pod needs a
+    # contiguous 16,250m / 66.5 GiB, which is 52% of a RISE-L's CPU and
+    # 57% of its memory, so at floor 0 each arrival waits for that hole
+    # to be manufactured by draining a host. The drain cannot converge
+    # here: `reservationTimeout` is 15m and the `16vcpu-32gb` jobs it
+    # queues behind run a p50 of 28m, so the reservation expires and the
+    # node then rests for `reservationCooldown`. Production 2026-09-11
+    # spent 36 minutes queued that way with the fleet at 88% committed
+    # and the account 96 GB under its own limit. Holding one Pod costs
+    # the same 66.5 GiB continuously and removes both the cold start and
+    # the drain, against ~4 jobs/day at a 46-minute median.
+    - vcpus: 16
+      memoryGb: 64
+      autoscaling:
+        minWarmPoolFloor: 1
 
 # In-cluster Valkey backs the auth rate limiter (Hammer.Redis). The
 # chart wires TUIST_REDIS_URL to the embedded Service; without it the

--- a/infra/runners-controller/controllers/runnerpool_controller.go
+++ b/infra/runners-controller/controllers/runnerpool_controller.go
@@ -187,8 +187,15 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		return r.reconcileDelete(ctx, pool)
 	}
+	// Patched, not Updated. A full-object Update writes back every
+	// field the controller decoded, including an
+	// `autoscaling.minWarmPoolFloor` the API server supplied from the
+	// CRD default because helm rendered none. That pins the floor and
+	// moves the field's manager from `helm` to this controller, after
+	// which the chart can no longer set it.
+	beforeFinalizer := pool.DeepCopy()
 	if controllerutil.AddFinalizer(pool, runnerPoolFinalizer) {
-		if err := r.Update(ctx, pool); err != nil {
+		if err := r.Patch(ctx, pool, client.MergeFrom(beforeFinalizer)); err != nil {
 			return ctrl.Result{}, fmt.Errorf("add drain finalizer: %w", err)
 		}
 	}
@@ -663,8 +670,9 @@ func (r *RunnerPoolReconciler) reconcileDelete(ctx context.Context, pool *tuistv
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
+	original := pool.DeepCopy()
 	controllerutil.RemoveFinalizer(pool, runnerPoolFinalizer)
-	if err := r.Update(ctx, pool); err != nil {
+	if err := r.Patch(ctx, pool, client.MergeFrom(original)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("remove drain finalizer: %w", err)
 	}
 	logger.Info("pool drained; finalizer released", "drainedIdle", drainedIdle)

--- a/infra/runners-controller/controllers/runnerpool_controller_test.go
+++ b/infra/runners-controller/controllers/runnerpool_controller_test.go
@@ -20,6 +20,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
@@ -1877,5 +1878,58 @@ func TestReconcileLeavesRecentlyDeletedPodAlone(t *testing.T) {
 
 	if err := c.Get(context.Background(), nn(sa.Namespace, sa.Name), &corev1.ServiceAccount{}); err != nil {
 		t.Fatalf("draining Pod's ServiceAccount was reaped early: %v", err)
+	}
+}
+
+// TestReconcile_FinalizerWriteDoesNotClaimSpec guards the field-manager
+// ownership of `spec.autoscaling.minWarmPoolFloor`.
+//
+// The finalizer used to be persisted with a full-object `Update`, which
+// sends every field the controller decoded — including the warm floor
+// the API server had just filled in from the CRD's `default: 1` because
+// helm had not rendered one. That write both pinned the floor at 1 and
+// moved the field's manager from `helm` to `manager`, after which helm
+// could no longer set it: production 2026-09-11 had six Linux pools at
+// floor 1 against a chart that says 0, five of them serving zero jobs
+// in seven days while holding 24,250m and 74.5 GiB of a 186,000m /
+// 703 GiB fleet.
+//
+// A patch sends only the diff, so the finalizer no longer drags spec
+// along with it.
+func TestReconcile_FinalizerWriteDoesNotClaimSpec(t *testing.T) {
+	scheme := mustScheme(t)
+	pool := newPool("p", "ghcr.io/tuist/tuist-runner@sha256:new", 1)
+
+	var poolUpdates int
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pool).
+		WithStatusSubresource(&tuistv1.RunnerPool{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if _, ok := obj.(*tuistv1.RunnerPool); ok {
+					poolUpdates++
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &RunnerPoolReconciler{Client: c, Scheme: scheme, DispatchURL: "http://dispatch"}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: nn(pool.Namespace, pool.Name),
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	stored := &tuistv1.RunnerPool{}
+	if err := c.Get(context.Background(), nn(pool.Namespace, pool.Name), stored); err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(stored, runnerPoolFinalizer) {
+		t.Fatalf("expected the drain finalizer to be added, finalizers = %v", stored.Finalizers)
+	}
+	if poolUpdates != 0 {
+		t.Fatalf("RunnerPool spec written back via %d full Update(s); the finalizer must be patched so helm keeps ownership of spec.autoscaling.minWarmPoolFloor", poolUpdates)
 	}
 }


### PR DESCRIPTION
## What changed

Two things, both aimed at the recurring `Runner queue age` alert on the Linux runner fleet.

1. The runners-controller no longer writes `spec.autoscaling.minWarmPoolFloor` back to the API server. The drain finalizer is now added and removed with a merge patch instead of a full-object `Update`.
2. The `16vcpu-64gb` shape gets an explicit `minWarmPoolFloor: 1` in the production values.

## Why

### The controller was silently overriding the chart

`RunnerPoolReconciler.Reconcile` persisted the drain finalizer with `r.Update(ctx, pool)`. An `Update` sends the whole object as the controller decoded it. On a pool where helm rendered no `minWarmPoolFloor`, the API server had already filled the field in from the CRD's structural `default: 1`, so the finalizer write did two things nobody asked for: it stored 1, and it moved the field's manager from `helm` to `manager`. Once the controller owns a field, the chart cannot set it.

Six of the nine production Linux pools are in that state today:

| pool | live floor | owns `minWarmPoolFloor` | jobs, last 7 days |
|---|---|---|---|
| 1vcpu-2gb | 1 | controller | 0 |
| 2vcpu-4gb | 1 | controller | 0 |
| 2vcpu-8gb | 4 | helm | 16896 |
| 4vcpu-8gb | 1 | controller | 0 |
| 4vcpu-16gb | 0 | helm | 8801 |
| 8vcpu-16gb | 1 | controller | 0 |
| 8vcpu-32gb | 1 | controller | 0 |
| 16vcpu-32gb | 1 | controller | 291 |
| 16vcpu-64gb | 0 | helm | 22 |

The split is exact: every pool the controller owns reads 1, every pool helm owns reads the chart value. `runnersFleetLinux.shapeAutoscaling.minWarmPoolFloor` has been `0` since 2026-06-02, so production has been running a floor the chart never asked for, for three months.

The cost is not theoretical. Five of those pools have served zero jobs in seven days and still hold one warm Pod each, which is 24,250m and 74.5 GiB permanently reserved on a fleet with 186,000m and 703 GiB allocatable across six OVH RISE-L boxes.

### Why that matters for the 16x64 shape

A `16vcpu-64gb` Pod requests 16,250m and 66.5 GiB after the kata RuntimeClass's 250m / 2560Mi `podFixed`. A RISE-L has 31,000m and 117.1 GiB allocatable, so the Pod needs 52% of a host's CPU and 57% of its memory, contiguous, and exactly one fits per box.

On 2026-09-11 the pool queued for 36 minutes. The scheduler rejected the Pod on every node in the fleet:

```
0/42 nodes are available: 31 node(s) had untolerated taint(s),
5 node(s) didn't match Pod's node affinity/selector,
6 Insufficient cpu, 6 Insufficient memory.
```

This was not the account concurrency cap. At 08:12 UTC the account ran five 16vcpu-32gb jobs, 80 vCPU and 160 GB against a 128 / 256 limit, so 96 GB of its own budget was unused and `queue_withheld` sat at 0 to 1 against a queue length of 1 to 2. It was not aggregate capacity either. It was that no single host had the hole.

At floor 0 the only way to get that hole is `reconcileReservation` draining a host, and on this fleet that drain cannot converge. `reservationTimeout` is 15 minutes; the `16vcpu-32gb` jobs the reservation waits behind run a p50 of 28 minutes and up to 58. The reservation expires before 66.5 GiB frees, the node then sits in a 15-minute `reservationCooldown`, and the 300-second `startTimeoutSeconds` reaper releases the provisioning slot in the meantime:

```
RunnerPodUnschedulable: No node could accommodate this Pod for 300 seconds;
releasing its fleet provisioning slot
```

Holding one Pod costs the same 66.5 GiB continuously and removes both the cold start and the drain, against roughly 4 jobs a day at a 46-minute median.

## Why this over the obvious alternatives

**Lowering the `tuist` account's concurrency limit.** Neither account was near its cap when this fired. The limit is an admission budget, not a placement mechanism, so trimming it does not create a contiguous hole on any particular host. Small Pods refill whatever it frees.

**Buying another RISE-L.** The fleet already went from four nodes to six on 2026-09-09 and this fired two days later. A box seats exactly one 16x64 Pod, and buying capacity does not fix the drain path. Worth revisiting on its own merits once the floors are honest: the `tuist` and `carousell` Linux entitlements sum to 256 vCPU against 186 vCPU of fleet, so those two accounts alone are already sold about 1.4x the metal. That is a pricing conversation, not a purchasing one, and it is out of scope here.

**Editing the values file alone.** It would not have worked. The chart already says 0 for the five dead pools and production ignores it, because helm does not own the field.

## Impact

After this merges and deploys, the next helm upgrade reclaims `minWarmPoolFloor` on the six affected pools and the controller stops taking it back, so the five zero-traffic pools drop to floor 0 and return 24,250m and 74.5 GiB to the fleet. `16vcpu-32gb` also drops from 1 to 0, which is what the chart has always specified for it. No manual `kubectl patch` is needed; the ownership transfer happens on the deploy's own apply.

Net memory change is 74.5 GiB returned against 66.5 GiB newly held by the `16vcpu-64gb` floor.

## Validation

- New regression test `TestReconcile_FinalizerWriteDoesNotClaimSpec` intercepts `Update` on the fake client and fails if the reconciler writes a RunnerPool back in full. It fails on the previous code with `RunnerPool spec written back via 1 full Update(s)` and passes after the change.
- `go build ./...`, `go vet ./...` and `go test ./...` pass for the `infra/runners-controller` module.
- `gofmt -l` is clean.
- `helm template` against the production values renders the intended floors: `16vcpu-64gb` at 1, `2vcpu-8gb` unchanged at 4, and every other Linux shape at 0.

Field ownership was read from the live production cluster with read-only `kubectl`; nothing was mutated there.

## Follow-ups, not in this PR

- `reservationTimeout` is shorter than the jobs a drain waits on for coarse shapes. Either scale it with the shape or accept that drains cannot serve them.
- `tuist_runners_pool_oldest_pending_pod_age_seconds` has no Linux series at all, only macOS, so pending-Pod age is unobservable on this fleet.
- The CRD's structural `default: 1` on `minWarmPoolFloor` no longer matches the Go source, which handles the nil case in `MinWarmPoolFloorOrDefault` with no `+kubebuilder:default` marker. Worth reconciling so a regenerated CRD does not change behaviour by surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
