### PR TITLE
fix(server): stop the mobile nav rows flashing unstyled on open and close

### DIFF
--- a/server/assets/marketing/css/new/layouts/components/navbar.css
+++ b/server/assets/marketing/css/new/layouts/components/navbar.css
@@ -450,6 +450,112 @@
     overscroll-behavior: contain;
     pointer-events: none;
 
+    /* The rows below are styled here, not under the open state: the panel
+       stays in the tree while closed and only fades, so gating them on
+       data-mobile-menu-open would swap every row between native button /
+       link defaults and its styled look on each toggle. The action and
+       chevron transitions (further down) then animated that swap as a grey
+       flash on open, and on close the rows lost their styling while the
+       panel was still fading out.
+
+       Accordion list items. */
+    & [data-part="dropdown"] > [data-part="item"] {
+      color: var(--noora-surface-label-primary);
+      font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
+      text-decoration: none;
+    }
+
+    /* Top-level entries (Pricing, Blog, Slack, GitHub) share the
+       section-heading treatment. */
+    & > [data-part="item"] {
+      color: var(--noora-surface-label-secondary);
+      font: var(--noora-font-weight-regular) var(--noora-font-heading-large);
+      text-decoration: none;
+    }
+
+    & > [data-part="menu"] {
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+
+      /* A real button (keyboard-operable before the hook mounts), reset
+         to the row it always was; the chevron carries the hover state. */
+      & > [data-part="action"] {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        appearance: none;
+        cursor: pointer;
+        margin: 0;
+        border: 0;
+        background: none;
+        padding: 0;
+        width: 100%;
+        color: inherit;
+        font: inherit;
+        text-align: left;
+
+        & > [data-part="title"] {
+          color: var(--noora-surface-label-secondary);
+          font: var(--noora-font-weight-regular) var(--noora-font-heading-large);
+        }
+
+        /* Chevron dressed as a neutral button, like the burger icon.
+           Points right when collapsed, rotates down when open. */
+        & > [data-part="chevron"] {
+          display: inline-flex;
+          justify-content: center;
+          align-items: center;
+          border-radius: var(--noora-radius-3);
+          padding: var(--noora-spacing-3);
+          color: var(--noora-button-neutral-label);
+
+          & svg {
+            transform: rotate(-90deg);
+            transition: transform 0.2s ease;
+            width: 20px;
+            height: 20px;
+          }
+        }
+
+        &:hover > [data-part="chevron"] {
+          background: var(--noora-button-neutral-background-hover);
+        }
+
+        &[data-open="true"] > [data-part="chevron"] svg {
+          transform: rotate(0deg);
+        }
+      }
+
+      & > [data-part="dropdown"] {
+        display: flex;
+        flex-direction: column;
+        gap: var(--noora-spacing-5);
+
+        /* Title-to-first-item spacing lives INSIDE the height-animated
+           box (child margin, not container padding): container padding
+           pops in before the height transition starts and makes the
+           sections below jump. */
+        & > [data-part="item"]:first-child {
+          margin-top: var(--noora-spacing-5);
+        }
+      }
+    }
+
+    /* Theme row: static placeholder until dark mode ships. */
+    & > [data-part="theme"] {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+
+      & > [data-part="title"] {
+        color: var(--noora-surface-label-secondary);
+        font: var(--noora-font-weight-regular) var(--noora-font-heading-large);
+      }
+    }
+
     @media (min-width: 960px) {
       display: none;
     }
@@ -469,104 +575,6 @@
         transform 0.2s var(--ease-out-cubic),
         visibility 0s;
       pointer-events: auto;
