### PR TITLE
perf(cli): stop hashing the graph twice during a cache warm

### DIFF
--- a/cli/Sources/TuistCache/CacheGraphContentHasher.swift
+++ b/cli/Sources/TuistCache/CacheGraphContentHasher.swift
@@ -151,16 +151,25 @@ public struct CacheGraphContentHasher: CacheGraphContentHashing {
         )
     }
 
+    /// Whether `excludedTargets` covers `target`, either by name or because the target is the resources
+    /// bundle of an excluded target.
+    ///
+    /// Callers that hash the full graph and narrow the result afterwards need the same rule the hashing
+    /// itself applies, so it lives here rather than being restated at every call site.
+    public static func isExcluded(
+        _ target: GraphTarget,
+        excludedTargets: Set<String>
+    ) -> Bool {
+        excludedTargets.contains(target.target.name) || excludedTargets
+            .contains(target.target.name.dropPrefix("\(target.project.name)_"))
+    }
+
     private func isGraphTargetHashable(
         _ target: GraphTarget,
         excludedTargets: Set<String>
     ) -> Bool {
         let product = target.target.product
-        let name = target.target.name
-
-        // The second condition is to exclude the resources bundle associated to the given target name
-        let isExcluded = excludedTargets.contains(name) || excludedTargets
-            .contains(target.target.name.dropPrefix("\(target.project.name)_"))
+        let isExcluded = CacheGraphContentHasher.isExcluded(target, excludedTargets: excludedTargets)
         let isTestBundle = target.target.product.testsBundle
         let isHashableProduct = CacheGraphContentHasher.cachableProducts.contains(product)
 

--- a/cli/Sources/TuistCache/CacheGraphContentHasher.swift
+++ b/cli/Sources/TuistCache/CacheGraphContentHasher.swift
@@ -151,25 +151,16 @@ public struct CacheGraphContentHasher: CacheGraphContentHashing {
         )
     }
 
-    /// Whether `excludedTargets` covers `target`, either by name or because the target is the resources
-    /// bundle of an excluded target.
-    ///
-    /// Callers that hash the full graph and narrow the result afterwards need the same rule the hashing
-    /// itself applies, so it lives here rather than being restated at every call site.
-    public static func isExcluded(
-        _ target: GraphTarget,
-        excludedTargets: Set<String>
-    ) -> Bool {
-        excludedTargets.contains(target.target.name) || excludedTargets
-            .contains(target.target.name.dropPrefix("\(target.project.name)_"))
-    }
-
     private func isGraphTargetHashable(
         _ target: GraphTarget,
         excludedTargets: Set<String>
     ) -> Bool {
         let product = target.target.product
-        let isExcluded = CacheGraphContentHasher.isExcluded(target, excludedTargets: excludedTargets)
+        let name = target.target.name
+
+        // The second condition is to exclude the resources bundle associated to the given target name
+        let isExcluded = excludedTargets.contains(name) || excludedTargets
+            .contains(target.target.name.dropPrefix("\(target.project.name)_"))
         let isTestBundle = target.target.product.testsBundle
         let isHashableProduct = CacheGraphContentHasher.cachableProducts.contains(product)
 

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -1089,28 +1089,6 @@ import XcodeGraph
             return try await cacheStorage.store(storableTargets, cacheCategory: .binaries)
         }
 
-        /// Narrows hashes to the targets a cache profile warms, applying the same rule `tuist generate` uses:
-        /// a target the profile declines to replace is not warmed either.
-        private func hashesKeptBy(
-            _ cacheProfile: CacheProfile,
-            in graph: Graph,
-            graphTraverser: GraphTraversing,
-            hashes: [GraphTarget: TargetContentHash]
-        ) -> [GraphTarget: TargetContentHash] {
-            let decider = CacheProfileTargetReplacementDecider(profile: cacheProfile, exceptions: [])
-            var excludedTargets = Set<String>()
-            for graphTarget in graphTraverser.allTargets() {
-                guard let project = graph.projects[graphTarget.path] else { continue }
-                if !decider.shouldReplace(project: project, target: graphTarget.target) {
-                    excludedTargets.insert(graphTarget.target.name)
-                }
-            }
-            guard !excludedTargets.isEmpty else { return hashes }
-            return hashes.filter {
-                !CacheGraphContentHasher.isExcluded($0.key, excludedTargets: excludedTargets)
-            }
-        }
-
         private func cacheableTargets(
             for graph: Graph,
             configuration: String?,
@@ -1121,22 +1099,32 @@ import XcodeGraph
         ) async throws -> CacheableTargets {
             let graphTraverser = GraphTraverser(graph: graph)
 
-            // Hash every cacheable target, not only the ones this profile keeps. Binary replacement in the
-            // warm project runs under `.allPossible` whatever profile warms the cache, so a map narrowed to
-            // the profile would leave it re-hashing the difference from scratch.
+            // Apply the same profile-based filtering used by `tuist generate`.
+            // Targets where shouldReplace returns false are excluded from cache warming.
+            let decider = CacheProfileTargetReplacementDecider(profile: cacheProfile, exceptions: [])
+            var excludedTargets = Set<String>()
+            for graphTarget in graphTraverser.allTargets() {
+                guard let project = graph.projects[graphTarget.path] else { continue }
+                if !decider.shouldReplace(project: project, target: graphTarget.target) {
+                    excludedTargets.insert(graphTarget.target.name)
+                }
+            }
+
             let hashesByCacheableTarget = try await cacheGraphContentHasher.contentHashes(
                 for: graph,
                 configuration: configuration,
                 defaultConfiguration: config.project.generatedProject?.generationOptions.defaultConfiguration,
-                excludedTargets: [],
+                excludedTargets: excludedTargets,
                 destination: nil
             )
-            let profileHashesByCacheableTarget = hashesKeptBy(
-                cacheProfile,
-                in: graph,
-                graphTraverser: graphTraverser,
-                hashes: hashesByCacheableTarget
-            )
+
+            // Binary replacement in the warm project runs under `.allPossible` whatever profile warms the
+            // cache, so it asks for hashes this map does not hold as soon as the profile excludes anything,
+            // and it has to hash the graph itself. Widening the hashing above to cover it is not an option:
+            // hashing a target runs its `additionalHashingInputs` scripts, and excluding a target also makes
+            // its dependents unhashable, which is what keeps a warm from storing artifacts the same profile
+            // could never read back.
+            let reusableHashes = excludedTargets.isEmpty ? hashesByCacheableTarget : [:]
 
             let selectedHashesByCacheableTarget: [GraphTarget: TargetContentHash]
             switch CacheWarmTargetGraphSelector.selection(
@@ -1144,13 +1132,14 @@ import XcodeGraph
                 requestedTargets: requestedTargetsToBinaryCache
             ) {
             case .allReachable:
-                selectedHashesByCacheableTarget = profileHashesByCacheableTarget
+                selectedHashesByCacheableTarget = hashesByCacheableTarget
             case let .explicit(allowedTargets):
-                selectedHashesByCacheableTarget = profileHashesByCacheableTarget
-                    .filter { allowedTargets.contains($0.key) }
+                selectedHashesByCacheableTarget = Dictionary(
+                    uniqueKeysWithValues: hashesByCacheableTarget.filter { allowedTargets.contains($0.key) }
+                )
             case .noNonTestRoots:
                 Logger.current.info("No non-test targets were selected for binary cache warming")
-                return CacheableTargets(targetsToBuild: [], hashes: hashesByCacheableTarget)
+                return CacheableTargets(targetsToBuild: [], hashes: reusableHashes)
             }
 
             let sortedCacheableTargets = try graphTraverser.allTargetsTopologicalSorted()
@@ -1192,7 +1181,7 @@ import XcodeGraph
                 targetsToBuild: cacheableTargets.compactMap {
                     existingTargetHashes.contains($0.hash) ? nil : ($0.target, $0.hash)
                 },
-                hashes: hashesByCacheableTarget
+                hashes: reusableHashes
             )
         }
     }
