### PR TITLE
fix(server): surface the task error from Tuist.Tasks.parallel_tasks/2

### DIFF
--- a/server/lib/tuist/tasks.ex
+++ b/server/lib/tuist/tasks.ex
@@ -19,8 +19,11 @@ defmodule Tuist.Tasks do
       max_concurrency: max_concurrency,
       timeout: @task_timeout
     )
-    |> Enum.to_list()
-    |> Enum.map(fn {:ok, result} -> result end)
+    |> Enum.map(fn
+      {:ok, result} -> result
+      {:exit, {exception, stacktrace}} when is_exception(exception) -> reraise(exception, stacktrace)
+      {:exit, reason} -> exit(reason)
+    end)
   end
 
   defp sync? do

--- a/server/test/tuist/tasks_test.exs
+++ b/server/test/tuist/tasks_test.exs
@@ -4,6 +4,7 @@ defmodule Tuist.TasksTest do
   alias Tuist.Tasks
 
   defmodule Query do
+    @moduledoc false
     def explode, do: raise("pool exhausted")
   end
 

--- a/server/test/tuist/tasks_test.exs
+++ b/server/test/tuist/tasks_test.exs
@@ -1,0 +1,53 @@
+defmodule Tuist.TasksTest do
+  use ExUnit.Case, async: true
+
+  alias Tuist.Tasks
+
+  defmodule Query do
+    def explode, do: raise("pool exhausted")
+  end
+
+  describe "parallel_tasks/2" do
+    test "returns the results in the order the functions were given" do
+      assert [1, 2, 3] = Tasks.parallel_tasks([fn -> 1 end, fn -> 2 end, fn -> 3 end])
+    end
+
+    test "reraises a task's exception with the task's stacktrace when the caller traps exits" do
+      Process.flag(:trap_exit, true)
+
+      {exception, stacktrace} =
+        try do
+          Tasks.parallel_tasks([fn -> :ok end, &Query.explode/0])
+        rescue
+          exception -> {exception, __STACKTRACE__}
+        end
+
+      assert %RuntimeError{message: "pool exhausted"} = exception
+      assert Enum.any?(stacktrace, &match?({Query, :explode, 0, _}, &1))
+    end
+
+    test "reraises as soon as a task fails instead of waiting for its siblings" do
+      Process.flag(:trap_exit, true)
+      parent = self()
+
+      queries = [
+        fn -> raise "pool exhausted" end,
+        fn ->
+          send(parent, {:sibling, self()})
+          Process.sleep(:infinity)
+        end
+      ]
+
+      assert_raise RuntimeError, "pool exhausted", fn -> Tasks.parallel_tasks(queries) end
+
+      assert_receive {:sibling, sibling}
+      refute Process.alive?(sibling)
+    end
+
+    test "exits with the reason when a task exits without an exception" do
+      Process.flag(:trap_exit, true)
+
+      assert catch_exit(Tasks.parallel_tasks([fn -> exit(:boom) end])) == :boom
+    end
+  end
+end


### PR DESCRIPTION
## What changed

`Tuist.Tasks.parallel_tasks/2` now handles the `{:exit, reason}` tuples `Task.async_stream/3` yields when a task crashes. An exception is reraised with the task's original stacktrace, and a non-exception exit reason is propagated with `exit/1`. Before, the unwrap only matched `{:ok, result}`.

The intermediate `Enum.to_list/1` is gone: mapping the stream directly reraises at the first failing element, and the stream's close path kills the still-running sibling tasks instead of waiting for them to finish.

Adds `server/test/tuist/tasks_test.exs` covering ordered results, reraise with the task's own stacktrace, fail-fast with sibling termination, and propagation of a plain exit.

## Why

Hive issue: https://hive.tuist.dev/errors/6c099bc6-5289-5c70-9c59-c20c74c52dc7

Every event on that issue is the same shape: the crashing clause's argument is `{:exit, {%DBConnection.ConnectionError{message: "[Elixir.Tuist.ClickHouseRepo] connection not available and request was dropped from queue ..."}, stacktrace}}`, raised from `TuistWeb.TestRunLive.mount/3` and `assign_tab_data/3` on the public test-run page, always through `Phoenix.LiveView.Static.do_render` (the dead render). It is the residential-proxy scraper incident from #13096 (sibling issue https://hive.tuist.dev/errors/58c2dd00-c05e-5cee-91e7-d28ef9b16f08) seen through a masking bug rather than a distinct failure.

### Root cause

`Task.async_stream/3` links each task to the caller (via its monitor process, which mirrors the caller's `trap_exit` flag). When a task crashes, a caller that does not trap exits crashes with it. A caller that does trap exits instead receives `{:exit, reason}` from the stream. During the dead render the Plug pipeline runs in Bandit's ThousandIsland handler, which traps exits (`ThousandIsland.Handler.init/1`), so a ClickHouse pool drop inside one of the three parallel queries reached the `Enum.map(fn {:ok, result} -> result end)` unwrap as `{:exit, ...}` and blew up as a `FunctionClauseError`, burying the actual `DBConnection.ConnectionError` and splitting one incident across two Hive issues.

### Scope: dead render only

`Phoenix.LiveView.Channel` does not trap exits, so on the connected path (subsequent `handle_params` navigations) the link still terminates the channel with `{{%DBConnection.ConnectionError{}, stacktrace}, {Task.Supervised, :stream, [60000]}}` before the stream yields anything. That path was never masked and is unchanged by this PR. Unifying both paths would need `Task.Supervisor.async_stream_nolink/4` under a supervisor; not worth it for an already-honest crash reason.

### Why reraise rather than return an error tuple

Callers destructure the result list positionally (`[a, b, c] = parallel_tasks([...])`). Returning `{:error, reason}` in a slot would just move the `MatchError` one line down in every caller. Reraising keeps the existing contract (the call either returns every result or fails) and makes the failure honest: the page still 500s on a pool drop, but with the ClickHouse error and its stacktrace, so it lands on the existing DBConnection issue in Hive.

### Why drop `Enum.to_list/1`

With the list materialised first, the reraise could only happen after every sibling settled, and a sibling hitting the 60 s task timeout exited the caller with `{:timeout, ...}` and discarded the captured exception. Reproduced standalone: task 0 raising while task 1 sleeps 3 s surfaced the exception after 3001 ms with `Enum.to_list/1` and after 0 ms without it; with a sibling sleeping forever, the old code replaced the exception with the timeout exit after 60 s.

## Impact

No behaviour change on the success path. On a task crash during the dead render the caller now fails with the task's own exception instead of a `FunctionClauseError`, and sibling queries stop instead of holding their ClickHouse checkouts until they finish. Rendering a friendlier 503 for pool exhaustion on public dashboards is a separate follow-up.

## Validation

- `Tuist.Tasks` has no app dependencies, so the test file was run standalone with `elixir -e 'ExUnit.start(...); Code.require_file(...)'`: 4 tests, 4 passed.
- Mutation checks: replacing `reraise(exception, stacktrace)` with `raise(exception)` fails the stacktrace test; restoring `Enum.to_list/1` fails the fail-fast test (it waits for the 60 s timeout and exits instead of raising).
- Reproduced the trap-exit dependency standalone: a non-trapping caller dies with the raw `{exception, stacktrace}` reason and the reraise clause never runs; a trapping caller rescues the reraised exception.
- Both files pass `Code.format_string!/2` at the project's line length.
- A full `mix test` was not run from this worktree (no deps fetched); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
