### PR TITLE
feat(cli): allow cache profiles to include external targets

### DIFF
--- a/cli/Sources/TuistCache/TargetReplacementDecider.swift
+++ b/cli/Sources/TuistCache/TargetReplacementDecider.swift
@@ -53,6 +53,8 @@ public struct CacheProfileTargetReplacementDecider: TargetReplacementDeciding {
     public func shouldReplace(project: Project, target: Target) -> Bool {
         if focusedTargetNames.contains(target.name) { return false }
         if !target.metadata.tags.isDisjoint(with: focusedTargetTags) { return false }
+        if profileTargetNames.contains(target.name) { return true }
+        if !target.metadata.tags.isDisjoint(with: profileTargetTags) { return true }
 
         switch project.type {
         case .external:
@@ -67,8 +69,6 @@ public struct CacheProfileTargetReplacementDecider: TargetReplacementDeciding {
             case .allPossible:
                 return true
             case .onlyExternal, .none:
-                if profileTargetNames.contains(target.name) { return true }
-                if !target.metadata.tags.isDisjoint(with: profileTargetTags) { return true }
                 return false
             }
         }

--- a/cli/Tests/TuistCacheTests/CacheProfileTargetReplacementDeciderTests.swift
+++ b/cli/Tests/TuistCacheTests/CacheProfileTargetReplacementDeciderTests.swift
@@ -67,6 +67,24 @@ struct CacheProfileTargetReplacementDeciderTests {
         #expect(decider.shouldReplace(project: .test(type: .local), target: .test(metadata: .test(tags: ["cacheable"]))))
     }
 
+    @Test func none_replaces_only_specific_external_targets() {
+        let profile = TuistConfig.CacheProfile(
+            base: .none,
+            targetQueries: ["ExternalMacro", "tag:cacheable"]
+        )
+        let decider = CacheProfileTargetReplacementDecider(profile: profile, exceptions: [])
+
+        #expect(decider.shouldReplace(
+            project: .test(type: .external()),
+            target: .test(name: "ExternalMacro")
+        ))
+        #expect(decider.shouldReplace(
+            project: .test(type: .external()),
+            target: .test(metadata: .test(tags: ["cacheable"]))
+        ))
+        #expect(!decider.shouldReplace(project: .test(type: .external()), target: .test(name: "Other")))
+    }
+
     @Test func onlyExternal_with_no_targets_does_not_replace_internals() {
         let profile = TuistConfig.CacheProfile(
             base: .onlyExternal,


### PR DESCRIPTION
Building on <https://github.com/tuist/tuist/pull/8122> and the original [cache profiles proposal](https://community.tuist.dev/t/indicate-that-internal-targets-prefer-replacement-with-binary-cache/701), this PR proposes extending `and:` target queries to external targets.

The original feature focused on selecting internal targets for binary replacement. This change makes the existing additive behavior consistent regardless of whether a target belongs to a local or external project.

## What changed

Cache profile target queries supplied through `and:` now apply to external as well as internal targets.

This allows a profile such as `.profile(.none, and: ["ExternalTarget"])` to make selected external targets eligible for cached binary replacement. Name and tag queries are both supported, and exclusions continue to take precedence.

## Why

The implementation currently evaluates `and:` queries only for local projects, while external targets are governed entirely by the base profile. As a result, a `.none` profile can selectively replace internal targets but not external targets, even when an external target matches one of its queries.

Since `and:` adds targets to the base profile and target queries do not otherwise distinguish between local and external targets, applying them consistently removes that implicit restriction without introducing a new API.

## Compatibility

The behavior changes only for custom profiles based on `.none` whose `and:` queries match an external target. Non-matching external targets remain source-based, while `.onlyExternal` and `.allPossible` profiles are unchanged because they already replace external targets.

## Validation

- Added coverage for matching external targets by name and tag, as well as a non-matching external target.
- `CacheProfileTargetReplacementDeciderTests`: 17 tests passed.
- `git diff --check`