@@ -1203,8 +1192,9 @@ import XcodeGraph
         /// Targets whose artifact is missing from the cache, paired with the hash to store it under.
         let targetsToBuild: [(GraphTarget, String)]
 
-        /// Content hash of every cacheable target in the graph, profile filtering aside. Handed to the
-        /// warm project's binary replacement so it does not hash the same graph a second time. Keyed by
+        /// Content hash of every cacheable target in the graph, handed to the warm project's binary
+        /// replacement so it does not hash the same graph a second time. Empty when a cache profile
+        /// narrowed the hashing, since replacement would then need hashes this does not hold. Keyed by
         /// reference rather than by graph target, because the warm project is a different graph.
         let targetHashes: [TargetReference: TargetContentHash]
 

--- a/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
+++ b/cli/Sources/TuistKit/Commands/Cache/CacheWarmCommandService.swift
@@ -192,7 +192,7 @@ import XcodeGraph
             // Hash
             Logger.current.info("Hashing cacheable targets")
 
-            let cacheableTargets = try await cacheableTargets(
+            let hashedGraph = try await cacheableTargets(
                 for: graph,
                 configuration: requestedConfiguration,
                 config: config,
@@ -200,6 +200,7 @@ import XcodeGraph
                 cacheProfile: profile,
                 cacheStorage: cacheStorage
             )
+            let cacheableTargets = hashedGraph.targetsToBuild
 
             try foreignBuildOutputValidator.validate(
                 targets: cacheableTargets.map(\.0),
@@ -228,7 +229,8 @@ import XcodeGraph
                     config: config,
                     targetsToBinaryCache: targetsToBinaryCache,
                     configuration: configuration,
-                    cacheStorage: cacheStorage
+                    cacheStorage: cacheStorage,
+                    targetHashes: hashedGraph.targetHashes
                 )
                 .generateWithGraph(path: path, options: config.project.generatedProject?.generationOptions)
 
@@ -1087,18 +1089,14 @@ import XcodeGraph
             return try await cacheStorage.store(storableTargets, cacheCategory: .binaries)
         }
 
-        private func cacheableTargets(
-            for graph: Graph,
-            configuration: String?,
-            config: Tuist,
-            requestedTargetsToBinaryCache: Set<TargetQuery>,
-            cacheProfile: CacheProfile,
-            cacheStorage: CacheStoring
-        ) async throws -> [(GraphTarget, String)] {
-            let graphTraverser = GraphTraverser(graph: graph)
-
-            // Apply the same profile-based filtering used by `tuist generate`.
-            // Targets where shouldReplace returns false are excluded from cache warming.
+        /// Narrows hashes to the targets a cache profile warms, applying the same rule `tuist generate` uses:
+        /// a target the profile declines to replace is not warmed either.
+        private func hashesKeptBy(
+            _ cacheProfile: CacheProfile,
+            in graph: Graph,
+            graphTraverser: GraphTraversing,
+            hashes: [GraphTarget: TargetContentHash]
+        ) -> [GraphTarget: TargetContentHash] {
             let decider = CacheProfileTargetReplacementDecider(profile: cacheProfile, exceptions: [])
             var excludedTargets = Set<String>()
             for graphTarget in graphTraverser.allTargets() {
@@ -1107,28 +1105,52 @@ import XcodeGraph
                     excludedTargets.insert(graphTarget.target.name)
                 }
             }
+            guard !excludedTargets.isEmpty else { return hashes }
+            return hashes.filter {
+                !CacheGraphContentHasher.isExcluded($0.key, excludedTargets: excludedTargets)
+            }
+        }
 
+        private func cacheableTargets(
+            for graph: Graph,
+            configuration: String?,
+            config: Tuist,
+            requestedTargetsToBinaryCache: Set<TargetQuery>,
+            cacheProfile: CacheProfile,
+            cacheStorage: CacheStoring
+        ) async throws -> CacheableTargets {
+            let graphTraverser = GraphTraverser(graph: graph)
+
+            // Hash every cacheable target, not only the ones this profile keeps. Binary replacement in the
+            // warm project runs under `.allPossible` whatever profile warms the cache, so a map narrowed to
+            // the profile would leave it re-hashing the difference from scratch.
             let hashesByCacheableTarget = try await cacheGraphContentHasher.contentHashes(
                 for: graph,
                 configuration: configuration,
                 defaultConfiguration: config.project.generatedProject?.generationOptions.defaultConfiguration,
-                excludedTargets: excludedTargets,
+                excludedTargets: [],
                 destination: nil
             )
+            let profileHashesByCacheableTarget = hashesKeptBy(
+                cacheProfile,
+                in: graph,
+                graphTraverser: graphTraverser,
+                hashes: hashesByCacheableTarget
+            )
+
             let selectedHashesByCacheableTarget: [GraphTarget: TargetContentHash]
             switch CacheWarmTargetGraphSelector.selection(
                 graphTraverser: graphTraverser,
                 requestedTargets: requestedTargetsToBinaryCache
             ) {
             case .allReachable:
-                selectedHashesByCacheableTarget = hashesByCacheableTarget
+                selectedHashesByCacheableTarget = profileHashesByCacheableTarget
             case let .explicit(allowedTargets):
-                selectedHashesByCacheableTarget = Dictionary(
-                    uniqueKeysWithValues: hashesByCacheableTarget.filter { allowedTargets.contains($0.key) }
-                )
+                selectedHashesByCacheableTarget = profileHashesByCacheableTarget
+                    .filter { allowedTargets.contains($0.key) }
             case .noNonTestRoots:
                 Logger.current.info("No non-test targets were selected for binary cache warming")
-                return []
+                return CacheableTargets(targetsToBuild: [], hashes: hashesByCacheableTarget)
             }
 
             let sortedCacheableTargets = try graphTraverser.allTargetsTopologicalSorted()
@@ -1166,9 +1188,33 @@ import XcodeGraph
                 cacheItems.map(\.key.hash)
             )
 
