### PR TITLE
test(kura): gate e2e suites on /ready instead of /up

### DIFF
--- a/kura/AGENTS.md
+++ b/kura/AGENTS.md
@@ -52,6 +52,7 @@ This node covers the `kura/` workspace, a Rust service for low-latency cache mes
 - rules_rs resolves the Bazel crate graph directly from `Cargo.toml`/`Cargo.lock` on each build, so
   changing Rust deps just updates `Cargo.lock` as usual and Bazel picks it up on the next build
 - Run the end-to-end suite with `docker compose build && mise exec -- shellspec`
+- Wait for `/ready` (`wait_for_node_ready` in `spec/e2e/support.sh`) before seeding or measuring an E2E node: the bootstrap listener answers `/up` successfully during store recovery while cache routes still return 503 and are never counted by the serving router's metrics middleware. Keep mid-backfill observations on joining nodes independent of readiness.
 
 ## Resource Budgets
 Kura is bound by memory, disk, CPU, and egress, and each of those is a hard, shared bound on a mesh node. A change that buys latency by keeping more bytes resident, writing more segments, spending more CPU per request, or moving the same artifact across peers twice is a regression even when every test passes. Staying inside the four budgets is part of the change, not a follow-up.

--- a/kura/spec/e2e/accelerated_serving_spec.sh
+++ b/kura/spec/e2e/accelerated_serving_spec.sh
@@ -18,7 +18,7 @@ Describe 'accelerated artifact serving'
     compose_up kura-us || return 1
 
     resolve_http_node KURA_US kura-us
