### PR TITLE
feat(server): add anon per-scope dashboard rate limit

### DIFF
--- a/server/lib/tuist/environment.ex
+++ b/server/lib/tuist/environment.ex
@@ -1583,6 +1583,24 @@ defmodule Tuist.Environment do
   end
 
   @doc """
+  Returns the bucket size for the anonymous per-scope dashboard rate limiter.
+
+  Applied on top of the per-subject dashboard limit and keyed by
+  `(method, account_handle[, project_handle])` for unauthenticated requests,
+  so a scraper distributed across many IPs is caught in aggregate.
+
+  The default values are:
+  - 600 requests per minute per scope for canary environments
+  - 120 requests per minute per scope for other environments
+  """
+  def public_project_rate_limit_bucket_size(secrets \\ secrets()) do
+    case get([:public_project_rate_limit, :bucket_size], secrets) do
+      bucket_size when is_binary(bucket_size) -> String.to_integer(bucket_size)
+      _ -> if can?(), do: 600, else: 120
+    end
+  end
+
+  @doc """
   Returns the bucket size for the MCP rate limiter.
 
   The default values are:

--- a/server/lib/tuist_web/rate_limit.ex
+++ b/server/lib/tuist_web/rate_limit.ex
@@ -30,11 +30,11 @@ defmodule TuistWeb.RateLimit do
       route = route_pattern(conn)
       key = "dashboard:#{conn.method}:#{route}:#{requester_key(conn)}"
 
-      case __MODULE__.hit(key, limit: limit, window: window) do
-        {:allow, _count} ->
-          conn
-
-        {:deny, _limit} ->
+      with :ok <- check(key, limit, window),
+           :ok <- check_anon_scope(conn, window, opts) do
+        conn
+      else
+        :deny ->
           raise TuistWeb.Errors.TooManyRequestsError,
             message: "You have made too many requests. Please try again later."
       end
@@ -42,6 +42,34 @@ defmodule TuistWeb.RateLimit do
       conn
     end
   end
+
+  defp check(key, limit, window) do
+    case __MODULE__.hit(key, limit: limit, window: window) do
+      {:allow, _count} -> :ok
+      {:deny, _limit} -> :deny
+    end
+  end
+
+  # Aggregate anonymous traffic per (method, account[, project]) so a scraper
+  # distributed across many residential-proxy IPs is caught even when no
+  # single IP trips the per-subject key above. Signed-in requests are already
+  # keyed by user and do not need this fallback.
+  defp check_anon_scope(%Plug.Conn{} = conn, window, opts) do
+    with nil <- Authentication.current_user(conn),
+         scope when is_binary(scope) <- anon_scope(conn) do
+      limit = opts[:anon_scope_limit] || Environment.public_project_rate_limit_bucket_size()
+      check("dashboard:anon-scope:#{conn.method}:#{scope}", limit, window)
+    else
+      _ -> :ok
+    end
+  end
+
+  defp anon_scope(%Plug.Conn{path_params: %{"account_handle" => account, "project_handle" => project}})
+       when is_binary(account) and is_binary(project), do: "#{account}/#{project}"
+
+  defp anon_scope(%Plug.Conn{path_params: %{"account_handle" => account}}) when is_binary(account), do: account
+
+  defp anon_scope(_conn), do: nil
 
   defp hit_persistent(:fixed_window, key, opts) do
     window = Keyword.fetch!(opts, :window)

--- a/server/priv/repo/migrations/20260911090100_pin_runner_kura_storage_claims.exs
+++ b/server/priv/repo/migrations/20260911090100_pin_runner_kura_storage_claims.exs
@@ -61,7 +61,7 @@ defmodule Tuist.Repo.Migrations.PinRunnerKuraStorageClaims do
 
       _ ->
         raise ArgumentError,
-              "invalid runner storage claim #{inspect(claim)} for kura_server #{id}; repair before enrollment"
+              "invalid runner storage claim #{inspect(claim)} for kura_server #{inspect(id)}; repair before enrollment"
     end
   end
 

--- a/server/test/tuist_web/live/public_account_live_test.exs
+++ b/server/test/tuist_web/live/public_account_live_test.exs
@@ -96,12 +96,19 @@ defmodule TuistWeb.PublicAccountLiveTest do
       end
     end
 
-    test "keys the limit on the visitor's address when signed out", %{conn: conn, account: account} do
+    test "keys the limit on the visitor's address and on the account scope when signed out",
+         %{conn: conn, account: account} do
       stub(Environment, :tuist_hosted?, fn -> true end)
       stub(Environment, :dashboard_rate_limit_bucket_size, fn -> 60 end)
+      stub(Environment, :public_project_rate_limit_bucket_size, fn -> 120 end)
 
       expect(RateLimit, :hit, fn key, _opts ->
         assert key == "dashboard:GET:/:account_handle/runners:ip:127.0.0.1"
+        {:allow, 1}
+      end)
+
+      expect(RateLimit, :hit, fn key, _opts ->
+        assert key == "dashboard:anon-scope:GET:#{account.name}"
         {:allow, 1}
       end)
 

--- a/server/test/tuist_web/rate_limit_test.exs
+++ b/server/test/tuist_web/rate_limit_test.exs
@@ -5,6 +5,7 @@ defmodule TuistWeb.RateLimitTest do
   alias Tuist.Accounts.User
   alias Tuist.Environment
   alias TuistWeb.Authentication
+  alias TuistWeb.Errors.TooManyRequestsError
   alias TuistWeb.RateLimit
   alias TuistWeb.RateLimit.InMemory
   alias TuistWeb.RateLimit.PersistentFixedWindow
@@ -135,9 +136,15 @@ defmodule TuistWeb.RateLimitTest do
     test "allows the request when the rate limit is not reached" do
       expect(Environment, :tuist_hosted?, fn -> true end)
       expect(Environment, :dashboard_rate_limit_bucket_size, fn -> 60 end)
+      expect(Environment, :public_project_rate_limit_bucket_size, fn -> 120 end)
 
       expect(RateLimit, :hit, fn
         "dashboard:GET:/:account_handle/:project_handle/bundles/:bundle_id:ip:127.0.0.1", [limit: 60, window: _window] ->
+          {:allow, 1}
+      end)
+
+      expect(RateLimit, :hit, fn
+        "dashboard:anon-scope:GET:tuist/ios_app_with_frameworks", [limit: 120, window: _window] ->
           {:allow, 1}
       end)
 
@@ -145,6 +152,7 @@ defmodule TuistWeb.RateLimitTest do
         :get
         |> build_conn("/tuist/ios_app_with_frameworks/bundles/01973a7f")
         |> Plug.Conn.put_private(:phoenix_router, TuistWeb.Router)
+        |> Map.put(:path_params, %{"account_handle" => "tuist", "project_handle" => "ios_app_with_frameworks"})
 
       assert conn == RateLimit.rate_limit(conn, %{})
     end
@@ -154,9 +162,81 @@ defmodule TuistWeb.RateLimitTest do
       expect(Environment, :dashboard_rate_limit_bucket_size, fn -> 60 end)
       expect(RateLimit, :hit, fn _key, _opts -> {:deny, 1} end)
 
-      assert_raise TuistWeb.Errors.TooManyRequestsError, fn ->
+      assert_raise TooManyRequestsError, fn ->
         RateLimit.rate_limit(build_conn(), %{})
       end
+    end
+
+    test "raises TooManyRequestsError when the anon per-scope limit is reached even if the per-IP limit allows" do
+      expect(Environment, :tuist_hosted?, fn -> true end)
+      expect(Environment, :dashboard_rate_limit_bucket_size, fn -> 60 end)
+      expect(Environment, :public_project_rate_limit_bucket_size, fn -> 120 end)
+
+      expect(RateLimit, :hit, fn "dashboard:GET:" <> _rest, _opts -> {:allow, 1} end)
+      expect(RateLimit, :hit, fn "dashboard:anon-scope:GET:tuist/ios_app_with_frameworks", _opts -> {:deny, 1} end)
+
+      conn =
+        :get
+        |> build_conn("/tuist/ios_app_with_frameworks/tests/test-runs")
+        |> Plug.Conn.put_private(:phoenix_router, TuistWeb.Router)
+        |> Map.put(:path_params, %{"account_handle" => "tuist", "project_handle" => "ios_app_with_frameworks"})
+
+      assert_raise TooManyRequestsError, fn ->
+        RateLimit.rate_limit(conn, %{})
+      end
+    end
+
+    test "keys the anon per-scope limit on the account when only an account handle is present" do
+      expect(Environment, :tuist_hosted?, fn -> true end)
+      expect(Environment, :dashboard_rate_limit_bucket_size, fn -> 60 end)
+      expect(Environment, :public_project_rate_limit_bucket_size, fn -> 120 end)
+
+      expect(RateLimit, :hit, fn "dashboard:GET:" <> _rest, _opts -> {:allow, 1} end)
+      expect(RateLimit, :hit, fn "dashboard:anon-scope:GET:tuist", _opts -> {:allow, 1} end)
+
+      conn =
+        :get
+        |> build_conn("/tuist")
+        |> Plug.Conn.put_private(:phoenix_router, TuistWeb.Router)
+        |> Map.put(:path_params, %{"account_handle" => "tuist"})
+
+      assert conn == RateLimit.rate_limit(conn, %{})
+    end
+
+    test "does not apply the anon per-scope limit when the request is authenticated" do
+      expect(Environment, :tuist_hosted?, fn -> true end)
+      expect(Environment, :dashboard_rate_limit_bucket_size, fn -> 60 end)
+      Mimic.reject(&Environment.public_project_rate_limit_bucket_size/0)
+      Mimic.reject(&RemoteIp.get/1)
+
+      expect(RateLimit, :hit, fn
+        "dashboard:GET:/:account_handle:user:123", [limit: 60, window: _window] ->
+          {:allow, 1}
+      end)
+
+      conn =
+        :get
+        |> build_conn("/tuist")
+        |> Plug.Conn.put_private(:phoenix_router, TuistWeb.Router)
+        |> Map.put(:path_params, %{"account_handle" => "tuist"})
+        |> Authentication.put_current_user(%User{id: 123})
+
+      assert conn == RateLimit.rate_limit(conn, %{})
+    end
+
+    test "does not apply the anon per-scope limit when the request path carries no scope" do
+      expect(Environment, :tuist_hosted?, fn -> true end)
+      expect(Environment, :dashboard_rate_limit_bucket_size, fn -> 60 end)
+      Mimic.reject(&Environment.public_project_rate_limit_bucket_size/0)
+
+      expect(RateLimit, :hit, fn _key, _opts -> {:allow, 1} end)
+
+      conn =
+        :get
+        |> build_conn("/")
+        |> Plug.Conn.put_private(:phoenix_router, TuistWeb.Router)
+
+      assert conn == RateLimit.rate_limit(conn, %{})
     end
 
     test "uses the authenticated user in the key" do
@@ -185,6 +265,26 @@ defmodule TuistWeb.RateLimitTest do
       conn = build_conn()
 
       assert conn == RateLimit.rate_limit(conn, limit: 10)
+    end
+
+    test "allows an anon per-scope limit override" do
+      expect(Environment, :tuist_hosted?, fn -> true end)
+      expect(Environment, :dashboard_rate_limit_bucket_size, fn -> 60 end)
+      Mimic.reject(&Environment.public_project_rate_limit_bucket_size/0)
+
+      expect(RateLimit, :hit, fn "dashboard:GET:" <> _rest, _opts -> {:allow, 1} end)
+
+      expect(RateLimit, :hit, fn "dashboard:anon-scope:GET:tuist/ios_app_with_frameworks", [limit: 42, window: _window] ->
+        {:allow, 1}
+      end)
+
+      conn =
+        :get
+        |> build_conn("/tuist/ios_app_with_frameworks/tests")
+        |> Plug.Conn.put_private(:phoenix_router, TuistWeb.Router)
+        |> Map.put(:path_params, %{"account_handle" => "tuist", "project_handle" => "ios_app_with_frameworks"})
+
+      assert conn == RateLimit.rate_limit(conn, anon_scope_limit: 42)
     end
 
     test "does not check the rate limit when self-hosted" do


### PR DESCRIPTION
## Motivation

Follow-up to #13096 and #13191. The Cloudflare bot-management pin from #13191 is now live in production (the operator image rolled forward at 06:54 UTC on 2026-09-12), but the origin defense still has a gap that showed up on the incidents leading up to it:

The scraper walks pages 1–11 of the public project's dashboards and toggles sort params at roughly 90 requests/min across ~100 residential-proxy IPs. In that shape no single IP comes close to the per-subject dashboard bucket (60/min in prod), so the existing `TuistWeb.RateLimit.rate_limit/2` — keyed on `(method, route, ip)` for anonymous requests — never denies. Cloudflare's `public-pages-anti-bombardment` rule also keys on IP and has the same blind spot. The origin absorbs the full Cartesian query storm regardless of edge classification.

## What changed

`TuistWeb.RateLimit.rate_limit/2` now hits a second bucket whenever a request is unauthenticated and its path carries an `account_handle`. The key is `dashboard:anon-scope:<method>:<account>[/<project>]` — aggregated across all IPs, independent of the specific route the scraper is touching, so cross-tab enumeration (test-runs plus build-runs plus run-detail plus gradle-build under the same project) rolls up to one counter. Authenticated requests already key by user and skip the new check.

Signed-out visitors on a busy public project can still burst; only sustained aggregate load trips it. Bucket size defaults to 120/min in prod and 600/min in canary, configurable via `TUIST_PUBLIC_PROJECT_RATE_LIMIT_BUCKET_SIZE` or `public_project_rate_limit.bucket_size` in secrets. Callers can override per-route with the new `anon_scope_limit` opt, mirroring the existing `limit` opt for the per-subject bucket.

## Why this shape

- **Keyed on the entity, not on the requester.** The whole point is to catch traffic that is distributed across IPs by design. The bucket has to aggregate what a scraper cannot split.
- **Route-agnostic within a project.** The scraper cycles route + sort + page combinations, so a per-route bucket would need to be small enough on every route to catch it, which would starve legitimate anonymous browsing. One rollup per project is the smallest useful catchment.
- **Only when unauthenticated.** Signed-in customers hitting their own private projects are already bounded by the per-user key at whatever load their session generates.
- **Fixed-window, one-minute, matching the existing plug.** Same algorithm, same window, same Valkey key space, same in-memory fallback path. Nothing new in the storage layer.

## Alternatives considered

- **Lower the per-IP bucket further.** Would either not catch a 0.9-req/min-per-IP scraper (if kept anywhere near tolerable for real users) or false-positive real anonymous viewers on a slow connection retrying a page. Wrong axis.
- **Cloudflare-side per-project rule.** Cloudflare only knows the URL path, not "is this a public project"; we'd have to maintain an allowlist that drifts. The `x-tuist-public` header from `PublicPageHeaderPlug` fixes classification at the edge, but keying its rate limit on the path still requires Cloudflare to know the account/project boundary. Doing it at the origin is where the boundary already lives.
- **Token bucket instead of fixed window.** Smoother, but the existing plug is fixed-window and mixing algorithms in one call would complicate the shared cache and give up its in-memory fallback semantics for one bucket. If sustained-vs-bursty tuning becomes a real problem we can switch this bucket to token-bucket later without touching the key shape.

## Impact

- Anonymous requests to the two `/:account_handle` and `/:account_handle/:project_handle` router scopes that already run `:rate_limit` now cost one extra Valkey `INCR` per request.
- Signed-in requests: no change.
- Self-hosted: no change (`Environment.tuist_hosted?()` still short-circuits the plug).
- A 90-req/min-across-100-IPs scraper on one public project trips the 120/min prod bucket in a minute and stays denied for as long as it keeps that rate.

## Verification

`mix test test/tuist_web/rate_limit_test.exs` — 17 examples, all pass. Five new tests cover:

- The allow path hits both keys with the expected shapes.
- The anon-scope denial raises `TooManyRequestsError` even when the per-IP key allows.
- Only-account paths key the anon bucket on the account alone.
- Authenticated requests skip the anon-scope check entirely (Environment fn is `Mimic.reject`ed).
- Routes with no `account_handle` in `path_params` skip the anon-scope check.
- The `anon_scope_limit` per-call override wins over the Environment default.

Also verified `mix credo lib/tuist_web/rate_limit.ex lib/tuist/environment.ex` clean.

## Follow-ups (not in this PR)

- Once we see how much sustained anonymous load real public projects generate (post-tuist/tuist visibility flip), revisit whether 120/min needs to move up or down.
- The Cloudflare `public-pages-anti-bombardment` rule can stay in place as a broader per-IP backstop; this bucket is orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019M5JiAu5Uxyh5brTh8vx4U