-            return cacheableTargets.compactMap {
-                existingTargetHashes.contains($0.hash) ? nil : ($0.target, $0.hash)
-            }
+            return CacheableTargets(
+                targetsToBuild: cacheableTargets.compactMap {
+                    existingTargetHashes.contains($0.hash) ? nil : ($0.target, $0.hash)
+                },
+                hashes: hashesByCacheableTarget
+            )
+        }
+    }
+
+    /// The outcome of hashing the graph before a warm: what has to be built, and the hashes every
+    /// cacheable target resolved to.
+    struct CacheableTargets {
+        /// Targets whose artifact is missing from the cache, paired with the hash to store it under.
+        let targetsToBuild: [(GraphTarget, String)]
+
+        /// Content hash of every cacheable target in the graph, profile filtering aside. Handed to the
+        /// warm project's binary replacement so it does not hash the same graph a second time. Keyed by
+        /// reference rather than by graph target, because the warm project is a different graph.
+        let targetHashes: [TargetReference: TargetContentHash]
+
+        init(targetsToBuild: [(GraphTarget, String)], hashes: [GraphTarget: TargetContentHash]) {
+            self.targetsToBuild = targetsToBuild
+            targetHashes = Dictionary(
+                uniqueKeysWithValues: hashes.map {
+                    (TargetReference(projectPath: $0.key.path, name: $0.key.target.name), $0.value)
+                }
+            )
         }
     }
 #endif

--- a/cli/Sources/TuistKit/Generator/GeneratorFactory.swift
+++ b/cli/Sources/TuistKit/Generator/GeneratorFactory.swift
@@ -3,6 +3,7 @@ import Mockable
 import TuistConfig
 import TuistCore
 import TuistGenerator
+import TuistHasher
 import TuistLoader
 import TuistServer
 import TuistSupport
@@ -192,12 +193,15 @@ public struct GeneratorFactory: GeneratorFactorying {
         /// - Parameter targetsToBinaryCache: The targets to binary cache.
         /// - Parameter configuration: The configuration to generate for.
         /// - Parameter cacheStorage: The cache storage instance.
+        /// - Parameter targetHashes: Content hashes the caller already computed for the same graph. Binary
+        /// replacement reuses them instead of hashing the graph again; pass an empty map to have it hash.
         /// - Returns: A Generator instance.
         func binaryCacheWarming(
             config: Tuist,
             targetsToBinaryCache: [Platform: Set<TargetQuery>],
             configuration: String,
-            cacheStorage: CacheStoring
+            cacheStorage: CacheStoring,
+            targetHashes: [TargetReference: TargetContentHash]
         ) -> Generating
 
         /// Returns a generator to load the graph before generating the project to warm the cache
@@ -437,7 +441,8 @@ public struct GeneratorFactory: GeneratorFactorying {
             config: Tuist,
             targetsToBinaryCache: [XcodeGraph.Platform: Set<TargetQuery>],
             configuration: String,
-            cacheStorage: CacheStoring
+            cacheStorage: CacheStoring,
+            targetHashes: [TargetReference: TargetContentHash]
         ) -> Generating {
             let contentHasher = ContentHasher()
             let projectMapperFactory = ProjectMapperFactory(contentHasher: contentHasher)
@@ -453,7 +458,8 @@ public struct GeneratorFactory: GeneratorFactorying {
                 targets: targetsToBinaryCache,
                 cacheSources: Set(targetsToBinaryCache.flatMap(\.value)),
                 configuration: configuration,
-                cacheStorage: cacheStorage
+                cacheStorage: cacheStorage,
+                targetHashes: targetHashes
             )
             graphMappers = graphMappers.filter { !($0 is ExplicitDependencyGraphMapper) }
 

--- a/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
+++ b/cli/Sources/TuistKit/Mappers/Factories/GraphMapperFactory.swift
@@ -6,6 +6,7 @@ import TuistConfig
 import TuistCore
 import TuistDependencies
 import TuistGenerator
+import TuistHasher
 import TuistServer
 import XcodeGraph
 
@@ -327,7 +328,8 @@ public struct GraphMapperFactory: GraphMapperFactorying {
             targets: [XcodeGraph.Platform: Set<TargetQuery>],
             cacheSources: Set<TargetQuery>,
             configuration: String,
-            cacheStorage: CacheStoring
+            cacheStorage: CacheStoring,
+            targetHashes: [TargetReference: TargetContentHash] = [:]
         ) -> [GraphMapping] {
             var mappers = self.default(
                 config: config,
@@ -346,7 +348,8 @@ public struct GraphMapperFactory: GraphMapperFactorying {
                     exceptions: cacheSources
                 ),
                 configuration: configuration,
-                cacheStorage: cacheStorage
+                cacheStorage: cacheStorage,
+                precomputedTargetHashes: targetHashes
             )
             mappers.append(focusTargetsGraphMapper)
             mappers.append(TreeShakePrunedTargetsGraphMapper())

--- a/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
+++ b/cli/Tests/TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests.swift
@@ -319,6 +319,55 @@ struct TuistCacheEEAcceptanceTests {
         )
     }
 
+    /// A warm that finds some targets already cached has to swap those in while it builds the rest, and it
+    /// resolves them from the hashes it computed before the build rather than hashing the graph a second
+    /// time. Warming `CoreStaticLibrary` on its own and then warming everything puts one target on the
+    /// cached side of that split and six on the built side, so a hash that did not survive the handover
+    /// would show up as an empty replacement list and a rebuilt `CoreStaticLibrary`.
+    @Test(
+        .inTemporaryDirectory,
+        .withMockedEnvironment(inheritingVariables: ["PATH"]),
+        .withMockedNoora,
+        .withMockedLogger(forwardLogs: true),
+        .withFixture("generated_macos_tool_with_cached_libraries_and_frameworks")
+    ) func warming_reuses_an_already_cached_target_while_building_the_rest() async throws {
+        let fixtureDirectory = try #require(TuistTest.fixtureDirectory)
+        let mockedEnvironment = try #require(Environment.mocked)
+        let fileSystem = FileSystem()
+
+        try await TuistTest.run(
+            CacheCommand.self,
+            ["CoreStaticLibrary", "--path", fixtureDirectory.pathString]
+        )
+
+        try await TuistTest.run(
+            CacheCommand.self,
+            ["--path", fixtureDirectory.pathString]
+        )
+
+        TuistTest.expectLogs(
+            "Using cache binaries for the following targets: CoreStaticLibrary",
+            at: .info,
+            <=
+        )
+
+        for target in [
+            "CoreCLibrary",
+            "CoreStaticLibrary",
+            "DiagnosticsDynamicLibrary",
+            "FeatureStaticLibrary",
+            "FeatureFramework",
+            "ModelsStaticFramework",
+            "NetworkingFramework",
+        ] {
+            let cachedArtifacts = try await fileSystem.glob(
+                directory: mockedEnvironment.cacheDirectory,
+                include: ["**/\(target).xcframework"]
+            ).collect()
+            #expect(!cachedArtifacts.isEmpty, "\(target) should be stored as an xcframework")
+        }
+    }
+
     /// Regression test for static Objective-C xcframeworks whose public headers live in a
     /// `Headers/<Module>/` subdirectory and re-import each other with the `<Module/...>` prefix,
     /// consumed through the binary cache. `NestedObjC`/`NestedObjCKit` are static `.a` xcframeworks

--- a/cli/Tests/TuistCacheEETests/Generator/TargetsToCacheBinariesGraphMapperTests.swift
+++ b/cli/Tests/TuistCacheEETests/Generator/TargetsToCacheBinariesGraphMapperTests.swift
@@ -147,6 +147,162 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
         )
     }
 
