### PR TITLE
fix(server): close review gaps in the automation existing-match backlog

### DIFF
--- a/server/lib/tuist/automations.ex
+++ b/server/lib/tuist/automations.ex
@@ -197,6 +197,8 @@ defmodule Tuist.Automations do
           generation = alert.baseline_generation + 1
           event_generation = if condition_changed?, do: generation, else: Alert.event_generation(alert)
 
+          discard_superseded_baseline_results(alert.id, generation)
+
           changeset
           |> Ecto.Changeset.put_change(:baseline_generation, generation)
           |> Ecto.Changeset.put_change(:event_generation, event_generation)
@@ -217,6 +219,22 @@ defmodule Tuist.Automations do
     end
     |> Repo.transaction()
     |> unwrap_update_alert_transaction()
+  end
+
+  # Generations only advance under the alert's row lock, and a worker rechecks
+  # the generation under that same lock before writing another result, so rows
+  # belonging to an older generation can never be read or extended again. Saves
+  # that bump the generation are a supported product flow now (opt-in,
+  # cancellation, action edit while pending), so leaving one row per matching
+  # test behind on every one of them would grow without bound.
+  defp discard_superseded_baseline_results(alert_id, generation) do
+    Repo.delete_all(
+      from(result in BaselineResult,
+        join: attempt in BaselineAttempt,
+        on: attempt.id == result.attempt_id,
+        where: attempt.alert_id == ^alert_id and attempt.baseline_generation < ^generation
+      )
+    )
   end
 
   defp unwrap_create_alert_transaction({:ok, %{alert: alert}}), do: {:ok, alert}
@@ -536,6 +554,23 @@ defmodule Tuist.Automations do
     }
   end
 
+  @doc """
+  Runs one bounded slice of an alert's baseline pass, resuming from the
+  attempt's durable checkpoints. Returns `:ok` whether it enumerated, published
+  or found nothing left to do.
+
+  `apply_match` turns the silent pass into the opted-in backlog pass. Both share
+  one pipeline on purpose: the backlog needs the same exact, resumable, bounded
+  matching set as the baseline, and running it separately would mean two
+  enumerations of the same project and two publishers racing for the same
+  events. The cost of that choice is real and deliberate — the pipeline only
+  runs while `baseline_established_at` is nil, so requesting a backlog clears it
+  and suspends this automation's triggers and recovery until the rescan
+  finishes, and separating `event_generation` from `baseline_generation` exists
+  only to keep the recovery ledger alive across that window. A backlog pass with
+  its own progress row could avoid the suspension, at the price of a second
+  enumeration and a second publisher to serialize against this one.
+  """
   def establish_alert_baseline(%Alert{} = alert, evaluate_batch, apply_match \\ nil)
       when is_function(evaluate_batch, 1) do
     case begin_alert_baseline(alert) do
@@ -547,8 +582,16 @@ defmodule Tuist.Automations do
 
       {:ok, %BaselineAttempt{state: "evaluating"} = attempt} ->
         case evaluate_alert_baseline(attempt, alert.project_id, evaluate_batch) do
-          {:ok, publishing_attempt} ->
+          {:ok, %BaselineAttempt{state: "publishing"} = publishing_attempt} ->
             publish_and_commit_alert_baseline(publishing_attempt, evaluate_batch, apply_match)
+
+          {:ok, %BaselineAttempt{}} ->
+            # A competing worker still owns the enumeration. The publication
+            # watermark orders by `test_case_id` while the evaluation cursor is
+            # keyset on the test case name tuple, so publishing now would filter
+            # out lower-id results that enumeration has not written yet and
+            # commit a baseline missing them. Leave the attempt for the next run.
+            :ok
 
           {:error, :stale} ->
             :ok

--- a/server/lib/tuist/automations/alerts/alert.ex
+++ b/server/lib/tuist/automations/alerts/alert.ex
@@ -382,7 +382,7 @@ defmodule Tuist.Automations.Alerts.Alert do
   defp validate_window_shape(config, max_rolling_window_size) do
     case window_type(config) do
       "last_days" ->
-        if valid_window?(config["window"]),
+        if valid_day_window?(config["window"]),
           do: :ok,
           else: {:error, "window must be a string like '30d' (day-level only)"}
 
@@ -408,10 +408,15 @@ defmodule Tuist.Automations.Alerts.Alert do
   defp window_type(%{"window_type" => type}) when type in @window_types, do: type
   defp window_type(_), do: :invalid
 
-  # The flaky-test monitor evaluates against a per-day-aggregated MV, so
-  # sub-day windows would silently round to a full day and look broken.
-  # Constrain `trigger_config.window` to day-level (`Nd`) up front so users
-  # don't think `1h` / `5m` are honored.
-  defp valid_window?(window) when is_binary(window), do: Regex.match?(~r/^[1-9]\d*d$/, window)
-  defp valid_window?(_), do: false
+  @doc """
+  Whether a `last_days` window string is day-level (`Nd`).
+
+  The flaky-test monitor evaluates against a per-day-aggregated MV, so sub-day
+  windows would silently round to a full day and look broken. Constrain
+  `trigger_config.window` to day-level up front so users don't think `1h` /
+  `5m` are honored. Public so the dashboard form can gate Save on the same
+  rule instead of letting an invalid window reach a silent no-op.
+  """
+  def valid_day_window?(window) when is_binary(window), do: Regex.match?(~r/^[1-9]\d*d$/, window)
+  def valid_day_window?(_window), do: false
 end

--- a/server/lib/tuist_web/live/project_automations_live.ex
+++ b/server/lib/tuist_web/live/project_automations_live.ex
@@ -1066,13 +1066,14 @@ defmodule TuistWeb.ProjectAutomationsLive do
   `max` attribute doesn't intercept the click.
   """
   def rolling_window_inputs_valid?(assigns) do
-    is_nil(
-      rolling_size_error(
-        assigns.create_automation_form_window_type,
-        assigns.create_automation_form_rolling_window_size,
-        Alert.max_rolling_trigger_window_size()
-      )
-    ) and
+    (event_driven_monitor_type?(assigns.create_automation_form_metric) or
+       is_nil(
+         rolling_size_error(
+           assigns.create_automation_form_window_type,
+           assigns.create_automation_form_rolling_window_size,
+           Alert.max_rolling_trigger_window_size()
+         )
+       )) and
       (not assigns.create_automation_form_recovery_enabled or
          is_nil(
            rolling_size_error(
@@ -1091,14 +1092,19 @@ defmodule TuistWeb.ProjectAutomationsLive do
   and nothing validates the recovery `last_days` window. Without this the Save
   button stayed enabled for `14` instead of `14d` and the click landed on the
   catch-all handler, leaving the modal open with no feedback.
+
+  Event-driven monitors hide both window fields and ignore them when building
+  the config, so a value left over from the metric the user started on must not
+  disable a Save they have no field to correct.
   """
   def day_window_inputs_valid?(assigns) do
