### PR TITLE
fix(infra): repair canary's ClickHouse gap and unblock its deploys

### DIFF
--- a/infra/helm/tuist/values-managed-canary.yaml
+++ b/infra/helm/tuist/values-managed-canary.yaml
@@ -357,35 +357,46 @@ clickhouse:
     # the deploy that turns dual writes on above has finished rolling out: the
     # backfill covers everything before it, the mirror covers everything after,
     # and naming the boundary is what stops the two from leaving a gap.
-    # Step 6a: the full parity gate, before reads move anywhere.
+    # A repair pass, and a step back from 6a.
     #
-    # Step 5 is done here. The backfill copied 260 chunks across 50 tables with
-    # 101 skipped and none failed, in 58 seconds, and a second run finished in
-    # 7 with everything skipped, which is the ledger doing its job.
+    # The full parity gate ran and failed, which is the gate working: 13 of 69
+    # copied tables differ over the whole dataset, and the deploy rolled back
+    # with it. The shape is consistent. Both servers report the same min_time
+    # and max_time, and the destination simply holds fewer rows: shard_plans
+    # short by 299, xcode_targets by 232, command_events by 215, and the test
+    # family by 24 to 55 each. Rows missing from the middle of the range, not a
+    # truncated range.
     #
-    # This is a different check from the hourly worker, and that distinction is
-    # the point. The worker compares a two-hour window, so it says recent
-    # writes agree. `check_clickhouse_parity` compares every copied table over
-    # the whole dataset, schemas included, which is what the backfill's
-    # coverage of history has never been measured against. The worker reporting
-    # "all 62 copied table(s) agree" is not evidence for this.
+    # That is writes the mirror lost, and the hourly worker could never have
+    # seen it: it compares a two-hour window, so this history slid past it
+    # every hour while reporting agreement. The full check is the first thing
+    # to look at all of it.
     #
-    # It raises rather than reports, and that is deliberate: it is the gate for
-    # the cutover, and schema drift in particular is fatal here because from
-    # the flip onward a missing column breaks the ingest path rather than
-    # costing one mirrored write.
+    # Most of it is explained. The xcresult-processor mirrored nothing at all
+    # until it had a tailnet route, so every test row written between the last
+    # backfill's cutoff and that landing reached Cloud alone, and the rest is
+    # the deploy churn of the last two days.
     #
-    # Consequence worth stating: a post-upgrade hook that raises fails the
-    # release, and the deploy runs with `--atomic`, so a parity failure rolls
-    # canary back. That is correct for a gate and it is also how three canary
-    # releases were lost last week. If it fails, read the Job, then disarm this
-    # rather than redeploying into the same wall.
+    # The repair is this, not something new: a chunk fills gaps by row identity
+    # rather than appending, so re-running with a later cutoff copies only what
+    # the destination lacks and cannot duplicate what it already holds.
     #
-    # `cutoff` is gone with the backfill it belonged to.
+    # The cutoff is deliberately ahead of now. The deploy that arms this
+    # restarts the server pods, and anything their mirror drops while warming
+    # up would otherwise land after the cutoff and survive the repair. Reaching
+    # past it costs nothing, because rows that arrive before the job runs are
+    # copied and rows after are covered by a mirror that has been clean since
+    # 08:00 today, with no error or retried series at all.
+    #
+    # One thing this will not fix: build_runs_new has identical row counts on
+    # both sides and sum_duration differing by 820. A value discrepancy, not a
+    # missing row, so a copy cannot repair it. Same family as the legacy_id
+    # default, and it needs its own look before the cutover.
     migration:
       enabled: true
-      name: parity
-      task: Tuist.Release.check_clickhouse_parity
+      name: backfill
+      task: Tuist.Release.backfill_clickhouse
+      cutoff: "2026-09-11T12:00:00Z"
 
   poolSize: "30"
   bufferPoolSize: "30"


### PR DESCRIPTION
## Two things at once: unblock canary, and repair the gap

The full parity gate from [#13143](https://github.com/tuist/tuist/pull/13143) ran and failed, and the deploy rolled back with it:

```
upgrade failed: post-upgrade hooks failed: resource Job/tuist-canary/tuist-tuist-clickhouse-parity
not ready. status: Failed, message: Job Failed. failed: 1/1
```

That is the gate doing its job, but it also means **canary stays red on every release** until it is disarmed. This swaps it for the repair, which does both.

## What the gate found

**13 of 69 copied tables differ**, and the shape is consistent: both servers report the **same `min_time` and `max_time`**, and the destination simply holds fewer rows.

| table | source | destination | short by |
|---|---|---|---|
| `shard_plans` | 3728 | 3429 | 299 |
| `xcode_targets` | 681 | 449 | 232 |
| `command_events` | 3349 | 3134 | 215 |
| `test_case_runs` | 7950 | 7895 | 55 |
| `test_cases` | 25294 | 25243 | 51 |
| `test_case_events` | 24549 | 24513 | 36 |
| `test_module_runs` | 17647 | 17614 | 33 |
| `test_run_destinations` | 1264 | 1240 | 24 |
| `shard_runs` | 3235 | 3223 | 12 |

Roughly 950 rows, missing from the **middle** of the range rather than the end. That is what lost writes look like, not an incomplete copy.

**The hourly worker could never have caught this.** It compares a two-hour window, so this history slid past it every hour while it reported "all 62 copied table(s) agree". The full check is the first thing to have looked at all of it, and it answers a question left open two days ago: yes, the deploy churn permanently lost rows, and this is how many.

Most of it is already explained. The xcresult-processor mirrored **nothing at all** until it had a tailnet route, so every test row written between the last backfill's cutoff and that landing reached Cloud alone. The rest is the churn itself: failed releases, `--atomic` rollbacks, and the ClickHouse pod restarts each one caused.

## Why a re-run repairs it

This is the mechanism the copy engine was built with. A chunk **fills gaps by row identity** rather than appending, so re-running with a later cutoff copies only what the destination lacks and cannot duplicate what it already holds. It is also why the second run on 09-10 finished in 7 seconds with everything skipped.

## Why the cutoff reaches past now

`2026-09-11T12:00:00Z` is deliberately ahead of the current time. The deploy that arms this restarts the server pods, and anything their mirror drops while warming up would otherwise land *after* the cutoff and survive the repair, which is exactly how the residue accumulated last time.

Reaching past it costs nothing. Rows arriving before the job runs are copied; rows after are covered by the mirror, which has shown **only successes since 08:00 today**, with no `error` and no `retried` series at all. The retry split from [#13084](https://github.com/tuist/tuist/pull/13084) appears to be holding.

## What this does not fix

`build_runs_new` has **identical row counts** on both sides, with `sum_duration` differing by 820. A value discrepancy rather than a missing row, so no amount of copying repairs it. It is the same family as the `legacy_id` per-server default and needs its own investigation before the cutover.

The 12 derived tables reported alongside are **not** a gate, correctly: materialized views recompute on the destination rather than being copied.

## After this

Re-arm the parity gate and expect it to pass, or to name a much smaller residue. The sequence from there is unchanged: `check_clickhouse_reads`, then the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