+    func test_map_reuses_precomputed_hashes_instead_of_hashing_the_graph() async throws {
+        let path = try temporaryPath()
+
+        // Given
+        let cFramework = Target.test(name: "C", platform: .iOS, product: .framework)
+        let bFramework = Target.test(name: "B", platform: .iOS, product: .framework)
+        let project = Project.test(path: path, targets: [bFramework, cFramework])
+        let cGraphTarget = GraphTarget(path: path, target: cFramework, project: project)
+        let bGraphTarget = GraphTarget(path: path, target: bFramework, project: project)
+
+        subject = TargetsToCacheBinariesGraphMapper(
+            config: config,
+            cacheGraphContentHasher: cacheGraphContentHasher,
+            decider: CacheProfileTargetReplacementDecider(profile: .allPossible, exceptions: []),
+            configuration: "Debug",
+            cacheGraphMutator: cacheGraphMutator,
+            cacheStorage: cacheStorage,
+            precomputedTargetHashes: [
+                TargetReference(projectPath: path, name: "B"): .test(hash: "B"),
+                TargetReference(projectPath: path, name: "C"): .test(hash: "C"),
+            ]
+        )
+
+        let inputGraph = Graph.test(
+            name: "input",
+            projects: [path: project],
+            dependencies: [
+                .target(name: bFramework.name, path: bGraphTarget.path): [
+                    .target(name: cFramework.name, path: cGraphTarget.path),
+                ],
+            ]
+        )
+        let outputGraph = Graph.test(
+            name: "output",
+            projects: inputGraph.projects,
+            dependencies: inputGraph.dependencies
+        )
+        let bXCFrameworkPath = path.appending(component: "B.xcframework")
+        let cXCFrameworkPath = path.appending(component: "C.xcframework")
+
+        given(cacheStorage).fetch(
+            .value(
+                Set([
+                    CacheStorableItem(name: "B", hash: "B"),
+                    CacheStorableItem(name: "C", hash: "C"),
+                ])
+            ), cacheCategory: .value(.binaries)
+        ).willReturn([
+            .test(name: "B", hash: "B"): bXCFrameworkPath,
+            .test(name: "C", hash: "C"): cXCFrameworkPath,
+        ])
+        given(cacheGraphMutator)
+            .map(
+                graph: .any,
+                precompiledArtifacts: .any,
+                sources: .any,
+                keepSourceTargets: .any
+            )
+            .willReturn(outputGraph)
+
+        // When
+        let (got, _, _) = try await subject.map(graph: inputGraph, environment: MapperEnvironment())
+
+        // Then
+        XCTAssertEqual(got, outputGraph)
+        verify(cacheGraphContentHasher)
+            .contentHashes(
+                for: .any,
+                configuration: .any,
+                defaultConfiguration: .any,
+                excludedTargets: .any,
+                destination: .any
+            )
+            .called(0)
+        verify(cacheGraphMutator)
+            .map(
+                graph: .any,
+                precompiledArtifacts: .value([
+                    bGraphTarget: bXCFrameworkPath,
+                    cGraphTarget: cXCFrameworkPath,
+                ]),
+                sources: .any,
+                keepSourceTargets: .any
+            )
+            .called(1)
+    }
+
+    func test_map_does_not_reuse_precomputed_hashes_of_source_targets() async throws {
+        let path = try temporaryPath()
+
+        // Given
+        let cFramework = Target.test(name: "C", platform: .iOS, product: .framework)
+        let bFramework = Target.test(name: "B", platform: .iOS, product: .framework)
+        let project = Project.test(path: path, targets: [bFramework, cFramework])
+        let cGraphTarget = GraphTarget(path: path, target: cFramework, project: project)
+        let bGraphTarget = GraphTarget(path: path, target: bFramework, project: project)
+
+        subject = TargetsToCacheBinariesGraphMapper(
+            config: config,
+            cacheGraphContentHasher: cacheGraphContentHasher,
+            decider: CacheProfileTargetReplacementDecider(
+                profile: .allPossible,
+                exceptions: [.named("B")]
+            ),
+            configuration: "Debug",
+            cacheGraphMutator: cacheGraphMutator,
+            cacheStorage: cacheStorage,
+            precomputedTargetHashes: [
+                TargetReference(projectPath: path, name: "B"): .test(hash: "B"),
+                TargetReference(projectPath: path, name: "C"): .test(hash: "C"),
+            ]
+        )
+
+        let inputGraph = Graph.test(
+            name: "input",
+            projects: [path: project],
+            dependencies: [
+                .target(name: bFramework.name, path: bGraphTarget.path): [
+                    .target(name: cFramework.name, path: cGraphTarget.path),
+                ],
+            ]
+        )
+        let outputGraph = Graph.test(
+            name: "output",
+            projects: inputGraph.projects,
+            dependencies: inputGraph.dependencies
+        )
+        let cXCFrameworkPath = path.appending(component: "C.xcframework")
+
+        given(cacheStorage).fetch(
+            .value(Set([CacheStorableItem(name: "C", hash: "C")])),
+            cacheCategory: .value(.binaries)
+        ).willReturn([.test(name: "C", hash: "C"): cXCFrameworkPath])
+        given(cacheGraphMutator)
+            .map(
+                graph: .any,
+                precompiledArtifacts: .any,
+                sources: .any,
+                keepSourceTargets: .any
+            )
+            .willReturn(outputGraph)
+
+        // When
+        _ = try await subject.map(graph: inputGraph, environment: MapperEnvironment())
+
+        // Then
+        verify(cacheGraphMutator)
+            .map(
+                graph: .any,
+                precompiledArtifacts: .value([cGraphTarget: cXCFrameworkPath]),
+                sources: .value([TargetQuery(stringLiteral: "B")]),
+                keepSourceTargets: .any
+            )
+            .called(1)
+    }
+
     func test_map_when_all_binaries_are_fetched_successfully() async throws {
         let path = try temporaryPath()
         let project = Project.test(path: path)

--- a/cli/Tests/TuistCacheEETests/Generator/TargetsToCacheBinariesGraphMapperTests.swift
+++ b/cli/Tests/TuistCacheEETests/Generator/TargetsToCacheBinariesGraphMapperTests.swift
@@ -1,5 +1,9 @@
+import FileSystem
+import FileSystemTesting
 import Foundation
 import Mockable
+import Path
+import Testing
 import TuistCache
 import TuistConfig
 import TuistCore
@@ -145,162 +149,6 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
             gotEnvironment.initialGraphWithSources,
             inputGraph
         )
