### PR TITLE
chore(renovate): ignore swifterpm fixtures and pinned server git-dep digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,9 +72,9 @@
   ],
   "packageRules": [
     {
-      "description": "server/mix.exs pins three git deps to commits that are deliberately NOT their repo's default-branch head: ex_aws_s3 (tuist fork branch fix/presigned-url-config-defaults, makes presigned URLs honour the virtual_host/bucket_as_host config production sets), emcp (branch fix/streamable-http-inline-response-on-post, keeps JSON-RPC responses inline on the POST instead of the SSE stream), and boruta (a 3.0 pre-release snapshot; moving it means running its bundled migrations and a nebulex 2->3 major). Renovate's digest updates for git deps only ever propose the default-branch head, so every PR it opens here would silently revert a patch or start a migration. Those bumps are done by hand.",
+      "description": "Digest updates for git deps in server/mix.exs. Renovate only ever proposes the default-branch head, but the ref-pinned deps there are deliberately NOT on it: ex_aws_s3 (tuist fork branch fix/presigned-url-config-defaults, makes presigned URLs honour the virtual_host/bucket_as_host config production sets), emcp (branch fix/streamable-http-inline-response-on-post, keeps JSON-RPC responses inline on the POST instead of the SSE stream), cachex (TBK145/cachex@patch-1, the Elixir 1.19 record/0 type rename from whitfin/cachex#433), and boruta (a 3.0 pre-release snapshot; moving it means running its bundled migrations and a nebulex 2->3 major). Every digest PR here would silently revert a patch or start a migration, and Renovate cannot regenerate mix.lock anyway, so the rule matches by datasource rather than by name: a new ref-pinned git dep is covered without editing this list. Tag-pinned git deps (e.g. heroicons) are version updates, not digests, and stay tracked. Those bumps are done by hand.",
       "matchManagers": ["mix"],
-      "matchDepNames": ["boruta", "emcp", "ex_aws_s3"],
+      "matchDatasources": ["git-tags", "github-tags"],
       "matchUpdateTypes": ["digest"],
       "enabled": false
     },

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Dependencies are batched on a weekly schedule. The tuist CLI dev-tooling pin in mise.toml is handled out-of-band by the update-tuist-cli workflow, not Renovate, because the bump must regenerate mise.lock in the same commit (six per-platform checksums) and Renovate's hosted app can't run mise lock. prConcurrentLimit/prHourlyLimit are raised off their defaults (10/2) and the dashboard is on because the default limit silently starved the queue: eleven never-reviewed PRs held every slot for months, so Renovate stopped opening branches entirely and the actions/runner pin sat three releases behind until GitHub deprecated it. With no dependency dashboard there was nothing anywhere that said an update was being withheld. The limits still exist to bound review load, so a saturated dashboard means PRs need merging or closing, not a higher limit.",
+  "description": "Dependencies are batched on a weekly schedule. The tuist CLI dev-tooling pin in mise.toml is handled out-of-band by the update-tuist-cli workflow, not Renovate, because the bump must regenerate mise.lock in the same commit (six per-platform checksums) and Renovate's hosted app can't run mise lock. prConcurrentLimit/prHourlyLimit are raised off their defaults (10/2) and the dashboard is on because the default limit silently starved the queue: eleven never-reviewed PRs held every slot for months, so Renovate stopped opening branches entirely and the actions/runner pin sat three releases behind until GitHub deprecated it. With no dependency dashboard there was nothing anywhere that said an update was being withheld. The limits still exist to bound review load, so a saturated dashboard means PRs need merging or closing, not a higher limit. swifterpm's test and e2e fixtures are frozen real-world manifests (Package.swift + Package.resolved) that the resolution tests assert against; Renovate bumping the pins inside them only rewrites test data, so those paths are ignored (the first two ignorePaths entries restate Renovate's defaults, which setting the option replaces).",
   "schedule": ["before 6am on monday"],
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "Renovate: dependency dashboard",
   "prConcurrentLimit": 25,
   "prHourlyLimit": 4,
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "swifterpm/Tests/**/Fixtures/**",
+    "swifterpm/e2e/fixtures/**"
+  ],
   "customManagers": [
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -72,6 +72,13 @@
   ],
   "packageRules": [
     {
+      "description": "server/mix.exs pins three git deps to commits that are deliberately NOT their repo's default-branch head: ex_aws_s3 (tuist fork branch fix/presigned-url-config-defaults, makes presigned URLs honour the virtual_host/bucket_as_host config production sets), emcp (branch fix/streamable-http-inline-response-on-post, keeps JSON-RPC responses inline on the POST instead of the SSE stream), and boruta (a 3.0 pre-release snapshot; moving it means running its bundled migrations and a nebulex 2->3 major). Renovate's digest updates for git deps only ever propose the default-branch head, so every PR it opens here would silently revert a patch or start a migration. Those bumps are done by hand.",
+      "matchManagers": ["mix"],
+      "matchDepNames": ["boruta", "emcp", "ex_aws_s3"],
+      "matchUpdateTypes": ["digest"],
+      "enabled": false
+    },
+    {
       "description": "actions/runner bumps: route through the runner-image release flow. prPriority puts them at the head of the queue — GitHub retires runner releases on a deadline, so these are the one bump class where being held behind a backlog of routine updates ends in broken CI rather than lag.",
       "matchManagers": ["custom.regex"],
       "matchFileNames": ["infra/runner-image/runner.pkr.hcl"],


### PR DESCRIPTION
## What changed

Two Renovate config changes in `renovate.json`:

1. `ignorePaths` for `swifterpm/Tests/**/Fixtures/**` and `swifterpm/e2e/fixtures/**` (restating Renovate's two default ignore globs, since setting the option replaces them).
2. A `packageRules` entry disabling `digest` updates from the `mix` manager for git deps (`git-tags` / `github-tags` datasources). Today that is `boruta`, `cachex`, `emcp` and `ex_aws_s3`.

## Why

**swifterpm fixtures.** Renovate has been opening PRs that bump dependency pins inside swifterpm's test fixtures (#12932, #12931, #12569, #12568). Those fixtures are frozen real-world manifests (`Package.swift` + `Package.resolved`, e.g. the Etsy and mixed registry/GitHub graphs) that `FixtureResolutionTests` and the e2e `resolution_spec.sh` assert against, including pin counts and lockfile round-trips. Bumping them rewrites test data without improving anything. The real swifterpm dependencies in `swifterpm/MODULE.bazel` (e.g. #12933) stay tracked.

**Pinned server git deps.** `server/mix.exs` pins four git deps to commits that are deliberately not their repo's default-branch head, and Renovate's digest update for git deps only ever proposes the default-branch head:

- `ex_aws_s3` is pinned to the tuist fork's `fix/presigned-url-config-defaults` branch, which makes `presigned_url`/`presigned_post` honour the `virtual_host` / `bucket_as_host` config that `config/runtime.exs` sets from the environment. #11403 would have moved it to upstream v2.5.8 and dropped that patch.
- `emcp` is pinned to `fix/streamable-http-inline-response-on-post`, which returns JSON-RPC responses inline on the POST. #11662 would have moved it to a head that pushes responses onto the SSE stream and answers the POST with 202.
- `cachex` is pinned to `TBK145/cachex@patch-1`, the Elixir 1.19 `record/0` type rename from whitfin/cachex#433. #11402 would have moved it to the fork's `main`, which is one commit behind that patch.
- `boruta` is a 3.0 pre-release snapshot. #12930 would have jumped it forward by ~150 files including ten new bundled migrations (e.g. defaulting clients to confidential) and a nebulex 2 to 3 major. That is a deliberate upgrade project, not a digest bump.

The rule matches by datasource rather than by dep name: a first draft listed `boruta`, `emcp` and `ex_aws_s3` and missed `cachex`, and the next ref-pinned git dep added to `mix.exs` would have had the same gap. Tag-pinned git deps such as `heroicons` produce version updates, not digests, so they stay tracked.

All four PRs were also un-mergeable as opened (Renovate cannot run `install-tool elixir` to regenerate `mix.lock`). They are closed with a pointer here; the bumps are done by hand when wanted.

## Validation

`renovate.json` still parses as JSON. Ran renovate 44.82.1 locally (`--platform=local --dry-run=full`, mix manager only, hex datasource disabled to dodge hex.pm rate limits) against `server/mix.exs`:

| config | result |
|---|---|
| main | 5 branches: `heroicons-2.x`, `ex_aws_s3-digest`, `cachex-digest`, `emcp-digest`, `boruta-digest` |
| name-list rule | "Filtered out 3 disabled update(s)": `heroicons-2.x`, `cachex-digest` |
| datasource rule (this PR) | "Filtered out 4 disabled update(s)": `heroicons-2.x` only |

The tag-based `heroicons` minor bump surviving shows the rule is digest-only and does not swallow version updates for mix git deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

