### PR TITLE
fix(kura): retry binary builds in production deployment

### DIFF
--- a/.github/workflows/server-production-deployment.yml
+++ b/.github/workflows/server-production-deployment.yml
@@ -466,7 +466,7 @@ jobs:
           # --binary-only builds just //:kura (opt via kura/.bazelrc); //... would pull in the test
           # target, which can't cross-compile. compile-args adds the cross --config on the macOS
           # x86_64 leg and is empty for the native legs.
-          mise run --skip-tools compile -- --binary-only ${{ matrix.compile-args }}
+          ../.github/scripts/retry-bazel-command.sh mise run --skip-tools compile -- --binary-only ${{ matrix.compile-args }}
 
           STAGE_DIR="$(mktemp -d)"
           cp bazel-bin/kura "$STAGE_DIR/kura"


### PR DESCRIPTION
## Summary

- Wrap the production Kura binary compilation command with the existing Bazel retry helper.
- Improve resilience against transient Bazel build failures during the matrix-based deployment workflow.
- Preserve the existing binary-only and platform-specific compilation arguments.

The bug was that a transient Bazel failure caused the deployment job to fail immediately, without retrying the same compilation. The change applies retry behavior at the workflow command boundary while leaving the build target and cross-compilation configuration unchanged.

## Testing

- Not run (not requested)