-    }
-
-    func test_map_reuses_precomputed_hashes_instead_of_hashing_the_graph() async throws {
-        let path = try temporaryPath()
-
-        // Given
-        let cFramework = Target.test(name: "C", platform: .iOS, product: .framework)
-        let bFramework = Target.test(name: "B", platform: .iOS, product: .framework)
-        let project = Project.test(path: path, targets: [bFramework, cFramework])
-        let cGraphTarget = GraphTarget(path: path, target: cFramework, project: project)
-        let bGraphTarget = GraphTarget(path: path, target: bFramework, project: project)
-
-        subject = TargetsToCacheBinariesGraphMapper(
-            config: config,
-            cacheGraphContentHasher: cacheGraphContentHasher,
-            decider: CacheProfileTargetReplacementDecider(profile: .allPossible, exceptions: []),
-            configuration: "Debug",
-            cacheGraphMutator: cacheGraphMutator,
-            cacheStorage: cacheStorage,
-            precomputedTargetHashes: [
-                TargetReference(projectPath: path, name: "B"): .test(hash: "B"),
-                TargetReference(projectPath: path, name: "C"): .test(hash: "C"),
-            ]
-        )
-
-        let inputGraph = Graph.test(
-            name: "input",
-            projects: [path: project],
-            dependencies: [
-                .target(name: bFramework.name, path: bGraphTarget.path): [
-                    .target(name: cFramework.name, path: cGraphTarget.path),
-                ],
-            ]
-        )
-        let outputGraph = Graph.test(
-            name: "output",
-            projects: inputGraph.projects,
-            dependencies: inputGraph.dependencies
-        )
-        let bXCFrameworkPath = path.appending(component: "B.xcframework")
-        let cXCFrameworkPath = path.appending(component: "C.xcframework")
-
-        given(cacheStorage).fetch(
-            .value(
-                Set([
-                    CacheStorableItem(name: "B", hash: "B"),
-                    CacheStorableItem(name: "C", hash: "C"),
-                ])
-            ), cacheCategory: .value(.binaries)
-        ).willReturn([
-            .test(name: "B", hash: "B"): bXCFrameworkPath,
-            .test(name: "C", hash: "C"): cXCFrameworkPath,
-        ])
-        given(cacheGraphMutator)
-            .map(
-                graph: .any,
-                precompiledArtifacts: .any,
-                sources: .any,
-                keepSourceTargets: .any
-            )
-            .willReturn(outputGraph)
-
-        // When
-        let (got, _, _) = try await subject.map(graph: inputGraph, environment: MapperEnvironment())
-
-        // Then
-        XCTAssertEqual(got, outputGraph)
-        verify(cacheGraphContentHasher)
-            .contentHashes(
-                for: .any,
-                configuration: .any,
-                defaultConfiguration: .any,
-                excludedTargets: .any,
-                destination: .any
-            )
-            .called(0)
-        verify(cacheGraphMutator)
-            .map(
-                graph: .any,
-                precompiledArtifacts: .value([
-                    bGraphTarget: bXCFrameworkPath,
-                    cGraphTarget: cXCFrameworkPath,
-                ]),
-                sources: .any,
-                keepSourceTargets: .any
-            )
-            .called(1)
-    }
-
-    func test_map_does_not_reuse_precomputed_hashes_of_source_targets() async throws {
-        let path = try temporaryPath()
-
-        // Given
-        let cFramework = Target.test(name: "C", platform: .iOS, product: .framework)
-        let bFramework = Target.test(name: "B", platform: .iOS, product: .framework)
-        let project = Project.test(path: path, targets: [bFramework, cFramework])
-        let cGraphTarget = GraphTarget(path: path, target: cFramework, project: project)
-        let bGraphTarget = GraphTarget(path: path, target: bFramework, project: project)
-
-        subject = TargetsToCacheBinariesGraphMapper(
-            config: config,
-            cacheGraphContentHasher: cacheGraphContentHasher,
-            decider: CacheProfileTargetReplacementDecider(
-                profile: .allPossible,
-                exceptions: [.named("B")]
-            ),
-            configuration: "Debug",
-            cacheGraphMutator: cacheGraphMutator,
-            cacheStorage: cacheStorage,
-            precomputedTargetHashes: [
-                TargetReference(projectPath: path, name: "B"): .test(hash: "B"),
-                TargetReference(projectPath: path, name: "C"): .test(hash: "C"),
-            ]
-        )
-
-        let inputGraph = Graph.test(
-            name: "input",
-            projects: [path: project],
-            dependencies: [
-                .target(name: bFramework.name, path: bGraphTarget.path): [
-                    .target(name: cFramework.name, path: cGraphTarget.path),
-                ],
-            ]
-        )
-        let outputGraph = Graph.test(
-            name: "output",
-            projects: inputGraph.projects,
-            dependencies: inputGraph.dependencies
-        )
-        let cXCFrameworkPath = path.appending(component: "C.xcframework")
-
-        given(cacheStorage).fetch(
-            .value(Set([CacheStorableItem(name: "C", hash: "C")])),
-            cacheCategory: .value(.binaries)
-        ).willReturn([.test(name: "C", hash: "C"): cXCFrameworkPath])
-        given(cacheGraphMutator)
-            .map(
-                graph: .any,
-                precompiledArtifacts: .any,
-                sources: .any,
-                keepSourceTargets: .any
-            )
-            .willReturn(outputGraph)
-
-        // When
-        _ = try await subject.map(graph: inputGraph, environment: MapperEnvironment())
-
-        // Then
-        verify(cacheGraphMutator)
-            .map(
-                graph: .any,
-                precompiledArtifacts: .value([cGraphTarget: cXCFrameworkPath]),
-                sources: .value([TargetQuery(stringLiteral: "B")]),
-                keepSourceTargets: .any
-            )
-            .called(1)
     }
 
     func test_map_when_all_binaries_are_fetched_successfully() async throws {
@@ -920,5 +768,136 @@ final class TargetsToCacheBinariesGraphMapperTests: TuistUnitTestCase {
             XCTAssertEqual(storedSubhashes[cHash], cSubhashes)
             XCTAssertEqual(storedSubhashes[bHash], bSubhashes)
         }
+    }
+}
+
+@Suite struct TargetsToCacheBinariesGraphMapperPrecomputedHashesTests {
+    private let cacheStorage = MockCacheStoring()
+    private let cacheGraphContentHasher = MockCacheGraphContentHashing()
+    private let cacheGraphMutator = MockCacheGraphMutating()
+    private let config = Tuist.test()
+
+    private func subject(
+        exceptions: Set<TargetQuery>,
+        precomputedTargetHashes: [TargetReference: TargetContentHash]
+    ) -> TargetsToCacheBinariesGraphMapper {
+        TargetsToCacheBinariesGraphMapper(
+            config: config,
+            cacheGraphContentHasher: cacheGraphContentHasher,
+            decider: CacheProfileTargetReplacementDecider(profile: .allPossible, exceptions: exceptions),
+            configuration: "Debug",
+            cacheGraphMutator: cacheGraphMutator,
+            cacheStorage: cacheStorage,
+            precomputedTargetHashes: precomputedTargetHashes
+        )
+    }
+
+    /// `B` depends on `C`, and both are cacheable frameworks.
+    private func graphs(at path: AbsolutePath) -> (input: Graph, output: Graph, b: GraphTarget, c: GraphTarget) {
+        let cFramework = Target.test(name: "C", platform: .iOS, product: .framework)
+        let bFramework = Target.test(name: "B", platform: .iOS, product: .framework)
+        let project = Project.test(path: path, targets: [bFramework, cFramework])
+        let input = Graph.test(
+            name: "input",
+            projects: [path: project],
+            dependencies: [
+                .target(name: "B", path: path): [.target(name: "C", path: path)],
+            ]
+        )
+        return (
+            input: input,
+            output: Graph.test(name: "output", projects: input.projects, dependencies: input.dependencies),
+            b: GraphTarget(path: path, target: bFramework, project: project),
+            c: GraphTarget(path: path, target: cFramework, project: project)
+        )
+    }
+
+    @Test(.inTemporaryDirectory) func map_reusesPrecomputedHashes_insteadOfHashingTheGraph() async throws {
+        // Given
+        let path = try #require(FileSystem.temporaryTestDirectory)
+        let graphs = graphs(at: path)
+        let bXCFrameworkPath = path.appending(component: "B.xcframework")
+        let cXCFrameworkPath = path.appending(component: "C.xcframework")
+
+        given(cacheStorage).fetch(
+            .value(
+                Set([
+                    CacheStorableItem(name: "B", hash: "B"),
+                    CacheStorableItem(name: "C", hash: "C"),
+                ])
+            ), cacheCategory: .value(.binaries)
+        ).willReturn([
+            .test(name: "B", hash: "B"): bXCFrameworkPath,
+            .test(name: "C", hash: "C"): cXCFrameworkPath,
+        ])
+        given(cacheGraphMutator)
+            .map(graph: .any, precompiledArtifacts: .any, sources: .any, keepSourceTargets: .any)
+            .willReturn(graphs.output)
+
+        // When
+        let (got, _, _) = try await subject(
+            exceptions: [],
+            precomputedTargetHashes: [
+                TargetReference(projectPath: path, name: "B"): .test(hash: "B"),
+                TargetReference(projectPath: path, name: "C"): .test(hash: "C"),
+            ]
+        ).map(graph: graphs.input, environment: MapperEnvironment())
+
+        // Then
+        #expect(got == graphs.output)
+        verify(cacheGraphContentHasher)
+            .contentHashes(
+                for: .any,
+                configuration: .any,
+                defaultConfiguration: .any,
+                excludedTargets: .any,
+                destination: .any
+            )
+            .called(0)
+        verify(cacheGraphMutator)
+            .map(
+                graph: .any,
+                precompiledArtifacts: .value([
+                    graphs.b: bXCFrameworkPath,
+                    graphs.c: cXCFrameworkPath,
+                ]),
+                sources: .any,
+                keepSourceTargets: .any
+            )
+            .called(1)
+    }
+
+    @Test(.inTemporaryDirectory) func map_doesNotReusePrecomputedHashes_ofSourceTargets() async throws {
+        // Given
+        let path = try #require(FileSystem.temporaryTestDirectory)
+        let graphs = graphs(at: path)
+        let cXCFrameworkPath = path.appending(component: "C.xcframework")
+
+        given(cacheStorage).fetch(
+            .value(Set([CacheStorableItem(name: "C", hash: "C")])),
+            cacheCategory: .value(.binaries)
+        ).willReturn([.test(name: "C", hash: "C"): cXCFrameworkPath])
+        given(cacheGraphMutator)
+            .map(graph: .any, precompiledArtifacts: .any, sources: .any, keepSourceTargets: .any)
+            .willReturn(graphs.output)
+
+        // When
+        _ = try await subject(
+            exceptions: [.named("B")],
+            precomputedTargetHashes: [
+                TargetReference(projectPath: path, name: "B"): .test(hash: "B"),
+                TargetReference(projectPath: path, name: "C"): .test(hash: "C"),
+            ]
+        ).map(graph: graphs.input, environment: MapperEnvironment())
+
+        // Then
+        verify(cacheGraphMutator)
+            .map(
+                graph: .any,
+                precompiledArtifacts: .value([graphs.c: cXCFrameworkPath]),
+                sources: .value([TargetQuery(stringLiteral: "B")]),
+                keepSourceTargets: .any
+            )
+            .called(1)
     }
 }

