### PR TITLE
fix(server): drop the dead ingest tables left by past rebuilds

### DIFF
--- a/server/priv/ingest_repo/migrations/20260911140000_drop_dead_ingest_tables.exs
+++ b/server/priv/ingest_repo/migrations/20260911140000_drop_dead_ingest_tables.exs
@@ -1,0 +1,46 @@
+defmodule Tuist.IngestRepo.Migrations.DropDeadIngestTables do
+  use Ecto.Migration
+
+  alias Tuist.IngestRepo
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  # Leftovers of table rebuilds, each one the staging half of a create-copy-swap
+  # that was never cleaned up. Nothing reads any of them: not `lib/`, not the
+  # templates, not the CLI. `test_case_runs_by_commit_v2` is the legacy
+  # no-scheme table the live `test_case_runs_by_commit` replaced, and the
+  # schema's own docs say the drop is owed once the rollout is stable.
+  #
+  # They were cleared out of the system of record by hand in September, which
+  # is why this is overdue rather than new. Doing it by hand does not hold: a
+  # database built from this migration history recreates them, so the
+  # in-cluster server has them again and has been copying and parity-checking
+  # corpses. `build_runs_new` is the one that forced the issue, failing the
+  # cutover's parity gate on a value mismatch no repair can clear, on a table
+  # that should not exist.
+  #
+  # `IF EXISTS` because which of these is present depends on when the database
+  # was built, and `SYNC` because on a `Replicated` database a plain DROP is
+  # queued: without it the next statement can run before the table is gone and
+  # the Keeper path is still held.
+  @tables ~w(
+    build_runs_new
+    test_case_runs_new
+    test_case_runs_by_commit_v2
+    xcode_targets_backup
+    xcode_projects_backup
+  )
+
+  def up do
+    for table <- @tables do
+      # excellent_migrations:safety-assured-for-next-line raw_sql_executed
+      # excellent_migrations:safety-assured-for-next-line table_dropped
+      IngestRepo.query!("DROP TABLE IF EXISTS #{table} SYNC", [], timeout: :infinity)
+    end
+  end
+
+  # Not reversible. These hold no data anything reads, and recreating empty
+  # shells of rebuild staging tables would put back exactly what this removes.
+  def down, do: :ok
+end


### PR DESCRIPTION
## What changed

`DROP TABLE IF EXISTS … SYNC` for five ingest tables:

`build_runs_new`, `test_case_runs_new`, `test_case_runs_by_commit_v2`, `xcode_targets_backup`, `xcode_projects_backup`.

## Why they exist

Each is the staging half of a create-copy-swap table rebuild that was never cleaned up. `build_runs_new` was the March 2026 conversion of `build_runs` to a `ReplacingMergeTree`; `test_case_runs_by_commit_v2` is the legacy no-scheme table the live `test_case_runs_by_commit` replaced, and that schema's own moduledoc says so: "the legacy table is dropped in a follow-up migration once the rollout is stable". This is that follow-up, overdue.

**Nothing reads any of them.** Not `lib/`, not templates, not the CLI. The only `lib/` hit for `test_case_runs_by_commit_v2` is the doc comment quoted above, and I positive-controlled that search against the 19 files that do reference `build_runs`.

## How they surfaced

Not by being looked for. `build_runs_new` **failed canary's cutover parity gate**: identical row counts on both servers with `sum_duration` differing by 820. A value discrepancy rather than a missing row, so no re-copy can repair it, on a table that should not exist at all. Left alone it would have blocked the gate indefinitely, since the repair loop has nothing to fix.

The backfill has been copying it at 18 chunks a run, along with the rest of the corpses.

## Why a migration rather than a manual drop

This is the part worth keeping. Removing them by hand does not hold: the in-cluster ClickHouse was built from this migration history, so it **recreated every one of them**. `20260318120000_drop_build_runs_new` already exists and did not help, because a later migration recreates the table after it runs.

So any database built from migrations brings these back, and only a migration at the end of the history removes them for good.

## Mechanics

`IF EXISTS` because which of these is present depends on when a given database was built. `SYNC` because a plain `DROP` on a `Replicated` database is queued: without it the next statement can run while the table still exists and its Keeper path is still held.

Not reversible. `down` is a no-op: these hold nothing anything reads, and recreating empty shells of rebuild staging tables would put back exactly what this removes.

## Deliberately excluded

Three more dead-looking tables are **not** in here, each needing its own decision:

`_peerdb_raw_mirror_a6e67ab5…` appears in every backfill report at 16 chunks, but no migration creates or references it and its name carries a UUID, so it belongs to PeerDB. If that mirror is still live, dropping its raw table breaks replication.

`xcode_projects_test` and `my_first_table` exist in no migration and no code, so they were created by hand. Almost certainly junk, but a migration that drops hand-made tables is a different kind of act, and it should be a deliberate one.

## Worth knowing for review

**This is destructive against the system of record.** I had believed these were already cleared from Cloud by hand in early September, which would have made this close to a no-op there. The evidence contradicts that: canary's destination was cloned from Cloud on 09-09 and has `xcode_targets_backup`, so at least some were still present. Treat this as the first reliable removal, and expect it to do real work on Cloud rather than only on the rebuilt databases.

## Validation

`mix compile` clean, `mix format --check-formatted` clean, and `mix excellent_migrations.check_safety` raises nothing against this migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
