### PR TITLE
feat(cli): log archive compression duration and sizes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1251,6 +1251,7 @@ targets.append(contentsOf: [
     .target(
         name: "TuistAppleArchiver",
         dependencies: [
+            "TuistLogging",
             mockableDependency,
             pathDependency,
         ],
@@ -1263,6 +1264,7 @@ targets.append(contentsOf: [
         name: "TuistAppleArchiverTests",
         dependencies: [
             "TuistAppleArchiver",
+            "TuistLoggerTesting",
             fileSystemDependency,
             .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
             pathDependency,

--- a/Package.swift
+++ b/Package.swift
@@ -1265,6 +1265,7 @@ targets.append(contentsOf: [
         dependencies: [
             "TuistAppleArchiver",
             "TuistLoggerTesting",
+            "TuistLogging",
             fileSystemDependency,
             .product(name: "FileSystemTesting", package: "tuist.FileSystem"),
             pathDependency,

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -1474,6 +1474,7 @@ public enum Module: String, CaseIterable {
                 ]
             case .appleArchiver:
                 [
+                    .target(name: Module.logging.targetName),
                     .external(name: "Path"),
                     .external(name: "Mockable"),
                 ]
@@ -1626,6 +1627,7 @@ public enum Module: String, CaseIterable {
                 ]
             case .appleArchiver:
                 [
+                    .target(name: Module.loggerTesting.targetName),
                     .external(name: "FileSystem"),
                     .external(name: "FileSystemTesting"),
                 ]

--- a/Tuist/ProjectDescriptionHelpers/Module.swift
+++ b/Tuist/ProjectDescriptionHelpers/Module.swift
@@ -1628,6 +1628,7 @@ public enum Module: String, CaseIterable {
             case .appleArchiver:
                 [
                     .target(name: Module.loggerTesting.targetName),
+                    .target(name: Module.logging.targetName),
                     .external(name: "FileSystem"),
                     .external(name: "FileSystemTesting"),
                 ]

--- a/cli/Sources/TuistAppleArchiver/AppleArchiver.swift
+++ b/cli/Sources/TuistAppleArchiver/AppleArchiver.swift
@@ -186,7 +186,7 @@ public struct AppleArchiver: AppleArchiving {
         to archivePath: AbsolutePath,
         filter: @escaping ArchiveHeader.EntryFilter
     ) throws {
-        Logger.current.info("Compressing archive at \(archivePath.pathString) using LZFSE")
+        Logger.current.debug("Compressing archive at \(archivePath.pathString) using LZFSE")
         let start = ContinuousClock.now
         let inputSize = Mutex((bytes: UInt64(0), complete: true))
         let measuringFilter: ArchiveHeader.EntryFilter = { message, path, data in
@@ -239,8 +239,8 @@ public struct AppleArchiver: AppleArchiving {
         let input = inputSize.withLock { $0.complete ? "\($0.bytes) bytes" : "unavailable" }
         let archiveSize = (try? FileManager.default.attributesOfItem(atPath: archivePath.pathString)[.size]) as? NSNumber
         let output = archiveSize.map { "\($0.uint64Value) bytes" } ?? "unavailable"
-        Logger.current.info(
-            "Compressed archive at \(archivePath.pathString) in \(String(format: "%.2fs", seconds)) (input: \(input), archive: \(output), compression: LZFSE)"
+        Logger.current.debug(
+            "Compressed archive at \(archivePath.pathString) in \(String(format: "%.2fs", seconds)) wall time (input: \(input), archive: \(output), compression: LZFSE)"
         )
     }
 

--- a/cli/Sources/TuistAppleArchiver/AppleArchiver.swift
+++ b/cli/Sources/TuistAppleArchiver/AppleArchiver.swift
@@ -4,6 +4,7 @@ import Mockable
 import Path
 import Synchronization
 import System
+import TuistLogging
 
 public enum AppleArchiverError: LocalizedError, Equatable {
     case compressionFailed(String)
@@ -185,10 +186,22 @@ public struct AppleArchiver: AppleArchiving {
         to archivePath: AbsolutePath,
         filter: @escaping ArchiveHeader.EntryFilter
     ) throws {
-        let destination = FilePath(archivePath.pathString)
-
+        Logger.current.info("Compressing archive at \(archivePath.pathString) using LZFSE")
+        let start = ContinuousClock.now
+        let inputSize = Mutex((bytes: UInt64(0), complete: true))
+        let measuringFilter: ArchiveHeader.EntryFilter = { message, path, data in
+            let status = filter(message, path, data)
+            guard status == .ok, message == .searchExclude else { return status }
+            // Measure only included entries during the existing walk, without following symlinks.
+            let bytes = Self.regularFileSize(at: "\(source.string)/\(path.string)")
+            inputSize.withLock { size in
+                size.bytes += bytes ?? 0
+                size.complete = size.complete && bytes != nil
+            }
+            return status
+        }
         guard let writeStream = ArchiveByteStream.fileStream(
-            path: destination,
+            path: FilePath(archivePath.pathString),
             mode: .writeOnly,
             options: [.create, .truncate],
             permissions: [.ownerReadWrite, .groupRead, .otherRead]
@@ -214,12 +227,27 @@ public struct AppleArchiver: AppleArchiving {
         try encodeStream.writeDirectoryContents(
             archiveFrom: source,
             keySet: keySet,
-            selectUsing: filter
+            selectUsing: measuringFilter
         )
 
         try encodeStream.close()
         try compressStream.close()
         try writeStream.close()
+
+        let elapsed = start.duration(to: .now).components
+        let seconds = Double(elapsed.seconds) + Double(elapsed.attoseconds) / 1e18
+        let input = inputSize.withLock { $0.complete ? "\($0.bytes) bytes" : "unavailable" }
+        let archiveSize = (try? FileManager.default.attributesOfItem(atPath: archivePath.pathString)[.size]) as? NSNumber
+        let output = archiveSize.map { "\($0.uint64Value) bytes" } ?? "unavailable"
+        Logger.current.info(
+            "Compressed archive at \(archivePath.pathString) in \(String(format: "%.2fs", seconds)) (input: \(input), archive: \(output), compression: LZFSE)"
+        )
+    }
+
+    private static func regularFileSize(at path: String) -> UInt64? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path) else { return nil }
+        guard attributes[.type] as? FileAttributeType == .typeRegular else { return 0 }
+        return (attributes[.size] as? NSNumber)?.uint64Value
     }
 
     public func decompress(archive: AbsolutePath, to directory: AbsolutePath) async throws {

--- a/cli/Sources/TuistKit/Services/Sharding/ShardPlanService.swift
+++ b/cli/Sources/TuistKit/Services/Sharding/ShardPlanService.swift
@@ -226,6 +226,10 @@
             // Each artifact (the shared bundle plus one per module) is an independent compress + upload;
             // run them concurrently, capped so a project with many modules doesn't oversubscribe the host.
             let artifacts: [SplitArtifact] = [.shared] + moduleArtifacts
+            Logger.current.debug(
+                "Archiving and uploading \(artifacts.count) test products artifacts concurrently; per-archive wall times may overlap."
+            )
+            let start = ContinuousClock.now
             _ = try await artifacts.concurrentMap(maxConcurrentTasks: Self.maxConcurrentArtifactUploads) { artifact in
                 switch artifact {
                 case .shared:
@@ -260,7 +264,11 @@
                 }
             }
 
-            Logger.current.debug("Upload complete. Shard matrix ready.")
+            let elapsed = start.duration(to: .now).components
+            let seconds = Double(elapsed.seconds) + Double(elapsed.attoseconds) / 1e18
+            Logger.current.debug(
+                "Archived and uploaded \(artifacts.count) test products artifacts in \(String(format: "%.2fs", seconds)) total wall time. Shard matrix ready."
+            )
         }
 
         private func uploadArtifact(

--- a/cli/Tests/TuistAppleArchiverTests/AppleArchiverTests.swift
+++ b/cli/Tests/TuistAppleArchiverTests/AppleArchiverTests.swift
@@ -33,6 +33,7 @@ struct AppleArchiverTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedLogger()) func compress_and_decompress_preserves_symlinks() async throws {
+        Logger.testingLogHandler.logLevel = .debug
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let fileSystem = FileSystem()
 
@@ -47,7 +48,7 @@ struct AppleArchiverTests {
         let archivePath = temporaryDirectory.appending(component: "archive.aar")
         try await subject.compress(directory: sourceDir, to: archivePath, excludePatterns: [])
 
-        #expect(Logger.testingLogHandler.collected[.info]?.contains { $0.contains("input: 14 bytes") } == true)
+        #expect(Logger.testingLogHandler.collected[.debug]?.contains { $0.contains("input: 14 bytes") } == true)
 
         let extractDir = temporaryDirectory.appending(component: "extracted")
         try await fileSystem.makeDirectory(at: extractDir)
@@ -87,6 +88,7 @@ struct AppleArchiverTests {
     }
 
     @Test(.inTemporaryDirectory, .withMockedLogger()) func compress_excludes_matching_patterns() async throws {
+        Logger.testingLogHandler.logLevel = .debug
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let fileSystem = FileSystem()
 
@@ -108,11 +110,12 @@ struct AppleArchiverTests {
         )
 
         let archiveBytes = try Data(contentsOf: URL(fileURLWithPath: archivePath.pathString)).count
-        let compressionLog = try #require(Logger.testingLogHandler.collected[.info]?.first { $0.hasPrefix("Compressed archive") })
+        let compressionLog = try #require(Logger.testingLogHandler.collected[.debug]?
+            .first { $0.hasPrefix("Compressed archive") })
         #expect(compressionLog.contains(archivePath.pathString))
         #expect(compressionLog.contains("input: 4 bytes, archive: \(archiveBytes) bytes"))
         #expect(compressionLog.contains("compression: LZFSE"))
-        #expect(compressionLog.range(of: #"in \d+\.\d{2}s"#, options: .regularExpression) != nil)
+        #expect(compressionLog.range(of: #"in \d+\.\d{2}s wall time"#, options: .regularExpression) != nil)
 
         let extractDir = temporaryDirectory.appending(component: "extracted")
         try await fileSystem.makeDirectory(at: extractDir)
@@ -308,6 +311,7 @@ struct AppleArchiverTests {
     /// relative to the products root (so it merges back in place), while nothing else is read.
     @Test(.inTemporaryDirectory, .withMockedLogger())
     func compress_subdirectory_preservesRelativePath_andPrunesSiblings() async throws {
+        Logger.testingLogHandler.logLevel = .debug
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let fileSystem = FileSystem()
 
@@ -330,7 +334,7 @@ struct AppleArchiverTests {
         let archivePath = temporaryDirectory.appending(component: "FooTests.aar")
         try await subject.compress(subdirectory: targetXCTest, relativeTo: productsDir, to: archivePath)
 
-        #expect(Logger.testingLogHandler.collected[.info]?.contains { $0.contains("input: 10 bytes") } == true)
+        #expect(Logger.testingLogHandler.collected[.debug]?.contains { $0.contains("input: 10 bytes") } == true)
 
         let extractDir = temporaryDirectory.appending(component: "extracted")
         try await fileSystem.makeDirectory(at: extractDir)

--- a/cli/Tests/TuistAppleArchiverTests/AppleArchiverTests.swift
+++ b/cli/Tests/TuistAppleArchiverTests/AppleArchiverTests.swift
@@ -4,6 +4,8 @@ import Foundation
 import Path
 import Testing
 import TuistAppleArchiver
+import TuistLoggerTesting
+import TuistLogging
 
 struct AppleArchiverTests {
     let subject = AppleArchiver()
@@ -30,7 +32,7 @@ struct AppleArchiverTests {
         #expect(content == "hello world")
     }
 
-    @Test(.inTemporaryDirectory) func compress_and_decompress_preserves_symlinks() async throws {
+    @Test(.inTemporaryDirectory, .withMockedLogger()) func compress_and_decompress_preserves_symlinks() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let fileSystem = FileSystem()
 
@@ -44,6 +46,8 @@ struct AppleArchiverTests {
 
         let archivePath = temporaryDirectory.appending(component: "archive.aar")
         try await subject.compress(directory: sourceDir, to: archivePath, excludePatterns: [])
+
+        #expect(Logger.testingLogHandler.collected[.info]?.contains { $0.contains("input: 14 bytes") } == true)
 
         let extractDir = temporaryDirectory.appending(component: "extracted")
         try await fileSystem.makeDirectory(at: extractDir)
@@ -82,7 +86,7 @@ struct AppleArchiverTests {
         #expect(deepContent == "deep")
     }
 
-    @Test(.inTemporaryDirectory) func compress_excludes_matching_patterns() async throws {
+    @Test(.inTemporaryDirectory, .withMockedLogger()) func compress_excludes_matching_patterns() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let fileSystem = FileSystem()
 
@@ -102,6 +106,13 @@ struct AppleArchiverTests {
             to: archivePath,
             excludePatterns: [".dSYM", ".swiftmodule"]
         )
+
+        let archiveBytes = try Data(contentsOf: URL(fileURLWithPath: archivePath.pathString)).count
+        let compressionLog = try #require(Logger.testingLogHandler.collected[.info]?.first { $0.hasPrefix("Compressed archive") })
+        #expect(compressionLog.contains(archivePath.pathString))
+        #expect(compressionLog.contains("input: 4 bytes, archive: \(archiveBytes) bytes"))
+        #expect(compressionLog.contains("compression: LZFSE"))
+        #expect(compressionLog.range(of: #"in \d+\.\d{2}s"#, options: .regularExpression) != nil)
 
         let extractDir = temporaryDirectory.appending(component: "extracted")
         try await fileSystem.makeDirectory(at: extractDir)
@@ -295,7 +306,8 @@ struct AppleArchiverTests {
     /// The shard split archives one module's `.xctest` out of a products directory that also holds
     /// the other modules and the shared bundle. The archive must carry the `.xctest`'s full path
     /// relative to the products root (so it merges back in place), while nothing else is read.
-    @Test(.inTemporaryDirectory) func compress_subdirectory_preservesRelativePath_andPrunesSiblings() async throws {
+    @Test(.inTemporaryDirectory, .withMockedLogger())
+    func compress_subdirectory_preservesRelativePath_andPrunesSiblings() async throws {
         let temporaryDirectory = try #require(FileSystem.temporaryTestDirectory)
         let fileSystem = FileSystem()
 
@@ -317,6 +329,8 @@ struct AppleArchiverTests {
 
         let archivePath = temporaryDirectory.appending(component: "FooTests.aar")
         try await subject.compress(subdirectory: targetXCTest, relativeTo: productsDir, to: archivePath)
+
+        #expect(Logger.testingLogHandler.collected[.info]?.contains { $0.contains("input: 10 bytes") } == true)
 
         let extractDir = temporaryDirectory.appending(component: "extracted")
         try await fileSystem.makeDirectory(at: extractDir)


### PR DESCRIPTION
### Motivation and observed behavior

A sharded test build showed `Test Build Succeeded` at 11:19:24, shard planning starting at 11:19:26, the plan being created at 11:19:31, and the local shard archive being written at 11:19:55. Tracing the last interval to `archiveXCTestProducts` identified approximately 24 seconds of local packaging, separate from the roughly five seconds spent planning the shards. There is no artifact upload in that local-archive branch.

The surrounding timestamps let us estimate elapsed time, but the shard compression path did not record input or output sizes. The result-bundle uploader has its own timing messages, which do not cover this path. Consequently, session logs could not establish whether a long packaging step reflected a large payload or poor compression throughput without collecting more information from the runner.

This PR adds debug-level start and completion messages to `AppleArchiver`. Both normal and Noora logger configurations already capture debug messages in the session log file, so these measurements remain available without `--verbose`; verbose mode also exposes them in the console. This avoids adding interleaved temporary archive paths to ordinary command output. It improves observability; it does not claim to fix the observed compression time or establish its underlying performance cause.

### Implementation and tradeoffs

- Measure elapsed archiving time with `ContinuousClock`, including directory traversal, file reads, compression, output writes, and stream finalization. The duration is explicitly labeled wall time for the operation, not CPU time alone or isolated compressor throughput. Concurrent archives can contend for CPU and I/O.
- Time the complete concurrent split-artifact batch in `ShardPlanService`. Its start message gives the artifact count and warns that per-archive wall times may overlap. Its completion message reports total wall time for **archiving and uploading** together; it does not mislabel transport time as compression. Retain per-archive measurements to identify payload sizes and slow artifacts, but do not add those overlapping durations to estimate the batch cost.
- Report the archive path, included regular-file input bytes, completed archive bytes, and the LZFSE algorithm. Archive bytes are measured after all streams close.
- Wrap the existing entry filter and count sizes only for accepted entries. Excluded dSYMs and pruned sibling modules do not inflate the input count, and symbolic-link targets are not followed for measurement. Updates use a mutex because archive callbacks may run concurrently.
- Keep size collection best-effort: unavailable metadata produces `unavailable` rather than a misleading partial total or an additional compression failure.
- Wire logging and logger-testing dependencies into both the Swift package manifest and generated-project definitions. The archive test target explicitly declares both `TuistLoggerTesting` and `TuistLogging`: importing logging through a transitive dependency compiles locally, but fails CI's `tuist inspect dependencies --only implicit` check.

The shared archiver is the measurement point so local shard archives, split shard artifacts, and other AppleArchive compression callers receive consistent instrumentation. Counting during the existing traversal avoids a separate recursive size scan, although it adds a metadata lookup for each accepted entry. That overhead has not been benchmarked on a large test bundle. Input bytes describe selected regular-file sizes, not filesystem allocation or archive metadata.

### Validation and how to test locally

Restored dependencies with `tuist install`, then generated the focused targets:

```sh
tuist generate tuist TuistAppleArchiver TuistAppleArchiverTests ProjectDescription --no-open
xcodebuild test -workspace Tuist.xcworkspace -scheme TuistUnitTests \
  -only-testing:TuistAppleArchiverTests/AppleArchiverTests \
  -destination 'platform=macOS,arch=arm64' \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' \
  COMPILATION_CACHE_ENABLE_CACHING=NO
```

All 11 archive test cases passed with Xcode 26.5, including a rerun after switching the messages and assertions to debug level. The generated scheme executed each case twice, with all 22 executions passing. Existing round-trip checks continue to cover directory structure, symlinks, broken symlinks, exclusions, bundle wrapping, and merging split archives. Added assertions verify that symlink targets are not counted twice, excluded files and sibling modules are omitted, the output byte count matches the actual archive, and completion messages include the path, wall-time duration, and algorithm. The three logging tests explicitly enable debug capture on their scoped mock handlers and assert debug-level output.

The full CLI also built successfully after the review changes with `xcodebuild build -workspace Tuist.xcworkspace -scheme tuist -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' COMPILATION_CACHE_ENABLE_CACHING=NO`. This compiles the new `ShardPlanService` batch timing as well as the shared archiver. The build emitted existing dependency/deprecation/concurrency warnings but exited successfully. No live split-artifact upload was performed locally.

SwiftFormat passed for the edited archiver, tests, project helper, and shard-plan service. Scoped SwiftLint completed successfully for both modified production files; `ShardPlanService.swift` has an existing function-length warning outside the edited method. `git diff --check` passed. Broader lint checks encountered existing type/function-length violations in the test/project-helper files and existing formatting issues in `Package.swift`; unrelated formatting was left untouched.

The [CI Lint job](https://github.com/tuist/tuist/actions/runs/34610603705/job/103300248238) passed on `930a34932d`, including the full CLI/app formatting checks, source lint, test fatal-error rule, and `tuist inspect dependencies --only implicit`. This verifies the direct `TuistLogging` test dependency that was missing from the initial PR revision. [CI for review-fix commit `0765bbc223`](https://github.com/tuist/tuist/actions/runs/34627622730) is running; its result is not yet included in the local validation above.

An earlier broad test build was stopped because it also built unrelated CLI targets; archive test runs used the generated unit-test scheme containing only the archive tests. No production payload benchmark was performed, so the original 24-second duration remains diagnostic evidence rather than a reproduced performance result.

### Rollout and follow-up

The messages become available in session logs when the updated CLI is used, and in console output with verbose logging. No server changes, archive-format changes, or migration are required. Future session logs can relate packaging wall time to payload size and distinguish per-archive measurements from the concurrent batch duration before choosing compression or artifact-transport optimizations. The batch duration includes uploads; it does not separate network time or measure compression throughput in isolation. Reverting this change removes the instrumentation without changing how archives are consumed.
