### PR TITLE
fix(infra): roll the Cloudflare operator forward to the bot-management controller

### DIFF
--- a/infra/helm/cloudflare-operator/values-mgmt.yaml
+++ b/infra/helm/cloudflare-operator/values-mgmt.yaml
@@ -3,8 +3,9 @@
 # configuration is global, not per-env.
 
 image:
-  # Built from fff611d7d7d9, the commit that added crawler protection.
+  # Built from a8112699ff19, the #13096 merge that added the
+  # CloudflareBotManagement controller.
   # Keep the human-readable tag and immutable multi-platform digest
   # together so reviewers can trace both the source and deployed bytes.
-  tag: sha-fff611d7d7d9
-  digest: sha256:51298683de6c24666b4e2b1a6d788782a40cdfc9f2075a8cd1bbd4e1e5302b55
+  tag: sha-a8112699ff19
+  digest: sha256:6e9540ee3c3028d2d8f8d3c4ae71392e1cbbfd46534509b5885b1240a927aff3


### PR DESCRIPTION
## What changed

Bumps the management-cluster pin in `infra/helm/cloudflare-operator/values-mgmt.yaml` from `sha-fff611d7d7d9` to `sha-a8112699ff19` (digest `sha256:6e9540ee3c3028d2d8f8d3c4ae71392e1cbbfd46534509b5885b1240a927aff3`), the image the `Cloudflare Operator Image` workflow built from the merge commit of #13096.

## Why

#13096 shipped two layers against the residential-proxy scraper that saturates the ClickHouse pool by walking public test-run pagination: origin-side page caps, and a `CloudflareBotManagement` CRD + controller with a `tuist-dev` CR that raises Super Bot Fight Mode's `definitelyAutomated` bucket from `allow` to `managed_challenge`.

The origin half is live (production runs `sha-fc9bd116e684`). The Cloudflare half never took effect: #13096 added the controller, CRD, chart templates and the Flux-managed CR, but did not bump the operator image pin. `values-mgmt.yaml` has only three commits on `main`, all from 2026-09-05/06, and the pinned image was built from `fff611d7d7d9`, whose `controllers/` directory contains only the rate-limit and custom-rule controllers. The CR has sat unreconciled since it was applied, and the zone is still on `allow`.

That is consistent with what Hive shows: the scraper came back on 2026-09-12 00:27–00:36 UTC from a fresh proxy pool (BR/VE/ES/EC/CL instead of HK/ID/SG) and produced the same `DBConnection.ConnectionError` pool drops and the `FunctionClauseError` in `Tuist.Tasks.parallel_tasks/2` that masks them:

- https://hive.tuist.dev/errors/6c099bc6-5289-5c70-9c59-c20c74c52dc7
- https://hive.tuist.dev/errors/58c2dd00-c05e-5cee-91e7-d28ef9b16f08

## Validation

- `gh run list --workflow cloudflare-operator-image.yml --branch main` shows the `a8112699ff19` build succeeded on 2026-09-10.
- Digest resolved with `docker buildx imagetools inspect ghcr.io/tuist/cloudflare-operator:sha-a8112699ff19` (multi-platform index digest, matching how the previous pin was recorded).
- No operator source commits on `main` after `a8112699ff` (`git log origin/main -- infra/cloudflare-operator`), so this is the newest build.
- Not verified from here: the live CR status in the management cluster (no kubeconfig context on this machine). After Flux rolls the HelmRelease, confirm with `kubectl get cloudflarebotmanagement tuist-dev -o yaml` that `status` reports a reconcile, and check the zone's `bot_management` config shows `sbfm_definitely_automated: managed_challenge`.

## Follow-ups (not in this PR)

- `Tuist.Tasks.parallel_tasks/2` only matches `{:ok, result}`, so a task that crashes on a pool drop surfaces as a `FunctionClauseError` instead of the underlying `DBConnection.ConnectionError`.
- The scraper stays on pages 1–11 and toggles sort params at roughly 90 requests/min across ~100 IPs, so neither the page cap nor the per-IP `public-pages-rate-limit` rule catches it. An origin per-project rate limit for unauthenticated dashboard reads would close that gap regardless of Cloudflare classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