-    is_nil(
-      day_window_error(
-        assigns.create_automation_form_window_type,
-        assigns.create_automation_form_window
-      )
-    ) and
+    (event_driven_monitor_type?(assigns.create_automation_form_metric) or
+       is_nil(
+         day_window_error(
+           assigns.create_automation_form_window_type,
+           assigns.create_automation_form_window
+         )
+       )) and
       (not assigns.create_automation_form_recovery_enabled or
          is_nil(
            day_window_error(

--- a/server/lib/tuist_web/live/project_automations_live.ex
+++ b/server/lib/tuist_web/live/project_automations_live.ex
@@ -73,8 +73,15 @@ defmodule TuistWeb.ProjectAutomationsLive do
     end
   end
 
-  defp refresh_match_count_on_event("close_create_automation_modal", _params, socket) do
-    {:cont, socket |> cancel_match_count() |> assign(match_count: :idle, match_count_ref: nil)}
+  defp refresh_match_count_on_event(event, params, socket)
+       when event in ["close_create_automation_modal", "create_automation_modal_open_change"] do
+    # Noora wires `on_dismiss` to the ✕ only; Escape and click-outside close the
+    # dialog client-side and surface here through `on_open_change` instead.
+    if event == "close_create_automation_modal" or params["open"] == false do
+      {:cont, socket |> cancel_match_count() |> assign(match_count: :idle, match_count_ref: nil)}
+    else
+      {:cont, socket}
+    end
   end
 
   defp refresh_match_count_on_event(_event, _params, socket), do: {:cont, socket}
@@ -330,6 +337,8 @@ defmodule TuistWeb.ProjectAutomationsLive do
     {:noreply, push_event(socket, "close-modal", %{id: "create-automation-modal"})}
   end
 
+  def handle_event("create_automation_modal_open_change", _params, socket), do: {:noreply, socket}
+
   def handle_event("toggle_create_automation_form_section", %{"section" => section}, socket)
       when section in ["condition", "actions", "recovery"] do
     sections = socket.assigns.create_automation_form_sections
@@ -573,7 +582,8 @@ defmodule TuistWeb.ProjectAutomationsLive do
   end
 
   def handle_event("save_automation", _params, %{assigns: assigns} = socket) do
-    if condition_inputs_valid?(assigns) and rolling_window_inputs_valid?(assigns) do
+    if condition_inputs_valid?(assigns) and rolling_window_inputs_valid?(assigns) and
+         day_window_inputs_valid?(assigns) do
       save_automation(socket)
     else
       {:noreply, socket}
@@ -777,11 +787,24 @@ defmodule TuistWeb.ProjectAutomationsLive do
       assigns.create_automation_form_rolling_window_size
     )
     |> maybe_put_states(assigns.create_automation_form_trigger_states)
-    |> maybe_put_apply_existing_matches(assigns.create_automation_form_apply_existing_matches)
+    |> maybe_put_apply_existing_matches(
+      assigns.create_automation_form_apply_existing_matches,
+      assigns.create_automation_form_existing_matches_pending
+    )
   end
 
-  defp maybe_put_apply_existing_matches(config, true), do: Map.put(config, "apply_actions_to_existing_matches", true)
-  defp maybe_put_apply_existing_matches(config, false), do: Map.put(config, "apply_actions_to_existing_matches", false)
+  # The key records a pending operation for one save, not a persistent
+  # preference, so an unchecked box only writes `false` when there is a request
+  # to cancel. Writing it unconditionally made every no-op save of a metric
+  # automation record a `trigger_config` revision whose from/to render
+  # identically, and ping-ponged with API updates that omit `trigger_config`.
+  defp maybe_put_apply_existing_matches(config, true, _pending),
+    do: Map.put(config, "apply_actions_to_existing_matches", true)
+
+  defp maybe_put_apply_existing_matches(config, false, true),
+    do: Map.put(config, "apply_actions_to_existing_matches", false)
+
+  defp maybe_put_apply_existing_matches(config, false, false), do: config
 
   defp recovery_config_for("test_updated", _assigns), do: %{}
 
@@ -1059,6 +1082,43 @@ defmodule TuistWeb.ProjectAutomationsLive do
            )
          ))
   end