-    wait_for_http "${KURA_US_URL}/up"
+    wait_for_node_ready "${KURA_US_URL}"
   }
 
   teardown_suite() {

--- a/kura/spec/e2e/forced_pressure_spec.sh
+++ b/kura/spec/e2e/forced_pressure_spec.sh
@@ -21,7 +21,7 @@ Describe 'forced memory-pressure simulation'
     compose_up kura-us || return 1
 
     resolve_http_node KURA_US kura-us
-    wait_for_http "${KURA_US_URL}/up"
+    wait_for_node_ready "${KURA_US_URL}"
   }
 
   teardown_suite() {

--- a/kura/spec/e2e/multipart_admission_spec.sh
+++ b/kura/spec/e2e/multipart_admission_spec.sh
@@ -30,7 +30,7 @@ YAML
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     compose_up kura-us || return 1
     resolve_http_node KURA_US kura-us
-    wait_for_http "${KURA_US_URL}/up"
+    wait_for_node_ready "${KURA_US_URL}"
   }
 
   teardown_suite() {

--- a/kura/spec/e2e/support.sh
+++ b/kura/spec/e2e/support.sh
@@ -189,6 +189,18 @@ wait_for_http() {
   return 1
 }
 
+# `/up` alone only proves the process is alive: the bootstrap listener answers it
+# with 200 throughout store recovery while every cache route is short-circuited
+# with a plain-text 503 that never reaches the serving router or its metrics
+# middleware, so traffic driven at that point is neither served nor counted.
+# Gate on `/ready` before seeding or measuring a node. Joining nodes observed
+# mid-backfill are deliberately excluded: their readiness latches on ring
+# fullness, so those waits stay on `/up`.
+wait_for_node_ready() {
+  wait_for_http "$1/up" 60 1 || return 1
+  wait_for_status "$1/ready" 200 90 1 >/dev/null || return 1
+}
+
 wait_for_status() {
   local url="$1"
   local expected_status="$2"

--- a/kura/spec/e2e/sync_spec.sh
+++ b/kura/spec/e2e/sync_spec.sh
@@ -74,11 +74,6 @@ sync_start_nodes() {
   resolve_sync_nodes "$@"
 }
 
-wait_for_node_ready() {
-  wait_for_http "$1/up" 60 1 || return 1
-  wait_for_status "$1/ready" 200 90 1 >/dev/null || return 1
-}
-
 wait_for_ring_members() {
   wait_for_contains "$1/status/cluster" "\"ring_members\":$2" 45 2 >/dev/null
 }

--- a/kura/spec/e2e/tmp_budget_spec.sh
+++ b/kura/spec/e2e/tmp_budget_spec.sh
@@ -15,7 +15,7 @@ Describe 'temporary staging budget'
     compose_up kura-us || return 1
 
     resolve_http_node KURA_US kura-us
-    wait_for_http "${KURA_US_URL}/up"
+    wait_for_node_ready "${KURA_US_URL}"
   }
 
   teardown_suite() {

--- a/kura/spec/e2e/upload_errors_spec.sh
+++ b/kura/spec/e2e/upload_errors_spec.sh
@@ -15,7 +15,7 @@ Describe 'upload body failure classification'
     dc down -v --remove-orphans >/dev/null 2>&1 || true
     compose_up kura-us || return 1
     resolve_http_node KURA_US kura-us
-    wait_for_http "${KURA_US_URL}/up"
+    wait_for_node_ready "${KURA_US_URL}"
   }
 
   teardown_suite() {


### PR DESCRIPTION
## What changed

E2E suites that drove traffic at a node as soon as `/up` returned 200 now wait for `/ready` via a shared `wait_for_node_ready` helper in `spec/e2e/support.sh`.

- `spec/e2e/support.sh` — new `wait_for_node_ready` (`/up`, then `/ready` 200).
- `spec/e2e/sync_spec.sh` — drops its private copy of the same helper.
- `upload_errors`, `accelerated_serving`, `forced_pressure`, `multipart_admission`, `tmp_budget` — use the helper in `setup_suite`.
- `kura/AGENTS.md` — records the convention and its exception.

## Why

[The `E2E (clients)` job on main](https://github.com/tuist/tuist/actions/runs/34614843072/job/103314794485) failed in `upload_errors_spec.sh`:

```
1.1) The status should be success
       expected: success (zero)
            got: failure (non-zero) [status: 1]
     stderr: AssertionError: ('truncated', {}, {})
```

Both metric snapshots were empty — no `kura_http_requests_total_total{route="/api/cache/cas/{id}"}` series and no `kura_artifact_writes_total_total{result="error"}` series ever appeared within the example's 5s deadline.

## Root cause

Not the upload classification the spec was testing — the readiness gate.

During store recovery the public port is served by the bootstrap router in `src/startup.rs`. It answers `/up` with **200** and `/metrics` with real counters, but short-circuits every other route through its fallback with a plain-text `503 startup recovery in progress`. That response is produced before the serving router exists, so it never passes through `track_http_metrics` — the request is neither served nor counted, which is exactly the `{}, {}` the assertion printed.

`setup_suite` waited only on `/up`, so on a loaded runner the suite's first upload lands inside that window.

## Reproduction

Using the failing run's own `kura:e2e` image, CPU-throttled to mimic a loaded runner:

```
/up 200 at 0.34s   /status/rollout 200 at 1.33s
socket closed after 0.00s, response = HTTP/1.1 503 ... "startup recovery in progress"
NO CHANGE after 90.15s: before={}
```

The counter never arrives, because the request never reached a router that records one.

| gate | failures |
| --- | --- |
| `/up` (before) | 8/8 |
| `/ready` (after) | 0/32 |

## Why `/ready`, and why the sweep is narrow

`/status/rollout` would also work — it is the weaker "serving router is mounted" signal and cannot stall. I used `/ready` instead because the convention already exists in the repo: #12982 introduced a `wait_for_node_ready` helper doing `/up` then `/ready` 200, and `b38e1a05c` ("wait for readiness before seeding backfill tests", on `codex/fix-main-ci-failure`) reached the same diagnosis independently and fixed `backfill_spec.sh` the same way. This promotes that helper to `support.sh` rather than adding a second convention.

Not every `/up` wait is a bug. Three groups deliberately stay as they are:

1. **`rollout_spec.sh`** asserts the liveness/readiness split itself (`/up` 200 while `/ready` 503) — gating it would delete the test's subject.
2. **Joining nodes observed mid-backfill** (`backfill_spec.sh`, `sync_spec.sh:456`) — their readiness latches on ring fullness, so waiting for it would hide what is being measured.
3. **Most multi-node suites are already gated implicitly** — `authorization`, `cluster`, `clients`, `handoff`, `faults`, `discovery`, `large_artifact`, `memory_pressure`, `tenant_scope` and `mtls` follow `/up` with a `wait_for_contains .../status/cluster '"ring_members":N'`, a route only the serving router answers, so they retry through recovery already.

That leaves the five suites changed here, where `/up` was the only gate before traffic.

## Impact

Test-only. No runtime or product code is touched — the `/up` vs `/ready` split is working as designed; the specs were reading the wrong one.

## Validation

- `upload_errors` (4/4), `accelerated_serving`, `forced_pressure`, `multipart_admission` all pass locally against the CI `kura:e2e` image.
- `tmp_budget` fails on this host **identically with and without this change** (expects 429, gets 204 under amd64 emulation) — pre-existing and unrelated.
- Helper resolution proven with a throwaway spec that `Include`s `support.sh`; every `Describe` in `sync_spec.sh` includes it, so dropping the local copy is safe. `shellspec --dry-run` green across all touched specs.
- `shellcheck -x`: no new findings (SC2329 count unchanged at 2).

## Merge note

`kura/AGENTS.md` will conflict trivially with `b38e1a05c` if that branch lands first. This line is a superset of that one — resolve by keeping this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