--- a/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
@@ -71,7 +71,11 @@
                 .called(1)
         }
 
-        @Test(.inTemporaryDirectory) func run_hashesEveryCacheableTarget_whenAProfileNarrowsWhatIsWarmed() async throws {
+        /// Hashing a target runs its `additionalHashingInputs` scripts, and excluding one also makes its
+        /// dependents unhashable, which is what stops a warm from storing artifacts the same profile could
+        /// never read back. So a narrowing profile keeps its exclusions on the hashing call, and the
+        /// resulting map is too narrow to hand to binary replacement, which runs under `.allPossible`.
+        @Test(.inTemporaryDirectory) func run_keepsProfileExclusions_andHandsOverNoHashes() async throws {
             let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
             let externalProjectPath = temporaryDirectory.appending(component: "external")
             let localTarget = Target.test(name: "Local", product: .framework)
@@ -82,7 +86,6 @@
                 targets: [externalTarget],
                 type: .external(hash: nil)
             )
-            let localGraphTarget = GraphTarget(path: temporaryDirectory, target: localTarget, project: localProject)
             let externalGraphTarget = GraphTarget(
                 path: externalProjectPath,
                 target: externalTarget,
@@ -106,20 +109,15 @@
             given(defaultConfigurationFetcher)
                 .fetch(configuration: .any, defaultConfiguration: .any, graph: .value(graph))
                 .willReturn("Debug")
-            // The profile narrows what gets warmed, never what gets hashed: binary replacement in the warm
-            // project needs a hash for the local target too.
             given(cacheGraphContentHasher)
                 .contentHashes(
                     for: .value(graph),
                     configuration: .any,
                     defaultConfiguration: .any,
-                    excludedTargets: .value([]),
+                    excludedTargets: .value(["Local"]),
                     destination: .value(nil)
                 )
-                .willReturn([
-                    localGraphTarget: .test(hash: "local-hash"),
-                    externalGraphTarget: .test(hash: "external-hash"),
-                ])
+                .willReturn([externalGraphTarget: .test(hash: "external-hash")])
             given(cacheStorage).fetch(.any, cacheCategory: .value(.binaries)).willReturn([:])
             given(generatorFactory)
                 .binaryCacheWarming(
@@ -154,11 +152,7 @@
                     },
                     configuration: .any,
                     cacheStorage: .any,
-                    targetHashes: .value([
-                        TargetReference(projectPath: temporaryDirectory, name: "Local"): .test(hash: "local-hash"),
-                        TargetReference(projectPath: externalProjectPath, name: "External"):
-                            .test(hash: "external-hash"),
-                    ])
+                    targetHashes: .value([:])
                 )
                 .called(1)
         }