+
+  @doc """
+  True when both day-level window inputs hold a value the schema accepts.
+
+  `condition_alert/1` builds its changeset from a bare `%Alert{}` and never
+  sets `recovery_enabled`, so `Alert.validate_recovery_config/1` short-circuits
+  and nothing validates the recovery `last_days` window. Without this the Save
+  button stayed enabled for `14` instead of `14d` and the click landed on the
+  catch-all handler, leaving the modal open with no feedback.
+  """
+  def day_window_inputs_valid?(assigns) do
+    is_nil(
+      day_window_error(
+        assigns.create_automation_form_window_type,
+        assigns.create_automation_form_window
+      )
+    ) and
+      (not assigns.create_automation_form_recovery_enabled or
+         is_nil(
+           day_window_error(
+             assigns.create_automation_form_recovery_window_type,
+             assigns.create_automation_form_recovery_window
+           )
+         ))
+  end
+
+  @doc """
+  User-facing error string for a day-level window input, or `nil` when the
+  value is valid (or the window mode isn't `last_days`).
+  """
+  def day_window_error("last_days", raw_window) do
+    if Alert.valid_day_window?(to_string(raw_window)),
+      do: nil,
+      else: dgettext("dashboard_projects", "e.g. 30d")
+  end
+
+  def day_window_error(_window_type, _raw_window), do: nil
 
   @doc """
   User-facing error string for a rolling-window size input, or `nil` when

--- a/server/lib/tuist_web/live/project_automations_live.html.heex
+++ b/server/lib/tuist_web/live/project_automations_live.html.heex
@@ -67,6 +67,7 @@
         }
         header_size="large"
         on_dismiss="close_create_automation_modal"
+        on_open_change="create_automation_modal_open_change"
       >
         <:trigger :let={attrs}>
           <.button
@@ -279,6 +280,12 @@
                         name="window"
                         value={@create_automation_form_window}
                         placeholder="30d"
+                        error={
+                          day_window_error(
+                            @create_automation_form_window_type,
+                            @create_automation_form_window
+                          )
+                        }
                         phx-keyup="update_create_automation_form_window"
                         phx-debounce="300"
                       />
@@ -776,6 +783,12 @@
                             name="recovery_days"
                             value={@create_automation_form_recovery_window}
                             placeholder="14d"
+                            error={
+                              day_window_error(
+                                @create_automation_form_recovery_window_type,
+                                @create_automation_form_recovery_window
+                              )
+                            }
                             phx-keyup="update_create_automation_form_recovery_window"
                             phx-debounce="300"
                           />
@@ -1093,6 +1106,7 @@
                 disabled={
                   @create_automation_form_name == "" or
                     not rolling_window_inputs_valid?(assigns) or
+                    not day_window_inputs_valid?(assigns) or
                     not condition_inputs_valid?(assigns) or
                     Enum.empty?(@create_automation_form_trigger_actions)
                 }

--- a/server/priv/gettext/dashboard_projects.pot
+++ b/server/priv/gettext/dashboard_projects.pot
@@ -161,7 +161,7 @@ msgstr ""
 #: lib/tuist_web/live/bazel_invocations_live.ex:232
 #: lib/tuist_web/live/bazel_overview_live.ex:137
 #: lib/tuist_web/live/bazel_overview_live.ex:332
-#: lib/tuist_web/live/project_automations_live.html.heex:1069
+#: lib/tuist_web/live/project_automations_live.html.heex:1082
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:194
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:354
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:498
@@ -308,8 +308,8 @@ msgid "Local"
 msgstr ""
 
 #: lib/tuist_web/live/create_project_live.ex:82
-#: lib/tuist_web/live/project_automations_live.html.heex:87
-#: lib/tuist_web/live/project_automations_live.html.heex:1126
+#: lib/tuist_web/live/project_automations_live.html.heex:88
+#: lib/tuist_web/live/project_automations_live.html.heex:1140
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:111
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:220
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:269
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1086
+#: lib/tuist_web/live/project_automations_live.html.heex:1099
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:363
 #: lib/tuist_web/live/project_notifications_live.html.heex:180
 #: lib/tuist_web/live/project_settings_live.html.heex:153
@@ -686,9 +686,9 @@ msgstr ""
 msgid "Test duration"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:1035
-#: lib/tuist_web/live/project_automations_live.html.heex:257
-#: lib/tuist_web/live/project_automations_live.html.heex:755
+#: lib/tuist_web/live/project_automations_live.ex:1058
+#: lib/tuist_web/live/project_automations_live.html.heex:258
+#: lib/tuist_web/live/project_automations_live.html.heex:762
 #: lib/tuist_web/live/project_notifications_live.html.heex:400
 #: lib/tuist_web/live/project_notifications_live.html.heex:540
 #: lib/tuist_web/live/project_notifications_live.html.heex:724
@@ -758,8 +758,8 @@ msgstr ""
 msgid "Slack"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:534
-#: lib/tuist_web/live/project_automations_live.html.heex:911
+#: lib/tuist_web/live/project_automations_live.html.heex:541
+#: lib/tuist_web/live/project_automations_live.html.heex:924
 #: lib/tuist_web/live/project_notifications_live.html.heex:210
 #: lib/tuist_web/live/project_notifications_live.html.heex:220
 #: lib/tuist_web/live/project_notifications_live.html.heex:480
@@ -769,8 +769,8 @@ msgstr ""
 msgid "Select channel"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:533
-#: lib/tuist_web/live/project_automations_live.html.heex:910
+#: lib/tuist_web/live/project_automations_live.html.heex:540
+#: lib/tuist_web/live/project_automations_live.html.heex:923
 #: lib/tuist_web/live/project_notifications_live.html.heex:219
 #: lib/tuist_web/live/project_notifications_live.html.heex:479
 #: lib/tuist_web/live/project_notifications_live.html.heex:817
@@ -815,7 +815,7 @@ msgstr ""
 msgid "tests"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1089
+#: lib/tuist_web/live/project_automations_live.html.heex:1102
 #: lib/tuist_web/live/project_bundle_settings_live.html.heex:202
 #: lib/tuist_web/live/project_notifications_live.html.heex:507
 #: lib/tuist_web/live/projects_live.ex:427
@@ -1088,51 +1088,51 @@ msgid "Select organization"
 msgstr ""
 
 #: lib/tuist_web/live/bazel_invocation_live.ex:633
-#: lib/tuist_web/live/project_automations_live.html.heex:393
+#: lib/tuist_web/live/project_automations_live.html.heex:400
 #, elixir-autogen, elixir-format
 msgid "Action"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:404
+#: lib/tuist_web/live/project_automations_live.html.heex:411
 #, elixir-autogen, elixir-format
 msgid "Add action"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:73
+#: lib/tuist_web/live/project_automations_live.html.heex:74
 #, elixir-autogen, elixir-format
 msgid "Add automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:938
+#: lib/tuist_web/live/project_automations_live.ex:961
 #, elixir-autogen, elixir-format
 msgid "Add label"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:959
+#: lib/tuist_web/live/project_automations_live.ex:982
 #, elixir-autogen, elixir-format
 msgid "Add label: %{label}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:674
+#: lib/tuist_web/live/project_automations_live.html.heex:681
 #, elixir-autogen, elixir-format
 msgid "Add recovery action"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:588
-#: lib/tuist_web/live/project_automations_live.html.heex:965
+#: lib/tuist_web/live/project_automations_live.html.heex:595
+#: lib/tuist_web/live/project_automations_live.html.heex:978
 #, elixir-autogen, elixir-format
 msgid "Available variables:"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:936
-#: lib/tuist_web/live/project_automations_live.html.heex:414
-#: lib/tuist_web/live/project_automations_live.html.heex:684
+#: lib/tuist_web/live/project_automations_live.ex:959
+#: lib/tuist_web/live/project_automations_live.html.heex:421
+#: lib/tuist_web/live/project_automations_live.html.heex:691
 #, elixir-autogen, elixir-format
 msgid "Change state"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:469
-#: lib/tuist_web/live/project_automations_live.html.heex:846
+#: lib/tuist_web/live/project_automations_live.html.heex:476
+#: lib/tuist_web/live/project_automations_live.html.heex:859
 #, elixir-autogen, elixir-format
 msgid "Change state to"
 msgstr ""
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Create automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1165
+#: lib/tuist_web/live/project_automations_live.html.heex:1179
 #, elixir-autogen, elixir-format
 msgid "Delete this automation?"
 msgstr ""
@@ -1162,105 +1162,105 @@ msgstr ""
 msgid "Edit automation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:928
+#: lib/tuist_web/live/project_automations_live.ex:951
 #, elixir-autogen, elixir-format
 msgid "Enable"
 msgstr ""
 
 #: lib/tuist_web/live/project_automation_live.ex:292
 #: lib/tuist_web/live/project_automation_live.html.heex:26
-#: lib/tuist_web/live/project_automations_live.ex:933
-#: lib/tuist_web/live/project_automations_live.html.heex:508
-#: lib/tuist_web/live/project_automations_live.html.heex:854
+#: lib/tuist_web/live/project_automations_live.ex:956
+#: lib/tuist_web/live/project_automations_live.html.heex:515
+#: lib/tuist_web/live/project_automations_live.html.heex:867
 #, elixir-autogen, elixir-format
 msgid "Enabled"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:580
-#: lib/tuist_web/live/project_automations_live.html.heex:957
+#: lib/tuist_web/live/project_automations_live.html.heex:587
+#: lib/tuist_web/live/project_automations_live.html.heex:970
 #, elixir-autogen, elixir-format
 msgid "Enter message template..."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:875
-#: lib/tuist_web/live/project_automations_live.html.heex:139
+#: lib/tuist_web/live/project_automations_live.ex:898
+#: lib/tuist_web/live/project_automations_live.html.heex:140
 #, elixir-autogen, elixir-format
 msgid "Flakiness rate"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:876
-#: lib/tuist_web/live/project_automations_live.html.heex:147
+#: lib/tuist_web/live/project_automations_live.ex:899
+#: lib/tuist_web/live/project_automations_live.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Flaky runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:431
-#: lib/tuist_web/live/project_automations_live.html.heex:718
+#: lib/tuist_web/live/project_automations_live.html.heex:438
+#: lib/tuist_web/live/project_automations_live.html.heex:725
 #, elixir-autogen, elixir-format
 msgid "Mark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:735
-#: lib/tuist_web/live/project_automations_live.html.heex:600
-#: lib/tuist_web/live/project_automations_live.html.heex:977
+#: lib/tuist_web/live/project_automations_live.ex:745
+#: lib/tuist_web/live/project_automations_live.html.heex:607
+#: lib/tuist_web/live/project_automations_live.html.heex:990
 #, elixir-autogen, elixir-format
 msgid "Mark test as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:558
-#: lib/tuist_web/live/project_automations_live.html.heex:935
+#: lib/tuist_web/live/project_automations_live.html.heex:565
+#: lib/tuist_web/live/project_automations_live.html.heex:948
 #, elixir-autogen, elixir-format
 msgid "Message template"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1109
+#: lib/tuist_web/live/project_automations_live.html.heex:1123
 #, elixir-autogen, elixir-format
 msgid "No automations yet. Add one to start automatically managing test case state based on conditions."
 msgstr ""
 
 #: lib/tuist_web/live/project_automation_live.html.heex:56
-#: lib/tuist_web/live/project_automations_live.html.heex:638
-#: lib/tuist_web/live/project_automations_live.html.heex:662
+#: lib/tuist_web/live/project_automations_live.html.heex:645
+#: lib/tuist_web/live/project_automations_live.html.heex:669
 #, elixir-autogen, elixir-format
 msgid "Recovery"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:939
+#: lib/tuist_web/live/project_automations_live.ex:962
 #, elixir-autogen, elixir-format
 msgid "Remove label"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:962
+#: lib/tuist_web/live/project_automations_live.ex:985
 #, elixir-autogen, elixir-format
 msgid "Remove label: %{label}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:665
+#: lib/tuist_web/live/project_automations_live.html.heex:672
 #, elixir-autogen, elixir-format
 msgid "Run actions when the conditions no longer hold"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:396
+#: lib/tuist_web/live/project_automations_live.html.heex:403
 #, elixir-autogen, elixir-format
 msgid "Run these actions for each test case that meets the condition"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:937
-#: lib/tuist_web/live/project_automations_live.html.heex:453
-#: lib/tuist_web/live/project_automations_live.html.heex:521
-#: lib/tuist_web/live/project_automations_live.html.heex:723
-#: lib/tuist_web/live/project_automations_live.html.heex:898
+#: lib/tuist_web/live/project_automations_live.ex:960
+#: lib/tuist_web/live/project_automations_live.html.heex:460
+#: lib/tuist_web/live/project_automations_live.html.heex:528
+#: lib/tuist_web/live/project_automations_live.html.heex:730
+#: lib/tuist_web/live/project_automations_live.html.heex:911
 #, elixir-autogen, elixir-format
 msgid "Send Slack notification"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:956
+#: lib/tuist_web/live/project_automations_live.ex:979
 #, elixir-autogen, elixir-format
 msgid "Slack: not configured"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:561
-#: lib/tuist_web/live/project_automations_live.html.heex:938
+#: lib/tuist_web/live/project_automations_live.html.heex:568
+#: lib/tuist_web/live/project_automations_live.html.heex:951
 #, elixir-autogen, elixir-format
 msgid "Supports Slack"
 msgstr ""
@@ -1270,238 +1270,238 @@ msgstr ""
 msgid "Test case automations"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1129
+#: lib/tuist_web/live/project_automations_live.html.heex:1143
 #, elixir-autogen, elixir-format
 msgid "Trigger"
 msgstr ""
 
 #: lib/tuist_web/live/bazel_invocation_live.ex:811
-#: lib/tuist_web/live/project_automations_live.ex:879
-#: lib/tuist_web/live/project_automations_live.ex:890
+#: lib/tuist_web/live/project_automations_live.ex:902
 #: lib/tuist_web/live/project_automations_live.ex:913
-#: lib/tuist_web/live/project_automations_live.ex:929
-#: lib/tuist_web/live/project_automations_live.ex:934
-#: lib/tuist_web/live/project_automations_live.ex:940
+#: lib/tuist_web/live/project_automations_live.ex:936
+#: lib/tuist_web/live/project_automations_live.ex:952
+#: lib/tuist_web/live/project_automations_live.ex:957
+#: lib/tuist_web/live/project_automations_live.ex:963
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:448
-#: lib/tuist_web/live/project_automations_live.html.heex:701
+#: lib/tuist_web/live/project_automations_live.html.heex:455
+#: lib/tuist_web/live/project_automations_live.html.heex:708
 #, elixir-autogen, elixir-format
 msgid "Unmark as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:738
-#: lib/tuist_web/live/project_automations_live.html.heex:604
-#: lib/tuist_web/live/project_automations_live.html.heex:981
+#: lib/tuist_web/live/project_automations_live.ex:748
+#: lib/tuist_web/live/project_automations_live.html.heex:611
+#: lib/tuist_web/live/project_automations_live.html.heex:994
 #, elixir-autogen, elixir-format
 msgid "Unmark test as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:116
-#: lib/tuist_web/live/project_automations_live.html.heex:131
+#: lib/tuist_web/live/project_automations_live.html.heex:117
+#: lib/tuist_web/live/project_automations_live.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "When"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:735
+#: lib/tuist_web/live/project_automations_live.html.heex:742
 #, elixir-autogen, elixir-format
 msgid "Without trigger for"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:95
+#: lib/tuist_web/live/project_automations_live.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "e.g. Auto-quarantine flaky tests"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:569
-#: lib/tuist_web/live/project_automations_live.html.heex:946
+#: lib/tuist_web/live/project_automations_live.html.heex:576
+#: lib/tuist_web/live/project_automations_live.html.heex:959
 #, elixir-autogen, elixir-format
 msgid "formatting."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:926
+#: lib/tuist_web/live/project_automations_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:931
-#: lib/tuist_web/live/project_automations_live.html.heex:477
-#: lib/tuist_web/live/project_automations_live.html.heex:863
+#: lib/tuist_web/live/project_automations_live.ex:954
+#: lib/tuist_web/live/project_automations_live.html.heex:484
+#: lib/tuist_web/live/project_automations_live.html.heex:876
 #, elixir-autogen, elixir-format
 msgid "Muted"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:927
+#: lib/tuist_web/live/project_automations_live.ex:950
 #, elixir-autogen, elixir-format
 msgid "Skip"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:932
-#: lib/tuist_web/live/project_automations_live.html.heex:486
-#: lib/tuist_web/live/project_automations_live.html.heex:872
+#: lib/tuist_web/live/project_automations_live.ex:955
+#: lib/tuist_web/live/project_automations_live.html.heex:493
+#: lib/tuist_web/live/project_automations_live.html.heex:885
 #, elixir-autogen, elixir-format
 msgid "Skipped"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:177
+#: lib/tuist_web/live/project_automations_live.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Comparison"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:923
+#: lib/tuist_web/live/project_automations_live.ex:946
 #, elixir-autogen, elixir-format
 msgid "Count"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:909
-#: lib/tuist_web/live/project_automations_live.html.heex:185
+#: lib/tuist_web/live/project_automations_live.ex:932
+#: lib/tuist_web/live/project_automations_live.html.heex:186
 #, elixir-autogen, elixir-format
 msgid "Greater or equal"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:910
-#: lib/tuist_web/live/project_automations_live.html.heex:193
+#: lib/tuist_web/live/project_automations_live.ex:933
+#: lib/tuist_web/live/project_automations_live.html.heex:194
 #, elixir-autogen, elixir-format
 msgid "Greater than"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:912
-#: lib/tuist_web/live/project_automations_live.html.heex:209
+#: lib/tuist_web/live/project_automations_live.ex:935
+#: lib/tuist_web/live/project_automations_live.html.heex:210
 #, elixir-autogen, elixir-format
 msgid "Less or equal"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:911
-#: lib/tuist_web/live/project_automations_live.html.heex:201
+#: lib/tuist_web/live/project_automations_live.ex:934
+#: lib/tuist_web/live/project_automations_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Less than"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:921
-#: lib/tuist_web/live/project_automations_live.ex:922
+#: lib/tuist_web/live/project_automations_live.ex:944
+#: lib/tuist_web/live/project_automations_live.ex:945
 #, elixir-autogen, elixir-format
 msgid "Percent"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:924
+#: lib/tuist_web/live/project_automations_live.ex:947
 #, elixir-autogen, elixir-format
 msgid "Threshold"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:970
+#: lib/tuist_web/live/project_automations_live.ex:993
 #, elixir-autogen, elixir-format
 msgid "When flakiness rate %{symbol} %{threshold}% over %{window}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:983
+#: lib/tuist_web/live/project_automations_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "When flaky runs %{symbol} %{threshold} over %{window}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:295
-#: lib/tuist_web/live/project_automations_live.html.heex:789
+#: lib/tuist_web/live/project_automations_live.html.heex:302
+#: lib/tuist_web/live/project_automations_live.html.heex:802
 #, elixir-autogen, elixir-format
 msgid "Last N runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:1036
-#: lib/tuist_web/live/project_automations_live.html.heex:249
-#: lib/tuist_web/live/project_automations_live.html.heex:745
+#: lib/tuist_web/live/project_automations_live.ex:1059
+#: lib/tuist_web/live/project_automations_live.html.heex:250
+#: lib/tuist_web/live/project_automations_live.html.heex:752
 #, elixir-autogen, elixir-format
 msgid "Last days"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:241
+#: lib/tuist_web/live/project_automations_live.html.heex:242
 #, elixir-autogen, elixir-format
 msgid "Over"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:274
-#: lib/tuist_web/live/project_automations_live.html.heex:771
+#: lib/tuist_web/live/project_automations_live.html.heex:275
+#: lib/tuist_web/live/project_automations_live.html.heex:778
 #, elixir-autogen, elixir-format
 msgid "Window"
 msgstr ""
 
 #: lib/tuist_web/live/project_automation_live.ex:304
-#: lib/tuist_web/live/project_automations_live.ex:1023
+#: lib/tuist_web/live/project_automations_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "the last %{size} runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:1072
+#: lib/tuist_web/live/project_automations_live.ex:1132
 #, elixir-autogen, elixir-format
 msgid "1–%{max}"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:893
+#: lib/tuist_web/live/project_automations_live.ex:916
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is manually flagged as flaky."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:902
+#: lib/tuist_web/live/project_automations_live.ex:925
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is muted (still runs, failures ignored)."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:905
+#: lib/tuist_web/live/project_automations_live.ex:928
 #, elixir-autogen, elixir-format
 msgid "Fires when a test is skipped entirely."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:899
+#: lib/tuist_web/live/project_automations_live.ex:922
 #, elixir-autogen, elixir-format
 msgid "Fires when a test returns to the default enabled state."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:896
+#: lib/tuist_web/live/project_automations_live.ex:919
 #, elixir-autogen, elixir-format
 msgid "Fires when the flaky flag is manually removed."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:881
+#: lib/tuist_web/live/project_automations_live.ex:904
 #, elixir-autogen, elixir-format
 msgid "Marked as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:320
+#: lib/tuist_web/live/project_automations_live.html.heex:327
 #, elixir-autogen, elixir-format
 msgid "On these events"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:884
+#: lib/tuist_web/live/project_automations_live.ex:907
 #, elixir-autogen, elixir-format
 msgid "State changed to Enabled"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:886
+#: lib/tuist_web/live/project_automations_live.ex:909
 #, elixir-autogen, elixir-format
 msgid "State changed to Muted"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:888
+#: lib/tuist_web/live/project_automations_live.ex:911
 #, elixir-autogen, elixir-format
 msgid "State changed to Skipped"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:878
-#: lib/tuist_web/live/project_automations_live.html.heex:163
+#: lib/tuist_web/live/project_automations_live.ex:901
+#: lib/tuist_web/live/project_automations_live.html.heex:164
 #, elixir-autogen, elixir-format
 msgid "Test updated"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:882
+#: lib/tuist_web/live/project_automations_live.ex:905
 #, elixir-autogen, elixir-format
 msgid "Unmarked as flaky"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:1010
+#: lib/tuist_web/live/project_automations_live.ex:1033
 #, elixir-autogen, elixir-format
 msgid "When a test is updated"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:1014
+#: lib/tuist_web/live/project_automations_live.ex:1037
 #, elixir-autogen, elixir-format
 msgid "When a test is updated: %{events}"
 msgstr ""
@@ -1511,8 +1511,8 @@ msgstr ""
 msgid "New Project"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:877
-#: lib/tuist_web/live/project_automations_live.html.heex:155
+#: lib/tuist_web/live/project_automations_live.ex:900
+#: lib/tuist_web/live/project_automations_live.html.heex:156
 #, elixir-autogen, elixir-format
 msgid "Test reliability"
 msgstr ""
@@ -1552,7 +1552,7 @@ msgstr ""
 msgid "can't be blank"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:604
+#: lib/tuist_web/live/project_automations_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "This automation uses an unsupported trigger configuration. Edit it before enabling it."
 msgstr ""
@@ -1701,7 +1701,7 @@ msgstr ""
 msgid "Tuist"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1139
+#: lib/tuist_web/live/project_automations_live.html.heex:1153
 #, elixir-autogen, elixir-format
 msgid "View automation details"
 msgstr ""
@@ -1716,8 +1716,8 @@ msgstr ""
 msgid "the dashboard"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:342
-#: lib/tuist_web/live/project_automations_live.html.heex:814
+#: lib/tuist_web/live/project_automations_live.html.heex:349
+#: lib/tuist_web/live/project_automations_live.html.heex:827
 #, elixir-autogen, elixir-format
 msgid "Only apply to tests in these states"
 msgstr ""
@@ -1840,7 +1840,7 @@ msgstr ""
 msgid "That is not a valid GitHub username."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:996
+#: lib/tuist_web/live/project_automations_live.ex:1019
 #, elixir-autogen, elixir-format
 msgid "When test reliability on the default branch %{symbol} %{threshold}% over %{window}"
 msgstr ""
@@ -2642,8 +2642,8 @@ msgstr ""
 msgid "Invocation"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:495
-#: lib/tuist_web/live/project_automations_live.html.heex:881
+#: lib/tuist_web/live/project_automations_live.html.heex:502
+#: lib/tuist_web/live/project_automations_live.html.heex:894
 #, elixir-autogen, elixir-format
 msgid "Skips the entire target, including healthy tests."
 msgstr ""
@@ -2668,62 +2668,62 @@ msgstr ""
 msgid "Total size of build outputs uploaded to the remote cache. Excludes action cache writes, which store metadata rather than outputs."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1057
+#: lib/tuist_web/live/project_automations_live.html.heex:1070
 #, elixir-autogen, elixir-format
 msgid "Actions for existing matches are pending. Save with this option unchecked to cancel any remaining actions."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:725
+#: lib/tuist_web/live/project_automations_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "After %{window} without a trigger: %{actions}."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1018
+#: lib/tuist_web/live/project_automations_live.html.heex:1031
 #, elixir-autogen, elixir-format
 msgid "Apply to existing matches"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1024
+#: lib/tuist_web/live/project_automations_live.html.heex:1037
 #, elixir-autogen, elixir-format
 msgid "By default, actions run only for new matches."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1045
+#: lib/tuist_web/live/project_automations_live.html.heex:1058
 #, elixir-autogen, elixir-format
 msgid "Complete a valid condition to see matching tests."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:694
+#: lib/tuist_web/live/project_automations_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Complete a valid condition."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1038
+#: lib/tuist_web/live/project_automations_live.html.heex:1051
 #, elixir-autogen, elixir-format
 msgid "Counting matching tests…"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1083
+#: lib/tuist_web/live/project_automations_live.html.heex:1096
 #, elixir-autogen, elixir-format
 msgid "Create and apply actions"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:717
+#: lib/tuist_web/live/project_automations_live.ex:727
 #, elixir-autogen, elixir-format
 msgid "For each matching test: %{actions}."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1040
+#: lib/tuist_web/live/project_automations_live.html.heex:1053
 #, elixir-autogen, elixir-format
 msgid "Match count unavailable. You can still save."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:714
+#: lib/tuist_web/live/project_automations_live.ex:724
 #, elixir-autogen, elixir-format
 msgid "No actions selected."
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:730
+#: lib/tuist_web/live/project_automations_live.ex:740
 #, elixir-autogen, elixir-format
 msgid "Recovery is disabled."
 msgstr ""
@@ -2733,19 +2733,24 @@ msgstr ""
 msgid "Requested actions for existing matches"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1082
+#: lib/tuist_web/live/project_automations_live.html.heex:1095
 #, elixir-autogen, elixir-format
 msgid "Save and apply actions"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:1031
+#: lib/tuist_web/live/project_automations_live.html.heex:1044
 #, elixir-autogen, elixir-format
 msgid "Select to also run them once after saving for %{count} test that currently matches."
 msgid_plural "Select to also run them once after saving for %{count} tests that currently match."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/tuist_web/live/project_automations_live.html.heex:377
+#: lib/tuist_web/live/project_automations_live.html.heex:384
 #, elixir-autogen, elixir-format
 msgid "What"
+msgstr ""
+
+#: lib/tuist_web/live/project_automations_live.ex:1118
+#, elixir-autogen, elixir-format
+msgid "e.g. 30d"
 msgstr ""

--- a/server/priv/gettext/dashboard_projects.pot
+++ b/server/priv/gettext/dashboard_projects.pot
@@ -1430,7 +1430,7 @@ msgstr ""
 msgid "the last %{size} runs"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:1132
+#: lib/tuist_web/live/project_automations_live.ex:1138
 #, elixir-autogen, elixir-format
 msgid "1–%{max}"
 msgstr ""
@@ -2750,7 +2750,7 @@ msgstr[1] ""
 msgid "What"
 msgstr ""
 
-#: lib/tuist_web/live/project_automations_live.ex:1118
+#: lib/tuist_web/live/project_automations_live.ex:1124
 #, elixir-autogen, elixir-format
 msgid "e.g. 30d"
 msgstr ""

--- a/server/test/tuist/automations/baseline_test.exs
+++ b/server/test/tuist/automations/baseline_test.exs
@@ -428,6 +428,47 @@ defmodule Tuist.Automations.BaselineTest do
     assert Repo.reload!(attempt).state == "committed"
   end
 
+  test "leaves publication to the next run when a competing worker still owns the enumeration" do
+    project = ProjectsFixtures.project_fixture()
+    alert = AutomationsFixtures.automation_alert_fixture(project: project, baseline_established_at: nil)
+    {:ok, attempt} = Automations.begin_alert_baseline(alert)
+    late_id = Ecto.UUID.generate()
+
+    # A second evaluation job advances the shared attempt's keyset cursor while
+    # this one is reading its page, so the page this worker sees is already
+    # empty. The competing worker has not yet written the results for that page.
+    expect(ClickHouseRepo, :all, fn _query, _opts ->
+      attempt
+      |> BaselineAttempt.changeset(%{
+        evaluation_cursor: %{"module_name" => "Tests", "suite_name" => "Baseline", "name" => "z", "id" => late_id}
+      })
+      |> Repo.update!()
+
+      []
+    end)
+
+    assert :ok = Automations.establish_alert_baseline(alert, & &1)
+
+    reloaded = Repo.reload!(attempt)
+    assert reloaded.state == "evaluating"
+    assert reloaded.last_published_test_case_id == nil
+    assert is_nil(Repo.reload!(alert).baseline_established_at)
+    assert Automations.list_active_alert_events(alert.id) == []
+  end
+
+  test "discards the superseded attempt's results when a save advances the generation" do
+    alert = AutomationsFixtures.automation_alert_fixture(baseline_established_at: nil)
+    attempt = publishing_attempt(alert, [Ecto.UUID.generate(), Ecto.UUID.generate()])
+
+    assert Repo.aggregate(where(BaselineResult, attempt_id: ^attempt.id), :count) == 2
+
+    config = Map.put(alert.trigger_config, "apply_actions_to_existing_matches", true)
+    assert {:ok, requested} = Automations.update_alert(alert, %{trigger_config: config})
+
+    assert requested.baseline_generation > attempt.baseline_generation
+    assert Repo.aggregate(where(BaselineResult, attempt_id: ^attempt.id), :count) == 0
+  end
+
   defp publishing_attempt(alert, test_case_ids) do
     {:ok, attempt} = Automations.begin_alert_baseline(alert)
 

--- a/server/test/tuist_web/live/project_automations_live_test.exs
+++ b/server/test/tuist_web/live/project_automations_live_test.exs
@@ -128,6 +128,74 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
       assert updated.baseline_generation == automation.baseline_generation + 1
     end
 
+    test "cancels the in-flight count when the dialog closes without the dismiss button", context do
+      test_pid = self()
+
+      stub(Automations, :count_existing_matches, fn _alert ->
+        send(test_pid, {:counting, self()})
+
+        receive do
+          :finish -> 1
+        end
+      end)
+
+      {:ok, lv, _} = open(context.conn, context.organization, context.project)
+      render_hook(lv, "open_create_automation_modal", %{})
+      assert_receive {:counting, task}
+
+      # Escape and click-outside close the dialog client-side and only reach the
+      # server through `on_open_change`, never through `on_dismiss`.
+      render_hook(lv, "create_automation_modal_open_change", %{"open" => false})
+
+      monitor = Process.monitor(task)
+      assert_receive {:DOWN, ^monitor, :process, ^task, _}
+      refute render(lv) =~ "Counting matching tests"
+    end
+
+    test "an unchanged save records no revision and leaves trigger_config alone", context do
+      # The form normalises the threshold and always emits a comparison, so the
+      # fixture starts from the config a dashboard save would produce. Any
+      # remaining diff is then the one this test is about.
+      automation =
+        AutomationsFixtures.automation_alert_fixture(
+          project: context.project,
+          trigger_config: %{
+            "threshold" => 10.0,
+            "comparison" => "gte",
+            "window_type" => "last_days",
+            "window" => "30d"
+          }
+        )
+
+      revisions_before = length(Automations.list_alert_revisions(automation.id))
+
+      {:ok, lv, _} = open(context.conn, context.organization, context.project)
+      render_hook(lv, "edit_automation", %{"id" => automation.id})
+      render_hook(lv, "save_automation", %{})
+
+      reloaded = Repo.reload!(automation)
+      refute Map.has_key?(reloaded.trigger_config, "apply_actions_to_existing_matches")
+      assert reloaded.trigger_config == automation.trigger_config
+      assert length(Automations.list_alert_revisions(automation.id)) == revisions_before
+    end
+
+    test "a malformed recovery window blocks save instead of silently doing nothing", context do
+      {:ok, lv, _} = open(context.conn, context.organization, context.project)
+      render_hook(lv, "open_create_automation_modal", %{})
+      render_hook(lv, "update_create_automation_form_name", %{"value" => "Recovery window"})
+      render_hook(lv, "toggle_create_automation_form_recovery", %{})
+      html = render_hook(lv, "update_create_automation_form_recovery_window", %{"value" => "14"})
+
+      assert html =~ ~s(disabled="" type="button" phx-click="save_automation")
+      render_hook(lv, "save_automation", %{})
+      assert Automations.list_alerts(context.project.id) == []
+
+      render_hook(lv, "update_create_automation_form_recovery_window", %{"value" => "14d"})
+      render_hook(lv, "save_automation", %{})
+      assert [automation] = Automations.list_alerts(context.project.id)
+      assert automation.recovery_config["window"] == "14d"
+    end
+
     test "shows failure without blocking save and refreshes when reopened for editing", context do
       stub(Automations, :count_existing_matches, fn _alert -> exit(:unavailable) end)
       {:ok, lv, _html} = open(context.conn, context.organization, context.project)

--- a/server/test/tuist_web/live/project_automations_live_test.exs
+++ b/server/test/tuist_web/live/project_automations_live_test.exs
@@ -196,6 +196,30 @@ defmodule TuistWeb.ProjectAutomationsLiveTest do
       assert automation.recovery_config["window"] == "14d"
     end
 
+    test "window inputs an event-driven monitor hides do not block its save", context do
+      {:ok, lv, _} = open(context.conn, context.organization, context.project)
+      render_hook(lv, "open_create_automation_modal", %{})
+      render_hook(lv, "update_create_automation_form_name", %{"value" => "On update"})
+      render_hook(lv, "update_create_automation_form_window", %{"value" => "14"})
+      render_hook(lv, "update_create_automation_form_rolling_window_size", %{"value" => "0"})
+
+      # `test_updated` hides both window fields entirely, so a value left behind
+      # from the metric the user started on must not disable a Save they have
+      # no field to correct.
+      render_hook(lv, "update_create_automation_form_metric", %{"data" => "test_updated"})
+      # `test_updated` strips the default flaky label action, so restore one to
+      # isolate the window inputs as the only thing that could disable Save.
+      html = render_hook(lv, "add_create_automation_form_trigger_action", %{"data" => "change_state"})
+      refute html =~ ~s(disabled="" type="button" phx-click="save_automation")
+
+      html = render_hook(lv, "update_create_automation_form_window_type", %{"data" => "rolling"})
+      refute html =~ ~s(disabled="" type="button" phx-click="save_automation")
+
+      render_hook(lv, "save_automation", %{})
+      assert [automation] = Automations.list_alerts(context.project.id)
+      assert automation.monitor_type == "test_updated"
+    end
+
     test "shows failure without blocking save and refreshes when reopened for editing", context do
       stub(Automations, :count_existing_matches, fn _alert -> exit(:unavailable) end)
       {:ok, lv, _html} = open(context.conn, context.organization, context.project)


### PR DESCRIPTION
Follow-up to [#13147](https://github.com/tuist/tuist/pull/13147), addressing the issues raised in [its review](https://github.com/tuist/tuist/pull/13147#pullrequestreview-5179352770). The feature's design is unchanged; this only closes the defects found in the merged implementation.

## What changed and why

### Publication can commit a baseline that is missing tests

`publish_silent_baseline_batch/2` kept the watermark comparison from the old `advance_alert_baseline_publication/2` but dropped its `current_attempt.state != "publishing"` disjunct, and that disjunct was load-bearing.

`finish_alert_baseline_evaluation/1` returns the attempt unchanged when it hits a cursor mismatch — which happens when a second evaluation job for the same alert advanced the shared attempt's keyset cursor. `establish_alert_baseline/3` then fed whatever came back straight into publication without looking at the state. Publication sets `last_published_test_case_id` to the highest id in the batch, but that watermark orders by `test_case_id` while the evaluation cursor is keyset on `(module_name, suite_name, name, id)`. The two orderings are unrelated, so any result the still-running enumeration persisted afterwards with a lower UUID was filtered out permanently — and the baseline committed anyway. Those test cases ended up with no baseline event at all, so the next evaluation read them as fresh matches and ran the trigger actions. That is exactly what the silent baseline exists to prevent, and on the opted-in path it means a second round of Slack for tests that were already actioned.

Reachability needs two evaluation jobs for the same alert to overlap: `AutomationScheduler`'s uniqueness omits `:retryable`, so a job that failed once no longer blocks a fresh insert, and the `alert_evaluations: 1` limit is per node. #13147 also made "alert is mid-baseline" a routine state rather than a just-after-creation one, since every opt-in and cancellation puts it back there.

The fix is at the call site, as suggested in review: `establish_alert_baseline/3` now only publishes an attempt that actually reached `publishing` and treats anything else as another worker's, leaving it for the next scheduled evaluation. Restoring the disjunct inside the batch function was the other option, but it would have had `publish_and_commit_alert_baseline/3` recurse on an identical attempt.

### Preview cancellation only fired on the ✕ button

The modal passed `on_dismiss` but not `on_open_change`. In Noora, `on_dismiss` is wired only to the dismiss icon's `phx-click`, and `onOpenChange` pushes an event only when `data-on-open-change` is set — `closeOnEscape` and `closeOnInteractOutside` close the dialog entirely client-side. So `cancel_match_count/1` never ran for two of the three close paths, and a full-project scan kept running for a modal that was already gone, with the LiveView sitting at `:loading`. Nothing ended up in a wrong state (the next open resets `match_count`), but the PR described closing as cancelling outstanding preview work, and that was true for one path out of three. The modal now passes `on_open_change` and the hook cancels on `open: false`.

### The recovery window had no validation at all

`condition_alert/1` builds its changeset from a bare `%Alert{}` and never sets `recovery_enabled`, so `Alert.validate_recovery_config/1` short-circuits. `rolling_window_inputs_valid?/1` only covers the rolling recovery size, which left the recovery `last_days` window — a plain text input with no error state — validated by nobody. Enabling Recovery and changing the window from `14d` to `14` left Save enabled, rendered "After 0d without a trigger: …" in the section summary, and the click fell into the bare `_ -> {:noreply, socket}` arm: no flash, no change, modal just sitting there.

`main` did not validate this either, so it is not a regression from #13147. What makes it worth closing now is the asymmetry — the same dead end on the trigger window *is* closed, so anyone reading `condition_alert/1` would reasonably assume the whole form is covered. A new `day_window_inputs_valid?/1` gates Save on both day-level windows, and both fields now show the error inline the way the rolling-size fields already did. `Alert.valid_window?/1` became the public `Alert.valid_day_window?/1` so the form gates on the schema's own rule rather than a second copy of the regex.

### `apply_actions_to_existing_matches: false` produced phantom revisions

`maybe_put_apply_existing_matches/2`'s `false` clause wrote the key rather than being a no-op, so every dashboard save of a metric automation persisted it until a baseline commit deleted it. That contradicts how the field is documented — a pending operation for a particular save, not a persistent preference — and it showed up in the audit trail: opening an existing automation and clicking Save without changing anything produced a `trigger_config` diff, so `insert_alert_revision/5` wrote a revision whose from/to render identically. It also ping-ponged with the API: `prepare_baseline_update/2` strips the key when a caller omits `trigger_config`, so an API `PATCH {"name": …}` removed it and the next dashboard save added it back, each one recording a `trigger_config` change nobody made. `data-export.md` lists revisions as exportable, so this is customer-visible noise.

Emitting the key only when `true` would have broken the documented cancel flow, which depends on an explicit `false` — so the unchecked box now writes `false` only when there is a pending request to cancel, and omits the key otherwise.

### Superseded baseline attempts stranded their result rows

The only `delete_all` for `automation_alert_baseline_results` lived inside `commit_alert_baseline/1` and covered the attempt that actually commits. An attempt abandoned by a generation bump kept every result row it had written, until the alert was deleted. The mechanism predates #13147 — a condition change mid-baseline already did it — but the frequency does not: `reset_baseline_for_save?/3` now bumps the generation for an opt-in, for a cancellation, and for an action edit while a request is pending, so a supported product flow stranded up to one row per matching test each time it was used. `update_alert/3` now discards the results of every attempt below the new generation, inside the same transaction that advances it.

This is safe against a concurrent publisher: generations only advance under the alert's `FOR UPDATE` row lock, and every publisher path rechecks `stale_alert_baseline_attempt?/2` under that same lock before reading or writing more results. A publisher that already read a now-deleted batch halts at its next preflight instead of publishing. The attempt rows themselves are kept — one per generation is negligible, and deleting them would make `with_locked_alert_baseline_attempt/2`'s `Repo.one!` raise on an in-flight worker instead of returning `{:error, :stale}`.

### Hidden window inputs blocked an event-driven save

Found by `/code-review high` on the commit above, and confirmed with a LiveView test before fixing. `test_updated` hides both window fields and ignores them when building `trigger_config`, but the Save gates evaluated them anyway: starting a new automation on a metric monitor, typing `14` in the window (or a rolling size of `0`), then switching the metric to `test_updated` left Save permanently disabled with no field on screen to correct — the same silent dead end the day-window gate was added to close. `update_create_automation_form_metric` resets the threshold and comparison but not the window. `condition_alert/1` already exempts event-driven monitors from its numeric checks; `day_window_inputs_valid?/1` and the pre-existing `rolling_window_inputs_valid?/1` now do the same.

## On the approach

The review asked whether a backlog pass with its own progress row — one that never touches `baseline_established_at` — would avoid suspending triggers and recovery for the duration of a rescan, and noted that the coupling reads as incidental from the diff. Reusing the pipeline is still the right call: the backlog needs the same exact, resumable, bounded matching set as the baseline, and a separate pass means a second full-project enumeration and a second publisher to serialize against the first. The coupling is a deliberate trade, not an accident, and `establish_alert_baseline/3` now says so in its docs — including what it costs and what the alternative would buy.

## Impact

No migration, no schema change, no API change. Behaviour changes are: a baseline no longer commits while a competing worker is enumerating; two more modal close paths cancel preview work; Save is gated on the recovery window and ungated on window fields an event-driven monitor hides; a no-op save no longer records a revision; and abandoned attempts no longer leak result rows.

## Validation

- **279 tests pass** across `test/tuist/automations/`, `test/tuist/automations_test.exs` and both automation LiveView suites (58.3s).
- Six new regression tests, each confirmed to **fail against the unfixed modules** before the fix landed: competing-worker publication, superseded-result pruning, cancellation on a non-dismiss close, the no-op save recording no revision, the malformed recovery window blocking Save, and the event-driven monitor's hidden window inputs.
- `mix format`, `mix compile` (no new warnings), and `mix credo --strict` are clean — credo's only hits in these files are on pre-existing lines (`mount/3`, `toggle_create_automation_form_recovery`).
- `mix gettext.extract` added exactly one string (`e.g. 30d`) to the English `.pot`; no `.po` translations were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)