### PR TITLE
test(server): wait for the builds page to load before checking its empty state

### DIFF
--- a/server/test/tuist_web/live/builds_live_test.exs
+++ b/server/test/tuist_web/live/builds_live_test.exs
@@ -20,6 +20,7 @@ defmodule TuistWeb.BuildsLiveTest do
   } do
     # When
     {:ok, lv, _html} = live(conn, ~p"/#{organization.account.name}/#{project.name}/builds")
+    render_async(lv, @render_async_timeout)
 
     # Then
     assert has_element?(lv, "span", "No data yet")


### PR DESCRIPTION
`TuistWeb.BuildsLiveTest` "renders empty view when no builds are available" fails intermittently in CI. It failed that way on #13117, where 9,131 of 9,132 tests passed.

The Xcode builds page loads its widget analytics with `assign_async`, so the widgets only render their "No data yet" label once those assigns resolve. This test asserted right after `live/2`, so on a slow run it checked the page before the async work finished. The other tests in the file already wait with `render_async/2`, and this one now does too, with the same timeout.

I couldn't reproduce the failure locally (the file passed 21 runs in a row before the change), so the fix is based on the CI failure and the page's async loading rather than a local reproduction.

### How to test locally

From `server/`, run `mix test test/tuist_web/live/builds_live_test.exs --repeat-until-failure 20`. All 21 runs passed with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NFzXnMSxf5gLdTVSxQQYY
