### PR TITLE
fix(kura): wait for readiness before seeding backfill tests

### DIFF
--- a/kura/AGENTS.md
+++ b/kura/AGENTS.md
@@ -50,6 +50,7 @@ This node covers the `kura/` workspace, a Rust service for low-latency cache mes
 - rules_rs resolves the Bazel crate graph directly from `Cargo.toml`/`Cargo.lock` on each build, so
   changing Rust deps just updates `Cargo.lock` as usual and Bazel picks it up on the next build
 - Run the end-to-end suite with `docker compose build && mise exec -- shellspec`
+- Wait for `/ready` before seeding an E2E source node: the bootstrap listener answers `/up` successfully during store recovery while cache routes still return 503. Keep mid-backfill observations on joining nodes independent of readiness.
 
 ## Maintenance Notes
 - Keep `README.md` aligned with any protocol, configuration, or deployment changes

--- a/kura/spec/e2e/backfill_spec.sh
+++ b/kura/spec/e2e/backfill_spec.sh
@@ -267,7 +267,8 @@ Describe 'backfill throughput sanity'
     fi
     dc up -d kura-us >/dev/null 2>&1
     resolve_http_node KURA_US kura-us
-    wait_for_http "${KURA_US_URL}/up" || return 1
+    # /up also succeeds during store recovery, before cache writes are accepted.
+    wait_for_http "${KURA_US_URL}/ready" || return 1
 
     entry_block="${SUITE_TMP_DIR}/entry.bin"
     dd if=/dev/urandom of="${entry_block}" bs="${THROUGHPUT_ENTRY_BYTES}" count=1 2>/dev/null
@@ -277,7 +278,10 @@ Describe 'backfill throughput sanity'
         "${KURA_US_URL}/api/cache/cas/tp-${index}?tenant_id=acme&namespace_id=ios" \
         -H "content-type: application/octet-stream" \
         --data-binary "@${entry_block}")"
-      [ "$status" = 204 ] || return 1
+      if [ "$status" != 204 ]; then
+        printf 'Failed to seed tp-%s: expected HTTP 204, got %s\n' "$index" "$status" >&2
+        return 1
+      fi
     done
     local kv_status
     for index in $(seq 1 16); do
@@ -285,7 +289,10 @@ Describe 'backfill throughput sanity'
         "${KURA_US_URL}/api/cache/keyvalue?tenant_id=acme&namespace_id=ios" \
         -H "content-type: application/json" \
         -d "{\"cas_id\":\"tp-kv-${index}\",\"entries\":[{\"value\":\"throughput-${index}\"}]}")"
-      [ "$kv_status" = 204 ] || return 1
+      if [ "$kv_status" != 204 ]; then
+        printf 'Failed to seed tp-kv-%s: expected HTTP 204, got %s\n' "$index" "$kv_status" >&2
+        return 1
+      fi
     done
   }
 


### PR DESCRIPTION
## Summary

- Fix the backfill throughput E2E setup to wait for `/ready` instead of `/up` before seeding data.
- `/up` can succeed during store recovery while cache writes still return HTTP 503, causing CI failures.
- Add explicit seed failure diagnostics for CAS and key-value writes.
- Document the readiness requirement and keep joining-node observations independent of readiness.

## Testing

- Not run (not requested)