--- a/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
+++ b/cli/Tests/TuistKitTests/Services/Cache/CacheWarmCommandServiceTests.swift
@@ -52,6 +52,117 @@
                 .called(1)
         }
 
+        @Test(.inTemporaryDirectory) func run_handsTheHashesItComputedToTheWarmProjectGenerator() async throws {
+            let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+
+            try await run(noUpload: false)
+
+            verify(generatorFactory)
+                .binaryCacheWarming(
+                    config: .any,
+                    targetsToBinaryCache: .any,
+                    configuration: .any,
+                    cacheStorage: .any,
+                    targetHashes: .value([
+                        TargetReference(projectPath: temporaryDirectory, name: "Fixtures"):
+                            .test(hash: "fixtures-hash"),
+                    ])
+                )
+                .called(1)
+        }
+
+        @Test(.inTemporaryDirectory) func run_hashesEveryCacheableTarget_whenAProfileNarrowsWhatIsWarmed() async throws {
+            let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
+            let externalProjectPath = temporaryDirectory.appending(component: "external")
+            let localTarget = Target.test(name: "Local", product: .framework)
+            let externalTarget = Target.test(name: "External", product: .framework)
+            let localProject = Project.test(path: temporaryDirectory, targets: [localTarget])
+            let externalProject = Project.test(
+                path: externalProjectPath,
+                targets: [externalTarget],
+                type: .external(hash: nil)
+            )
+            let localGraphTarget = GraphTarget(path: temporaryDirectory, target: localTarget, project: localProject)
+            let externalGraphTarget = GraphTarget(
+                path: externalProjectPath,
+                target: externalTarget,
+                project: externalProject
+            )
+            let graph = Graph.test(
+                path: temporaryDirectory,
+                workspace: .test(path: temporaryDirectory),
+                projects: [temporaryDirectory: localProject, externalProjectPath: externalProject]
+            )
+
+            given(configLoader).loadConfig(path: .value(temporaryDirectory)).willReturn(config)
+            given(cacheStorageFactory).cacheStorage(config: .value(config)).willReturn(cacheStorage)
+            given(cacheStorageFactory).cacheLocalStorage().willReturn(localCacheStorage)
+            given(generatorFactory)
+                .binaryCacheWarmingPreload(config: .value(config), targetsToBinaryCache: .value([]))
+                .willReturn(preloadGenerator)
+            given(preloadGenerator)
+                .load(path: .value(temporaryDirectory), options: .value(config.project.generatedProject?.generationOptions))
+                .willReturn(graph)
+            given(defaultConfigurationFetcher)
+                .fetch(configuration: .any, defaultConfiguration: .any, graph: .value(graph))
+                .willReturn("Debug")
+            // The profile narrows what gets warmed, never what gets hashed: binary replacement in the warm
+            // project needs a hash for the local target too.
+            given(cacheGraphContentHasher)
+                .contentHashes(
+                    for: .value(graph),
+                    configuration: .any,
+                    defaultConfiguration: .any,
+                    excludedTargets: .value([]),
+                    destination: .value(nil)
+                )
+                .willReturn([
+                    localGraphTarget: .test(hash: "local-hash"),
+                    externalGraphTarget: .test(hash: "external-hash"),
+                ])
+            given(cacheStorage).fetch(.any, cacheCategory: .value(.binaries)).willReturn([:])
+            given(generatorFactory)
+                .binaryCacheWarming(
+                    config: .any,
+                    targetsToBinaryCache: .any,
+                    configuration: .any,
+                    cacheStorage: .any,
+                    targetHashes: .any
+                )
+                .willReturn(generator)
+            given(generator)
+                .generateWithGraph(path: .value(temporaryDirectory), options: .any)
+                .willReturn((temporaryDirectory, graph, MapperEnvironment()))
+            given(cacheStorage).store(.any, cacheCategory: .value(.binaries)).willReturn([])
+
+            try await subject.run(
+                path: temporaryDirectory.pathString,
+                configuration: nil,
+                targetsToBinaryCache: [],
+                externalOnly: true,
+                generateOnly: true,
+                noUpload: false,
+                cacheProfile: nil,
+                scratchDirectory: nil
+            )
+
+            verify(generatorFactory)
+                .binaryCacheWarming(
+                    config: .any,
+                    targetsToBinaryCache: .matching { targets in
+                        Set(targets.values.flatMap { $0 }) == [TargetQuery(stringLiteral: "External")]
+                    },
+                    configuration: .any,
+                    cacheStorage: .any,
+                    targetHashes: .value([
+                        TargetReference(projectPath: temporaryDirectory, name: "Local"): .test(hash: "local-hash"),
+                        TargetReference(projectPath: externalProjectPath, name: "External"):
+                            .test(hash: "external-hash"),
+                    ])
+                )
+                .called(1)
+        }
+
         @Test(.inTemporaryDirectory) func run_usesConfiguredCacheStorage_whenUploading() async throws {
             try await run(noUpload: false)
 
@@ -124,7 +235,8 @@
                     config: .any,
                     targetsToBinaryCache: .any,
                     configuration: .any,
-                    cacheStorage: .any
+                    cacheStorage: .any,
+                    targetHashes: .any
                 )
                 .called(0)
         }
