### PR TITLE
fix(infra): add go.work.sum entries for the k8s.io/utils digest bump

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -22,6 +22,8 @@ github.com/flatcar/container-linux-config-transpiler v0.9.4/go.mod h1:LxanhPvXkW
 github.com/flatcar/ignition v0.36.2/go.mod h1:uk1tpzLFRXus4RrvzgMI+IqmmB8a/RGFSBlI+tMTbbA=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -67,6 +69,7 @@ github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIK
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+Ntkg=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
@@ -110,4 +113,5 @@ google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWn
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 k8s.io/code-generator v0.32.0/go.mod h1:b7Q7KMZkvsYFy72A79QYjiv4aTz3GvW0f1T3UfhFq4s=
 k8s.io/gengo/v2 v2.0.0-20240911193312-2b36238f13e9/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
+k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kms v0.32.0/go.mod h1:Bk2evz/Yvk0oVrvm4MvZbgq8BD34Ksxs2SRHn4/UiOM=


### PR DESCRIPTION
## What

Adds the four `/go.mod` hashes (`go-logr/logr` v1.2.0 and v1.4.1, `k8s.io/klog/v2` v2.80.1, `stretchr/testify` v1.11.1) that the Go workspace now needs after the `k8s.io/utils` digest bump.

## Why

The push run of *CAPI Scaleway Apple Silicon Provider Image* on `main` after #12382 merged failed in the `generated` job: https://github.com/tuist/tuist/actions/runs/34646827416

Root cause: Renovate updates each module's `go.mod` / `go.sum` but never touches the workspace-level `go.work.sum`. The `generated` job runs controller-gen through the workspace, Go appends the missing hashes to `go.work.sum`, and the job's clean-tree check fails on that diff. The check was added in #13019 (2026-09-09), after the Renovate PR's last CI run (2026-09-07), so the PR itself was green.

No code, CRD, or DeepCopy drift is involved. The new `k8s.io/utils` digest only changes `ptr` cosmetically (`interface{}` to `any`) and adds packages; both consuming modules build, vet, and pass their tests.

## Validation

- Reproduced the exact `go.work.sum` diff locally by building `infra/cluster-api-provider-tuist` through the workspace with Go 1.26.4.
- `go build ./... && go vet ./... && go test ./...` pass in `infra/cluster-api-provider-tuist` and `infra/runners-controller`.
- After this commit the tree stays clean when building through the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)