-
-      /* Accordion list items. */
-      & [data-part="dropdown"] > [data-part="item"] {
-        color: var(--noora-surface-label-primary);
-        font: var(--noora-font-weight-regular) var(--noora-font-heading-medium);
-        text-decoration: none;
-      }
-
-      /* Top-level entries (Pricing, Blog, Slack, GitHub) share the
-         section-heading treatment. */
-      & > [data-part="item"] {
-        color: var(--noora-surface-label-secondary);
-        font: var(--noora-font-weight-regular) var(--noora-font-heading-large);
-        text-decoration: none;
-      }
-
-      & > [data-part="menu"] {
-        display: flex;
-        flex-direction: column;
-        align-items: stretch;
-
-        /* A real button (keyboard-operable before the hook mounts), reset
-           to the row it always was; the chevron carries the hover state. */
-        & > [data-part="action"] {
-          display: flex;
-          flex-direction: row;
-          justify-content: space-between;
-          align-items: center;
-          appearance: none;
-          cursor: pointer;
-          margin: 0;
-          border: 0;
-          background: none;
-          padding: 0;
-          width: 100%;
-          color: inherit;
-          font: inherit;
-          text-align: left;
-
-          & > [data-part="title"] {
-            color: var(--noora-surface-label-secondary);
-            font: var(--noora-font-weight-regular) var(--noora-font-heading-large);
-          }
-
-          /* Chevron dressed as a neutral button, like the burger icon.
-             Points right when collapsed, rotates down when open. */
-          & > [data-part="chevron"] {
-            display: inline-flex;
-            justify-content: center;
-            align-items: center;
-            border-radius: var(--noora-radius-3);
-            padding: var(--noora-spacing-3);
-            color: var(--noora-button-neutral-label);
-
-            & svg {
-              transform: rotate(-90deg);
-              transition: transform 0.2s ease;
-              width: 20px;
-              height: 20px;
-            }
-          }
-
-          &:hover > [data-part="chevron"] {
-            background: var(--noora-button-neutral-background-hover);
-          }
-
-          &[data-open="true"] > [data-part="chevron"] svg {
-            transform: rotate(0deg);
-          }
-        }
-
-        & > [data-part="dropdown"] {
-          display: flex;
-          flex-direction: column;
-          gap: var(--noora-spacing-5);
-
-          /* Title-to-first-item spacing lives INSIDE the height-animated
-             box (child margin, not container padding): container padding
-             pops in before the height transition starts and makes the
-             sections below jump. */
-          & > [data-part="item"]:first-child {
-            margin-top: var(--noora-spacing-5);
-          }
-        }
-      }
-
-      /* Theme row: static placeholder until dark mode ships. */
-      & > [data-part="theme"] {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
-
-        & > [data-part="title"] {
-          color: var(--noora-surface-label-secondary);
-          font: var(--noora-font-weight-regular) var(--noora-font-heading-large);
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
Before:

<img width="426" height="440" alt="Screenshot 2026-09-11 at 16 49 00" src="https://github.com/user-attachments/assets/52d1fef2-b303-4265-b3d6-35e87e5825cc" />

## Why

Opening the mobile menu on a phone showed a one-frame-ish grey flash across every row with a half-rotated chevron, and closing it showed the rows dropping to browser-default styling (blue underlined links, native grey pill buttons, small font) while the panel was still fading out.

## Root cause

The panel stays in the tree while closed and only fades, but all of its row styles were nested under the open attribute, so they switched on and off with every toggle:

- **Open:** the trigger has an always-on `background-color` transition and its chevron an always-on `transform` transition. When the open attribute landed, the button animated from the UA `buttonface` grey to transparent, and the chevron rotated from down to right, over 0.2s. That was the grey bars.
- **Close:** the attribute flips immediately, so the rows reverted to native button and link defaults while the panel's 0.18s fade-out was still showing them.


## Validation

- Prettier check passes on the file; esbuild bundles the stylesheet without warnings.
- Sampled computed styles per animation frame through one open and one close in headless Chrome and in Playwright WebKit 26 (the Simulator's engine) with iPhone emulation. Trigger background, font size, width, chevron transform and link color stay constant throughout; only the panel opacity animates.
- Mid-fade screenshots on WebKit in light mode show fully styled rows on both open and close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
