### PR TITLE
fix(server): show kura server ids as UUIDs in the claim enrollment error

### DIFF
--- a/server/priv/repo/migrations/20260911090100_pin_runner_kura_storage_claims.exs
+++ b/server/priv/repo/migrations/20260911090100_pin_runner_kura_storage_claims.exs
@@ -60,8 +60,9 @@ defmodule Tuist.Repo.Migrations.PinRunnerKuraStorageClaims do
           else: "50Gi"
 
       _ ->
+        # Raw queries return the id as its 16 raw bytes.
         raise ArgumentError,
-              "invalid runner storage claim #{inspect(claim)} for kura_server #{id}; repair before enrollment"
+              "invalid runner storage claim #{inspect(claim)} for kura_server #{Ecto.UUID.load!(id)}; repair before enrollment"
     end
   end
 


### PR DESCRIPTION
The runner storage claim migration from #13101 puts the Kura server id it reads with a raw query into its `ArgumentError` message. Raw queries return uuid columns as their 16 raw bytes, so the message showed unreadable bytes instead of an id someone repairing the data could look up. The message now converts the id with `Ecto.UUID.load!/1`.

The same bug made `PinRunnerKuraStorageClaimsTest` flaky. The test matches the message with `~r/invalid runner storage claim.*repair before enrollment/`, and `.` doesn't match a newline, so whenever the random id contains a `0x0A` byte, which happens in about 5% of runs, the assertion fails. That's how it failed on #13117, where I first fixed it before moving the fix here.

This edits a migration that's already on main, on purpose. The migration only raises when it can't enroll a claim, and a migration that raises never records its version, so any environment where it raised will run the edited file on its next attempt. Environments where it succeeded never produce this message, so a new migration wouldn't change anything for them.

### How to test locally

From `server/`, run `mix test test/tuist/repo/migrations/pin_runner_kura_storage_claims_test.exs:74 --repeat-until-failure 300`. Without this change it failed within 4 repetitions for me; with it, all 300 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NFzXnMSxf5gLdTVSxQQYY