@@ -332,7 +444,8 @@
                     config: .value(config),
                     targetsToBinaryCache: .any,
                     configuration: .value(resolvedConfiguration),
-                    cacheStorage: .any
+                    cacheStorage: .any,
+                    targetHashes: .any
                 )
                 .willReturn(generator)
             given(generator)


### PR DESCRIPTION
`tuist cache` hashed the graph twice. This makes the second pass reuse the first one's result.

### What changed

The warm command hashes every cacheable target to decide what is missing from the cache, and then generates a warm project whose binary replacement hashed the same graph again to decide what to swap for a cached artifact. The two passes produced identical hashes for every target they shared.

`CacheWarmCommandService` now returns those hashes alongside the targets to build and passes them through the generator factory into `TargetsToCacheBinariesGraphMapper`, which uses them instead of hashing. Given no hashes the mapper hashes exactly as before, which is what `generate`, `build` and `test` do since nothing has hashed the graph for them.

The mapper still excludes the targets being built from source, including their resources bundles, so nothing about to be rebuilt gets replaced by a binary.

### Why

Traced from a customer cache run whose log showed the same target hashed twice with the same value. Splitting the log by phase:

| Phase | Targets hashed |
| --- | --- |
| Hashing cacheable targets | 848 |
| Warm project generation | 419 |

Every one of the 419 was byte identical to its counterpart in the first pass, sub-hash components included. 419 was exactly the set of cache hits, and 419 plus the 429 misses is the 848 from the first pass. The duplicate work was about 3.5 seconds of re-reading and re-hashing sources on that run, on top of a second graph load.

### Why this is safe

The two passes were already required to agree. A warm stores artifacts under the hashes from the first pass and replacement looks them up by the hashes from the second, so a disagreement would mean the cache never reads back what it just wrote. `CacheHashingGraphMapper` exists precisely to keep the graph the second pass hashes equivalent to the one the first pass saw. Reusing the first result makes an existing invariant explicit rather than introducing a new one.

The alternative considered was sharing a memoizing content hasher between the two passes. That would have cut the file reads while still walking the graph and rebuilding the merkle nodes twice, and it needed the same cross-repository plumbing. Reusing the result removes the pass outright for the same change surface.

### When the handover happens

Only when the cache profile excluded nothing, which is the default and the case the duplicate pass was costing. Under a narrowing profile the map is short of what replacement asks for, since replacement runs under `.allPossible` whatever profile warmed the cache, so the mapper hashes the graph itself exactly as it does today.

An earlier revision of this pull request widened the hashing pass to cover the profile-excluded targets instead. Review caught two regressions in that, both real, and it has been reverted:

- Hashing a target executes its `additionalHashingInputs` scripts. Widening the pass ran them for targets the user deliberately excluded, so a script shelling out to a tool the machine does not have would fail the whole command even when every requested artifact was already cached.
- Excluding a target also makes its dependents unhashable, because a target is hashable only when its whole dependency closure is. That is what stops a warm from storing an artifact the same profile can never read back. Generation rejects the dependent for the same reason and the graph mutator will not replace a target whose dependencies are not replaceable, so `A` depending on an excluded `B` would have been built and stored on every warm and consumed by nothing.

The selection logic is now byte for byte what it was before this pull request. The only new behaviour is the handover itself.

### Depends on

The enterprise half is https://github.com/tuist/TuistCacheEE/pull/81, which adds the `precomputedTargetHashes` parameter to the mapper. It is merged, and the submodule here points at the TuistCacheEE `main` commit it landed as.

### How to test locally

```bash
TUIST_EE=1 tuist generate tuist TuistCacheEE TuistCacheEETests TuistCacheEEAcceptanceTests TuistKitTests TuistCacheTests ProjectDescription --no-open
xcodebuild test -workspace Tuist.xcworkspace -scheme Tuist-Workspace -only-testing:TuistKitTests -only-testing:TuistCacheEETests -only-testing:TuistCacheTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

```bash
xcodebuild test -workspace Tuist.xcworkspace -scheme TuistCacheEEAcceptanceTests "-only-testing:TuistCacheEEAcceptanceTests/TuistCacheEEAcceptanceTests/warming_reuses_an_already_cached_target_while_building_the_rest()" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
```

### Validation that was run

- `tuist` scheme builds clean.
- TuistKitTests (384), TuistCacheTests (110) and TuistCacheEETests (79) pass.
- A new end-to-end test warms one leaf target, then warms the whole fixture, so one target sits on the cached side of the split and six on the built side. It fails when the handover drops that target: the replacement list comes back empty.
- Every new test was confirmed red against the old code path before being made green.
- Lint introduces no new violations, and `tuist inspect dependencies --only implicit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



